### PR TITLE
ci: restrict PR workflows to mc/** branches and bump artifact uploads

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,14 +2,8 @@ name: Build (PR)
 
 on:
   pull_request:
-    branches: [main, 'mc/**']
+    branches: ['mc/**']
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'src/**'
-      - 'gradle.properties'
-      - 'build.gradle'
-      - 'settings.gradle'
-      - 'gradle/**'
 
 jobs:
   build:
@@ -65,7 +59,7 @@ jobs:
           MOD_VERSION: ${{ steps.version.outputs.mod_version }}
 
       - name: Upload JAR
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logistics-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
           path: build/libs/logistics-*.jar

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -2,7 +2,7 @@ name: Check Code
 
 on:
   pull_request:
-    branches: [main, 'mc/**']
+    branches: ['mc/**']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Tighten PR CI triggers to only run on Minecraft version branches.

## Changes
- PR workflows (`Build (PR)` and `Check Code`) now trigger only for PRs targeting `mc/**` branches.
- Update `actions/upload-artifact` usage from `v4` to `v6` for PR build uploads.

## Notes
- This reduces unnecessary CI runs for non-`mc/**` targets while keeping PR JAR artifacts available on supported branches.