### PR TITLE
fix: remove invalid property references from pipe blockstates

### DIFF
--- a/src/main/resources/assets/logistics/blockstates/copper_transport_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/copper_transport_pipe.json
@@ -1,18 +1,5 @@
 {
-  "multipart": [
-    { "apply": { "model": "logistics:block/copper_transport_pipe_core" }},
-
-    { "when": { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] }, "apply": { "model": "logistics:block/copper_transport_pipe_north" }},
-    { "when": { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] }, "apply": { "model": "logistics:block/copper_transport_pipe_south" }},
-    { "when": { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] }, "apply": { "model": "logistics:block/copper_transport_pipe_east"  }},
-    { "when": { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] }, "apply": { "model": "logistics:block/copper_transport_pipe_west"  }},
-    { "when": { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] }, "apply": { "model": "logistics:block/copper_transport_pipe_up"    }},
-    { "when": { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] }, "apply": { "model": "logistics:block/copper_transport_pipe_down"  }},
-
-    { "when": { "north": "inventory" }, "apply": { "model": "logistics:block/copper_transport_pipe_north_extension" }},
-    { "when": { "south": "inventory" }, "apply": { "model": "logistics:block/copper_transport_pipe_south_extension" }},
-    { "when": { "east":  "inventory" }, "apply": { "model": "logistics:block/copper_transport_pipe_east_extension"  }},
-    { "when": { "west":  "inventory" }, "apply": { "model": "logistics:block/copper_transport_pipe_west_extension"  }},
-    { "when": { "down":  "inventory" }, "apply": { "model": "logistics:block/copper_transport_pipe_down_extension"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/copper_transport_pipe_core" }
+  }
 }

--- a/src/main/resources/assets/logistics/blockstates/gold_transport_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/gold_transport_pipe.json
@@ -1,32 +1,5 @@
 {
-  "multipart": [
-    { "when": { "powered": "false" },"apply": { "model": "logistics:block/gold_transport_pipe_core" }},
-    { "when": { "powered": "true" },"apply": { "model": "logistics:block/gold_transport_pipe_core_powered" }},
-
-    { "when": { "AND": [ { "powered": "false" }, { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_north" }},
-    { "when": { "AND": [ { "powered": "false" }, { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_south" }},
-    { "when": { "AND": [ { "powered": "false" }, { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_east"  }},
-    { "when": { "AND": [ { "powered": "false" }, { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_west"  }},
-    { "when": { "AND": [ { "powered": "false" }, { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_up"    }},
-    { "when": { "AND": [ { "powered": "false" }, { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_down"  }},
-
-    { "when": { "powered": "false", "north": "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_north_extension" }},
-    { "when": { "powered": "false", "south": "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_south_extension" }},
-    { "when": { "powered": "false", "east":  "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_east_extension"  }},
-    { "when": { "powered": "false", "west":  "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_west_extension"  }},
-    { "when": { "powered": "false", "down":  "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_down_extension"  }},
-
-    { "when": { "AND": [ { "powered": "true" }, { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_north_powered" }},
-    { "when": { "AND": [ { "powered": "true" }, { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_south_powered" }},
-    { "when": { "AND": [ { "powered": "true" }, { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_east_powered"  }},
-    { "when": { "AND": [ { "powered": "true" }, { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_west_powered"  }},
-    { "when": { "AND": [ { "powered": "true" }, { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_up_powered"    }},
-    { "when": { "AND": [ { "powered": "true" }, { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] } ] }, "apply": { "model": "logistics:block/gold_transport_pipe_down_powered"  }},
-
-    { "when": { "powered": "true", "north": "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_north_powered_extension" }},
-    { "when": { "powered": "true", "south": "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_south_powered_extension" }},
-    { "when": { "powered": "true", "east":  "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_east_powered_extension"  }},
-    { "when": { "powered": "true", "west":  "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_west_powered_extension"  }},
-    { "when": { "powered": "true", "down":  "inventory" }, "apply": { "model": "logistics:block/gold_transport_pipe_down_powered_extension"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/gold_transport_pipe_core" }
+  }
 }

--- a/src/main/resources/assets/logistics/blockstates/item_extractor_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/item_extractor_pipe.json
@@ -1,31 +1,5 @@
 {
-  "multipart": [
-    { "apply": { "model": "logistics:block/item_extractor_pipe_core" }},
-
-    { "when": { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] }, "apply": { "model": "logistics:block/item_extractor_pipe_north" }},
-    { "when": { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] }, "apply": { "model": "logistics:block/item_extractor_pipe_south" }},
-    { "when": { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] }, "apply": { "model": "logistics:block/item_extractor_pipe_east"  }},
-    { "when": { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] }, "apply": { "model": "logistics:block/item_extractor_pipe_west"  }},
-    { "when": { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] }, "apply": { "model": "logistics:block/item_extractor_pipe_up"    }},
-    { "when": { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] }, "apply": { "model": "logistics:block/item_extractor_pipe_down"  }},
-
-    { "when": { "feature_face": "!north", "north": "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_north_extension" }},
-    { "when": { "feature_face": "!south", "south": "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_south_extension" }},
-    { "when": { "feature_face": "!east",  "east":  "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_east_extension"  }},
-    { "when": { "feature_face": "!west",  "west":  "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_west_extension"  }},
-    { "when": { "feature_face": "!down",  "down":  "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_down_extension"  }},
-
-    { "when": { "feature_face": "north" }, "apply": { "model": "logistics:block/item_extractor_pipe_north_feature" }},
-    { "when": { "feature_face": "south" }, "apply": { "model": "logistics:block/item_extractor_pipe_south_feature" }},
-    { "when": { "feature_face": "east"  }, "apply": { "model": "logistics:block/item_extractor_pipe_east_feature"  }},
-    { "when": { "feature_face": "west"  }, "apply": { "model": "logistics:block/item_extractor_pipe_west_feature"  }},
-    { "when": { "feature_face": "up"    }, "apply": { "model": "logistics:block/item_extractor_pipe_up_feature"    }},
-    { "when": { "feature_face": "down"  }, "apply": { "model": "logistics:block/item_extractor_pipe_down_feature"  }},
-
-    { "when": { "feature_face": "north", "north": "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_north_feature_extension" }},
-    { "when": { "feature_face": "south", "south": "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_south_feature_extension" }},
-    { "when": { "feature_face": "east",  "east":  "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_east_feature_extension"  }},
-    { "when": { "feature_face": "west",  "west":  "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_west_feature_extension"  }},
-    { "when": { "feature_face": "down",  "down":  "inventory" }, "apply": { "model": "logistics:block/item_extractor_pipe_down_feature_extension"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/item_extractor_pipe_core" }
+  }
 }

--- a/src/main/resources/assets/logistics/blockstates/item_filter_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/item_filter_pipe.json
@@ -1,18 +1,5 @@
 {
-  "multipart": [
-    { "apply": { "model": "logistics:block/item_filter_pipe_core" }},
-
-    { "when": { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] }, "apply": { "model": "logistics:block/item_filter_pipe_north" }},
-    { "when": { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] }, "apply": { "model": "logistics:block/item_filter_pipe_south" }},
-    { "when": { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] }, "apply": { "model": "logistics:block/item_filter_pipe_east"  }},
-    { "when": { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] }, "apply": { "model": "logistics:block/item_filter_pipe_west"  }},
-    { "when": { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] }, "apply": { "model": "logistics:block/item_filter_pipe_up"    }},
-    { "when": { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] }, "apply": { "model": "logistics:block/item_filter_pipe_down"  }},
-
-    { "when": { "north": "inventory" }, "apply": { "model": "logistics:block/item_filter_pipe_north_extension" }},
-    { "when": { "south": "inventory" }, "apply": { "model": "logistics:block/item_filter_pipe_south_extension" }},
-    { "when": { "east":  "inventory" }, "apply": { "model": "logistics:block/item_filter_pipe_east_extension"  }},
-    { "when": { "west":  "inventory" }, "apply": { "model": "logistics:block/item_filter_pipe_west_extension"  }},
-    { "when": { "down":  "inventory" }, "apply": { "model": "logistics:block/item_filter_pipe_down_extension"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/item_filter_pipe_core" }
+  }
 }

--- a/src/main/resources/assets/logistics/blockstates/item_merger_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/item_merger_pipe.json
@@ -1,31 +1,5 @@
 {
-  "multipart": [
-    { "apply": { "model": "logistics:block/item_merger_pipe_core" }},
-
-    { "when": { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] }, "apply": { "model": "logistics:block/item_merger_pipe_north" }},
-    { "when": { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] }, "apply": { "model": "logistics:block/item_merger_pipe_south" }},
-    { "when": { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] }, "apply": { "model": "logistics:block/item_merger_pipe_east"  }},
-    { "when": { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] }, "apply": { "model": "logistics:block/item_merger_pipe_west"  }},
-    { "when": { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] }, "apply": { "model": "logistics:block/item_merger_pipe_up"    }},
-    { "when": { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] }, "apply": { "model": "logistics:block/item_merger_pipe_down"  }},
-
-    { "when": { "feature_face": "!north", "north": "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_north_extension" }},
-    { "when": { "feature_face": "!south", "south": "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_south_extension" }},
-    { "when": { "feature_face": "!east",  "east":  "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_east_extension"  }},
-    { "when": { "feature_face": "!west",  "west":  "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_west_extension"  }},
-    { "when": { "feature_face": "!down",  "down":  "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_down_extension"  }},
-
-    { "when": { "feature_face": "north" }, "apply": { "model": "logistics:block/item_merger_pipe_north_feature" }},
-    { "when": { "feature_face": "south" }, "apply": { "model": "logistics:block/item_merger_pipe_south_feature" }},
-    { "when": { "feature_face": "east"  }, "apply": { "model": "logistics:block/item_merger_pipe_east_feature"  }},
-    { "when": { "feature_face": "west"  }, "apply": { "model": "logistics:block/item_merger_pipe_west_feature"  }},
-    { "when": { "feature_face": "up"    }, "apply": { "model": "logistics:block/item_merger_pipe_up_feature"    }},
-    { "when": { "feature_face": "down"  }, "apply": { "model": "logistics:block/item_merger_pipe_down_feature"  }},
-
-    { "when": { "feature_face": "north", "north": "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_north_feature_extension" }},
-    { "when": { "feature_face": "south", "south": "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_south_feature_extension" }},
-    { "when": { "feature_face": "east",  "east":  "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_east_feature_extension"  }},
-    { "when": { "feature_face": "west",  "west":  "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_west_feature_extension"  }},
-    { "when": { "feature_face": "down",  "down":  "inventory" }, "apply": { "model": "logistics:block/item_merger_pipe_down_feature_extension"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/item_merger_pipe_core" }
+  }
 }

--- a/src/main/resources/assets/logistics/blockstates/item_sensor_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/item_sensor_pipe.json
@@ -1,18 +1,5 @@
 {
-  "multipart": [
-    { "apply": { "model": "logistics:block/item_sensor_pipe_core" }},
-
-    { "when": { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] }, "apply": { "model": "logistics:block/item_sensor_pipe_north" }},
-    { "when": { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] }, "apply": { "model": "logistics:block/item_sensor_pipe_south" }},
-    { "when": { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] }, "apply": { "model": "logistics:block/item_sensor_pipe_east"  }},
-    { "when": { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] }, "apply": { "model": "logistics:block/item_sensor_pipe_west"  }},
-    { "when": { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] }, "apply": { "model": "logistics:block/item_sensor_pipe_up"    }},
-    { "when": { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] }, "apply": { "model": "logistics:block/item_sensor_pipe_down"  }},
-
-    { "when": { "north": "inventory" }, "apply": { "model": "logistics:block/item_sensor_pipe_north_extension" }},
-    { "when": { "south": "inventory" }, "apply": { "model": "logistics:block/item_sensor_pipe_south_extension" }},
-    { "when": { "east":  "inventory" }, "apply": { "model": "logistics:block/item_sensor_pipe_east_extension"  }},
-    { "when": { "west":  "inventory" }, "apply": { "model": "logistics:block/item_sensor_pipe_west_extension"  }},
-    { "when": { "down":  "inventory" }, "apply": { "model": "logistics:block/item_sensor_pipe_down_extension"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/item_sensor_pipe_core" }
+  }
 }

--- a/src/main/resources/assets/logistics/blockstates/item_void_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/item_void_pipe.json
@@ -1,12 +1,5 @@
 {
-  "multipart": [
-    { "apply": { "model": "logistics:block/item_void_pipe_core" }},
-
-    { "when": { "north": "pipe"  }, "apply": { "model": "logistics:block/item_void_pipe_north" }},
-    { "when": { "south": "pipe"  }, "apply": { "model": "logistics:block/item_void_pipe_south" }},
-    { "when": { "east":  "pipe"  }, "apply": { "model": "logistics:block/item_void_pipe_east"  }},
-    { "when": { "west":  "pipe"  }, "apply": { "model": "logistics:block/item_void_pipe_west"  }},
-    { "when": { "up":    "pipe"  }, "apply": { "model": "logistics:block/item_void_pipe_up"    }},
-    { "when": { "down":  "pipe"  }, "apply": { "model": "logistics:block/item_void_pipe_down"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/item_void_pipe_core" }
+  }
 }

--- a/src/main/resources/assets/logistics/blockstates/stone_transport_pipe.json
+++ b/src/main/resources/assets/logistics/blockstates/stone_transport_pipe.json
@@ -1,18 +1,5 @@
 {
-  "multipart": [
-    { "apply": { "model": "logistics:block/stone_transport_pipe_core" }},
-
-    { "when": { "OR": [ { "north": "pipe" }, { "north": "inventory" } ] }, "apply": { "model": "logistics:block/stone_transport_pipe_north" }},
-    { "when": { "OR": [ { "south": "pipe" }, { "south": "inventory" } ] }, "apply": { "model": "logistics:block/stone_transport_pipe_south" }},
-    { "when": { "OR": [ { "east":  "pipe" }, { "east":  "inventory" } ] }, "apply": { "model": "logistics:block/stone_transport_pipe_east"  }},
-    { "when": { "OR": [ { "west":  "pipe" }, { "west":  "inventory" } ] }, "apply": { "model": "logistics:block/stone_transport_pipe_west"  }},
-    { "when": { "OR": [ { "up":    "pipe" }, { "up":    "inventory" } ] }, "apply": { "model": "logistics:block/stone_transport_pipe_up"    }},
-    { "when": { "OR": [ { "down":  "pipe" }, { "down":  "inventory" } ] }, "apply": { "model": "logistics:block/stone_transport_pipe_down"  }},
-
-    { "when": { "north": "inventory" }, "apply": { "model": "logistics:block/stone_transport_pipe_north_extension" }},
-    { "when": { "south": "inventory" }, "apply": { "model": "logistics:block/stone_transport_pipe_south_extension" }},
-    { "when": { "east":  "inventory" }, "apply": { "model": "logistics:block/stone_transport_pipe_east_extension"  }},
-    { "when": { "west":  "inventory" }, "apply": { "model": "logistics:block/stone_transport_pipe_west_extension"  }},
-    { "when": { "down":  "inventory" }, "apply": { "model": "logistics:block/stone_transport_pipe_down_extension"  }}
-  ]
+  "variants": {
+    "": { "model": "logistics:block/stone_transport_pipe_core" }
+  }
 }


### PR DESCRIPTION
Blockstate JSONs were still referencing connection properties that were removed from PipeBlock, causing failed blockstate loads and console spam on startup. All pipe blockstates now point to a single core variant with no property-based definitions.