### PR TITLE
fix: allow extraction pipes to accept items using default pipe rules

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
@@ -90,11 +90,6 @@ public class ExtractionModule implements Module {
         return ActionResult.SUCCESS;
     }
 
-    @Override
-    public boolean canAcceptFrom(PipeContext ctx, Direction from, ItemStack stack) {
-        return false;
-    }
-
     private @Nullable Direction getExtractionDirection(PipeContext ctx) {
         NbtCompound state = ctx.moduleState(getStateKey());
         if (!state.contains(EXTRACT_FROM)) {


### PR DESCRIPTION
This PR changes the behavior of the Extraction module which was preventing the acceptance of items from any source. This was put in place before implementing the module that prevented wooden pipes from connecting to each other and is no longer relevant, and to the point of #37 is un-intuitive behavior from the pipe. 

fixes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item acceptance behavior in extraction modules, enabling proper item handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->