### PR TITLE
fix: preserve pipe block entity state on normal pick-block

### DIFF
--- a/src/main/java/com/logistics/block/PipeBlock.java
+++ b/src/main/java/com/logistics/block/PipeBlock.java
@@ -264,13 +264,10 @@ public class PipeBlock extends BlockWithEntity implements Waterloggable {
             net.minecraft.world.WorldView world, BlockPos pos, BlockState state, boolean includeData) {
         ItemStack stack = super.getPickStack(world, pos, state, includeData);
 
-        // Copy components from block entity to preserve state (e.g., weathering)
-        // Only when includeData is true (Ctrl+pick) to match vanilla behavior
-        if (includeData) {
-            BlockEntity blockEntity = world.getBlockEntity(pos);
-            if (blockEntity instanceof PipeBlockEntity pipeEntity) {
-                stack.applyComponentsFrom(pipeEntity.createComponentMap());
-            }
+        // Copy components from block entity to preserve state (e.g., weathering) on normal pick-block.
+        BlockEntity blockEntity = world.getBlockEntity(pos);
+        if (blockEntity instanceof PipeBlockEntity pipeEntity) {
+            stack.applyComponentsFrom(pipeEntity.createComponentMap());
         }
 
         return stack;


### PR DESCRIPTION
### Summary
- Fixes a regression where picking a pipe block wouldn’t retain its saved state (such as copper oxidation/weathering), making picked pipes behave like fresh items.

### Changes
- Normal pick-block now copies the pipe’s stored components from the block entity onto the picked `ItemStack`, so the picked item matches what’s placed in-world.

### Notes
- This affects standard pick-block behavior (not just “include data”/Ctrl-pick), improving consistency when duplicating pipes in creative or when inspecting variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where pipe block components and weathering states were not properly preserved when picked from the world.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->