### PR TITLE
refactor: extract shared engine block behavior into core power lib

### DIFF
--- a/src/client/java/com/logistics/power/registry/PowerClientBootstrap.java
+++ b/src/client/java/com/logistics/power/registry/PowerClientBootstrap.java
@@ -1,7 +1,7 @@
 package com.logistics.power.registry;
 
 import com.logistics.core.bootstrap.ClientDomainBootstrap;
-import com.logistics.power.engine.block.entity.AbstractEngineBlockEntity;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.power.render.EngineBlockEntityRenderer;
 import com.logistics.power.screen.StirlingEngineScreen;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;

--- a/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
+++ b/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
@@ -1,11 +1,11 @@
 package com.logistics.power.render;
 
-import static com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.STAGE;
+import static com.logistics.core.lib.power.AbstractEngineBlockEntity.STAGE;
 
 import com.logistics.LogisticsMod;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
 import com.logistics.core.render.ModelRegistry;
-import com.logistics.power.engine.block.entity.AbstractEngineBlockEntity;
-import com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.HeatStage;
 import com.logistics.power.engine.block.entity.CreativeEngineBlockEntity;
 import com.logistics.power.engine.block.entity.RedstoneEngineBlockEntity;
 import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;

--- a/src/client/java/com/logistics/power/render/EngineRenderState.java
+++ b/src/client/java/com/logistics/power/render/EngineRenderState.java
@@ -1,6 +1,6 @@
 package com.logistics.power.render;
 
-import com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
 import net.minecraft.client.render.block.entity.state.BlockEntityRenderState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
@@ -1,0 +1,266 @@
+package com.logistics.core.lib.power;
+
+import static com.logistics.core.lib.power.AbstractEngineBlockEntity.STAGE;
+
+import com.logistics.core.lib.block.Probeable;
+import com.logistics.core.lib.block.Wrenchable;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.core.lib.support.ProbeResult;
+import java.util.Collections;
+import java.util.List;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.sound.BlockSoundGroup;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.EnumProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.state.property.Property;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import net.minecraft.world.block.WireOrientation;
+import org.jetbrains.annotations.Nullable;
+import team.reborn.energy.api.EnergyStorage;
+
+/**
+ * Abstract base class for all engine blocks.
+ * Provides common functionality for FACING, POWERED, STAGE properties and redstone handling.
+ *
+ * @param <E> The type of engine block entity this block creates
+ */
+public abstract class AbstractEngineBlock<E extends AbstractEngineBlockEntity> extends BlockWithEntity
+        implements Probeable, Wrenchable {
+    public static final EnumProperty<Direction> FACING = Properties.FACING;
+    public static final BooleanProperty POWERED = Properties.POWERED;
+
+    protected AbstractEngineBlock(Settings settings, BlockSoundGroup soundGroup) {
+        super(settings.strength(3.5f)
+                .sounds(soundGroup)
+                .nonOpaque()
+                .solidBlock((state, world, pos) -> false)
+                .suffocates((state, world, pos) -> false)
+                .blockVision((state, world, pos) -> false));
+        setDefaultState(getDefaultState()
+                .with(FACING, Direction.NORTH)
+                .with(POWERED, false)
+                .with(STAGE, HeatStage.COLD));
+    }
+
+    /**
+     * Returns additional properties that subclasses want to add to the block state.
+     * Base implementation returns empty list. Subclasses override to add properties like LIT.
+     */
+    protected List<Property<?>> getAdditionalProperties() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Applies additional placement state that subclasses want to add.
+     * Base implementation returns the state unchanged.
+     *
+     * @param base the base placement state with FACING, POWERED, STAGE already set
+     * @param ctx the placement context
+     * @return the state with additional properties applied
+     */
+    protected BlockState applyAdditionalPlacementState(BlockState base, ItemPlacementContext ctx) {
+        return base;
+    }
+
+    /**
+     * Type-safe getter for the engine block entity.
+     * Subclasses implement this to cast to their specific block entity type.
+     */
+    protected abstract E getEngineBlockEntity(BlockEntity be);
+
+    /**
+     * Handles special wrench behavior before the default rotation.
+     * Return true to skip the default rotation behavior.
+     * Base implementation returns false (always perform rotation).
+     */
+    protected boolean handleSpecialWrench(World world, BlockPos pos, PlayerEntity player, BlockState state) {
+        return false;
+    }
+
+    @Override
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        builder.add(FACING, POWERED, STAGE);
+        for (Property<?> property : getAdditionalProperties()) {
+            builder.add(property);
+        }
+    }
+
+    @Override
+    public BlockRenderType getRenderType(BlockState state) {
+        return BlockRenderType.MODEL;
+    }
+
+    @Nullable @Override
+    public BlockState getPlacementState(ItemPlacementContext ctx) {
+        // Output faces an adjacent EnergyStorage if available, otherwise player look direction
+        Direction defaultFacing = ctx.getPlayerLookDirection();
+        Direction facing = findBestOutputDirection(ctx.getWorld(), ctx.getBlockPos(), defaultFacing);
+        boolean powered = hasDirectRedstonePower(ctx.getWorld(), ctx.getBlockPos());
+
+        BlockState base =
+                getDefaultState().with(FACING, facing).with(POWERED, powered).with(STAGE, HeatStage.COLD);
+
+        return applyAdditionalPlacementState(base, ctx);
+    }
+
+    @Override
+    public ProbeResult onProbe(World world, BlockPos pos, PlayerEntity player) {
+        BlockEntity be = world.getBlockEntity(pos);
+        if (be != null) {
+            E engine = getEngineBlockEntity(be);
+            if (engine != null) {
+                return engine.getProbeResult();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ActionResult onWrench(World world, BlockPos pos, PlayerEntity player) {
+        BlockState state = world.getBlockState(pos);
+
+        // Let subclasses handle special wrench behavior first
+        if (handleSpecialWrench(world, pos, player, state)) {
+            return ActionResult.SUCCESS;
+        }
+
+        // Default behavior: snap to next EnergyStorage or rotate through all directions
+        if (!world.isClient()) {
+            Direction currentFacing = state.get(FACING);
+            Direction newFacing = findNextOutputDirection(world, pos, currentFacing);
+            world.setBlockState(pos, state.with(FACING, newFacing), Block.NOTIFY_ALL);
+        }
+
+        return ActionResult.SUCCESS;
+    }
+
+    @Override
+    protected void neighborUpdate(
+            BlockState state,
+            World world,
+            BlockPos pos,
+            Block block,
+            @Nullable WireOrientation wireOrientation,
+            boolean notify) {
+        if (!world.isClient()) {
+            boolean powered = hasDirectRedstonePower(world, pos);
+            if (powered != state.get(POWERED)) {
+                world.setBlockState(pos, state.with(POWERED, powered), Block.NOTIFY_LISTENERS);
+            }
+        }
+        super.neighborUpdate(state, world, pos, block, wireOrientation, notify);
+    }
+
+    /**
+     * Check if the block has direct redstone power (from levers, buttons, etc.)
+     * but not from redstone dust passing by.
+     */
+    private boolean hasDirectRedstonePower(World world, BlockPos pos) {
+        for (Direction direction : Direction.values()) {
+            // Get emitted redstone power directly from neighbors
+            // This excludes weak power from dust and only counts strong power sources
+            int power = world.getEmittedRedstonePower(pos.offset(direction), direction);
+            if (power > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, BlockRotation rotation) {
+        return state.with(FACING, rotation.rotate(state.get(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, BlockMirror mirror) {
+        return state.rotate(mirror.getRotation(state.get(FACING)));
+    }
+
+    /**
+     * Gets the direction this engine outputs energy to.
+     */
+    public static Direction getOutputDirection(BlockState state) {
+        return state.get(FACING);
+    }
+
+    /**
+     * Finds the best direction for an engine to face based on adjacent EnergyStorage blocks.
+     * Prefers the given default direction if it points to an EnergyStorage, otherwise returns
+     * the first adjacent direction with an EnergyStorage, or the default if none found.
+     *
+     * @param world the world
+     * @param pos the engine's position
+     * @param defaultDirection the preferred direction (usually player look direction)
+     * @return the direction to face
+     */
+    public static Direction findBestOutputDirection(World world, BlockPos pos, Direction defaultDirection) {
+        // First check if the default direction has an EnergyStorage
+        if (hasEnergyStorage(world, pos, defaultDirection)) {
+            return defaultDirection;
+        }
+
+        // Check all other directions
+        for (Direction dir : Direction.values()) {
+            if (dir != defaultDirection && hasEnergyStorage(world, pos, dir)) {
+                return dir;
+            }
+        }
+
+        // No EnergyStorage found, use default
+        return defaultDirection;
+    }
+
+    /**
+     * Finds the next direction with an EnergyStorage when rotating from the current direction.
+     * If no EnergyStorage is found in any direction, cycles to the next sequential direction.
+     *
+     * @param world the world
+     * @param pos the engine's position
+     * @param current the current facing direction
+     * @return the next direction to face
+     */
+    public static Direction findNextOutputDirection(World world, BlockPos pos, Direction current) {
+        // Try to find an EnergyStorage in the remaining directions (cycling from current)
+        Direction[] directions = Direction.values();
+        int startIdx = (current.ordinal() + 1) % directions.length;
+
+        // First pass: look for EnergyStorage
+        for (int i = 0; i < directions.length; i++) {
+            Direction dir = directions[(startIdx + i) % directions.length];
+            if (hasEnergyStorage(world, pos, dir)) {
+                return dir;
+            }
+        }
+
+        // No EnergyStorage found, just cycle to next direction
+        return directions[startIdx];
+    }
+
+    /**
+     * Checks if there's a block with EnergyStorage capability in the given direction.
+     *
+     * @param world the world
+     * @param pos the engine's position
+     * @param direction the direction to check
+     * @return true if an EnergyStorage exists in that direction
+     */
+    private static boolean hasEnergyStorage(World world, BlockPos pos, Direction direction) {
+        BlockPos targetPos = pos.offset(direction);
+        EnergyStorage storage = EnergyStorage.SIDED.find(world, targetPos, direction.getOpposite());
+        return storage != null && storage.supportsInsertion();
+    }
+}

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -1,4 +1,4 @@
-package com.logistics.power.engine.block.entity;
+package com.logistics.core.lib.power;
 
 import com.logistics.api.EnergyStorage;
 import com.logistics.core.lib.support.ProbeResult;
@@ -404,6 +404,8 @@ public abstract class AbstractEngineBlockEntity extends BlockEntity implements E
     public float getProgress() {
         return progress;
     }
+
+    // ==================== Public Getters ====================
 
     public HeatStage getHeatStage() {
         return heatStage;

--- a/src/main/java/com/logistics/power/engine/block/CreativeEngineBlock.java
+++ b/src/main/java/com/logistics/power/engine/block/CreativeEngineBlock.java
@@ -1,36 +1,19 @@
 package com.logistics.power.engine.block;
 
-import static com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.STAGE;
-
-import com.logistics.core.lib.block.Probeable;
-import com.logistics.core.lib.block.Wrenchable;
-import com.logistics.core.lib.support.ProbeResult;
-import com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.power.engine.block.entity.CreativeEngineBlockEntity;
 import com.logistics.power.registry.PowerBlockEntities;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.sound.BlockSoundGroup;
-import net.minecraft.state.StateManager;
-import net.minecraft.state.property.BooleanProperty;
-import net.minecraft.state.property.EnumProperty;
-import net.minecraft.state.property.Properties;
 import net.minecraft.text.Text;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.BlockMirror;
-import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
-import net.minecraft.world.block.WireOrientation;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -45,22 +28,11 @@ import org.jetbrains.annotations.Nullable;
  *   <li>Cannot overheat - always safe to use</li>
  * </ul>
  */
-public class CreativeEngineBlock extends BlockWithEntity implements Probeable, Wrenchable {
+public class CreativeEngineBlock extends AbstractEngineBlock<CreativeEngineBlockEntity> {
     public static final MapCodec<CreativeEngineBlock> CODEC = createCodec(CreativeEngineBlock::new);
-    public static final EnumProperty<Direction> FACING = Properties.FACING;
-    public static final BooleanProperty POWERED = Properties.POWERED;
 
     public CreativeEngineBlock(Settings settings) {
-        super(settings.strength(3.5f)
-                .sounds(BlockSoundGroup.STONE)
-                .nonOpaque()
-                .solidBlock((state, world, pos) -> false)
-                .suffocates((state, world, pos) -> false)
-                .blockVision((state, world, pos) -> false));
-        setDefaultState(getDefaultState()
-                .with(FACING, Direction.NORTH)
-                .with(POWERED, false)
-                .with(STAGE, HeatStage.COLD));
+        super(settings, BlockSoundGroup.STONE);
     }
 
     @Override
@@ -69,25 +41,21 @@ public class CreativeEngineBlock extends BlockWithEntity implements Probeable, W
     }
 
     @Override
-    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        builder.add(FACING, POWERED, STAGE);
+    protected CreativeEngineBlockEntity getEngineBlockEntity(BlockEntity be) {
+        return be instanceof CreativeEngineBlockEntity ? (CreativeEngineBlockEntity) be : null;
     }
 
     @Override
-    public BlockRenderType getRenderType(BlockState state) {
-        return BlockRenderType.MODEL;
-    }
-
-    @Override
-    public BlockSoundGroup getSoundGroup(BlockState state) {
-        return BlockSoundGroup.STONE;
-    }
-
-    @Nullable @Override
-    public BlockState getPlacementState(ItemPlacementContext ctx) {
-        Direction facing = ctx.getPlayerLookDirection();
-        boolean powered = hasDirectRedstonePower(ctx.getWorld(), ctx.getBlockPos());
-        return getDefaultState().with(FACING, facing).with(POWERED, powered).with(STAGE, HeatStage.COLD);
+    protected boolean handleSpecialWrench(World world, BlockPos pos, PlayerEntity player, BlockState state) {
+        // Sneak + wrench: cycle output level
+        if (player.isSneaking() && world.getBlockEntity(pos) instanceof CreativeEngineBlockEntity engine) {
+            if (!world.isClient()) {
+                long newRate = engine.cycleOutputLevel();
+                player.sendMessage(Text.translatable("message.logistics.power.creative_engine.output", newRate), true);
+            }
+            return true;
+        }
+        return false;
     }
 
     @Nullable @Override
@@ -99,81 +67,5 @@ public class CreativeEngineBlock extends BlockWithEntity implements Probeable, W
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(
             World world, BlockState state, BlockEntityType<T> type) {
         return validateTicker(type, PowerBlockEntities.CREATIVE_ENGINE_BLOCK_ENTITY, CreativeEngineBlockEntity::tick);
-    }
-
-    @Override
-    public ProbeResult onProbe(World world, BlockPos pos, PlayerEntity player) {
-        if (world.getBlockEntity(pos) instanceof CreativeEngineBlockEntity engine) {
-            return engine.getProbeResult();
-        }
-        return null;
-    }
-
-    @Override
-    public ActionResult onWrench(World world, BlockPos pos, PlayerEntity player) {
-        // Sneak + wrench: cycle output level
-        if (player.isSneaking() && world.getBlockEntity(pos) instanceof CreativeEngineBlockEntity engine) {
-            if (!world.isClient()) {
-                long newRate = engine.cycleOutputLevel();
-                player.sendMessage(Text.translatable("message.logistics.power.creative_engine.output", newRate), true);
-            }
-            return ActionResult.SUCCESS;
-        }
-
-        // Normal wrench: rotate facing
-        if (!world.isClient()) {
-            BlockState state = world.getBlockState(pos);
-            Direction currentFacing = state.get(FACING);
-            Direction newFacing = getNextDirection(currentFacing);
-            world.setBlockState(pos, state.with(FACING, newFacing), Block.NOTIFY_ALL);
-        }
-
-        return ActionResult.SUCCESS;
-    }
-
-    private static Direction getNextDirection(Direction current) {
-        Direction[] directions = Direction.values();
-        return directions[(current.ordinal() + 1) % directions.length];
-    }
-
-    @Override
-    protected void neighborUpdate(
-            BlockState state,
-            World world,
-            BlockPos pos,
-            Block block,
-            @Nullable WireOrientation wireOrientation,
-            boolean notify) {
-        if (!world.isClient()) {
-            boolean powered = hasDirectRedstonePower(world, pos);
-            if (powered != state.get(POWERED)) {
-                world.setBlockState(pos, state.with(POWERED, powered), Block.NOTIFY_LISTENERS);
-            }
-        }
-        super.neighborUpdate(state, world, pos, block, wireOrientation, notify);
-    }
-
-    private boolean hasDirectRedstonePower(World world, BlockPos pos) {
-        for (Direction direction : Direction.values()) {
-            int power = world.getEmittedRedstonePower(pos.offset(direction), direction);
-            if (power > 0) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    protected BlockState rotate(BlockState state, BlockRotation rotation) {
-        return state.with(FACING, rotation.rotate(state.get(FACING)));
-    }
-
-    @Override
-    protected BlockState mirror(BlockState state, BlockMirror mirror) {
-        return state.rotate(mirror.getRotation(state.get(FACING)));
-    }
-
-    public static Direction getOutputDirection(BlockState state) {
-        return state.get(FACING);
     }
 }

--- a/src/main/java/com/logistics/power/engine/block/RedstoneEngineBlock.java
+++ b/src/main/java/com/logistics/power/engine/block/RedstoneEngineBlock.java
@@ -1,35 +1,17 @@
 package com.logistics.power.engine.block;
 
-import static com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.STAGE;
-
-import com.logistics.core.lib.block.Probeable;
-import com.logistics.core.lib.block.Wrenchable;
-import com.logistics.core.lib.support.ProbeResult;
-import com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.power.engine.block.entity.RedstoneEngineBlockEntity;
 import com.logistics.power.registry.PowerBlockEntities;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.sound.BlockSoundGroup;
-import net.minecraft.state.StateManager;
-import net.minecraft.state.property.BooleanProperty;
-import net.minecraft.state.property.EnumProperty;
-import net.minecraft.state.property.Properties;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.BlockMirror;
-import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
-import net.minecraft.world.block.WireOrientation;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -43,22 +25,11 @@ import org.jetbrains.annotations.Nullable;
  *   <li>Has a small internal buffer (10 MJ) and stalls when full</li>
  * </ul>
  */
-public class RedstoneEngineBlock extends BlockWithEntity implements Probeable, Wrenchable {
+public class RedstoneEngineBlock extends AbstractEngineBlock<RedstoneEngineBlockEntity> {
     public static final MapCodec<RedstoneEngineBlock> CODEC = createCodec(RedstoneEngineBlock::new);
-    public static final EnumProperty<Direction> FACING = Properties.FACING;
-    public static final BooleanProperty POWERED = Properties.POWERED;
 
     public RedstoneEngineBlock(Settings settings) {
-        super(settings.strength(3.5f)
-                .sounds(BlockSoundGroup.STONE)
-                .nonOpaque()
-                .solidBlock((state, world, pos) -> false)
-                .suffocates((state, world, pos) -> false)
-                .blockVision((state, world, pos) -> false));
-        setDefaultState(getDefaultState()
-                .with(FACING, Direction.NORTH)
-                .with(POWERED, false)
-                .with(STAGE, HeatStage.COLD));
+        super(settings, BlockSoundGroup.STONE);
     }
 
     @Override
@@ -67,26 +38,8 @@ public class RedstoneEngineBlock extends BlockWithEntity implements Probeable, W
     }
 
     @Override
-    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        builder.add(FACING, POWERED, STAGE);
-    }
-
-    @Override
-    public BlockRenderType getRenderType(BlockState state) {
-        return BlockRenderType.MODEL;
-    }
-
-    @Override
-    public BlockSoundGroup getSoundGroup(BlockState state) {
-        return BlockSoundGroup.STONE;
-    }
-
-    @Nullable @Override
-    public BlockState getPlacementState(ItemPlacementContext ctx) {
-        // Output faces the direction the player is looking
-        Direction facing = ctx.getPlayerLookDirection();
-        boolean powered = hasDirectRedstonePower(ctx.getWorld(), ctx.getBlockPos());
-        return getDefaultState().with(FACING, facing).with(POWERED, powered).with(STAGE, HeatStage.COLD);
+    protected RedstoneEngineBlockEntity getEngineBlockEntity(BlockEntity be) {
+        return be instanceof RedstoneEngineBlockEntity ? (RedstoneEngineBlockEntity) be : null;
     }
 
     @Nullable @Override
@@ -98,84 +51,5 @@ public class RedstoneEngineBlock extends BlockWithEntity implements Probeable, W
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(
             World world, BlockState state, BlockEntityType<T> type) {
         return validateTicker(type, PowerBlockEntities.REDSTONE_ENGINE_BLOCK_ENTITY, RedstoneEngineBlockEntity::tick);
-    }
-
-    @Override
-    public ProbeResult onProbe(World world, BlockPos pos, PlayerEntity player) {
-        if (world.getBlockEntity(pos) instanceof RedstoneEngineBlockEntity engine) {
-            return engine.getProbeResult();
-        }
-        return null;
-    }
-
-    @Override
-    public ActionResult onWrench(World world, BlockPos pos, PlayerEntity player) {
-        // Normal wrench: rotate facing
-        if (!world.isClient()) {
-            BlockState state = world.getBlockState(pos);
-            Direction currentFacing = state.get(FACING);
-            Direction newFacing = getNextDirection(currentFacing);
-            world.setBlockState(pos, state.with(FACING, newFacing), Block.NOTIFY_ALL);
-        }
-
-        return ActionResult.SUCCESS;
-    }
-
-    /**
-     * Gets the next direction in the rotation cycle (cycles through all 6 directions).
-     */
-    private static Direction getNextDirection(Direction current) {
-        Direction[] directions = Direction.values();
-        return directions[(current.ordinal() + 1) % directions.length];
-    }
-
-    @Override
-    protected void neighborUpdate(
-            BlockState state,
-            World world,
-            BlockPos pos,
-            Block block,
-            @Nullable WireOrientation wireOrientation,
-            boolean notify) {
-        if (!world.isClient()) {
-            boolean powered = hasDirectRedstonePower(world, pos);
-            if (powered != state.get(POWERED)) {
-                world.setBlockState(pos, state.with(POWERED, powered), Block.NOTIFY_LISTENERS);
-            }
-        }
-        super.neighborUpdate(state, world, pos, block, wireOrientation, notify);
-    }
-
-    /**
-     * Check if the block has direct redstone power (from levers, buttons, etc.)
-     * but not from redstone dust passing by.
-     */
-    private boolean hasDirectRedstonePower(World world, BlockPos pos) {
-        for (Direction direction : Direction.values()) {
-            // Get emitted redstone power directly from neighbors
-            // This excludes weak power from dust and only counts strong power sources
-            int power = world.getEmittedRedstonePower(pos.offset(direction), direction);
-            if (power > 0) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    protected BlockState rotate(BlockState state, BlockRotation rotation) {
-        return state.with(FACING, rotation.rotate(state.get(FACING)));
-    }
-
-    @Override
-    protected BlockState mirror(BlockState state, BlockMirror mirror) {
-        return state.rotate(mirror.getRotation(state.get(FACING)));
-    }
-
-    /**
-     * Gets the direction this engine outputs energy to.
-     */
-    public static Direction getOutputDirection(BlockState state) {
-        return state.get(FACING);
     }
 }

--- a/src/main/java/com/logistics/power/engine/block/StirlingEngineBlock.java
+++ b/src/main/java/com/logistics/power/engine/block/StirlingEngineBlock.java
@@ -1,16 +1,10 @@
 package com.logistics.power.engine.block;
 
-import static com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.STAGE;
-
-import com.logistics.core.lib.block.Probeable;
-import com.logistics.core.lib.block.Wrenchable;
-import com.logistics.core.lib.support.ProbeResult;
-import com.logistics.power.engine.block.entity.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;
 import com.logistics.power.registry.PowerBlockEntities;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRenderType;
+import java.util.List;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
@@ -20,19 +14,14 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.BlockSoundGroup;
-import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
-import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.state.property.Property;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.BlockMirror;
-import net.minecraft.util.BlockRotation;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
-import net.minecraft.world.block.WireOrientation;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -48,24 +37,13 @@ import org.jetbrains.annotations.Nullable;
  *   <li>Thermal shutdown at 250°C if output is blocked (no explosion)</li>
  * </ul>
  */
-public class StirlingEngineBlock extends BlockWithEntity implements Probeable, Wrenchable {
+public class StirlingEngineBlock extends AbstractEngineBlock<StirlingEngineBlockEntity> {
     public static final MapCodec<StirlingEngineBlock> CODEC = createCodec(StirlingEngineBlock::new);
-    public static final EnumProperty<Direction> FACING = Properties.FACING;
-    public static final BooleanProperty POWERED = Properties.POWERED;
     public static final BooleanProperty LIT = Properties.LIT; // True when burning fuel
 
     public StirlingEngineBlock(Settings settings) {
-        super(settings.strength(3.5f)
-                .sounds(BlockSoundGroup.COPPER)
-                .nonOpaque()
-                .solidBlock((state, world, pos) -> false)
-                .suffocates((state, world, pos) -> false)
-                .blockVision((state, world, pos) -> false));
-        setDefaultState(getDefaultState()
-                .with(FACING, Direction.NORTH)
-                .with(POWERED, false)
-                .with(LIT, false)
-                .with(STAGE, HeatStage.COLD));
+        super(settings, BlockSoundGroup.COPPER);
+        setDefaultState(getDefaultState().with(LIT, false));
     }
 
     @Override
@@ -74,29 +52,30 @@ public class StirlingEngineBlock extends BlockWithEntity implements Probeable, W
     }
 
     @Override
-    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        builder.add(FACING, POWERED, LIT, STAGE);
+    protected List<Property<?>> getAdditionalProperties() {
+        return List.of(LIT);
     }
 
     @Override
-    public BlockRenderType getRenderType(BlockState state) {
-        return BlockRenderType.MODEL;
+    protected BlockState applyAdditionalPlacementState(BlockState base, ItemPlacementContext ctx) {
+        return base.with(LIT, false);
     }
 
     @Override
-    public BlockSoundGroup getSoundGroup(BlockState state) {
-        return BlockSoundGroup.COPPER;
+    protected StirlingEngineBlockEntity getEngineBlockEntity(BlockEntity be) {
+        return be instanceof StirlingEngineBlockEntity ? (StirlingEngineBlockEntity) be : null;
     }
 
-    @Nullable @Override
-    public BlockState getPlacementState(ItemPlacementContext ctx) {
-        Direction facing = ctx.getPlayerLookDirection();
-        boolean powered = hasDirectRedstonePower(ctx.getWorld(), ctx.getBlockPos());
-        return getDefaultState()
-                .with(FACING, facing)
-                .with(POWERED, powered)
-                .with(LIT, false)
-                .with(STAGE, HeatStage.COLD);
+    @Override
+    protected boolean handleSpecialWrench(World world, BlockPos pos, PlayerEntity player, BlockState state) {
+        // Reset overheat if engine is overheated
+        if (world.getBlockEntity(pos) instanceof StirlingEngineBlockEntity engine && engine.isOverheated()) {
+            if (!world.isClient()) {
+                engine.resetOverheat();
+            }
+            return true;
+        }
+        return false;
     }
 
     @Nullable @Override
@@ -108,35 +87,6 @@ public class StirlingEngineBlock extends BlockWithEntity implements Probeable, W
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(
             World world, BlockState state, BlockEntityType<T> type) {
         return validateTicker(type, PowerBlockEntities.STIRLING_ENGINE_BLOCK_ENTITY, StirlingEngineBlockEntity::tick);
-    }
-
-    @Override
-    public ProbeResult onProbe(World world, BlockPos pos, PlayerEntity player) {
-        if (world.getBlockEntity(pos) instanceof StirlingEngineBlockEntity engine) {
-            return engine.getProbeResult();
-        }
-        return null;
-    }
-
-    @Override
-    public ActionResult onWrench(World world, BlockPos pos, PlayerEntity player) {
-        // Reset overheat if engine is overheated
-        if (world.getBlockEntity(pos) instanceof StirlingEngineBlockEntity engine && engine.isOverheated()) {
-            if (!world.isClient()) {
-                engine.resetOverheat();
-            }
-            return ActionResult.SUCCESS;
-        }
-
-        // Normal wrench: rotate facing
-        if (!world.isClient()) {
-            BlockState state = world.getBlockState(pos);
-            Direction currentFacing = state.get(FACING);
-            Direction newFacing = getNextDirection(currentFacing);
-            world.setBlockState(pos, state.with(FACING, newFacing), Block.NOTIFY_ALL);
-        }
-
-        return ActionResult.SUCCESS;
     }
 
     @Override
@@ -165,61 +115,5 @@ public class StirlingEngineBlock extends BlockWithEntity implements Probeable, W
             }
         }
         return ActionResult.SUCCESS;
-    }
-
-    /**
-     * Gets the next direction in the rotation cycle (cycles through all 6 directions).
-     */
-    private static Direction getNextDirection(Direction current) {
-        Direction[] directions = Direction.values();
-        return directions[(current.ordinal() + 1) % directions.length];
-    }
-
-    @Override
-    protected void neighborUpdate(
-            BlockState state,
-            World world,
-            BlockPos pos,
-            Block block,
-            @Nullable WireOrientation wireOrientation,
-            boolean notify) {
-        if (!world.isClient()) {
-            boolean powered = hasDirectRedstonePower(world, pos);
-            if (powered != state.get(POWERED)) {
-                world.setBlockState(pos, state.with(POWERED, powered), Block.NOTIFY_LISTENERS);
-            }
-        }
-        super.neighborUpdate(state, world, pos, block, wireOrientation, notify);
-    }
-
-    /**
-     * Check if the block has direct redstone power (from levers, buttons, etc.)
-     * but not from redstone dust passing by.
-     */
-    private boolean hasDirectRedstonePower(World world, BlockPos pos) {
-        for (Direction direction : Direction.values()) {
-            int power = world.getEmittedRedstonePower(pos.offset(direction), direction);
-            if (power > 0) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    protected BlockState rotate(BlockState state, BlockRotation rotation) {
-        return state.with(FACING, rotation.rotate(state.get(FACING)));
-    }
-
-    @Override
-    protected BlockState mirror(BlockState state, BlockMirror mirror) {
-        return state.rotate(mirror.getRotation(state.get(FACING)));
-    }
-
-    /**
-     * Gets the direction this engine outputs energy to.
-     */
-    public static Direction getOutputDirection(BlockState state) {
-        return state.get(FACING);
     }
 }

--- a/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -1,5 +1,6 @@
 package com.logistics.power.engine.block.entity;
 
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.power.engine.block.CreativeEngineBlock;
 import com.logistics.power.registry.PowerBlockEntities;
 import net.minecraft.block.Block;

--- a/src/main/java/com/logistics/power/engine/block/entity/RedstoneEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/RedstoneEngineBlockEntity.java
@@ -1,5 +1,6 @@
 package com.logistics.power.engine.block.entity;
 
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.power.engine.block.RedstoneEngineBlock;
 import com.logistics.power.registry.PowerBlockEntities;
 import net.minecraft.block.BlockState;

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -1,5 +1,6 @@
 package com.logistics.power.engine.block.entity;
 
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.core.lib.support.ProbeResult;
 import com.logistics.power.engine.PIDController;
 import com.logistics.power.engine.block.StirlingEngineBlock;


### PR DESCRIPTION
## Summary
- Consolidates common engine block logic into a reusable core library base to reduce duplication and keep engine behavior consistent.

## Changes
- Added `AbstractEngineBlock` in `core/lib/power` as the shared base for engine blocks (common state, placement, redstone handling, wrench behavior, etc.).
- Moved `AbstractEngineBlockEntity` into `core/lib/power` and updated client rendering/bootstrap imports accordingly.
- Updated Creative, Redstone, and Stirling engine blocks to extend the new base class while preserving their unique interactions (e.g., Creative output cycling, Stirling overheat reset, Stirling `LIT` state).

## Notes
- No intended gameplay changes; this is primarily a structural refactor to make engine functionality easier to reuse and maintain across modules.