### PR TITLE
fix: correct engine renderer rotation for north/south facing

### DIFF
--- a/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
+++ b/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
@@ -298,8 +298,8 @@ public class EngineBlockEntityRenderer implements BlockEntityRenderer<AbstractEn
         matrices.translate(0.5, 0.5, 0.5);
         switch (facing) {
             case DOWN -> matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180));
-            case NORTH -> matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90));
-            case SOUTH -> matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90));
+            case NORTH -> matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90));
+            case SOUTH -> matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90));
             case EAST -> matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90));
             case WEST -> matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90));
             default -> {} // UP - default orientation, no rotation needed


### PR DESCRIPTION
## Summary
- Fixes the engine’s visual orientation when placed facing north or south.

## Changes
- Swapped the north/south rotation mapping in the Engine Block Entity Renderer so the model renders in the expected direction.

## Notes
- Rendering-only change; no gameplay logic, block behavior, or world data is affected.

Closes #68 