### PR TITLE
fix: quarry now drops item when broken

### DIFF
--- a/src/main/resources/data/logistics/loot_table/blocks/quarry.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/quarry.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:quarry",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}


### PR DESCRIPTION
### Summary
- Fixes a bug where breaking the quarry block didn't drop the quarry item.

### Changes
- Added a loot table for the quarry block with quarry item as drop. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proper loot behavior for the Quarry block, allowing it to drop as a recoverable item when destroyed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->