### PR TITLE
fix: correct engine blockstates, particles, and drops

### DIFF
--- a/src/main/resources/assets/logistics/blockstates/power/creative_engine.json
+++ b/src/main/resources/assets/logistics/blockstates/power/creative_engine.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "": {
-      "model": "logistics:block/power/engine_empty"
+      "model": "logistics:block/power/creative_engine"
     }
   }
 }

--- a/src/main/resources/assets/logistics/blockstates/power/redstone_engine.json
+++ b/src/main/resources/assets/logistics/blockstates/power/redstone_engine.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "": {
-      "model": "logistics:block/power/engine_empty"
+      "model": "logistics:block/power/redstone_engine"
     }
   }
 }

--- a/src/main/resources/assets/logistics/blockstates/power/stirling_engine.json
+++ b/src/main/resources/assets/logistics/blockstates/power/stirling_engine.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "": {
-      "model": "logistics:block/power/engine_empty"
+      "model": "logistics:block/power/stirling_engine"
     }
   }
 }

--- a/src/main/resources/assets/logistics/models/block/power/creative_engine.json
+++ b/src/main/resources/assets/logistics/models/block/power/creative_engine.json
@@ -1,0 +1,5 @@
+{
+  "textures": {
+    "particle": "logistics:block/power/creative_engine_side"
+  }
+}

--- a/src/main/resources/assets/logistics/models/block/power/engine_empty.json
+++ b/src/main/resources/assets/logistics/models/block/power/engine_empty.json
@@ -1,5 +1,0 @@
-{
-  "textures": {
-    "particle": "logistics:block/power/engine_side"
-  }
-}

--- a/src/main/resources/assets/logistics/models/block/power/redstone_engine.json
+++ b/src/main/resources/assets/logistics/models/block/power/redstone_engine.json
@@ -1,0 +1,5 @@
+{
+  "textures": {
+    "particle": "logistics:block/power/redstone_engine_side"
+  }
+}

--- a/src/main/resources/assets/logistics/models/block/power/stirling_engine.json
+++ b/src/main/resources/assets/logistics/models/block/power/stirling_engine.json
@@ -1,0 +1,5 @@
+{
+  "textures": {
+    "particle": "logistics:block/power/stirling_engine_side"
+  }
+}

--- a/src/main/resources/data/logistics/loot_table/blocks/power/creative_engine.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/power/creative_engine.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "logistics:power/creative_engine"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/logistics/loot_table/blocks/power/redstone_engine.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/power/redstone_engine.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "logistics:power/redstone_engine"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/logistics/loot_table/blocks/power/stirling_engine.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/power/stirling_engine.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "logistics:power/stirling_engine"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
- Fixes engine resource definitions so each engine renders with the correct model/particle and drops properly when broken.

### Changes
- Updated Creative/Redstone/Stirling engine blockstates to point at their own models (instead of the shared placeholder).
- Added per-engine block models to ensure the correct particle texture shows up (e.g., during block breaking).
- Added loot tables for each engine so they drop themselves in survival (and respect explosion survival rules).

### Notes
- Resource-only change; no gameplay balance or API changes intended.
- Resolves #76 