### PR TITLE
fix: split item stacks when inventories have partial capacity

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/InsertionModule.java
+++ b/src/main/java/com/logistics/pipe/modules/InsertionModule.java
@@ -145,7 +145,8 @@ public class InsertionModule implements Module {
     }
 
     private Direction chooseRandomDirection(PipeContext ctx, TravelingItem item, List<Direction> options) {
-        long seed = mixHash(ctx.pos().asLong(), ctx.world().getTime(), item.getDirection().getIndex());
+        long seed = mixHash(
+                ctx.pos().asLong(), ctx.world().getTime(), item.getDirection().getIndex());
         Random random = new Random(seed);
         return options.get(random.nextInt(options.size()));
     }


### PR DESCRIPTION
### Summary
- Improves insertion routing so items no longer get forced entirely into pipes (or bounce) when a connected inventory can only accept part of a stack.

### Changes
- Detects *how much* space a target inventory can accept (not just whether it can accept anything).
- Splits stacks across multiple partially-available inventories when possible.
- When some items can be inserted but not all, routes the remainder into available pipe outputs instead of failing the whole route.
- Accounts for already-routed items heading to the same inventory to avoid overcommitting capacity.

### Notes
- Affects routing behavior for insertion modules in mixed networks (inventories + pipes), especially under near-full inventory conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved item routing that splits deliveries across multiple destinations when a single inventory lacks space.
  * More accurate space accounting that considers items already en route for better allocation.
  * Smarter, deterministic routing decisions that prefer partial inventories first and automatically reroute any remainder via alternative paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->