### PR TITLE
fix: tune pipe item speeds

### DIFF
--- a/src/client/java/com/logistics/client/render/PipeRenderState.java
+++ b/src/client/java/com/logistics/client/render/PipeRenderState.java
@@ -12,4 +12,7 @@ public class PipeRenderState extends BlockEntityRenderState {
     public final List<Identifier> modelIds = new ArrayList<>();
     public BlockState blockState;
     public float tickDelta;
+    public float accelerationRate;
+    public float dragCoefficient;
+    public float maxSpeed;
 }

--- a/src/client/java/com/logistics/client/render/TravelingItemRenderState.java
+++ b/src/client/java/com/logistics/client/render/TravelingItemRenderState.java
@@ -8,7 +8,4 @@ public class TravelingItemRenderState {
     public Direction direction;
     public float progress;
     public float currentSpeed;
-    public float targetSpeed;
-    public float accelerationRate;
-    public boolean canAccelerate;
 }

--- a/src/main/java/com/logistics/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/block/entity/PipeBlockEntity.java
@@ -13,7 +13,6 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtElement;
 import net.minecraft.network.listener.ClientPlayPacketListener;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
@@ -27,7 +26,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 public class PipeBlockEntity extends BlockEntity {
     public static final int VIRTUAL_CAPACITY = 5 * 64;
@@ -326,16 +324,15 @@ public class PipeBlockEntity extends BlockEntity {
 
     private float getInitialSpeed() {
         if (world == null) {
-            return PipeConfig.BASE_PIPE_SPEED;
+            return PipeConfig.ITEM_MIN_SPEED;
         }
 
         BlockState state = getCachedState();
         if (state.getBlock() instanceof PipeBlock pipeBlock && pipeBlock.getPipe() != null) {
-            PipeContext context = new PipeContext(world, pos, state, this);
-            return pipeBlock.getPipe().getTargetSpeed(context);
+            return PipeConfig.ITEM_MIN_SPEED;
         }
 
-        return PipeConfig.BASE_PIPE_SPEED;
+        return PipeConfig.ITEM_MIN_SPEED;
     }
 
     private boolean isNeighborPipe(Direction fromDirection) {

--- a/src/main/java/com/logistics/pipe/Pipe.java
+++ b/src/main/java/com/logistics/pipe/Pipe.java
@@ -111,16 +111,6 @@ public abstract class Pipe {
         return null;
     }
 
-    public float getTargetSpeed(PipeContext ctx) {
-        for (Module module : modules) {
-            float speed = module.getTargetSpeed(ctx);
-            if (speed > 0f) {
-                return speed;
-            }
-        }
-        return PipeConfig.BASE_PIPE_SPEED;
-    }
-
     public float getAccelerationRate(PipeContext ctx) {
         for (Module module : modules) {
             float accel = module.getAcceleration(ctx);
@@ -131,6 +121,16 @@ public abstract class Pipe {
         return 0f;
     }
 
+    public float getDrag(PipeContext ctx) {
+        for (Module module : modules) {
+            float drag = module.getDrag(ctx);
+            if (drag > 0f) {
+                return drag;
+            }
+        }
+        return PipeConfig.DRAG_COEFFICIENT;
+    }
+
     public float getMaxSpeed(PipeContext ctx) {
         for (Module module : modules) {
             float max = module.getMaxSpeed(ctx);
@@ -138,16 +138,7 @@ public abstract class Pipe {
                 return max;
             }
         }
-        return 0f;
-    }
-
-    public boolean canAccelerate(PipeContext ctx) {
-        for (Module module : modules) {
-            if (module.applyAcceleration(ctx)) {
-                return true;
-            }
-        }
-        return false;
+        return PipeConfig.PIPE_MAX_SPEED;
     }
 
     public RoutePlan route(PipeContext ctx, TravelingItem item, List<Direction> options) {

--- a/src/main/java/com/logistics/pipe/PipeTypes.java
+++ b/src/main/java/com/logistics/pipe/PipeTypes.java
@@ -9,8 +9,9 @@ public final class PipeTypes {
     // -----------------
 
     // Early transport pipe - slow item movement.
-    // TODO: This pipe should have a slower speed
-    public static final Pipe STONE_TRANSPORT_PIPE = new Pipe() {};
+    public static final Pipe STONE_TRANSPORT_PIPE = new Pipe(
+            new TransportModule(PipeConfig.ITEM_MIN_SPEED, PipeConfig.DRAG_COEFFICIENT)
+    ) {};
 
     // Base transport pipe - simple item movement.
     // NOTE: No special connection restrictions; this is the default backbone pipe.

--- a/src/main/java/com/logistics/pipe/modules/BoostModule.java
+++ b/src/main/java/com/logistics/pipe/modules/BoostModule.java
@@ -1,21 +1,24 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.pipe.PipeContext;
+import com.logistics.pipe.runtime.PipeConfig;
 
 public class BoostModule implements Module {
     private final float accelerationRate;
+    private final float maxSpeed;
 
     public BoostModule(float accelerationRate) {
         this.accelerationRate = accelerationRate;
-    }
-
-    @Override
-    public boolean applyAcceleration(PipeContext ctx) {
-        return ctx.isPowered();
+        this.maxSpeed = PipeConfig.PIPE_MAX_SPEED * 4.0f;
     }
 
     @Override
     public float getAcceleration(PipeContext ctx) {
-        return this.accelerationRate;
+        return ctx.isPowered() ? this.accelerationRate : 0f;
+    }
+
+    @Override
+    public float getMaxSpeed(PipeContext ctx) {
+        return maxSpeed;
     }
 }

--- a/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
@@ -136,7 +136,7 @@ public class ExtractionModule implements Module {
                 long extracted = view.extract(variant, 1, transaction);
                 if (extracted > 0) {
                     ItemStack stack = variant.toStack((int) extracted);
-                    TravelingItem item = new TravelingItem(stack, direction.getOpposite(), PipeConfig.EXTRACTED_ITEM_SPEED);
+                    TravelingItem item = new TravelingItem(stack, direction.getOpposite(), PipeConfig.ITEM_MIN_SPEED);
                     ctx.blockEntity().forceAddItem(item, direction);
                     transaction.commit();
                     return true;

--- a/src/main/java/com/logistics/pipe/modules/Module.java
+++ b/src/main/java/com/logistics/pipe/modules/Module.java
@@ -2,6 +2,7 @@ package com.logistics.pipe.modules;
 
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
+import com.logistics.pipe.runtime.PipeConfig;
 import com.logistics.pipe.runtime.RoutePlan;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -17,20 +18,16 @@ public interface Module {
     default void onTick(PipeContext ctx) {
     }
 
-    default float getTargetSpeed(PipeContext ctx) {
-        return 0f;
-    }
-
     default float getAcceleration(PipeContext ctx) {
         return 0f;
     }
 
-    default float getMaxSpeed(PipeContext ctx) {
-        return 0f;
+    default float getDrag(PipeContext ctx) {
+        return PipeConfig.DRAG_COEFFICIENT;
     }
 
-    default boolean applyAcceleration(PipeContext ctx) {
-        return false;
+    default float getMaxSpeed(PipeContext ctx) {
+        return PipeConfig.PIPE_MAX_SPEED;
     }
 
     default RoutePlan route(PipeContext ctx, com.logistics.pipe.runtime.TravelingItem item, List<Direction> options) {

--- a/src/main/java/com/logistics/pipe/modules/TransportModule.java
+++ b/src/main/java/com/logistics/pipe/modules/TransportModule.java
@@ -1,0 +1,23 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.pipe.PipeContext;
+
+public class TransportModule implements Module {
+    private final float maxSpeed;
+    private final float dragCoefficient;
+
+    public TransportModule(float maxSpeed, float dragCoefficient) {
+        this.maxSpeed = maxSpeed;
+        this.dragCoefficient = dragCoefficient;
+    }
+
+    @Override
+    public float getMaxSpeed(PipeContext ctx) {
+        return maxSpeed;
+    }
+
+    @Override
+    public float getDrag(PipeContext ctx) {
+        return dragCoefficient;
+    }
+}

--- a/src/main/java/com/logistics/pipe/runtime/PipeConfig.java
+++ b/src/main/java/com/logistics/pipe/runtime/PipeConfig.java
@@ -1,15 +1,28 @@
 package com.logistics.pipe.runtime;
 
 public class PipeConfig {
-    // Wooden pipes are slower - 3 seconds to traverse
-    public static final float EXTRACTED_ITEM_SPEED = 1.0f / 60.0f; // Blocks per tick
+    // Constant speed added per tick when a pipe applies acceleration (e.g., powered boost pipes).
+    // This is a linear delta, not a multiplier, so larger values ramp speed faster each tick.
+    // 1/200 blocks per tick^2 means +0.005 blocks/tick after one tick of acceleration.
+    public static final float ACCELERATION_RATE = 1.0f / 200.0f;
 
-    // Acceleration rate - how quickly items adjust to pipe speed
-    public static final float ACCELERATION_RATE = 0.004f; // Speed change per tick (doubled)
+    // Fraction of the current speed removed per tick when not accelerating.
+    // This creates a smooth exponential decay (speed -= speed * DRAG_COEFFICIENT).
+    // Tuned so one fully-powered boost segment (starting at ITEM_MIN_SPEED with ACCELERATION_RATE)
+    // keeps the item just above ITEM_MIN_SPEED after ~15 more unpowered segments.
+    public static final float DRAG_COEFFICIENT = 0.00536f;
 
+    // Ticks between extraction attempts for extractor pipes.
+    // Larger values reduce throughput but also reduce work per tick.
     public static final int EXTRACTION_INTERVAL = 60;
 
-    // Base pipe speed - matches the speed after ~3 powered gold pipes
-    // At 0.15 blocks/tick, takes ~6.67 ticks (0.33 seconds) to traverse one segment
-    public static final float BASE_PIPE_SPEED = 3.0f / 20.0f; // Blocks per tick (0.15)
+    // Hard floor for item speed while traveling through pipes.
+    // Items will never slow below this, even under drag, so movement doesn't stall.
+    // 1/60 blocks per tick = 1.2 blocks/sec = 60 ticks per block.
+    public static final float ITEM_MIN_SPEED = 1.0f / 60.0f;
+
+    // Default ceiling for item speed while traveling through pipes.
+    // Individual pipes can override this up or down via getMaxSpeed.
+    // 1/4 blocks per tick = 5 blocks/sec = 4 ticks per block.
+    public static final float PIPE_MAX_SPEED = 1.0f / 4.0f;
 }


### PR DESCRIPTION
Release notes:
- Stone transport pipes now use a dedicated transport module with a slower max speed and drag.
- Item movement now uses acceleration, drag, and max-speed clamps instead of a fixed target speed.
- Extracted items start at the minimum speed, with boost pipes only accelerating when powered.
- Rendering mirrors the new speed model to keep visuals consistent with server movement.