### PR TITLE
refactor: centralize resource identifier creation

### DIFF
--- a/src/client/java/com/logistics/automation/render/LaserQuarryBlockEntityRenderer.java
+++ b/src/client/java/com/logistics/automation/render/LaserQuarryBlockEntityRenderer.java
@@ -1,6 +1,6 @@
 package com.logistics.automation.render;
 
-import com.logistics.LogisticsMod;
+import com.logistics.LogisticsAutomation;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.automation.laserquarry.LaserQuarryConfig;
 import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
@@ -32,17 +32,17 @@ import net.minecraft.world.phys.Vec3;
  */
 public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<LaserQuarryBlockEntity, LaserQuarryRenderState> {
     private static final Identifier ARM_MODEL_ID =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/automation/laser_quarry_gantry_arm");
+            LogisticsAutomation.blockModelIdentifier("laser_quarry_gantry_arm");
     private static final Identifier DRILL_MODEL_ID =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/automation/laser_quarry_drill");
+            LogisticsAutomation.blockModelIdentifier("laser_quarry_drill");
     private static final Identifier LED_GREEN_MODEL_ID =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/automation/laser_quarry_led_green");
+            LogisticsAutomation.blockModelIdentifier("laser_quarry_led_green");
     private static final Identifier LED_RED_MODEL_ID =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/automation/laser_quarry_led_red");
+            LogisticsAutomation.blockModelIdentifier("laser_quarry_led_red");
     private static final Identifier DISPLAY_MODEL_ID =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/automation/laser_quarry_display");
+            LogisticsAutomation.blockModelIdentifier("laser_quarry_display");
     private static final Identifier TOP_HATCH_MODEL_ID =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/automation/laser_quarry_top_hatch");
+            LogisticsAutomation.blockModelIdentifier("laser_quarry_top_hatch");
 
     public LaserQuarryBlockEntityRenderer(BlockEntityRendererProvider.Context ctx) {}
 

--- a/src/client/java/com/logistics/core/render/MarkerBlockEntityRenderer.java
+++ b/src/client/java/com/logistics/core/render/MarkerBlockEntityRenderer.java
@@ -1,6 +1,6 @@
 package com.logistics.core.render;
 
-import com.logistics.LogisticsMod;
+import com.logistics.LogisticsCore;
 import com.logistics.core.marker.MarkerBlockEntity;
 import com.logistics.core.marker.MarkerManager;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -23,7 +23,7 @@ import net.minecraft.world.phys.Vec3;
  */
 public class MarkerBlockEntityRenderer implements BlockEntityRenderer<MarkerBlockEntity, MarkerRenderState> {
     private static final Identifier BEAM_MODEL_ID =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/core/marker_beam");
+            LogisticsCore.blockModelIdentifier("marker_beam");
 
     // No tinting needed - texture is pre-colored blue (#0132FD)
     private static final float BEAM_RED = 1.0f;

--- a/src/client/java/com/logistics/core/render/ModelRegistry.java
+++ b/src/client/java/com/logistics/core/render/ModelRegistry.java
@@ -86,7 +86,7 @@ public final class ModelRegistry {
                     return;
                 }
                 String name = relative.substring(0, relative.length() - ".json".length());
-                modelIds.add(Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/" + name));
+                modelIds.add(LogisticsMod.getIdentifier("block/" + name));
             });
         } catch (IOException e) {
             LogisticsMod.LOGGER.warn("Failed to scan model resources", e);

--- a/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
+++ b/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
@@ -2,7 +2,7 @@ package com.logistics.power.render;
 
 import static com.logistics.core.lib.power.AbstractEngineBlockEntity.STAGE;
 
-import com.logistics.LogisticsMod;
+import com.logistics.LogisticsPower;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
 import com.logistics.core.render.ModelRegistry;
@@ -37,24 +37,24 @@ import net.minecraft.world.phys.Vec3;
 public class EngineBlockEntityRenderer implements BlockEntityRenderer<AbstractEngineBlockEntity, EngineRenderState> {
     // Shared model identifiers
     private static final Identifier TRUNK_BASE_MODEL =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/engine_trunk_base");
+            LogisticsPower.blockModelIdentifier("engine_trunk_base");
     private static final Identifier TRUNK_OVERLAY_MODEL =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/engine_trunk_overlay");
-    private static final Identifier CHAMBER_MODEL = Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/engine_chamber");
+            LogisticsPower.blockModelIdentifier("engine_trunk_overlay");
+    private static final Identifier CHAMBER_MODEL = LogisticsPower.blockModelIdentifier("engine_chamber");
 
     // Per-engine model identifiers (base static and moving have engine-specific textures)
     private static final Identifier REDSTONE_BASE_STATIC =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/redstone_engine_base_static");
+            LogisticsPower.blockModelIdentifier("redstone_engine_base_static");
     private static final Identifier REDSTONE_BASE_MOVING =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/redstone_engine_base_moving");
+            LogisticsPower.blockModelIdentifier("redstone_engine_base_moving");
     private static final Identifier STIRLING_BASE_STATIC =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/stirling_engine_base_static");
+            LogisticsPower.blockModelIdentifier("stirling_engine_base_static");
     private static final Identifier STIRLING_BASE_MOVING =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/stirling_engine_base_moving");
+            LogisticsPower.blockModelIdentifier("stirling_engine_base_moving");
     private static final Identifier CREATIVE_BASE_STATIC =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/creative_engine_base_static");
+            LogisticsPower.blockModelIdentifier("creative_engine_base_static");
     private static final Identifier CREATIVE_BASE_MOVING =
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/power/creative_engine_base_moving");
+            LogisticsPower.blockModelIdentifier("creative_engine_base_moving");
 
     // Stage colors (RGB 0-1 range) for trunk tinting
     private static final float[] COLOR_BLUE = {0.2f, 0.4f, 0.8f};

--- a/src/client/java/com/logistics/power/screen/StirlingEngineScreen.java
+++ b/src/client/java/com/logistics/power/screen/StirlingEngineScreen.java
@@ -1,5 +1,6 @@
 package com.logistics.power.screen;
 
+import com.logistics.LogisticsMod;
 import com.logistics.power.engine.ui.StirlingEngineScreenHandler;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -14,7 +15,7 @@ import net.minecraft.world.entity.player.Inventory;
  */
 public class StirlingEngineScreen extends AbstractContainerScreen<StirlingEngineScreenHandler> {
     private static final Identifier BACKGROUND_TEXTURE =
-            Identifier.fromNamespaceAndPath("logistics", "textures/gui/power/stirling_engine.png");
+            LogisticsMod.getIdentifier("textures/gui/power/stirling_engine.png");
 
     // Reuse vanilla's lit flame sprite
     private static final Identifier LIT_PROGRESS_SPRITE = Identifier.withDefaultNamespace("container/furnace/lit_progress");

--- a/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/src/main/java/com/logistics/LogisticsAutomation.java
@@ -25,6 +25,10 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         return INSTANCE.getDomainIdentifier(name);
     }
 
+    public static Identifier blockModelIdentifier(String name) {
+        return INSTANCE.getBlockModelIdentifier(name);
+    }
+
     @Override
     public int order() {
         return 20;

--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -34,6 +34,10 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         return INSTANCE.getDomainIdentifier(name);
     }
 
+    public static Identifier blockModelIdentifier(String name) {
+        return INSTANCE.getBlockModelIdentifier(name);
+    }
+
     @Override
     public void initCommon() {
         LOGGER.info("Registering {}", domain());

--- a/src/main/java/com/logistics/LogisticsMod.java
+++ b/src/main/java/com/logistics/LogisticsMod.java
@@ -53,6 +53,16 @@ public class LogisticsMod implements ModInitializer {
         return getIdentifier(d.isEmpty() ? name : d + "/" + name);
     }
 
+    /**
+     * Creates an identifier for a block model resource.
+     * Automatically prepends "block/" and the domain path.
+     * Example: LogisticsPipe.blockIdentifier("copper_pipe_core") → logistics:block/pipe/copper_pipe_core
+     */
+    @NonNull protected Identifier getBlockModelIdentifier(String name) {
+        String d = domain();
+        return getIdentifier(d.isEmpty() ? "block/" + name : "block/" + d + "/" + name);
+    }
+
     protected Item registerItem(String name, Function<Item.Properties, Item> itemFactory) {
         ResourceKey<Item> itemKey = ResourceKey.create(Registries.ITEM, getDomainIdentifier(name));
         Item item = itemFactory.apply(new Item.Properties().setId(itemKey));

--- a/src/main/java/com/logistics/LogisticsMod.java
+++ b/src/main/java/com/logistics/LogisticsMod.java
@@ -56,7 +56,7 @@ public class LogisticsMod implements ModInitializer {
     /**
      * Creates an identifier for a block model resource.
      * Automatically prepends "block/" and the domain path.
-     * Example: LogisticsPipe.blockIdentifier("copper_pipe_core") → logistics:block/pipe/copper_pipe_core
+     * Example: LogisticsPipe.blockModelIdentifier("copper_pipe_core") → logistics:block/pipe/copper_pipe_core
      */
     @NonNull protected Identifier getBlockModelIdentifier(String name) {
         String d = domain();

--- a/src/main/java/com/logistics/LogisticsPipe.java
+++ b/src/main/java/com/logistics/LogisticsPipe.java
@@ -49,6 +49,10 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
         return INSTANCE.getDomainIdentifier(name);
     }
 
+    public static Identifier blockModelIdentifier(String name) {
+        return INSTANCE.getBlockModelIdentifier(name);
+    }
+
     @Override
     public void initCommon() {
         LOGGER.info("Registering {}", domain());

--- a/src/main/java/com/logistics/LogisticsPower.java
+++ b/src/main/java/com/logistics/LogisticsPower.java
@@ -33,6 +33,10 @@ public final class LogisticsPower extends LogisticsMod implements DomainBootstra
         return INSTANCE.getDomainIdentifier(name);
     }
 
+    public static Identifier blockModelIdentifier(String name) {
+        return INSTANCE.getBlockModelIdentifier(name);
+    }
+
     @Override
     public int order() {
         return 10;

--- a/src/main/java/com/logistics/core/lib/pipe/PipeConnectionRegistry.java
+++ b/src/main/java/com/logistics/core/lib/pipe/PipeConnectionRegistry.java
@@ -25,7 +25,7 @@ public final class PipeConnectionRegistry {
      * Returns a {@link PipeConnection} if a pipe can connect from the given direction, null otherwise.
      */
     public static final BlockApiLookup<PipeConnection, Direction> SIDED = BlockApiLookup.get(
-            Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "pipe_connection"), PipeConnection.class, Direction.class);
+            LogisticsMod.getIdentifier("pipe_connection"), PipeConnection.class, Direction.class);
 
     private PipeConnectionRegistry() {}
 }

--- a/src/main/java/com/logistics/pipe/Pipe.java
+++ b/src/main/java/com/logistics/pipe/Pipe.java
@@ -76,7 +76,7 @@ public class Pipe {
                 return override;
             }
         }
-        return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/" + getPipeName() + "_core");
+        return LogisticsMod.getIdentifier("block/" + getPipeName() + "_core");
     }
 
     /**
@@ -109,7 +109,7 @@ public class Pipe {
         }
 
         String suffix = ctx.isInventoryConnection(direction) ? "_arm_extended" : "_arm";
-        return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/" + getPipeName() + suffix);
+        return LogisticsMod.getIdentifier("block/" + getPipeName() + suffix);
     }
 
     /**

--- a/src/main/java/com/logistics/pipe/modules/BoostModule.java
+++ b/src/main/java/com/logistics/pipe/modules/BoostModule.java
@@ -1,6 +1,5 @@
 package com.logistics.pipe.modules;
 
-import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.PipeContext;
 import net.minecraft.core.Direction;
@@ -29,7 +28,7 @@ public class BoostModule implements Module {
     @Override
     public @Nullable Identifier getCoreModel(PipeContext ctx) {
         if (ctx.isPowered()) {
-            return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/pipe/gold_transport_pipe_core_powered");
+            return LogisticsPipe.blockModelIdentifier("gold_transport_pipe_core_powered");
         }
         return null;
     }
@@ -38,7 +37,7 @@ public class BoostModule implements Module {
     public @Nullable Identifier getPipeArm(PipeContext ctx, Direction direction) {
         if (ctx.isPowered()) {
             String suffix = ctx.isInventoryConnection(direction) ? "_arm_extended_powered" : "_arm_powered";
-            return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/pipe/gold_transport_pipe" + suffix);
+            return LogisticsPipe.blockModelIdentifier("gold_transport_pipe" + suffix);
         }
         return null;
     }

--- a/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
@@ -1,6 +1,5 @@
 package com.logistics.pipe.modules;
 
-import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
@@ -233,7 +232,7 @@ public class ExtractionModule implements Module {
             return null;
         }
         String suffix = ctx.isInventoryConnection(direction) ? "_feature_extended" : "_feature";
-        return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/pipe/item_extractor_pipe" + suffix);
+        return LogisticsPipe.blockModelIdentifier("item_extractor_pipe" + suffix);
     }
 
     private boolean isExtractionFace(PipeContext ctx, Direction direction) {

--- a/src/main/java/com/logistics/pipe/modules/MergerModule.java
+++ b/src/main/java/com/logistics/pipe/modules/MergerModule.java
@@ -1,6 +1,6 @@
 package com.logistics.pipe.modules;
 
-import com.logistics.LogisticsMod;
+import com.logistics.LogisticsPipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.runtime.RoutePlan;
 import java.util.List;
@@ -114,7 +114,7 @@ public class MergerModule implements Module {
             return null;
         }
         String suffix = ctx.isInventoryConnection(direction) ? "_feature_extended" : "_feature";
-        return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/pipe/item_merger_pipe" + suffix);
+        return LogisticsPipe.blockModelIdentifier("item_merger_pipe" + suffix);
     }
 
     private boolean isOutputDirection(PipeContext ctx, Direction direction) {

--- a/src/main/java/com/logistics/pipe/modules/PipeMarkingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/PipeMarkingModule.java
@@ -1,11 +1,10 @@
 package com.logistics.pipe.modules;
 
-import com.logistics.LogisticsMod;
+import com.logistics.LogisticsPipe;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.LogisticsPipe;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
@@ -99,7 +98,7 @@ public class PipeMarkingModule implements Module {
         if (color == null || ctx.pipe() == null) {
             return java.util.List.of();
         }
-        Identifier pipeMarkings = Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/pipe/pipe_markings");
+        Identifier pipeMarkings = LogisticsPipe.blockModelIdentifier("pipe_markings");
         return java.util.List.of(new Pipe.CoreDecoration(pipeMarkings, color.getFireworkColor()));
     }
 

--- a/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
+++ b/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
@@ -1,6 +1,5 @@
 package com.logistics.pipe.modules;
 
-import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
@@ -204,7 +203,7 @@ public class WeatheringModule implements Module {
             return null; // Use default model
         }
         String suffix = getStageSuffix(stage);
-        return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/pipe/copper_transport_pipe_core" + suffix);
+        return LogisticsPipe.blockModelIdentifier("copper_transport_pipe_core" + suffix);
     }
 
     @Override
@@ -215,7 +214,7 @@ public class WeatheringModule implements Module {
         }
         String suffix = getStageSuffix(stage);
         String armType = ctx.isInventoryConnection(direction) ? "_arm_extended" : "_arm";
-        return Identifier.fromNamespaceAndPath(LogisticsMod.MOD_ID, "block/pipe/copper_transport_pipe" + armType + suffix);
+        return LogisticsPipe.blockModelIdentifier("copper_transport_pipe" + armType + suffix);
     }
 
     // --- Item component handling ---


### PR DESCRIPTION
### Summary
- Standardized how the mod builds `Identifier`s for block models and GUI textures across domains (core/pipe/power/automation) to reduce duplication and make backports safer.

### Changes
- Added domain helpers for block model identifiers (e.g., `LogisticsCore/Power/Pipe/Automation.blockModelIdentifier(...)`) and updated renderers/modules to use them.
- Switched remaining hard-coded `Identifier.fromNamespaceAndPath(...)` calls to `LogisticsMod.getIdentifier(...)` where a domain-specific helper isn’t required.
- Normalized the Stirling Engine screen background texture lookup to use the shared identifier helper.

### Notes
- No gameplay/content changes expected; this is a consistency/maintenance improvement aimed at avoiding path/namespace mismatches during future refactors and backports.