### PR TITLE
refactor: standardize block entity NBT persistence and client sync

### DIFF
--- a/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -1218,6 +1218,8 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     @Override
     protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        super.loadLegacyData(view);
+
         useCustomBounds = false;
         customMinX = 0;
         customMinZ = 0;

--- a/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -1123,19 +1123,19 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     // NBT serialization
     @Override
-    protected void saveCustomData(CompoundTag nbt) {
-        super.saveCustomData(nbt);
+    protected void saveLogisticsData(CompoundTag nbt) {
+        super.saveLogisticsData(nbt);
 
-        // Save energy (using old key name for compatibility)
-        nbt.putLong("Amount", energyStorage.amount);
+        // Save energy
+        nbt.putLong("StoredEnergy", energyStorage.amount);
 
-        // Save mining state (using old key names)
-        nbt.putInt("X", miningX);
-        nbt.putInt("Y", miningY);
-        nbt.putInt("Z", miningZ);
-        nbt.putFloat("Progress", breakProgress);
-        nbt.putBoolean("Finished", finished);
-        nbt.putString("Phase", currentPhase.name());
+        // Save mining state
+        nbt.putInt("MiningX", miningX);
+        nbt.putInt("MiningY", miningY);
+        nbt.putInt("MiningZ", miningZ);
+        nbt.putFloat("BreakProgress", breakProgress);
+        nbt.putBoolean("MiningFinished", finished);
+        nbt.putString("CurrentPhase", currentPhase.name());
         nbt.putInt("FrameBuildIndex", frameBuildIndex);
 
         // Save arm state
@@ -1144,35 +1144,36 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         nbt.putFloat("ArmY", armY);
         nbt.putFloat("ArmZ", armZ);
         nbt.putBoolean("ArmInitialized", armInitialized);
-        nbt.putInt("SettlingTicks", settlingTicksRemaining);
-        nbt.putInt("ExpectedTravelTicks", expectedTravelTicks);
-        nbt.putFloat("SyncedArmSpeed", syncedArmSpeed);
+        nbt.putInt("ArmSettlingTicks", settlingTicksRemaining);
+        nbt.putInt("ArmExpectedTravelTicks", expectedTravelTicks);
+        nbt.putFloat("ArmSyncedSpeed", syncedArmSpeed);
 
         // Save custom bounds
+        nbt.putBoolean("UseCustomBounds", useCustomBounds);
         if (useCustomBounds) {
-            nbt.putInt("MinX", customMinX);
-            nbt.putInt("MinZ", customMinZ);
-            nbt.putInt("MaxX", customMaxX);
-            nbt.putInt("MaxZ", customMaxZ);
+            nbt.putInt("CustomBoundsMinX", customMinX);
+            nbt.putInt("CustomBoundsMinZ", customMinZ);
+            nbt.putInt("CustomBoundsMaxX", customMaxX);
+            nbt.putInt("CustomBoundsMaxZ", customMaxZ);
         }
     }
 
     @Override
-    protected void loadCustomData(CompoundTag nbt) {
-        super.loadCustomData(nbt);
+    protected void loadLogisticsData(CompoundTag nbt) {
+        super.loadLogisticsData(nbt);
 
-        // Load energy (using old key name for compatibility)
-        energyStorage.amount = nbt.getLong("Amount").orElse(0L);
+        // Load energy
+        energyStorage.amount = nbt.getLong("StoredEnergy").orElse(0L);
 
-        // Load mining state (using old key names)
-        miningX = nbt.getInt("X").orElse(0);
-        miningY = nbt.getInt("Y").orElse(0);
-        miningZ = nbt.getInt("Z").orElse(0);
-        breakProgress = nbt.getFloat("Progress").orElse(0f);
-        finished = nbt.getBoolean("Finished").orElse(false);
+        // Load mining state
+        miningX = nbt.getInt("MiningX").orElse(0);
+        miningY = nbt.getInt("MiningY").orElse(0);
+        miningZ = nbt.getInt("MiningZ").orElse(0);
+        breakProgress = nbt.getFloat("BreakProgress").orElse(0f);
+        finished = nbt.getBoolean("MiningFinished").orElse(false);
         frameBuildIndex = nbt.getInt("FrameBuildIndex").orElse(0);
 
-        nbt.getString("Phase").ifPresent(phaseName -> {
+        nbt.getString("CurrentPhase").ifPresent(phaseName -> {
             try {
                 currentPhase = Phase.valueOf(phaseName);
             } catch (IllegalArgumentException e) {
@@ -1192,23 +1193,80 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         armY = nbt.getFloat("ArmY").orElse(0f);
         armZ = nbt.getFloat("ArmZ").orElse(0f);
         armInitialized = nbt.getBoolean("ArmInitialized").orElse(false);
-        settlingTicksRemaining = nbt.getInt("SettlingTicks").orElse(0);
-        expectedTravelTicks = nbt.getInt("ExpectedTravelTicks").orElse(0);
-        syncedArmSpeed = nbt.getFloat("SyncedArmSpeed").orElse(LaserQuarryConfig.ARM_SPEED);
+        settlingTicksRemaining = nbt.getInt("ArmSettlingTicks").orElse(0);
+        expectedTravelTicks = nbt.getInt("ArmExpectedTravelTicks").orElse(0);
+        syncedArmSpeed = nbt.getFloat("ArmSyncedSpeed").orElse(LaserQuarryConfig.ARM_SPEED);
 
-        // Load custom bounds (check if any bounds keys exist)
-        useCustomBounds = nbt.contains("MinX");
+        // Load custom bounds
+        useCustomBounds = nbt.getBoolean("UseCustomBounds").orElse(false);
         if (useCustomBounds) {
-            customMinX = nbt.getInt("MinX").orElse(0);
-            customMinZ = nbt.getInt("MinZ").orElse(0);
-            customMaxX = nbt.getInt("MaxX").orElse(0);
-            customMaxZ = nbt.getInt("MaxZ").orElse(0);
+            customMinX = nbt.getInt("CustomBoundsMinX").orElse(0);
+            customMinZ = nbt.getInt("CustomBoundsMinZ").orElse(0);
+            customMaxX = nbt.getInt("CustomBoundsMaxX").orElse(0);
+            customMaxZ = nbt.getInt("CustomBoundsMaxZ").orElse(0);
         } else {
             customMinX = 0;
             customMinZ = 0;
             customMaxX = 0;
             customMaxZ = 0;
         }
+    }
+
+    @Override
+    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        useCustomBounds = false;
+        customMinX = 0;
+        customMinZ = 0;
+        customMaxX = 0;
+        customMaxZ = 0;
+
+        // Load energy from old "Energy" tag
+        view.read("Energy", CompoundTag.CODEC).ifPresent(energyState -> {
+            energyStorage.amount = energyState.getLong("Amount").orElse(0L);
+        });
+
+        // Load mining state from old "MiningState" tag
+        view.read("MiningState", CompoundTag.CODEC).ifPresent(miningState -> {
+            miningX = miningState.getInt("X").orElse(0);
+            miningY = miningState.getInt("Y").orElse(0);
+            miningZ = miningState.getInt("Z").orElse(0);
+            breakProgress = miningState.getFloat("Progress").orElse(0f);
+            finished = miningState.getBoolean("Finished").orElse(false);
+            frameBuildIndex = miningState.getInt("FrameBuildIndex").orElse(0);
+
+            miningState.getString("Phase").ifPresent(phaseName -> {
+                try {
+                    currentPhase = Phase.valueOf(phaseName);
+                } catch (IllegalArgumentException e) {
+                    currentPhase = Phase.CLEARING;
+                }
+            });
+
+            // Load arm state
+            miningState.getString("ArmState").ifPresent(armStateName -> {
+                try {
+                    armState = ArmState.valueOf(armStateName);
+                } catch (IllegalArgumentException e) {
+                    armState = ArmState.MOVING;
+                }
+            });
+            armX = miningState.getFloat("ArmX").orElse(0f);
+            armY = miningState.getFloat("ArmY").orElse(0f);
+            armZ = miningState.getFloat("ArmZ").orElse(0f);
+            armInitialized = miningState.getBoolean("ArmInitialized").orElse(false);
+            settlingTicksRemaining = miningState.getInt("SettlingTicks").orElse(0);
+            expectedTravelTicks = miningState.getInt("ExpectedTravelTicks").orElse(0);
+            syncedArmSpeed = miningState.getFloat("SyncedArmSpeed").orElse(LaserQuarryConfig.ARM_SPEED);
+        });
+
+        // Load custom bounds from old "CustomBounds" tag
+        view.read("CustomBounds", CompoundTag.CODEC).ifPresent(customBoundsNbt -> {
+            useCustomBounds = true;
+            customMinX = customBoundsNbt.getInt("MinX").orElse(0);
+            customMinZ = customBoundsNbt.getInt("MinZ").orElse(0);
+            customMaxX = customBoundsNbt.getInt("MaxX").orElse(0);
+            customMaxZ = customBoundsNbt.getInt("MaxZ").orElse(0);
+        });
     }
 
     @Override

--- a/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -138,6 +138,10 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     /**
      * Sync arm state to clients. Called on arm state transitions.
+     *
+     * Note: Does not call setChanged() - chunk dirty is managed separately by tick(),
+     * which marks dirty when energy is consumed or mining advances. This avoids
+     * redundant chunk dirty marks on every arm position update (per-tick).
      */
     private void syncToClients() {
         if (level != null && !level.isClientSide()) {

--- a/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -146,7 +146,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     private void syncToClients() {
         if (level != null && !level.isClientSide()) {
             BlockState state = getBlockState();
-            level.sendBlockUpdated(worldPosition, state, state, 3);
+            level.sendBlockUpdated(worldPosition, state, state, Block.UPDATE_ALL);
         }
     }
 

--- a/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -9,6 +9,7 @@ import com.logistics.automation.laserquarry.LaserQuarryFrameBlock;
 import com.logistics.automation.render.ClientRenderCacheHooks;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.pipe.PipeConnection;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.core.lib.support.ProbeResult;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1167,47 +1168,45 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         super.loadLogisticsData(nbt);
 
         // Load energy
-        energyStorage.amount = nbt.getLong("StoredEnergy").orElse(0L);
+        energyStorage.amount = NbtCompat.getLong(nbt, "StoredEnergy", 0L);
 
         // Load mining state
-        miningX = nbt.getInt("MiningX").orElse(0);
-        miningY = nbt.getInt("MiningY").orElse(0);
-        miningZ = nbt.getInt("MiningZ").orElse(0);
-        breakProgress = nbt.getFloat("BreakProgress").orElse(0f);
-        finished = nbt.getBoolean("MiningFinished").orElse(false);
-        frameBuildIndex = nbt.getInt("FrameBuildIndex").orElse(0);
+        miningX = NbtCompat.getInt(nbt, "MiningX", 0);
+        miningY = NbtCompat.getInt(nbt, "MiningY", 0);
+        miningZ = NbtCompat.getInt(nbt, "MiningZ", 0);
+        breakProgress = NbtCompat.getFloat(nbt, "BreakProgress", 0f);
+        finished = NbtCompat.getBoolean(nbt, "MiningFinished", false);
+        frameBuildIndex = NbtCompat.getInt(nbt, "FrameBuildIndex", 0);
 
-        nbt.getString("CurrentPhase").ifPresent(phaseName -> {
-            try {
-                currentPhase = Phase.valueOf(phaseName);
-            } catch (IllegalArgumentException e) {
-                currentPhase = Phase.CLEARING;
-            }
-        });
+        String phaseName = NbtCompat.getString(nbt, "CurrentPhase", "CLEARING");
+        try {
+            currentPhase = Phase.valueOf(phaseName);
+        } catch (IllegalArgumentException e) {
+            currentPhase = Phase.CLEARING;
+        }
 
         // Load arm state
-        nbt.getString("ArmState").ifPresent(armStateName -> {
-            try {
-                armState = ArmState.valueOf(armStateName);
-            } catch (IllegalArgumentException e) {
-                armState = ArmState.MOVING;
-            }
-        });
-        armX = nbt.getFloat("ArmX").orElse(0f);
-        armY = nbt.getFloat("ArmY").orElse(0f);
-        armZ = nbt.getFloat("ArmZ").orElse(0f);
-        armInitialized = nbt.getBoolean("ArmInitialized").orElse(false);
-        settlingTicksRemaining = nbt.getInt("ArmSettlingTicks").orElse(0);
-        expectedTravelTicks = nbt.getInt("ArmExpectedTravelTicks").orElse(0);
-        syncedArmSpeed = nbt.getFloat("ArmSyncedSpeed").orElse(LaserQuarryConfig.ARM_SPEED);
+        String armStateName = NbtCompat.getString(nbt, "ArmState", "MOVING");
+        try {
+            armState = ArmState.valueOf(armStateName);
+        } catch (IllegalArgumentException e) {
+            armState = ArmState.MOVING;
+        }
+        armX = NbtCompat.getFloat(nbt, "ArmX", 0f);
+        armY = NbtCompat.getFloat(nbt, "ArmY", 0f);
+        armZ = NbtCompat.getFloat(nbt, "ArmZ", 0f);
+        armInitialized = NbtCompat.getBoolean(nbt, "ArmInitialized", false);
+        settlingTicksRemaining = NbtCompat.getInt(nbt, "ArmSettlingTicks", 0);
+        expectedTravelTicks = NbtCompat.getInt(nbt, "ArmExpectedTravelTicks", 0);
+        syncedArmSpeed = NbtCompat.getFloat(nbt, "ArmSyncedSpeed", LaserQuarryConfig.ARM_SPEED);
 
         // Load custom bounds
-        useCustomBounds = nbt.getBoolean("UseCustomBounds").orElse(false);
+        useCustomBounds = NbtCompat.getBoolean(nbt, "UseCustomBounds", false);
         if (useCustomBounds) {
-            customMinX = nbt.getInt("CustomBoundsMinX").orElse(0);
-            customMinZ = nbt.getInt("CustomBoundsMinZ").orElse(0);
-            customMaxX = nbt.getInt("CustomBoundsMaxX").orElse(0);
-            customMaxZ = nbt.getInt("CustomBoundsMaxZ").orElse(0);
+            customMinX = NbtCompat.getInt(nbt, "CustomBoundsMinX", 0);
+            customMinZ = NbtCompat.getInt(nbt, "CustomBoundsMinZ", 0);
+            customMaxX = NbtCompat.getInt(nbt, "CustomBoundsMaxX", 0);
+            customMaxZ = NbtCompat.getInt(nbt, "CustomBoundsMaxZ", 0);
         } else {
             customMinX = 0;
             customMinZ = 0;
@@ -1228,50 +1227,48 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
         // Load energy from old "Energy" tag
         view.read("Energy", CompoundTag.CODEC).ifPresent(energyState -> {
-            energyStorage.amount = energyState.getLong("Amount").orElse(0L);
+            energyStorage.amount = NbtCompat.getLong(energyState, "Amount", 0L);
         });
 
         // Load mining state from old "MiningState" tag
         view.read("MiningState", CompoundTag.CODEC).ifPresent(miningState -> {
-            miningX = miningState.getInt("X").orElse(0);
-            miningY = miningState.getInt("Y").orElse(0);
-            miningZ = miningState.getInt("Z").orElse(0);
-            breakProgress = miningState.getFloat("Progress").orElse(0f);
-            finished = miningState.getBoolean("Finished").orElse(false);
-            frameBuildIndex = miningState.getInt("FrameBuildIndex").orElse(0);
+            miningX = NbtCompat.getInt(miningState, "X", 0);
+            miningY = NbtCompat.getInt(miningState, "Y", 0);
+            miningZ = NbtCompat.getInt(miningState, "Z", 0);
+            breakProgress = NbtCompat.getFloat(miningState, "Progress", 0f);
+            finished = NbtCompat.getBoolean(miningState, "Finished", false);
+            frameBuildIndex = NbtCompat.getInt(miningState, "FrameBuildIndex", 0);
 
-            miningState.getString("Phase").ifPresent(phaseName -> {
-                try {
-                    currentPhase = Phase.valueOf(phaseName);
-                } catch (IllegalArgumentException e) {
-                    currentPhase = Phase.CLEARING;
-                }
-            });
+            String phaseName = NbtCompat.getString(miningState, "Phase", "CLEARING");
+            try {
+                currentPhase = Phase.valueOf(phaseName);
+            } catch (IllegalArgumentException e) {
+                currentPhase = Phase.CLEARING;
+            }
 
             // Load arm state
-            miningState.getString("ArmState").ifPresent(armStateName -> {
-                try {
-                    armState = ArmState.valueOf(armStateName);
-                } catch (IllegalArgumentException e) {
-                    armState = ArmState.MOVING;
-                }
-            });
-            armX = miningState.getFloat("ArmX").orElse(0f);
-            armY = miningState.getFloat("ArmY").orElse(0f);
-            armZ = miningState.getFloat("ArmZ").orElse(0f);
-            armInitialized = miningState.getBoolean("ArmInitialized").orElse(false);
-            settlingTicksRemaining = miningState.getInt("SettlingTicks").orElse(0);
-            expectedTravelTicks = miningState.getInt("ExpectedTravelTicks").orElse(0);
-            syncedArmSpeed = miningState.getFloat("SyncedArmSpeed").orElse(LaserQuarryConfig.ARM_SPEED);
+            String armStateName = NbtCompat.getString(miningState, "ArmState", "MOVING");
+            try {
+                armState = ArmState.valueOf(armStateName);
+            } catch (IllegalArgumentException e) {
+                armState = ArmState.MOVING;
+            }
+            armX = NbtCompat.getFloat(miningState, "ArmX", 0f);
+            armY = NbtCompat.getFloat(miningState, "ArmY", 0f);
+            armZ = NbtCompat.getFloat(miningState, "ArmZ", 0f);
+            armInitialized = NbtCompat.getBoolean(miningState, "ArmInitialized", false);
+            settlingTicksRemaining = NbtCompat.getInt(miningState, "SettlingTicks", 0);
+            expectedTravelTicks = NbtCompat.getInt(miningState, "ExpectedTravelTicks", 0);
+            syncedArmSpeed = NbtCompat.getFloat(miningState, "SyncedArmSpeed", LaserQuarryConfig.ARM_SPEED);
         });
 
         // Load custom bounds from old "CustomBounds" tag
         view.read("CustomBounds", CompoundTag.CODEC).ifPresent(customBoundsNbt -> {
             useCustomBounds = true;
-            customMinX = customBoundsNbt.getInt("MinX").orElse(0);
-            customMinZ = customBoundsNbt.getInt("MinZ").orElse(0);
-            customMaxX = customBoundsNbt.getInt("MaxX").orElse(0);
-            customMaxZ = customBoundsNbt.getInt("MaxZ").orElse(0);
+            customMinX = NbtCompat.getInt(customBoundsNbt, "MinX", 0);
+            customMinZ = NbtCompat.getInt(customBoundsNbt, "MinZ", 0);
+            customMaxX = NbtCompat.getInt(customBoundsNbt, "MaxX", 0);
+            customMaxZ = NbtCompat.getInt(customBoundsNbt, "MaxZ", 0);
         });
     }
 

--- a/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -1,42 +1,37 @@
 package com.logistics.automation.laserquarry.entity;
 
+import com.logistics.LogisticsAutomation;
 import com.logistics.api.LogisticsApi;
 import com.logistics.api.TransportApi;
-import team.reborn.energy.api.base.SimpleEnergyStorage;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.automation.laserquarry.LaserQuarryConfig;
 import com.logistics.automation.laserquarry.LaserQuarryFrameBlock;
-import com.logistics.LogisticsAutomation;
 import com.logistics.automation.render.ClientRenderCacheHooks;
+import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.pipe.PipeConnection;
 import com.logistics.core.lib.support.ProbeResult;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.Container;
-import net.minecraft.world.WorldlyContainer;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.storage.ValueInput;
-import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
+import team.reborn.energy.api.base.SimpleEnergyStorage;
 
-public class LaserQuarryBlockEntity extends BlockEntity implements PipeConnection {
+public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConnection {
     private static final long REGISTRY_TTL_TICKS = 200L;
     private static final Map<ResourceKey<Level>, Map<Long, Long>> ACTIVE_QUARRIES = new HashMap<>();
 
@@ -1126,114 +1121,94 @@ public class LaserQuarryBlockEntity extends BlockEntity implements PipeConnectio
         return builder.build();
     }
 
-    // NBT serialization using the new WriteView/ReadView API
+    // NBT serialization
     @Override
-    protected void saveAdditional(ValueOutput view) {
-        super.saveAdditional(view);
+    protected void saveCustomData(CompoundTag nbt) {
+        super.saveCustomData(nbt);
 
-        // Save energy
-        CompoundTag energyState = new CompoundTag();
-        energyState.putLong("Amount", energyStorage.amount);
-        view.store("Energy", CompoundTag.CODEC, energyState);
+        // Save energy (using old key name for compatibility)
+        nbt.putLong("Amount", energyStorage.amount);
 
-        // Save mining state
-        CompoundTag miningState = new CompoundTag();
-        miningState.putInt("X", miningX);
-        miningState.putInt("Y", miningY);
-        miningState.putInt("Z", miningZ);
-        miningState.putFloat("Progress", breakProgress);
-        miningState.putBoolean("Finished", finished);
-        miningState.putString("Phase", currentPhase.name());
-        miningState.putInt("FrameBuildIndex", frameBuildIndex);
-        // Arm state
-        miningState.putString("ArmState", armState.name());
-        miningState.putFloat("ArmX", armX);
-        miningState.putFloat("ArmY", armY);
-        miningState.putFloat("ArmZ", armZ);
-        miningState.putBoolean("ArmInitialized", armInitialized);
-        miningState.putInt("SettlingTicks", settlingTicksRemaining);
-        miningState.putInt("ExpectedTravelTicks", expectedTravelTicks);
-        miningState.putFloat("SyncedArmSpeed", syncedArmSpeed);
-        view.store("MiningState", CompoundTag.CODEC, miningState);
+        // Save mining state (using old key names)
+        nbt.putInt("X", miningX);
+        nbt.putInt("Y", miningY);
+        nbt.putInt("Z", miningZ);
+        nbt.putFloat("Progress", breakProgress);
+        nbt.putBoolean("Finished", finished);
+        nbt.putString("Phase", currentPhase.name());
+        nbt.putInt("FrameBuildIndex", frameBuildIndex);
+
+        // Save arm state
+        nbt.putString("ArmState", armState.name());
+        nbt.putFloat("ArmX", armX);
+        nbt.putFloat("ArmY", armY);
+        nbt.putFloat("ArmZ", armZ);
+        nbt.putBoolean("ArmInitialized", armInitialized);
+        nbt.putInt("SettlingTicks", settlingTicksRemaining);
+        nbt.putInt("ExpectedTravelTicks", expectedTravelTicks);
+        nbt.putFloat("SyncedArmSpeed", syncedArmSpeed);
 
         // Save custom bounds
         if (useCustomBounds) {
-            CompoundTag customBoundsNbt = new CompoundTag();
-            customBoundsNbt.putInt("MinX", customMinX);
-            customBoundsNbt.putInt("MinZ", customMinZ);
-            customBoundsNbt.putInt("MaxX", customMaxX);
-            customBoundsNbt.putInt("MaxZ", customMaxZ);
-            view.store("CustomBounds", CompoundTag.CODEC, customBoundsNbt);
-        } else {
-            view.discard("CustomBounds");
+            nbt.putInt("MinX", customMinX);
+            nbt.putInt("MinZ", customMinZ);
+            nbt.putInt("MaxX", customMaxX);
+            nbt.putInt("MaxZ", customMaxZ);
         }
     }
 
     @Override
-    protected void loadAdditional(ValueInput view) {
-        super.loadAdditional(view);
+    protected void loadCustomData(CompoundTag nbt) {
+        super.loadCustomData(nbt);
 
-        useCustomBounds = false;
-        customMinX = 0;
-        customMinZ = 0;
-        customMaxX = 0;
-        customMaxZ = 0;
+        // Load energy (using old key name for compatibility)
+        energyStorage.amount = nbt.getLong("Amount").orElse(0L);
 
-        // Load energy
-        view.read("Energy", CompoundTag.CODEC).ifPresent(energyState -> {
-            energyStorage.amount = energyState.getLong("Amount").orElse(0L);
+        // Load mining state (using old key names)
+        miningX = nbt.getInt("X").orElse(0);
+        miningY = nbt.getInt("Y").orElse(0);
+        miningZ = nbt.getInt("Z").orElse(0);
+        breakProgress = nbt.getFloat("Progress").orElse(0f);
+        finished = nbt.getBoolean("Finished").orElse(false);
+        frameBuildIndex = nbt.getInt("FrameBuildIndex").orElse(0);
+
+        nbt.getString("Phase").ifPresent(phaseName -> {
+            try {
+                currentPhase = Phase.valueOf(phaseName);
+            } catch (IllegalArgumentException e) {
+                currentPhase = Phase.CLEARING;
+            }
         });
 
-        // Load mining state
-        view.read("MiningState", CompoundTag.CODEC).ifPresent(miningState -> {
-            miningX = miningState.getInt("X").orElse(0);
-            miningY = miningState.getInt("Y").orElse(0);
-            miningZ = miningState.getInt("Z").orElse(0);
-            breakProgress = miningState.getFloat("Progress").orElse(0f);
-            finished = miningState.getBoolean("Finished").orElse(false);
-            frameBuildIndex = miningState.getInt("FrameBuildIndex").orElse(0);
-            miningState.getString("Phase").ifPresent(phaseName -> {
-                try {
-                    currentPhase = Phase.valueOf(phaseName);
-                } catch (IllegalArgumentException e) {
-                    currentPhase = Phase.CLEARING;
-                }
-            });
-            // Load arm state
-            miningState.getString("ArmState").ifPresent(armStateName -> {
-                try {
-                    armState = ArmState.valueOf(armStateName);
-                } catch (IllegalArgumentException e) {
-                    armState = ArmState.MOVING;
-                }
-            });
-            armX = miningState.getFloat("ArmX").orElse(0f);
-            armY = miningState.getFloat("ArmY").orElse(0f);
-            armZ = miningState.getFloat("ArmZ").orElse(0f);
-            armInitialized = miningState.getBoolean("ArmInitialized").orElse(false);
-            settlingTicksRemaining = miningState.getInt("SettlingTicks").orElse(0);
-            expectedTravelTicks = miningState.getInt("ExpectedTravelTicks").orElse(0);
-            syncedArmSpeed = miningState.getFloat("SyncedArmSpeed").orElse(LaserQuarryConfig.ARM_SPEED);
+        // Load arm state
+        nbt.getString("ArmState").ifPresent(armStateName -> {
+            try {
+                armState = ArmState.valueOf(armStateName);
+            } catch (IllegalArgumentException e) {
+                armState = ArmState.MOVING;
+            }
         });
+        armX = nbt.getFloat("ArmX").orElse(0f);
+        armY = nbt.getFloat("ArmY").orElse(0f);
+        armZ = nbt.getFloat("ArmZ").orElse(0f);
+        armInitialized = nbt.getBoolean("ArmInitialized").orElse(false);
+        settlingTicksRemaining = nbt.getInt("SettlingTicks").orElse(0);
+        expectedTravelTicks = nbt.getInt("ExpectedTravelTicks").orElse(0);
+        syncedArmSpeed = nbt.getFloat("SyncedArmSpeed").orElse(LaserQuarryConfig.ARM_SPEED);
 
-        // Load custom bounds
-        view.read("CustomBounds", CompoundTag.CODEC).ifPresent(customBoundsNbt -> {
-            useCustomBounds = true;
-            customMinX = customBoundsNbt.getInt("MinX").orElse(0);
-            customMinZ = customBoundsNbt.getInt("MinZ").orElse(0);
-            customMaxX = customBoundsNbt.getInt("MaxX").orElse(0);
-            customMaxZ = customBoundsNbt.getInt("MaxZ").orElse(0);
-        });
-    }
-
-    @Nullable @Override
-    public Packet<ClientGamePacketListener> getUpdatePacket() {
-        return ClientboundBlockEntityDataPacket.create(this);
-    }
-
-    @Override
-    public CompoundTag getUpdateTag(HolderLookup.Provider registryLookup) {
-        return saveWithoutMetadata(registryLookup);
+        // Load custom bounds (check if any bounds keys exist)
+        useCustomBounds = nbt.contains("MinX");
+        if (useCustomBounds) {
+            customMinX = nbt.getInt("MinX").orElse(0);
+            customMinZ = nbt.getInt("MinZ").orElse(0);
+            customMaxX = nbt.getInt("MaxX").orElse(0);
+            customMaxZ = nbt.getInt("MaxZ").orElse(0);
+        } else {
+            customMinX = 0;
+            customMinZ = 0;
+            customMaxX = 0;
+            customMaxZ = 0;
+        }
     }
 
     @Override

--- a/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
@@ -37,6 +37,8 @@ public abstract class BaseBlockEntity extends BlockEntity {
      * Save custom block entity data to NBT.
      * Override this instead of {@link #saveAdditional(ValueOutput)}.
      *
+     * <p>Note: Use {@code level.registryAccess()} to serialize ItemStacks and other registry objects.
+     *
      * @param tag the compound tag to write custom data into
      */
     protected void saveCustomData(CompoundTag tag) {
@@ -46,6 +48,8 @@ public abstract class BaseBlockEntity extends BlockEntity {
     /**
      * Load custom block entity data from NBT.
      * Override this instead of {@link #loadAdditional(ValueInput)}.
+     *
+     * <p>Note: Use {@code level.registryAccess()} to deserialize ItemStacks and other registry objects.
      *
      * @param tag the compound tag to read custom data from
      */

--- a/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
@@ -106,7 +106,14 @@ public abstract class BaseBlockEntity extends BlockEntity {
      * <ul>
      *   <li>Chunk saving (via {@link #setChanged()})</li>
      *   <li>Client block updates (via {@link net.minecraft.world.level.Level#sendBlockUpdated})</li>
+     *   <li>Neighbor block updates (comparators, redstone) via {@link Block#UPDATE_ALL}</li>
      * </ul>
+     *
+     * <p><b>Note on UPDATE_ALL:</b> Uses {@code Block.UPDATE_ALL} (flag 3) which includes
+     * both {@code UPDATE_CLIENTS} and {@code UPDATE_NEIGHBORS}. This ensures comparators
+     * and redstone circuits update correctly when block entity state changes (e.g., energy
+     * levels, inventory contents). If neighbor updates are not needed for performance,
+     * subclasses can call {@code level.sendBlockUpdated} directly with {@code UPDATE_CLIENTS}.
      */
     protected final void markDirtyAndSync() {
         setChanged();

--- a/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
@@ -1,0 +1,108 @@
+package com.logistics.core.lib.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Thin base class for block entities providing common patterns:
+ * <ul>
+ *   <li>Template methods for custom NBT serialization</li>
+ *   <li>Helper for marking dirty and syncing to clients</li>
+ *   <li>Proper client chunk sync and update packets</li>
+ * </ul>
+ *
+ * <p>Subclasses override {@link #saveCustomData(CompoundTag)} and {@link #loadCustomData(CompoundTag)}
+ * instead of dealing with {@link ValueInput}/{@link ValueOutput} directly.
+ */
+public abstract class BaseBlockEntity extends BlockEntity {
+
+    protected BaseBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
+
+    // ==================== Disk Persistence ====================
+
+    /**
+     * Save custom block entity data to NBT.
+     * Override this instead of {@link #saveAdditional(ValueOutput)}.
+     *
+     * @param tag the compound tag to write custom data into
+     */
+    protected void saveCustomData(CompoundTag tag) {
+        // Default: no custom data
+    }
+
+    /**
+     * Load custom block entity data from NBT.
+     * Override this instead of {@link #loadAdditional(ValueInput)}.
+     *
+     * @param tag the compound tag to read custom data from
+     */
+    protected void loadCustomData(CompoundTag tag) {
+        // Default: no custom data
+    }
+
+    @Override
+    protected final void saveAdditional(ValueOutput view) {
+        super.saveAdditional(view);
+        CompoundTag customData = new CompoundTag();
+        saveCustomData(customData);
+        if (!customData.isEmpty()) {
+            view.store("CustomData", CompoundTag.CODEC, customData);
+        }
+    }
+
+    @Override
+    protected final void loadAdditional(ValueInput view) {
+        super.loadAdditional(view);
+        view.read("CustomData", CompoundTag.CODEC).ifPresent(this::loadCustomData);
+    }
+
+    // ==================== Client Sync ====================
+
+    /**
+     * Marks the block entity as dirty and syncs changes to clients.
+     * Call this whenever component state changes that needs to be persisted or synced.
+     *
+     * <p>This triggers:
+     * <ul>
+     *   <li>Chunk saving (via {@link #setChanged()})</li>
+     *   <li>Client block updates (via {@link net.minecraft.world.level.Level#sendBlockUpdated})</li>
+     * </ul>
+     */
+    protected final void markDirtyAndSync() {
+        setChanged();
+        if (level != null && !level.isClientSide()) {
+            // Push block updates to clients (redraw + blockstate listeners)
+            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_ALL);
+        }
+    }
+
+    /**
+     * Client chunk sync: what the client receives when chunk loads.
+     */
+    @Override
+    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
+        return saveWithoutMetadata(registries);
+    }
+
+    /**
+     * Optional "live" update packet when you call {@link #markDirtyAndSync()}.
+     */
+    @Nullable
+    @Override
+    public Packet<ClientGamePacketListener> getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
+}

--- a/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
@@ -22,10 +22,12 @@ import org.jetbrains.annotations.Nullable;
  *   <li>Proper client chunk sync and update packets</li>
  * </ul>
  *
- * <p>Subclasses override {@link #saveCustomData(CompoundTag)} and {@link #loadCustomData(CompoundTag)}
+ * <p>Subclasses override {@link #saveLogisticsData(CompoundTag)} and {@link #loadLogisticsData(CompoundTag)}
  * instead of dealing with {@link ValueInput}/{@link ValueOutput} directly.
  */
 public abstract class BaseBlockEntity extends BlockEntity {
+
+    private static final String DATA_KEY = "LogisticsData";
 
     protected BaseBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -34,43 +36,64 @@ public abstract class BaseBlockEntity extends BlockEntity {
     // ==================== Disk Persistence ====================
 
     /**
-     * Save custom block entity data to NBT.
+     * Save logistics block entity data to NBT.
      * Override this instead of {@link #saveAdditional(ValueOutput)}.
      *
      * <p>Note: Use {@code level.registryAccess()} to serialize ItemStacks and other registry objects.
      *
-     * @param tag the compound tag to write custom data into
+     * @param tag the compound tag to write logistics data into
      */
-    protected void saveCustomData(CompoundTag tag) {
-        // Default: no custom data
+    protected void saveLogisticsData(CompoundTag tag) {
+        // Default: no logistics data
     }
 
     /**
-     * Load custom block entity data from NBT.
+     * Load logistics block entity data from NBT.
      * Override this instead of {@link #loadAdditional(ValueInput)}.
      *
      * <p>Note: Use {@code level.registryAccess()} to deserialize ItemStacks and other registry objects.
      *
-     * @param tag the compound tag to read custom data from
+     * @param tag the compound tag to read logistics data from
      */
-    protected void loadCustomData(CompoundTag tag) {
-        // Default: no custom data
+    protected void loadLogisticsData(CompoundTag tag) {
+        // Default: no logistics data
+    }
+
+    /**
+     * Load legacy NBT data from the root level (pre-BaseBlockEntity format).
+     * Override this to provide backward compatibility for worlds saved before the BaseBlockEntity migration.
+     *
+     * <p>This method is called when DATA_KEY tag is not present in the NBT,
+     * indicating an old save format where data was stored at the root level.
+     *
+     * <p>TODO: This method should be removed prior to v1.0 release
+     *
+     * @param view the value input to read legacy data from
+     */
+    protected void loadLegacyData(ValueInput view) {
+        // Default: no legacy data migration needed
     }
 
     @Override
     protected final void saveAdditional(ValueOutput view) {
         super.saveAdditional(view);
-        CompoundTag customData = new CompoundTag();
-        saveCustomData(customData);
-        if (!customData.isEmpty()) {
-            view.store("CustomData", CompoundTag.CODEC, customData);
+        CompoundTag logisticsData = new CompoundTag();
+        saveLogisticsData(logisticsData);
+        if (!logisticsData.isEmpty()) {
+            view.store(DATA_KEY, CompoundTag.CODEC, logisticsData);
         }
     }
 
     @Override
     protected final void loadAdditional(ValueInput view) {
         super.loadAdditional(view);
-        view.read("CustomData", CompoundTag.CODEC).ifPresent(this::loadCustomData);
+        // Try to read new format first (LogisticsData wrapper)
+        if (view.read(DATA_KEY, CompoundTag.CODEC).isPresent()) {
+            view.read(DATA_KEY, CompoundTag.CODEC).ifPresent(this::loadLogisticsData);
+        } else {
+            // Fall back to legacy format (root-level keys)
+            loadLegacyData(view);
+        }
     }
 
     // ==================== Client Sync ====================
@@ -88,7 +111,6 @@ public abstract class BaseBlockEntity extends BlockEntity {
     protected final void markDirtyAndSync() {
         setChanged();
         if (level != null && !level.isClientSide()) {
-            // Push block updates to clients (redraw + blockstate listeners)
             level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_ALL);
         }
     }

--- a/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/block/BaseBlockEntity.java
@@ -87,13 +87,11 @@ public abstract class BaseBlockEntity extends BlockEntity {
     @Override
     protected final void loadAdditional(ValueInput view) {
         super.loadAdditional(view);
-        // Try to read new format first (LogisticsData wrapper)
-        if (view.read(DATA_KEY, CompoundTag.CODEC).isPresent()) {
-            view.read(DATA_KEY, CompoundTag.CODEC).ifPresent(this::loadLogisticsData);
-        } else {
-            // Fall back to legacy format (root-level keys)
-            loadLegacyData(view);
-        }
+        // Try to read new format first; fall back to legacy root-level keys
+        view.read(DATA_KEY, CompoundTag.CODEC).ifPresentOrElse(
+                this::loadLogisticsData,
+                () -> loadLegacyData(view)
+        );
     }
 
     // ==================== Client Sync ====================

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.core.lib.power;
 
 import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.core.lib.support.ProbeResult;
 import java.util.Locale;
 import net.minecraft.ChatFormatting;
@@ -520,22 +521,22 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity {
 
     @Override
     protected void loadLogisticsData(CompoundTag engineData) {
-        energyStorage.amount = engineData.getLong("StoredEnergy").orElse(0L);
-        temperature = engineData.getDouble("Temperature").orElse(0.0);
-        progress = engineData.getFloat("CycleProgress").orElse(0f);
-        cyclePhase = CyclePhase.fromOrdinal(engineData.getInt("CyclePhase").orElse(0));
-        heatStage = HeatStage.fromOrdinal(engineData.getInt("HeatStage").orElse(0));
+        energyStorage.amount = NbtCompat.getLong(engineData, "StoredEnergy", 0L);
+        temperature = NbtCompat.getDouble(engineData, "Temperature", 0.0);
+        progress = NbtCompat.getFloat(engineData, "CycleProgress", 0f);
+        cyclePhase = CyclePhase.fromOrdinal(NbtCompat.getInt(engineData, "CyclePhase", 0));
+        heatStage = HeatStage.fromOrdinal(NbtCompat.getInt(engineData, "HeatStage", 0));
     }
 
     @Override
     protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
         view.read("Engine", CompoundTag.CODEC).ifPresent(engineData -> {
             // Load old key names (before BaseBlockEntity refactoring)
-            energyStorage.amount = engineData.getLong("energy").orElse(0L);
-            temperature = engineData.getDouble("heat").orElse(0.0);
-            progress = engineData.getFloat("progress").orElse(0f);
-            cyclePhase = CyclePhase.fromOrdinal(engineData.getInt("cyclePhase").orElse(0));
-            heatStage = HeatStage.fromOrdinal(engineData.getInt("stage").orElse(0));
+            energyStorage.amount = NbtCompat.getLong(engineData, "energy", 0L);
+            temperature = NbtCompat.getDouble(engineData, "heat", 0.0);
+            progress = NbtCompat.getFloat(engineData, "progress", 0f);
+            cyclePhase = CyclePhase.fromOrdinal(NbtCompat.getInt(engineData, "cyclePhase", 0));
+            heatStage = HeatStage.fromOrdinal(NbtCompat.getInt(engineData, "stage", 0));
         });
     }
 

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -1,30 +1,24 @@
 package com.logistics.core.lib.power;
 
+import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.support.ProbeResult;
-import team.reborn.energy.api.EnergyStorageUtil;
-import team.reborn.energy.api.base.SimpleSidedEnergyContainer;
-import team.reborn.energy.api.EnergyStorage;
 import java.util.Locale;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
-import net.minecraft.world.level.storage.ValueInput;
-import net.minecraft.world.level.storage.ValueOutput;
 import org.jetbrains.annotations.Nullable;
+import team.reborn.energy.api.EnergyStorage;
+import team.reborn.energy.api.EnergyStorageUtil;
+import team.reborn.energy.api.base.SimpleSidedEnergyContainer;
 
 /**
  * Abstract base class for all engine block entities.
@@ -44,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  *   <li>Compression stroke (0.5-1): energy is pushed to output</li>
  * </ul>
  */
-public abstract class AbstractEngineBlockEntity extends BlockEntity {
+public abstract class AbstractEngineBlockEntity extends BaseBlockEntity {
 
     // ==================== Heat Stage Enum ====================
 
@@ -516,36 +510,21 @@ public abstract class AbstractEngineBlockEntity extends BlockEntity {
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveAdditional(ValueOutput view) {
-        CompoundTag engineData = new CompoundTag();
+    protected void saveCustomData(CompoundTag engineData) {
         engineData.putLong("energy", energyStorage.amount);
-        engineData.putDouble("heat", temperature); // putDouble
-        engineData.putFloat("progress", progress); // putFloat
+        engineData.putDouble("heat", temperature);
+        engineData.putFloat("progress", progress);
         engineData.putInt("cyclePhase", cyclePhase.ordinal());
         engineData.putInt("stage", heatStage.ordinal());
-
-        view.store("Engine", CompoundTag.CODEC, engineData);
     }
 
     @Override
-    protected void loadAdditional(ValueInput view) {
-        view.read("Engine", CompoundTag.CODEC).ifPresent(engineData -> {
-            energyStorage.amount = engineData.getLong("energy").orElse(0L);
-            temperature = engineData.getDouble("heat").orElse(0.0);
-            progress = engineData.getFloat("progress").orElse(0f);
-            cyclePhase = CyclePhase.fromOrdinal(engineData.getInt("cyclePhase").orElse(0));
-            heatStage = HeatStage.fromOrdinal(engineData.getInt("stage").orElse(0));
-        });
-    }
-
-    @Nullable @Override
-    public Packet<ClientGamePacketListener> getUpdatePacket() {
-        return ClientboundBlockEntityDataPacket.create(this);
-    }
-
-    @Override
-    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
-        return saveWithoutMetadata(registries);
+    protected void loadCustomData(CompoundTag engineData) {
+        energyStorage.amount = engineData.getLong("energy").orElse(0L);
+        temperature = engineData.getDouble("heat").orElse(0.0);
+        progress = engineData.getFloat("progress").orElse(0f);
+        cyclePhase = CyclePhase.fromOrdinal(engineData.getInt("cyclePhase").orElse(0));
+        heatStage = HeatStage.fromOrdinal(engineData.getInt("stage").orElse(0));
     }
 
     // ==================== Lifecycle ====================

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -510,21 +510,33 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity {
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveCustomData(CompoundTag engineData) {
-        engineData.putLong("energy", energyStorage.amount);
-        engineData.putDouble("heat", temperature);
-        engineData.putFloat("progress", progress);
-        engineData.putInt("cyclePhase", cyclePhase.ordinal());
-        engineData.putInt("stage", heatStage.ordinal());
+    protected void saveLogisticsData(CompoundTag engineData) {
+        engineData.putLong("StoredEnergy", energyStorage.amount);
+        engineData.putDouble("Temperature", temperature);
+        engineData.putFloat("CycleProgress", progress);
+        engineData.putInt("CyclePhase", cyclePhase.ordinal());
+        engineData.putInt("HeatStage", heatStage.ordinal());
     }
 
     @Override
-    protected void loadCustomData(CompoundTag engineData) {
-        energyStorage.amount = engineData.getLong("energy").orElse(0L);
-        temperature = engineData.getDouble("heat").orElse(0.0);
-        progress = engineData.getFloat("progress").orElse(0f);
-        cyclePhase = CyclePhase.fromOrdinal(engineData.getInt("cyclePhase").orElse(0));
-        heatStage = HeatStage.fromOrdinal(engineData.getInt("stage").orElse(0));
+    protected void loadLogisticsData(CompoundTag engineData) {
+        energyStorage.amount = engineData.getLong("StoredEnergy").orElse(0L);
+        temperature = engineData.getDouble("Temperature").orElse(0.0);
+        progress = engineData.getFloat("CycleProgress").orElse(0f);
+        cyclePhase = CyclePhase.fromOrdinal(engineData.getInt("CyclePhase").orElse(0));
+        heatStage = HeatStage.fromOrdinal(engineData.getInt("HeatStage").orElse(0));
+    }
+
+    @Override
+    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        view.read("Engine", CompoundTag.CODEC).ifPresent(engineData -> {
+            // Load old key names (before BaseBlockEntity refactoring)
+            energyStorage.amount = engineData.getLong("energy").orElse(0L);
+            temperature = engineData.getDouble("heat").orElse(0.0);
+            progress = engineData.getFloat("progress").orElse(0f);
+            cyclePhase = CyclePhase.fromOrdinal(engineData.getInt("cyclePhase").orElse(0));
+            heatStage = HeatStage.fromOrdinal(engineData.getInt("stage").orElse(0));
+        });
     }
 
     // ==================== Lifecycle ====================

--- a/src/main/java/com/logistics/core/lib/storage/NbtCompat.java
+++ b/src/main/java/com/logistics/core/lib/storage/NbtCompat.java
@@ -1,0 +1,102 @@
+package com.logistics.core.lib.storage;
+
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * NBT compatibility layer to abstract API differences between Minecraft versions.
+ *
+ * <p><b>Minecraft 1.21.5+ (current mc/1.21.11):</b>
+ * NBT getters return {@code Optional<T>}, requiring {@code .orElse(default)}.
+ *
+ * <p><b>Minecraft 1.21.1-1.21.4:</b>
+ * NBT getters return primitives directly, with implicit defaults when keys are missing.
+ *
+ * <p>This abstraction allows code to work across versions - when backporting to mc/1.21.1,
+ * simply change the implementation in this class to use the old API.
+ *
+ * <p><b>Usage:</b>
+ * <pre>{@code
+ * // Instead of:
+ * int value = nbt.getInt("key").orElse(42);  // mc/1.21.5+
+ *
+ * // Write:
+ * int value = NbtCompat.getInt(nbt, "key", 42);  // Works on all versions
+ * }</pre>
+ */
+public final class NbtCompat {
+    private NbtCompat() {}
+
+    // ==================== Primitive Getters ====================
+
+    /**
+     * Read an int from NBT with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> Uses Optional-based API.
+     * <p><b>mc/1.21.1 backport:</b> Replace with {@code tag.contains(key, Tag.TAG_INT) ? tag.getInt(key) : defaultValue}
+     */
+    public static int getInt(CompoundTag tag, String key, int defaultValue) {
+        return tag.getInt(key).orElse(defaultValue);
+    }
+
+    /**
+     * Read a long from NBT with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> Uses Optional-based API.
+     * <p><b>mc/1.21.1 backport:</b> Replace with {@code tag.contains(key, Tag.TAG_LONG) ? tag.getLong(key) : defaultValue}
+     */
+    public static long getLong(CompoundTag tag, String key, long defaultValue) {
+        return tag.getLong(key).orElse(defaultValue);
+    }
+
+    /**
+     * Read a double from NBT with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> Uses Optional-based API.
+     * <p><b>mc/1.21.1 backport:</b> Replace with {@code tag.contains(key, Tag.TAG_DOUBLE) ? tag.getDouble(key) : defaultValue}
+     */
+    public static double getDouble(CompoundTag tag, String key, double defaultValue) {
+        return tag.getDouble(key).orElse(defaultValue);
+    }
+
+    /**
+     * Read a float from NBT with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> Uses Optional-based API.
+     * <p><b>mc/1.21.1 backport:</b> Replace with {@code tag.contains(key, Tag.TAG_FLOAT) ? tag.getFloat(key) : defaultValue}
+     */
+    public static float getFloat(CompoundTag tag, String key, float defaultValue) {
+        return tag.getFloat(key).orElse(defaultValue);
+    }
+
+    /**
+     * Read a boolean from NBT with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> Uses Optional-based API.
+     * <p><b>mc/1.21.1 backport:</b> Replace with {@code tag.contains(key, Tag.TAG_BYTE) ? tag.getBoolean(key) : defaultValue}
+     */
+    public static boolean getBoolean(CompoundTag tag, String key, boolean defaultValue) {
+        return tag.getBoolean(key).orElse(defaultValue);
+    }
+
+    /**
+     * Read a string from NBT with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> Uses Optional-based API.
+     * <p><b>mc/1.21.1 backport:</b> Replace with {@code tag.contains(key, Tag.TAG_STRING) ? tag.getString(key) : defaultValue}
+     */
+    public static String getString(CompoundTag tag, String key, String defaultValue) {
+        return tag.getString(key).orElse(defaultValue);
+    }
+
+    // ==================== Array Getters ====================
+
+    /**
+     * Read an int array from NBT with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> Uses Optional-based API.
+     * <p><b>mc/1.21.1 backport:</b> Replace with {@code tag.contains(key, Tag.TAG_INT_ARRAY) ? tag.getIntArray(key) : defaultValue}
+     */
+    public static int[] getIntArray(CompoundTag tag, String key, int[] defaultValue) {
+        return tag.getIntArray(key).orElse(defaultValue);
+    }
+}

--- a/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
@@ -222,6 +222,9 @@ public class MarkerBlockEntity extends BaseBlockEntity {
             if (data.contains("IsCorner")) massaged.putBoolean("IsCornerMarker", data.getBoolean("IsCorner").orElse(false));
 
             loadBounds(massaged);
+            if (!hasValidBounds()) {
+                isCornerMarker = false;
+            }
         });
     }
 

--- a/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
@@ -156,7 +156,7 @@ public class MarkerBlockEntity extends BaseBlockEntity {
     }
 
     @Override
-    protected void saveCustomData(CompoundTag data) {
+    protected void saveLogisticsData(CompoundTag data) {
         // Save connected markers
         if (!connectedMarkers.isEmpty()) {
             int[] positions = new int[connectedMarkers.size() * 3];
@@ -171,21 +171,21 @@ public class MarkerBlockEntity extends BaseBlockEntity {
 
         // Save bounds
         if (boundMin != null) {
-            data.putInt("MinX", boundMin.getX());
-            data.putInt("MinY", boundMin.getY());
-            data.putInt("MinZ", boundMin.getZ());
+            data.putInt("BoundMinX", boundMin.getX());
+            data.putInt("BoundMinY", boundMin.getY());
+            data.putInt("BoundMinZ", boundMin.getZ());
         }
         if (boundMax != null) {
-            data.putInt("MaxX", boundMax.getX());
-            data.putInt("MaxY", boundMax.getY());
-            data.putInt("MaxZ", boundMax.getZ());
+            data.putInt("BoundMaxX", boundMax.getX());
+            data.putInt("BoundMaxY", boundMax.getY());
+            data.putInt("BoundMaxZ", boundMax.getZ());
         }
 
-        data.putBoolean("IsCorner", isCornerMarker);
+        data.putBoolean("IsCornerMarker", isCornerMarker);
     }
 
     @Override
-    protected void loadCustomData(CompoundTag data) {
+    protected void loadLogisticsData(CompoundTag data) {
         connectedMarkers.clear();
         boundMin = null;
         boundMax = null;
@@ -195,23 +195,47 @@ public class MarkerBlockEntity extends BaseBlockEntity {
         loadBounds(data);
     }
 
+    @Override
+    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        view.read("MarkerData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
+            connectedMarkers.clear();
+            boundMin = null;
+            boundMax = null;
+            isCornerMarker = false;
+
+            loadConnectedMarkers(data);
+
+            // Convert old key names to new format for loadBounds
+            CompoundTag massaged = new CompoundTag();
+            if (data.contains("MinX")) massaged.putInt("BoundMinX", data.getInt("MinX").orElse(0));
+            if (data.contains("MinY")) massaged.putInt("BoundMinY", data.getInt("MinY").orElse(0));
+            if (data.contains("MinZ")) massaged.putInt("BoundMinZ", data.getInt("MinZ").orElse(0));
+            if (data.contains("MaxX")) massaged.putInt("BoundMaxX", data.getInt("MaxX").orElse(0));
+            if (data.contains("MaxY")) massaged.putInt("BoundMaxY", data.getInt("MaxY").orElse(0));
+            if (data.contains("MaxZ")) massaged.putInt("BoundMaxZ", data.getInt("MaxZ").orElse(0));
+            if (data.contains("IsCorner")) massaged.putBoolean("IsCornerMarker", data.getBoolean("IsCorner").orElse(false));
+
+            loadBounds(massaged);
+        });
+    }
+
     private void loadBounds(CompoundTag data) {
-        boolean hasMin = data.contains("MinX");
-        boolean hasMax = data.contains("MaxX");
+        boolean hasMin = data.contains("BoundMinX");
+        boolean hasMax = data.contains("BoundMaxX");
         if (hasMin && hasMax) {
-            int minX = data.getInt("MinX").orElse(0);
-            int minY = data.getInt("MinY").orElse(0);
-            int minZ = data.getInt("MinZ").orElse(0);
+            int minX = data.getInt("BoundMinX").orElse(0);
+            int minY = data.getInt("BoundMinY").orElse(0);
+            int minZ = data.getInt("BoundMinZ").orElse(0);
             boundMin = new BlockPos(minX, minY, minZ);
 
-            int maxX = data.getInt("MaxX").orElse(0);
-            int maxY = data.getInt("MaxY").orElse(0);
-            int maxZ = data.getInt("MaxZ").orElse(0);
+            int maxX = data.getInt("BoundMaxX").orElse(0);
+            int maxY = data.getInt("BoundMaxY").orElse(0);
+            int maxZ = data.getInt("BoundMaxZ").orElse(0);
             boundMax = new BlockPos(maxX, maxY, maxZ);
         }
 
-        if (data.contains("IsCorner")) {
-            isCornerMarker = data.getBoolean("IsCorner").orElse(false);
+        if (data.contains("IsCornerMarker")) {
+            isCornerMarker = data.getBoolean("IsCornerMarker").orElse(false);
         }
     }
 

--- a/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
@@ -2,6 +2,7 @@ package com.logistics.core.marker;
 
 import com.logistics.LogisticsCore;
 import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.storage.NbtCompat;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.BlockPos;
@@ -216,13 +217,13 @@ public class MarkerBlockEntity extends BaseBlockEntity {
 
             // Convert old key names to new format for loadBounds
             CompoundTag massaged = new CompoundTag();
-            if (data.contains("MinX")) massaged.putInt("BoundMinX", data.getInt("MinX").orElse(0));
-            if (data.contains("MinY")) massaged.putInt("BoundMinY", data.getInt("MinY").orElse(0));
-            if (data.contains("MinZ")) massaged.putInt("BoundMinZ", data.getInt("MinZ").orElse(0));
-            if (data.contains("MaxX")) massaged.putInt("BoundMaxX", data.getInt("MaxX").orElse(0));
-            if (data.contains("MaxY")) massaged.putInt("BoundMaxY", data.getInt("MaxY").orElse(0));
-            if (data.contains("MaxZ")) massaged.putInt("BoundMaxZ", data.getInt("MaxZ").orElse(0));
-            if (data.contains("IsCorner")) massaged.putBoolean("IsCornerMarker", data.getBoolean("IsCorner").orElse(false));
+            if (data.contains("MinX")) massaged.putInt("BoundMinX", NbtCompat.getInt(data, "MinX", 0));
+            if (data.contains("MinY")) massaged.putInt("BoundMinY", NbtCompat.getInt(data, "MinY", 0));
+            if (data.contains("MinZ")) massaged.putInt("BoundMinZ", NbtCompat.getInt(data, "MinZ", 0));
+            if (data.contains("MaxX")) massaged.putInt("BoundMaxX", NbtCompat.getInt(data, "MaxX", 0));
+            if (data.contains("MaxY")) massaged.putInt("BoundMaxY", NbtCompat.getInt(data, "MaxY", 0));
+            if (data.contains("MaxZ")) massaged.putInt("BoundMaxZ", NbtCompat.getInt(data, "MaxZ", 0));
+            if (data.contains("IsCorner")) massaged.putBoolean("IsCornerMarker", NbtCompat.getBoolean(data, "IsCorner", false));
 
             loadBounds(massaged);
             if (!hasValidBounds()) {
@@ -235,19 +236,19 @@ public class MarkerBlockEntity extends BaseBlockEntity {
         boolean hasMin = data.contains("BoundMinX");
         boolean hasMax = data.contains("BoundMaxX");
         if (hasMin && hasMax) {
-            int minX = data.getInt("BoundMinX").orElse(0);
-            int minY = data.getInt("BoundMinY").orElse(0);
-            int minZ = data.getInt("BoundMinZ").orElse(0);
+            int minX = NbtCompat.getInt(data, "BoundMinX", 0);
+            int minY = NbtCompat.getInt(data, "BoundMinY", 0);
+            int minZ = NbtCompat.getInt(data, "BoundMinZ", 0);
             boundMin = new BlockPos(minX, minY, minZ);
 
-            int maxX = data.getInt("BoundMaxX").orElse(0);
-            int maxY = data.getInt("BoundMaxY").orElse(0);
-            int maxZ = data.getInt("BoundMaxZ").orElse(0);
+            int maxX = NbtCompat.getInt(data, "BoundMaxX", 0);
+            int maxY = NbtCompat.getInt(data, "BoundMaxY", 0);
+            int maxZ = NbtCompat.getInt(data, "BoundMaxZ", 0);
             boundMax = new BlockPos(maxX, maxY, maxZ);
         }
 
         if (data.contains("IsCornerMarker")) {
-            isCornerMarker = data.getBoolean("IsCornerMarker").orElse(false);
+            isCornerMarker = NbtCompat.getBoolean(data, "IsCornerMarker", false);
         }
     }
 

--- a/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
@@ -157,6 +157,8 @@ public class MarkerBlockEntity extends BaseBlockEntity {
 
     @Override
     protected void saveLogisticsData(CompoundTag data) {
+        super.saveLogisticsData(data);
+
         // Save connected markers
         if (!connectedMarkers.isEmpty()) {
             int[] positions = new int[connectedMarkers.size() * 3];
@@ -186,6 +188,8 @@ public class MarkerBlockEntity extends BaseBlockEntity {
 
     @Override
     protected void loadLogisticsData(CompoundTag data) {
+        super.loadLogisticsData(data);
+
         connectedMarkers.clear();
         boundMin = null;
         boundMax = null;
@@ -197,6 +201,8 @@ public class MarkerBlockEntity extends BaseBlockEntity {
 
     @Override
     protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        super.loadLegacyData(view);
+
         view.read("MarkerData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
             connectedMarkers.clear();
             boundMin = null;

--- a/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
@@ -197,6 +197,9 @@ public class MarkerBlockEntity extends BaseBlockEntity {
 
         loadConnectedMarkers(data);
         loadBounds(data);
+        if (!hasValidBounds()) {
+            isCornerMarker = false;
+        }
     }
 
     @Override

--- a/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
@@ -1,26 +1,21 @@
 package com.logistics.core.marker;
 
 import com.logistics.LogisticsCore;
+import com.logistics.core.lib.block.BaseBlockEntity;
 import java.util.ArrayList;
 import java.util.List;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.storage.ValueInput;
-import net.minecraft.world.level.storage.ValueOutput;
-import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Block entity for markers that stores connection and bounding box data.
  */
-public class MarkerBlockEntity extends BlockEntity {
+public class MarkerBlockEntity extends BaseBlockEntity {
     // Connected marker positions (up to 2 horizontal + 1 vertical)
     private final List<BlockPos> connectedMarkers = new ArrayList<>();
 
@@ -88,8 +83,7 @@ public class MarkerBlockEntity extends BlockEntity {
         this.isCornerMarker = false;
 
         level.setBlock(worldPosition, getBlockState().setValue(MarkerBlock.ACTIVE, true), 3);
-        setChanged();
-        syncToClients();
+        markDirtyAndSync();
     }
 
     /**
@@ -105,8 +99,7 @@ public class MarkerBlockEntity extends BlockEntity {
         this.isCornerMarker = isCorner;
 
         level.setBlock(worldPosition, getBlockState().setValue(MarkerBlock.ACTIVE, true), 3);
-        setChanged();
-        syncToClients();
+        markDirtyAndSync();
     }
 
     /**
@@ -121,8 +114,7 @@ public class MarkerBlockEntity extends BlockEntity {
         isCornerMarker = false;
 
         level.setBlock(worldPosition, getBlockState().setValue(MarkerBlock.ACTIVE, false), 3);
-        setChanged();
-        syncToClients();
+        markDirtyAndSync();
     }
 
     /**
@@ -163,18 +155,8 @@ public class MarkerBlockEntity extends BlockEntity {
         return boundMin != null && boundMax != null;
     }
 
-    private void syncToClients() {
-        if (level != null && !level.isClientSide()) {
-            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), 3);
-        }
-    }
-
     @Override
-    protected void saveAdditional(ValueOutput view) {
-        super.saveAdditional(view);
-
-        CompoundTag data = new CompoundTag();
-
+    protected void saveCustomData(CompoundTag data) {
         // Save connected markers
         if (!connectedMarkers.isEmpty()) {
             int[] positions = new int[connectedMarkers.size() * 3];
@@ -200,41 +182,37 @@ public class MarkerBlockEntity extends BlockEntity {
         }
 
         data.putBoolean("IsCorner", isCornerMarker);
-
-        view.store("MarkerData", CompoundTag.CODEC, data);
     }
 
     @Override
-    protected void loadAdditional(ValueInput view) {
-        super.loadAdditional(view);
+    protected void loadCustomData(CompoundTag data) {
+        connectedMarkers.clear();
+        boundMin = null;
+        boundMax = null;
+        isCornerMarker = false;
 
-        view.read("MarkerData", CompoundTag.CODEC).ifPresent(data -> {
-            connectedMarkers.clear();
-            boundMin = null;
-            boundMax = null;
-            isCornerMarker = false;
+        loadConnectedMarkers(data);
+        loadBounds(data);
+    }
 
-            loadConnectedMarkers(data);
+    private void loadBounds(CompoundTag data) {
+        boolean hasMin = data.contains("MinX");
+        boolean hasMax = data.contains("MaxX");
+        if (hasMin && hasMax) {
+            int minX = data.getInt("MinX").orElse(0);
+            int minY = data.getInt("MinY").orElse(0);
+            int minZ = data.getInt("MinZ").orElse(0);
+            boundMin = new BlockPos(minX, minY, minZ);
 
-            // Load bounds
-            boolean hasMin = data.contains("MinX");
-            boolean hasMax = data.contains("MaxX");
-            if (hasMin && hasMax) {
-                int minX = data.getInt("MinX").orElse(0);
-                int minY = data.getInt("MinY").orElse(0);
-                int minZ = data.getInt("MinZ").orElse(0);
-                boundMin = new BlockPos(minX, minY, minZ);
+            int maxX = data.getInt("MaxX").orElse(0);
+            int maxY = data.getInt("MaxY").orElse(0);
+            int maxZ = data.getInt("MaxZ").orElse(0);
+            boundMax = new BlockPos(maxX, maxY, maxZ);
+        }
 
-                int maxX = data.getInt("MaxX").orElse(0);
-                int maxY = data.getInt("MaxY").orElse(0);
-                int maxZ = data.getInt("MaxZ").orElse(0);
-                boundMax = new BlockPos(maxX, maxY, maxZ);
-            }
-
-            if (data.contains("IsCorner")) {
-                isCornerMarker = data.getBoolean("IsCorner").orElse(false);
-            }
-        });
+        if (data.contains("IsCorner")) {
+            isCornerMarker = data.getBoolean("IsCorner").orElse(false);
+        }
     }
 
     private void loadConnectedMarkers(CompoundTag data) {
@@ -245,15 +223,5 @@ public class MarkerBlockEntity extends BlockEntity {
                 }
             });
         }
-    }
-
-    @Nullable @Override
-    public Packet<ClientGamePacketListener> getUpdatePacket() {
-        return ClientboundBlockEntityDataPacket.create(this);
-    }
-
-    @Override
-    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
-        return saveWithoutMetadata(registries);
     }
 }

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -141,7 +141,7 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
     }
 
     @Override
-    protected void saveCustomData(CompoundTag pipeData) {
+    protected void saveLogisticsData(CompoundTag pipeData) {
         // Save traveling items
         if (!travelingItems.isEmpty()) {
             ListTag itemsList = new ListTag();
@@ -151,7 +151,7 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
                         .getOrThrow();
                 itemsList.add(itemTag);
             }
-            pipeData.put("TravelingItems", itemsList);
+            pipeData.put("ItemsInTransit", itemsList);
         }
 
         // Save module state
@@ -168,18 +168,18 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
             }
         }
         if (!connectionsNbt.isEmpty()) {
-            pipeData.put("Connections", connectionsNbt);
+            pipeData.put("ConnectionTypes", connectionsNbt);
         }
     }
 
     @Override
-    protected void loadCustomData(CompoundTag pipeData) {
+    protected void loadLogisticsData(CompoundTag pipeData) {
         long readStart = System.nanoTime();
 
         // Load traveling items
         travelingItems.clear();
-        if (pipeData.contains("TravelingItems")) {
-            pipeData.getList("TravelingItems").ifPresent(itemsList -> {
+        if (pipeData.contains("ItemsInTransit")) {
+            pipeData.getList("ItemsInTransit").ifPresent(itemsList -> {
                 for (int i = 0; i < itemsList.size(); i++) {
                     itemsList.getCompound(i)
                             .flatMap(itemTag -> TravelingItem.CODEC.parse(NbtOps.INSTANCE, itemTag).result())
@@ -203,8 +203,8 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
         }
 
         // Load connection types
-        if (pipeData.contains("Connections")) {
-            CompoundTag connectionsNbt = pipeData.getCompound("Connections").orElse(new CompoundTag());
+        if (pipeData.contains("ConnectionTypes")) {
+            CompoundTag connectionsNbt = pipeData.getCompound("ConnectionTypes").orElse(new CompoundTag());
             // Reset all to NONE first
             for (int i = 0; i < 6; i++) {
                 connectionTypes[i] = PipeConnection.Type.NONE;
@@ -219,11 +219,48 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
         long durationMs = (System.nanoTime() - readStart) / 1_000_000L;
         if (durationMs >= 2L && Boolean.getBoolean("logistics.timing")) {
             com.logistics.LogisticsMod.LOGGER.info(
-                    "[timing] PipeBlockEntity loadCustomData at {} took {} ms (items={})",
+                    "[timing] PipeBlockEntity loadLogisticsData at {} took {} ms (items={})",
                     getBlockPos(),
                     durationMs,
                     travelingItems.size());
         }
+    }
+
+    @Override
+    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        view.read("PipeData", CompoundTag.CODEC).ifPresent(oldData -> {
+            long readStart = System.nanoTime();
+
+            // Massage old format to new format
+            CompoundTag massaged = new CompoundTag();
+
+            // Rename "TravelingItems" -> "ItemsInTransit"
+            if (oldData.contains("TravelingItems")) {
+                massaged.put("ItemsInTransit", oldData.get("TravelingItems"));
+            }
+
+            // "ModuleState" has same key name
+            if (oldData.contains("ModuleState")) {
+                massaged.put("ModuleState", oldData.get("ModuleState"));
+            }
+
+            // Rename "Connections" -> "ConnectionTypes"
+            if (oldData.contains("Connections")) {
+                massaged.put("ConnectionTypes", oldData.get("Connections"));
+            }
+
+            // Now load using the standard loader which expects new keys
+            loadLogisticsData(massaged);
+
+            long durationMs = (System.nanoTime() - readStart) / 1_000_000L;
+            if (durationMs >= 2L && Boolean.getBoolean("logistics.timing")) {
+                com.logistics.LogisticsMod.LOGGER.info(
+                        "[timing] PipeBlockEntity loadLegacyData at {} took {} ms (items={})",
+                        getBlockPos(),
+                        durationMs,
+                        travelingItems.size());
+            }
+        });
     }
 
     public static void tick(

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -1,12 +1,12 @@
 package com.logistics.pipe.block.entity;
 
+import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.pipe.PipeConnection;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
-import team.reborn.energy.api.base.SimpleEnergyStorage;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
-import com.logistics.LogisticsPipe;
 import com.logistics.pipe.runtime.PipeRuntime;
 import com.logistics.pipe.runtime.TravelingItem;
 import java.util.ArrayList;
@@ -15,25 +15,19 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.ValueInput;
-import net.minecraft.world.level.storage.ValueOutput;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
+import team.reborn.energy.api.base.SimpleEnergyStorage;
 
-public class PipeBlockEntity extends BlockEntity implements PipeConnection, AcceptsLowTierEnergy {
+public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, AcceptsLowTierEnergy {
     public static final int VIRTUAL_CAPACITY = 5 * 64;
     private final List<TravelingItem> travelingItems = new ArrayList<>();
     private final CompoundTag moduleState = new CompoundTag();
@@ -147,12 +141,7 @@ public class PipeBlockEntity extends BlockEntity implements PipeConnection, Acce
     }
 
     @Override
-    protected void saveAdditional(ValueOutput view) {
-        super.saveAdditional(view);
-
-        // Save all data to a CompoundTag, then store it
-        CompoundTag pipeData = new CompoundTag();
-
+    protected void saveCustomData(CompoundTag pipeData) {
         // Save traveling items
         if (!travelingItems.isEmpty()) {
             ListTag itemsList = new ListTag();
@@ -181,75 +170,60 @@ public class PipeBlockEntity extends BlockEntity implements PipeConnection, Acce
         if (!connectionsNbt.isEmpty()) {
             pipeData.put("Connections", connectionsNbt);
         }
-
-        view.store("PipeData", CompoundTag.CODEC, pipeData);
     }
 
     @Override
-    protected void loadAdditional(ValueInput view) {
+    protected void loadCustomData(CompoundTag pipeData) {
         long readStart = System.nanoTime();
-        super.loadAdditional(view);
 
-        view.read("PipeData", CompoundTag.CODEC).ifPresent(pipeData -> {
-            // Load traveling items
-            travelingItems.clear();
-            if (pipeData.contains("TravelingItems")) {
-                pipeData.getList("TravelingItems").ifPresent(itemsList -> {
-                    for (int i = 0; i < itemsList.size(); i++) {
-                        itemsList.getCompound(i)
-                                .flatMap(itemTag -> TravelingItem.CODEC.parse(NbtOps.INSTANCE, itemTag).result())
-                                .ifPresent(travelingItems::add);
-                    }
-                });
-            }
+        // Load traveling items
+        travelingItems.clear();
+        if (pipeData.contains("TravelingItems")) {
+            pipeData.getList("TravelingItems").ifPresent(itemsList -> {
+                for (int i = 0; i < itemsList.size(); i++) {
+                    itemsList.getCompound(i)
+                            .flatMap(itemTag -> TravelingItem.CODEC.parse(NbtOps.INSTANCE, itemTag).result())
+                            .ifPresent(travelingItems::add);
+                }
+            });
+        }
 
-            // Load module state
-            if (!moduleState.isEmpty()) {
-                for (String key : new java.util.ArrayList<>(moduleState.keySet())) {
-                    moduleState.remove(key);
+        // Load module state
+        if (!moduleState.isEmpty()) {
+            for (String key : new java.util.ArrayList<>(moduleState.keySet())) {
+                moduleState.remove(key);
+            }
+        }
+        if (pipeData.contains("ModuleState")) {
+            pipeData.getCompound("ModuleState").ifPresent(stored -> {
+                for (String key : stored.keySet()) {
+                    moduleState.put(key, java.util.Objects.requireNonNull(stored.get(key)).copy());
                 }
-            }
-            if (pipeData.contains("ModuleState")) {
-                pipeData.getCompound("ModuleState").ifPresent(stored -> {
-                    for (String key : stored.keySet()) {
-                        moduleState.put(key, java.util.Objects.requireNonNull(stored.get(key)).copy());
-                    }
-                });
-            }
+            });
+        }
 
-            // Load connection types
-            if (pipeData.contains("Connections")) {
-                CompoundTag connectionsNbt = pipeData.getCompound("Connections").orElse(new CompoundTag());
-                // Reset all to NONE first
-                for (int i = 0; i < 6; i++) {
-                    connectionTypes[i] = PipeConnection.Type.NONE;
-                }
-                // Load saved connections
-                for (Direction direction : Direction.values()) {
-                    String typeName = connectionsNbt.getString(direction.name().toLowerCase()).orElse("none");
-                    connectionTypes[direction.ordinal()] = PipeConnection.Type.fromSerializedName(typeName);
-                }
+        // Load connection types
+        if (pipeData.contains("Connections")) {
+            CompoundTag connectionsNbt = pipeData.getCompound("Connections").orElse(new CompoundTag());
+            // Reset all to NONE first
+            for (int i = 0; i < 6; i++) {
+                connectionTypes[i] = PipeConnection.Type.NONE;
             }
-        });
+            // Load saved connections
+            for (Direction direction : Direction.values()) {
+                String typeName = connectionsNbt.getString(direction.name().toLowerCase()).orElse("none");
+                connectionTypes[direction.ordinal()] = PipeConnection.Type.fromSerializedName(typeName);
+            }
+        }
 
         long durationMs = (System.nanoTime() - readStart) / 1_000_000L;
         if (durationMs >= 2L && Boolean.getBoolean("logistics.timing")) {
             com.logistics.LogisticsMod.LOGGER.info(
-                    "[timing] PipeBlockEntity loadAdditional at {} took {} ms (items={})",
+                    "[timing] PipeBlockEntity loadCustomData at {} took {} ms (items={})",
                     getBlockPos(),
                     durationMs,
                     travelingItems.size());
         }
-    }
-
-    @Nullable @Override
-    public Packet<ClientGamePacketListener> getUpdatePacket() {
-        return ClientboundBlockEntityDataPacket.create(this);
-    }
-
-    @Override
-    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
-        return saveWithoutMetadata(registries);
     }
 
     public static void tick(
@@ -351,11 +325,7 @@ public class PipeBlockEntity extends BlockEntity implements PipeConnection, Acce
         float speed = speedOverride != null ? speedOverride : getInitialSpeed();
         TravelingItem newItem = new TravelingItem(stack, fromDirection.getOpposite(), speed);
         travelingItems.add(newItem);
-        setChanged();
-
-        if (level != null && !level.isClientSide()) {
-            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), 3);
-        }
+        markDirtyAndSync();
     }
 
     private float getInitialSpeed() {

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -198,6 +198,7 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
         }
 
         // Load module state
+        // CompoundTag lacks clear() method, so copy keys then remove each
         new ArrayList<>(moduleState.keySet()).forEach(moduleState::remove);
         if (pipeData.contains("ModuleState")) {
             pipeData.getCompound("ModuleState").ifPresent(stored -> {
@@ -369,6 +370,8 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
         float speed = speedOverride != null ? speedOverride : getInitialSpeed();
         TravelingItem newItem = new TravelingItem(stack, fromDirection.getOpposite(), speed);
         travelingItems.add(newItem);
+        // Note: Per-item sync matches pre-refactoring behavior. Could potentially be
+        // batched at tick boundaries for high-throughput pipes, but unchanged for now.
         markDirtyAndSync();
     }
 

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -147,6 +147,8 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
 
     @Override
     protected void saveLogisticsData(CompoundTag pipeData) {
+        super.saveLogisticsData(pipeData);
+
         // Save traveling items
         if (!travelingItems.isEmpty()) {
             ListTag itemsList = new ListTag();
@@ -179,6 +181,8 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
 
     @Override
     protected void loadLogisticsData(CompoundTag pipeData) {
+        super.loadLogisticsData(pipeData);
+
         long readStart = System.nanoTime();
 
         // Load traveling items
@@ -229,6 +233,8 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
 
     @Override
     protected void loadLegacyData(ValueInput view) {
+        super.loadLegacyData(view);
+
         view.read("PipeData", CompoundTag.CODEC).ifPresent(oldData -> {
             long readStart = System.nanoTime();
 
@@ -237,17 +243,17 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
 
             // Rename "TravelingItems" -> "ItemsInTransit"
             if (oldData.contains("TravelingItems")) {
-                massaged.put("ItemsInTransit", oldData.get("TravelingItems"));
+                massaged.put("ItemsInTransit", Objects.requireNonNull(oldData.get("TravelingItems")));
             }
 
             // "ModuleState" has same key name
             if (oldData.contains("ModuleState")) {
-                massaged.put("ModuleState", oldData.get("ModuleState"));
+                massaged.put("ModuleState", Objects.requireNonNull(oldData.get("ModuleState")));
             }
 
             // Rename "Connections" -> "ConnectionTypes"
             if (oldData.contains("Connections")) {
-                massaged.put("ConnectionTypes", oldData.get("Connections"));
+                massaged.put("ConnectionTypes", Objects.requireNonNull(oldData.get("Connections")));
             }
 
             // Now load using the standard loader which expects new keys

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -1,5 +1,6 @@
 package com.logistics.pipe.block.entity;
 
+import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.pipe.PipeConnection;
@@ -11,6 +12,8 @@ import com.logistics.pipe.runtime.PipeRuntime;
 import com.logistics.pipe.runtime.TravelingItem;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
@@ -22,7 +25,9 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 import team.reborn.energy.api.base.SimpleEnergyStorage;
@@ -189,15 +194,11 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
         }
 
         // Load module state
-        if (!moduleState.isEmpty()) {
-            for (String key : new java.util.ArrayList<>(moduleState.keySet())) {
-                moduleState.remove(key);
-            }
-        }
+        new ArrayList<>(moduleState.keySet()).forEach(moduleState::remove);
         if (pipeData.contains("ModuleState")) {
             pipeData.getCompound("ModuleState").ifPresent(stored -> {
                 for (String key : stored.keySet()) {
-                    moduleState.put(key, java.util.Objects.requireNonNull(stored.get(key)).copy());
+                    moduleState.put(key, Objects.requireNonNull(stored.get(key)).copy());
                 }
             });
         }
@@ -227,7 +228,7 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
     }
 
     @Override
-    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+    protected void loadLegacyData(ValueInput view) {
         view.read("PipeData", CompoundTag.CODEC).ifPresent(oldData -> {
             long readStart = System.nanoTime();
 
@@ -254,7 +255,7 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
 
             long durationMs = (System.nanoTime() - readStart) / 1_000_000L;
             if (durationMs >= 2L && Boolean.getBoolean("logistics.timing")) {
-                com.logistics.LogisticsMod.LOGGER.info(
+                LogisticsMod.LOGGER.info(
                         "[timing] PipeBlockEntity loadLegacyData at {} took {} ms (items={})",
                         getBlockPos(),
                         durationMs,
@@ -264,14 +265,14 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
     }
 
     public static void tick(
-            net.minecraft.world.level.Level world, BlockPos pos, BlockState state, PipeBlockEntity blockEntity) {
+            Level world, BlockPos pos, BlockState state, PipeBlockEntity blockEntity) {
         PipeRuntime.tick(world, pos, state, blockEntity);
     }
 
     /**
      * Drop an item entity at the pipe's position
      */
-    public static void dropItem(net.minecraft.world.level.Level level, BlockPos pos, TravelingItem item) {
+    public static void dropItem(Level level, BlockPos pos, TravelingItem item) {
         // Create item entity at center of pipe
         Vec3 spawnPos = Vec3.atCenterOf(pos);
 

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.pipe.block.entity;
 import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.core.lib.pipe.PipeConnection;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.pipe.Pipe;
@@ -217,7 +218,7 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
             }
             // Load saved connections
             for (Direction direction : Direction.values()) {
-                String typeName = connectionsNbt.getString(direction.name().toLowerCase()).orElse("none");
+                String typeName = NbtCompat.getString(connectionsNbt, direction.name().toLowerCase(), "none");
                 connectionTypes[direction.ordinal()] = PipeConnection.Type.fromSerializedName(typeName);
             }
         }

--- a/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.power.block.entity;
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.core.lib.support.ProbeResult;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.ChatFormatting;
@@ -103,7 +104,7 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsL
     @Override
     protected void loadLogisticsData(CompoundTag nbt) {
         super.loadLogisticsData(nbt);
-        drainRateIndex = nbt.getInt("DrainRateIndex").orElse(4);
+        drainRateIndex = NbtCompat.getInt(nbt, "DrainRateIndex", 4);
         // Clamp to valid range
         if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
             drainRateIndex = 4; // Default to 5 RF/t
@@ -115,7 +116,7 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsL
         super.loadLegacyData(view);
         view.read("CreativeSink", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
             // Load old key name (before BaseBlockEntity refactoring)
-            drainRateIndex = data.getInt("drainRateIndex").orElse(4);
+            drainRateIndex = NbtCompat.getInt(data, "drainRateIndex", 4);
             // Clamp to valid range
             if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
                 drainRateIndex = 4; // Default to 5 RF/t

--- a/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -76,7 +76,7 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsL
      */
     public long cycleDrainRate() {
         drainRateIndex = (drainRateIndex + 1) % DRAIN_RATES.length;
-        setChanged();
+        markDirtyAndSync(); // Sync to clients for potential UI/tooltip updates
         return DRAIN_RATES[drainRateIndex];
     }
 

--- a/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -1,17 +1,15 @@
 package com.logistics.power.block.entity;
 
-import com.logistics.core.lib.power.AcceptsLowTierEnergy;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
-import com.logistics.core.lib.support.ProbeResult;
 import com.logistics.LogisticsPower;
+import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import com.logistics.core.lib.support.ProbeResult;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.ValueInput;
-import net.minecraft.world.level.storage.ValueOutput;
 import team.reborn.energy.api.EnergyStorage;
 
 /**
@@ -19,7 +17,7 @@ import team.reborn.energy.api.EnergyStorage;
  * Accepts energy from all sides and discards it at a configurable rate.
  * Useful for testing engine output and PID tuning.
  */
-public class CreativeSinkBlockEntity extends BlockEntity implements AcceptsLowTierEnergy {
+public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsLowTierEnergy {
     private static final long[] DRAIN_RATES = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 50, 100};
     private int drainRateIndex = 4; // Default 5 RF/t
     private long energyLastTick = 0;
@@ -95,20 +93,16 @@ public class CreativeSinkBlockEntity extends BlockEntity implements AcceptsLowTi
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveAdditional(ValueOutput view) {
-        CompoundTag data = new CompoundTag();
-        data.putInt("drainRateIndex", drainRateIndex);
-        view.store("CreativeSink", CompoundTag.CODEC, data);
+    protected void saveCustomData(CompoundTag nbt) {
+        nbt.putInt("drainRateIndex", drainRateIndex);
     }
 
     @Override
-    protected void loadAdditional(ValueInput view) {
-        view.read("CreativeSink", CompoundTag.CODEC).ifPresent(data -> {
-            drainRateIndex = data.getInt("drainRateIndex").orElse(4);
-            // Clamp to valid range
-            if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
-                drainRateIndex = 4; // Default to 5 RF/t
-            }
-        });
+    protected void loadCustomData(CompoundTag nbt) {
+        drainRateIndex = nbt.getInt("drainRateIndex").orElse(4);
+        // Clamp to valid range
+        if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
+            drainRateIndex = 4; // Default to 5 RF/t
+        }
     }
 }

--- a/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -93,16 +93,28 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsL
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveCustomData(CompoundTag nbt) {
-        nbt.putInt("drainRateIndex", drainRateIndex);
+    protected void saveLogisticsData(CompoundTag nbt) {
+        nbt.putInt("DrainRateIndex", drainRateIndex);
     }
 
     @Override
-    protected void loadCustomData(CompoundTag nbt) {
-        drainRateIndex = nbt.getInt("drainRateIndex").orElse(4);
+    protected void loadLogisticsData(CompoundTag nbt) {
+        drainRateIndex = nbt.getInt("DrainRateIndex").orElse(4);
         // Clamp to valid range
         if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
             drainRateIndex = 4; // Default to 5 RF/t
         }
+    }
+
+    @Override
+    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        view.read("CreativeSink", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
+            // Load old key name (before BaseBlockEntity refactoring)
+            drainRateIndex = data.getInt("drainRateIndex").orElse(4);
+            // Clamp to valid range
+            if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
+                drainRateIndex = 4; // Default to 5 RF/t
+            }
+        });
     }
 }

--- a/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -34,6 +34,8 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsL
             long canAccept = Math.max(0, getDrainRate() - energyThisTick);
             long toAccept = Math.min(maxAmount, canAccept);
             if (toAccept > 0) {
+                // Note: energyThisTick mutated outside transaction lifecycle is intentional.
+                // Counter resets every tick (Line ~65) and energy is discarded anyway.
                 energyThisTick += toAccept;
             }
             return toAccept;
@@ -94,11 +96,13 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsL
 
     @Override
     protected void saveLogisticsData(CompoundTag nbt) {
+        super.saveLogisticsData(nbt);
         nbt.putInt("DrainRateIndex", drainRateIndex);
     }
 
     @Override
     protected void loadLogisticsData(CompoundTag nbt) {
+        super.loadLogisticsData(nbt);
         drainRateIndex = nbt.getInt("DrainRateIndex").orElse(4);
         // Clamp to valid range
         if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
@@ -108,6 +112,7 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity implements AcceptsL
 
     @Override
     protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        super.loadLegacyData(view);
         view.read("CreativeSink", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
             // Load old key name (before BaseBlockEntity refactoring)
             drainRateIndex = data.getInt("drainRateIndex").orElse(4);

--- a/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -133,24 +133,18 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveAdditional(ValueOutput view) {
-        super.saveAdditional(view);
-
-        CompoundTag creativeData = new CompoundTag();
-        creativeData.putInt("outputLevelIndex", outputLevelIndex);
-        view.store("CreativeData", CompoundTag.CODEC, creativeData);
+    protected void saveCustomData(CompoundTag nbt) {
+        super.saveCustomData(nbt);
+        nbt.putInt("outputLevelIndex", outputLevelIndex);
     }
 
     @Override
-    protected void loadAdditional(ValueInput view) {
-        super.loadAdditional(view);
-
-        view.read("CreativeData", CompoundTag.CODEC).ifPresent(creativeData -> {
-            outputLevelIndex = creativeData.getInt("outputLevelIndex").orElse(0);
-            // Clamp to valid range
-            if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
-                outputLevelIndex = 0;
-            }
-        });
+    protected void loadCustomData(CompoundTag nbt) {
+        super.loadCustomData(nbt);
+        outputLevelIndex = nbt.getInt("outputLevelIndex").orElse(0);
+        // Clamp to valid range
+        if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
+            outputLevelIndex = 0;
+        }
     }
 }

--- a/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -9,8 +9,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.ValueInput;
-import net.minecraft.world.level.storage.ValueOutput;
 
 /**
  * Block entity for the Creative Engine.
@@ -133,18 +131,32 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveCustomData(CompoundTag nbt) {
-        super.saveCustomData(nbt);
-        nbt.putInt("outputLevelIndex", outputLevelIndex);
+    protected void saveLogisticsData(CompoundTag nbt) {
+        super.saveLogisticsData(nbt);
+        nbt.putInt("OutputLevelIndex", outputLevelIndex);
     }
 
     @Override
-    protected void loadCustomData(CompoundTag nbt) {
-        super.loadCustomData(nbt);
-        outputLevelIndex = nbt.getInt("outputLevelIndex").orElse(0);
+    protected void loadLogisticsData(CompoundTag nbt) {
+        super.loadLogisticsData(nbt);
+        outputLevelIndex = nbt.getInt("OutputLevelIndex").orElse(0);
         // Clamp to valid range
         if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
             outputLevelIndex = 0;
         }
+    }
+
+    @Override
+    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        super.loadLegacyData(view); // Loads engine data from "Engine" tag
+
+        // Load Creative-specific data from old "CreativeData" tag
+        view.read("CreativeData", CompoundTag.CODEC).ifPresent(creativeData -> {
+            outputLevelIndex = creativeData.getInt("outputLevelIndex").orElse(0);
+            // Clamp to valid range
+            if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
+                outputLevelIndex = 0;
+            }
+        });
     }
 }

--- a/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -7,7 +7,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 /**
@@ -104,13 +103,7 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
      */
     public long cycleOutputLevel() {
         outputLevelIndex = (outputLevelIndex + 1) % OUTPUT_LEVELS.length;
-        setChanged();
-
-        // Sync to clients so renderer can update piston speed
-        if (level != null) {
-            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-        }
-
+        markDirtyAndSync(); // Sync to clients so renderer can update piston speed
         return OUTPUT_LEVELS[outputLevelIndex];
     }
 

--- a/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.power.engine.block.entity;
 
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.power.engine.block.CreativeEngineBlock;
 import com.logistics.LogisticsPower;
 import net.minecraft.core.BlockPos;
@@ -132,7 +133,7 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     @Override
     protected void loadLogisticsData(CompoundTag nbt) {
         super.loadLogisticsData(nbt);
-        outputLevelIndex = nbt.getInt("OutputLevelIndex").orElse(0);
+        outputLevelIndex = NbtCompat.getInt(nbt, "OutputLevelIndex", 0);
         // Clamp to valid range
         if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
             outputLevelIndex = 0;
@@ -145,7 +146,7 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
 
         // Load Creative-specific data from old "CreativeData" tag
         view.read("CreativeData", CompoundTag.CODEC).ifPresent(creativeData -> {
-            outputLevelIndex = creativeData.getInt("outputLevelIndex").orElse(0);
+            outputLevelIndex = NbtCompat.getInt(creativeData, "outputLevelIndex", 0);
             // Clamp to valid range
             if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
                 outputLevelIndex = 0;

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -22,8 +22,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.ValueInput;
-import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.ticks.ContainerSingleItem;
@@ -340,43 +338,62 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveCustomData(CompoundTag nbt) {
-        super.saveCustomData(nbt);
+    protected void saveLogisticsData(CompoundTag nbt) {
+        super.saveLogisticsData(nbt);
 
         // Save Stirling-specific data
-        nbt.putInt("burnTime", burnTime);
-        nbt.putInt("fuelTime", fuelTime);
-        nbt.putDouble("currentGeneration", currentGeneration);
-        nbt.putDouble("generationCarry", generationCarry);
-        nbt.putDouble("pidIntegral", pidController.getIntegral());
+        nbt.putInt("BurnTimeRemaining", burnTime);
+        nbt.putInt("TotalFuelTime", fuelTime);
+        nbt.putDouble("CurrentGeneration", currentGeneration);
+        nbt.putDouble("GenerationCarryover", generationCarry);
+        nbt.putDouble("PIDIntegral", pidController.getIntegral());
 
         // Save fuel inventory using CODEC
         ItemStack fuelStack = inventory.getFirst();
         if (!fuelStack.isEmpty()) {
             ItemStack.CODEC.encodeStart(net.minecraft.nbt.NbtOps.INSTANCE, fuelStack)
                     .result()
-                    .ifPresent(tag -> nbt.put("Fuel", tag));
+                    .ifPresent(tag -> nbt.put("FuelStack", tag));
         }
     }
 
     @Override
-    protected void loadCustomData(CompoundTag nbt) {
-        super.loadCustomData(nbt);
+    protected void loadLogisticsData(CompoundTag nbt) {
+        super.loadLogisticsData(nbt);
 
         // Load Stirling-specific data
-        burnTime = nbt.getInt("burnTime").orElse(0);
-        fuelTime = nbt.getInt("fuelTime").orElse(0);
-        currentGeneration = nbt.getDouble("currentGeneration").orElse(MIN_GENERATION);
-        generationCarry = nbt.getDouble("generationCarry").orElse(0.0);
-        double pidIntegral = nbt.getDouble("pidIntegral").orElse(0.0);
+        burnTime = nbt.getInt("BurnTimeRemaining").orElse(0);
+        fuelTime = nbt.getInt("TotalFuelTime").orElse(0);
+        currentGeneration = nbt.getDouble("CurrentGeneration").orElse(MIN_GENERATION);
+        generationCarry = nbt.getDouble("GenerationCarryover").orElse(0.0);
+        double pidIntegral = nbt.getDouble("PIDIntegral").orElse(0.0);
         pidController.setIntegral(pidIntegral);
 
         // Load fuel inventory using CODEC
         inventory.set(0, ItemStack.EMPTY);
-        if (nbt.contains("Fuel")) {
-            ItemStack.CODEC.parse(net.minecraft.nbt.NbtOps.INSTANCE, nbt.get("Fuel"))
+        if (nbt.contains("FuelStack")) {
+            ItemStack.CODEC.parse(net.minecraft.nbt.NbtOps.INSTANCE, nbt.get("FuelStack"))
                     .result()
                     .ifPresent(stack -> inventory.set(0, stack));
         }
+    }
+
+    @Override
+    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
+        super.loadLegacyData(view); // Loads engine data from "Engine" tag
+
+        // Load Stirling-specific data from old "StirlingData" tag
+        view.read("StirlingData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(stirlingData -> {
+            burnTime = stirlingData.getInt("burnTime").orElse(0);
+            fuelTime = stirlingData.getInt("fuelTime").orElse(0);
+            currentGeneration = stirlingData.getDouble("currentGeneration").orElse(MIN_GENERATION);
+            generationCarry = stirlingData.getDouble("generationCarry").orElse(0.0);
+            double pidIntegral = stirlingData.getDouble("pidIntegral").orElse(0.0);
+            pidController.setIntegral(pidIntegral);
+        });
+
+        // Load fuel from old "Fuel" tag at root level
+        inventory.set(0, ItemStack.EMPTY);
+        view.read("Fuel", ItemStack.CODEC).ifPresent(stack -> inventory.set(0, stack));
     }
 }

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.power.engine.block.entity;
 
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.core.lib.support.ProbeResult;
 import com.logistics.power.engine.PIDController;
 import com.logistics.power.engine.block.StirlingEngineBlock;
@@ -362,11 +363,11 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         super.loadLogisticsData(nbt);
 
         // Load Stirling-specific data
-        burnTime = nbt.getInt("BurnTimeRemaining").orElse(0);
-        fuelTime = nbt.getInt("TotalFuelTime").orElse(0);
-        currentGeneration = nbt.getDouble("CurrentGeneration").orElse(MIN_GENERATION);
-        generationCarry = nbt.getDouble("GenerationCarryover").orElse(0.0);
-        double pidIntegral = nbt.getDouble("PIDIntegral").orElse(0.0);
+        burnTime = NbtCompat.getInt(nbt, "BurnTimeRemaining", 0);
+        fuelTime = NbtCompat.getInt(nbt, "TotalFuelTime", 0);
+        currentGeneration = NbtCompat.getDouble(nbt, "CurrentGeneration", MIN_GENERATION);
+        generationCarry = NbtCompat.getDouble(nbt, "GenerationCarryover", 0.0);
+        double pidIntegral = NbtCompat.getDouble(nbt, "PIDIntegral", 0.0);
         pidController.setIntegral(pidIntegral);
 
         // Load fuel inventory using CODEC
@@ -384,11 +385,11 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
         // Load Stirling-specific data from old "StirlingData" tag
         view.read("StirlingData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(stirlingData -> {
-            burnTime = stirlingData.getInt("burnTime").orElse(0);
-            fuelTime = stirlingData.getInt("fuelTime").orElse(0);
-            currentGeneration = stirlingData.getDouble("currentGeneration").orElse(MIN_GENERATION);
-            generationCarry = stirlingData.getDouble("generationCarry").orElse(0.0);
-            double pidIntegral = stirlingData.getDouble("pidIntegral").orElse(0.0);
+            burnTime = NbtCompat.getInt(stirlingData, "burnTime", 0);
+            fuelTime = NbtCompat.getInt(stirlingData, "fuelTime", 0);
+            currentGeneration = NbtCompat.getDouble(stirlingData, "currentGeneration", MIN_GENERATION);
+            generationCarry = NbtCompat.getDouble(stirlingData, "generationCarry", 0.0);
+            double pidIntegral = NbtCompat.getDouble(stirlingData, "pidIntegral", 0.0);
             pidController.setIntegral(pidIntegral);
         });
 

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -340,39 +340,43 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveAdditional(ValueOutput view) {
-        super.saveAdditional(view);
+    protected void saveCustomData(CompoundTag nbt) {
+        super.saveCustomData(nbt);
 
-        CompoundTag stirlingData = new CompoundTag();
-        stirlingData.putInt("burnTime", burnTime);
-        stirlingData.putInt("fuelTime", fuelTime);
-        stirlingData.putDouble("currentGeneration", currentGeneration);
-        stirlingData.putDouble("generationCarry", generationCarry);
-        stirlingData.putDouble("pidIntegral", pidController.getIntegral());
-        view.store("StirlingData", CompoundTag.CODEC, stirlingData);
+        // Save Stirling-specific data
+        nbt.putInt("burnTime", burnTime);
+        nbt.putInt("fuelTime", fuelTime);
+        nbt.putDouble("currentGeneration", currentGeneration);
+        nbt.putDouble("generationCarry", generationCarry);
+        nbt.putDouble("pidIntegral", pidController.getIntegral());
 
+        // Save fuel inventory using CODEC
         ItemStack fuelStack = inventory.getFirst();
         if (!fuelStack.isEmpty()) {
-            view.store("Fuel", ItemStack.CODEC, fuelStack);
-        } else {
-            view.discard("Fuel");
+            ItemStack.CODEC.encodeStart(net.minecraft.nbt.NbtOps.INSTANCE, fuelStack)
+                    .result()
+                    .ifPresent(tag -> nbt.put("Fuel", tag));
         }
     }
 
     @Override
-    protected void loadAdditional(ValueInput view) {
-        super.loadAdditional(view);
+    protected void loadCustomData(CompoundTag nbt) {
+        super.loadCustomData(nbt);
 
-        view.read("StirlingData", CompoundTag.CODEC).ifPresent(stirlingData -> {
-            burnTime = stirlingData.getInt("burnTime").orElse(0);
-            fuelTime = stirlingData.getInt("fuelTime").orElse(0);
-            currentGeneration = stirlingData.getDouble("currentGeneration").orElse(MIN_GENERATION);
-            generationCarry = stirlingData.getDouble("generationCarry").orElse(0.0);
-            double pidIntegral = stirlingData.getDouble("pidIntegral").orElse(0.0);
-            pidController.setIntegral(pidIntegral);
-        });
+        // Load Stirling-specific data
+        burnTime = nbt.getInt("burnTime").orElse(0);
+        fuelTime = nbt.getInt("fuelTime").orElse(0);
+        currentGeneration = nbt.getDouble("currentGeneration").orElse(MIN_GENERATION);
+        generationCarry = nbt.getDouble("generationCarry").orElse(0.0);
+        double pidIntegral = nbt.getDouble("pidIntegral").orElse(0.0);
+        pidController.setIntegral(pidIntegral);
 
+        // Load fuel inventory using CODEC
         inventory.set(0, ItemStack.EMPTY);
-        view.read("Fuel", ItemStack.CODEC).ifPresent(stack -> inventory.set(0, stack));
+        if (nbt.contains("Fuel")) {
+            ItemStack.CODEC.parse(net.minecraft.nbt.NbtOps.INSTANCE, nbt.get("Fuel"))
+                    .result()
+                    .ifPresent(stack -> inventory.set(0, stack));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Introduces `BaseBlockEntity` to unify how Logistics block entities save/load data and sync updates to clients
- Adds `NbtCompat` abstraction layer for cross-version NBT API compatibility (MC 1.21.5+ vs 1.21.1-1.21.4)
- Implements legacy data migration system for backward compatibility with existing worlds

## Changes

**BaseBlockEntity:**
- `saveLogisticsData` / `loadLogisticsData` / `loadLegacyData` template methods
- `markDirtyAndSync()` helper for consistent state management
- Centralizes MC 1.21.11 ValueOutput/ValueInput API handling
- Automatic "LogisticsData" wrapper for new saves

**NbtCompat:**
- Abstracts Optional-based API (MC 1.21.5+) vs primitive returns (MC 1.21.1-1.21.4)
- Methods: `getInt`, `getLong`, `getDouble`, `getFloat`, `getBoolean`, `getString`, `getIntArray`
- Single place to change when backporting to mc/1.21.1

**Migrated block entities:**
- Laser Quarry - Legacy data loader for Energy/MiningState/CustomBounds tags
- Pipes - Legacy data loader for PipeData tag, improved NBT keys (ItemsInTransit, ConnectionTypes)
- Marker - Legacy data loader for MarkerData tag, improved NBT keys (BoundMinX/Y/Z, IsCornerMarker)
- Engines (Abstract + Creative + Stirling) - Legacy data loader for Engine/CreativeData/StirlingData tags, improved NBT keys (StoredEnergy, Temperature, CycleProgress)
- Creative Sink - Legacy data loader for CreativeSink tag

**NBT improvements:**
- Descriptive PascalCase key names for better self-documentation
- Data massaging pattern in legacy loaders (convert old keys to new format)
- Removed 100+ lines of boilerplate NBT handling

## Notes
- Backward compatible with all existing worlds - legacy loaders verified against git history
- Version-specific code isolated in BaseBlockEntity and NbtCompat for easier cross-version maintenance
- When backporting to mc/1.21.1: update NbtCompat and BaseBlockEntity implementations, all BE code stays the same