### PR TITLE
chore: shorten Modrinth version in build-release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -106,9 +106,8 @@ jobs:
             MODRINTH_FEATURED="true"
           fi
 
-          # Create shortened version for Modrinth (32 char limit) by dropping loader suffix
-          MODRINTH_VERSION="${VERSION}+mc${MC_VERSION}"
-          # Explicitly truncate to 32 chars if needed
+          # Create potentially shortened version for Modrinth (32 char limit)
+          MODRINTH_VERSION="${FULL_VERSION}"
           if (( ${#MODRINTH_VERSION} > 32 )); then
             MODRINTH_VERSION="${MODRINTH_VERSION:0:32}"
             echo "⚠️  Modrinth version truncated to 32 chars: $MODRINTH_VERSION"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -108,6 +108,11 @@ jobs:
 
           # Create shortened version for Modrinth (32 char limit) by dropping loader suffix
           MODRINTH_VERSION="${VERSION}+mc${MC_VERSION}"
+          # Explicitly truncate to 32 chars if needed
+          if (( ${#MODRINTH_VERSION} > 32 )); then
+            MODRINTH_VERSION="${MODRINTH_VERSION:0:32}"
+            echo "⚠️  Modrinth version truncated to 32 chars: $MODRINTH_VERSION"
+          fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "modrinth_version=$MODRINTH_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -106,7 +106,11 @@ jobs:
             MODRINTH_FEATURED="true"
           fi
 
+          # Create shortened version for Modrinth (32 char limit) by dropping loader suffix
+          MODRINTH_VERSION="${VERSION}+mc${MC_VERSION}"
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "modrinth_version=$MODRINTH_VERSION" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "full_version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
           echo "minecraft_version=$MC_VERSION" >> "$GITHUB_OUTPUT"
@@ -121,6 +125,7 @@ jobs:
           echo "📦 Built for MC: $MC_VERSION"
           echo "📦 Loader: $LOADER"
           echo "📦 Full version: $FULL_VERSION (will be passed to Gradle as MOD_VERSION)"
+          echo "📦 Modrinth version: $MODRINTH_VERSION (shortened for 32 char limit)"
           echo "📦 Expected artifact: logistics-$FULL_VERSION.jar"
           echo "🔨 Gradle task: $GRADLE_TASK"
           echo "📦 Version type: $VERSION_TYPE"
@@ -146,6 +151,7 @@ jobs:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           modrinth-featured: ${{ steps.version.outputs.modrinth_featured }}
+          modrinth-version: ${{ steps.version.outputs.modrinth_version }}
 
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}


### PR DESCRIPTION
### Summary
- Prevent Modrinth publishing failures by ensuring the release version string fits Modrinth’s 32-character limit.

### Changes
- Generate a dedicated Modrinth version from the full build version.
- Truncate the Modrinth version to 32 characters when necessary.
- Pass the shortened version explicitly to the Modrinth publish step.

### Notes
- This only affects the version label used on Modrinth; the full project version/tagging remains unchanged.