### PR TITLE
docs: clarify release channels and align CI publish metadata

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,6 +53,7 @@ jobs:
           # Example: 0.3.0+mc.1.21.11
           BUILD_VERSION="${VERSION}+mc.${MC_VERSION}"
 
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "mod_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
           echo "minecraft_version=$MC_VERSION" >> "$GITHUB_OUTPUT"
           echo "📦 Version: $BUILD_VERSION"
@@ -79,3 +80,4 @@ jobs:
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-tag: ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
### Summary
 - Improved the clarity and consistency of published build names across release, dev, and snapshot channels.
 - Documented where to download the mod and how release channels differ, so users can pick the right build.
  
### Changes
 - Added a dedicated **Downloads** section to the README (Modrinth, CurseForge, GitHub Releases).
 - Added a **Release Channels** table explaining Release vs Dev vs Snapshot builds, with version examples and stability guidance.
 - Updated GitHub Actions publish names for **dev** and **snapshot** builds to use channel/version/build-number naming for easier identification.
 - Updated the release workflow to provide the GitHub tag to the publish step.\n\n### Notes\n- No gameplay or mod behavior changes—this is documentation and release/publishing metadata only."