### PR TITLE
ci: use branch-specific config for release-please

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.PERSONAL_TOKEN }}
+          target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Fixes release-please fetching config from wrong branch when triggered on non-default branches.

## Changes

- Add `target-branch: ${{ github.ref_name }}` parameter to release-please-action
- Ensures workflow uses config files from the triggering branch, not default branch

## Notes

Without this, pushing to `mc/26.1` caused the workflow to fetch config from `mc/1.21.11` (the repo's default branch), resulting in wrong component names and targeting the wrong PR.

This change allows each branch to maintain independent versioning with branch-specific release-please configs.