### PR TITLE
refactor: add NBT compatibility helpers for compound/list reads

### DIFF
--- a/src/main/java/com/logistics/core/lib/storage/NbtCompat.java
+++ b/src/main/java/com/logistics/core/lib/storage/NbtCompat.java
@@ -1,6 +1,7 @@
 package com.logistics.core.lib.storage;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 
 /**
  * NBT compatibility layer to abstract API differences between Minecraft versions.
@@ -98,5 +99,86 @@ public final class NbtCompat {
      */
     public static int[] getIntArray(CompoundTag tag, String key, int[] defaultValue) {
         return tag.getIntArray(key).orElse(defaultValue);
+    }
+
+    // ==================== Compound Tag Helpers ====================
+
+    /**
+     * Read a compound tag from NBT, or return an empty tag if missing.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> {@code tag.getCompound(key).orElse(new CompoundTag())}
+     * <p><b>mc/1.21.1 backport:</b> Same code works! (getCompound returns CompoundTag directly)
+     */
+    public static CompoundTag getCompoundOrEmpty(CompoundTag tag, String key) {
+        return tag.getCompound(key).orElse(new CompoundTag());
+    }
+
+    /**
+     * Execute action if compound tag exists at key.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> {@code tag.getCompound(key).ifPresent(action)}
+     * <p><b>mc/1.21.1 backport:</b> Same code works!
+     */
+    public static void ifHasCompound(CompoundTag tag, String key, java.util.function.Consumer<CompoundTag> action) {
+        tag.getCompound(key).ifPresent(action);
+    }
+
+    // ==================== List Tag Helpers ====================
+
+    /**
+     * Execute action if list tag exists at key.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> {@code tag.getList(key).ifPresent(action)}
+     * <p><b>mc/1.21.1 backport:</b> {@code if (tag.contains(key)) action.accept(tag.getList(key, 10));}
+     */
+    public static void ifHasList(CompoundTag tag, String key, java.util.function.Consumer<ListTag> action) {
+        tag.getList(key).ifPresent(action);
+    }
+
+    /**
+     * Get list tag or return empty list if missing.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> {@code tag.getList(key).orElseGet(ListTag::new)}
+     * <p><b>mc/1.21.1 backport:</b> {@code tag.contains(key) ? tag.getList(key, 10) : new ListTag()}
+     */
+    public static ListTag getListOrEmpty(CompoundTag tag, String key) {
+        return tag.getList(key).orElseGet(ListTag::new);
+    }
+
+    /**
+     * Execute action if compound tag exists at index in list.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> {@code list.getCompound(index).ifPresent(action)}
+     * <p><b>mc/1.21.1 backport:</b> Same code works!
+     */
+    public static void ifHasCompoundAt(ListTag list, int index, java.util.function.Consumer<CompoundTag> action) {
+        if (index >= 0 && index < list.size()) {
+            list.getCompound(index).ifPresent(action);
+        }
+    }
+
+    /**
+     * Get string at index in list with a default value.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> {@code list.getString(index).orElse(defaultValue)}
+     * <p><b>mc/1.21.1 backport:</b> {@code index < list.size() ? list.getString(index) : defaultValue}
+     */
+    public static String getStringAt(ListTag list, int index, String defaultValue) {
+        if (index >= 0 && index < list.size()) {
+            return list.getString(index).orElse(defaultValue);
+        }
+        return defaultValue;
+    }
+
+    // ==================== Int Array Helper ====================
+
+    /**
+     * Execute action if int array exists at key.
+     *
+     * <p><b>mc/1.21.11 implementation:</b> {@code tag.getIntArray(key).ifPresent(action)}
+     * <p><b>mc/1.21.1 backport:</b> Same code works!
+     */
+    public static void ifHasIntArray(CompoundTag tag, String key, java.util.function.Consumer<int[]> action) {
+        tag.getIntArray(key).ifPresent(action);
     }
 }

--- a/src/main/java/com/logistics/core/lib/storage/NbtCompat.java
+++ b/src/main/java/com/logistics/core/lib/storage/NbtCompat.java
@@ -3,6 +3,8 @@ package com.logistics.core.lib.storage;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 
+import java.util.function.Consumer;
+
 /**
  * NBT compatibility layer to abstract API differences between Minecraft versions.
  *
@@ -119,7 +121,7 @@ public final class NbtCompat {
      * <p><b>mc/1.21.11 implementation:</b> {@code tag.getCompound(key).ifPresent(action)}
      * <p><b>mc/1.21.1 backport:</b> Same code works!
      */
-    public static void ifHasCompound(CompoundTag tag, String key, java.util.function.Consumer<CompoundTag> action) {
+    public static void ifHasCompound(CompoundTag tag, String key, Consumer<CompoundTag> action) {
         tag.getCompound(key).ifPresent(action);
     }
 
@@ -131,7 +133,7 @@ public final class NbtCompat {
      * <p><b>mc/1.21.11 implementation:</b> {@code tag.getList(key).ifPresent(action)}
      * <p><b>mc/1.21.1 backport:</b> {@code if (tag.contains(key)) action.accept(tag.getList(key, 10));}
      */
-    public static void ifHasList(CompoundTag tag, String key, java.util.function.Consumer<ListTag> action) {
+    public static void ifHasList(CompoundTag tag, String key, Consumer<ListTag> action) {
         tag.getList(key).ifPresent(action);
     }
 
@@ -151,7 +153,7 @@ public final class NbtCompat {
      * <p><b>mc/1.21.11 implementation:</b> {@code list.getCompound(index).ifPresent(action)}
      * <p><b>mc/1.21.1 backport:</b> Same code works!
      */
-    public static void ifHasCompoundAt(ListTag list, int index, java.util.function.Consumer<CompoundTag> action) {
+    public static void ifHasCompoundAt(ListTag list, int index, Consumer<CompoundTag> action) {
         if (index >= 0 && index < list.size()) {
             list.getCompound(index).ifPresent(action);
         }
@@ -178,7 +180,7 @@ public final class NbtCompat {
      * <p><b>mc/1.21.11 implementation:</b> {@code tag.getIntArray(key).ifPresent(action)}
      * <p><b>mc/1.21.1 backport:</b> Same code works!
      */
-    public static void ifHasIntArray(CompoundTag tag, String key, java.util.function.Consumer<int[]> action) {
+    public static void ifHasIntArray(CompoundTag tag, String key, Consumer<int[]> action) {
         tag.getIntArray(key).ifPresent(action);
     }
 }

--- a/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/core/marker/MarkerBlockEntity.java
@@ -253,12 +253,10 @@ public class MarkerBlockEntity extends BaseBlockEntity {
     }
 
     private void loadConnectedMarkers(CompoundTag data) {
-        if (data.contains("ConnectedMarkers")) {
-            data.getIntArray("ConnectedMarkers").ifPresent(positions -> {
-                for (int i = 0; i < positions.length / 3; i++) {
-                    connectedMarkers.add(new BlockPos(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]));
-                }
-            });
-        }
+        NbtCompat.ifHasIntArray(data, "ConnectedMarkers", positions -> {
+            for (int i = 0; i < positions.length / 3; i++) {
+                connectedMarkers.add(new BlockPos(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]));
+            }
+        });
     }
 }

--- a/src/main/java/com/logistics/pipe/PipeContext.java
+++ b/src/main/java/com/logistics/pipe/PipeContext.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe;
 
 import com.logistics.core.lib.pipe.PipeConnection;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.Module;
@@ -31,7 +32,7 @@ public record PipeContext(Level world, BlockPos pos, BlockState state, PipeBlock
 
     // Convenience methods for module state access (with Module instance)
     public String getString(Module module, String key, String defaultValue) {
-        return moduleState(module.getStateKey()).getString(key).orElse(defaultValue);
+        return NbtCompat.getString(moduleState(module.getStateKey()), key, defaultValue);
     }
 
     public void saveString(Module module, String key, String value) {
@@ -39,7 +40,7 @@ public record PipeContext(Level world, BlockPos pos, BlockState state, PipeBlock
     }
 
     public int getInt(Module module, String key, int defaultValue) {
-        return moduleState(module.getStateKey()).getInt(key).orElse(defaultValue);
+        return NbtCompat.getInt(moduleState(module.getStateKey()), key, defaultValue);
     }
 
     public void saveInt(Module module, String key, int value) {
@@ -47,7 +48,7 @@ public record PipeContext(Level world, BlockPos pos, BlockState state, PipeBlock
     }
 
     public long getLong(Module module, String key, long defaultValue) {
-        return moduleState(module.getStateKey()).getLong(key).orElse(defaultValue);
+        return NbtCompat.getLong(moduleState(module.getStateKey()), key, defaultValue);
     }
 
     public void saveLong(Module module, String key, long value) {
@@ -70,7 +71,7 @@ public record PipeContext(Level world, BlockPos pos, BlockState state, PipeBlock
     }
 
     public CompoundTag getCompoundTag(Module module, String key) {
-        return moduleState(module.getStateKey()).getCompoundOrEmpty(key);
+        return NbtCompat.getCompoundOrEmpty(moduleState(module.getStateKey()), key);
     }
 
     public void putCompoundTag(Module module, String key, CompoundTag value) {

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -188,40 +188,35 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
 
         // Load traveling items
         travelingItems.clear();
-        if (pipeData.contains("ItemsInTransit")) {
-            pipeData.getList("ItemsInTransit").ifPresent(itemsList -> {
-                for (int i = 0; i < itemsList.size(); i++) {
-                    itemsList.getCompound(i)
-                            .flatMap(itemTag -> TravelingItem.CODEC.parse(NbtOps.INSTANCE, itemTag).result())
-                            .ifPresent(travelingItems::add);
-                }
-            });
-        }
+        NbtCompat.ifHasList(pipeData, "ItemsInTransit", itemsList -> {
+            for (int i = 0; i < itemsList.size(); i++) {
+                NbtCompat.ifHasCompoundAt(itemsList, i, itemTag ->
+                    TravelingItem.CODEC.parse(NbtOps.INSTANCE, itemTag).result()
+                            .ifPresent(travelingItems::add));
+            }
+        });
 
         // Load module state
         // CompoundTag lacks clear() method, so copy keys then remove each
         new ArrayList<>(moduleState.keySet()).forEach(moduleState::remove);
-        if (pipeData.contains("ModuleState")) {
-            pipeData.getCompound("ModuleState").ifPresent(stored -> {
-                for (String key : stored.keySet()) {
-                    moduleState.put(key, Objects.requireNonNull(stored.get(key)).copy());
-                }
-            });
-        }
+        NbtCompat.ifHasCompound(pipeData, "ModuleState", stored -> {
+            for (String key : stored.keySet()) {
+                moduleState.put(key, Objects.requireNonNull(stored.get(key)).copy());
+            }
+        });
 
         // Load connection types
-        if (pipeData.contains("ConnectionTypes")) {
-            CompoundTag connectionsNbt = pipeData.getCompound("ConnectionTypes").orElse(new CompoundTag());
-            // Reset all to NONE first
-            for (int i = 0; i < 6; i++) {
-                connectionTypes[i] = PipeConnection.Type.NONE;
-            }
+        // Reset all to NONE first
+        for (int i = 0; i < 6; i++) {
+            connectionTypes[i] = PipeConnection.Type.NONE;
+        }
+        NbtCompat.ifHasCompound(pipeData, "ConnectionTypes", connectionsNbt -> {
             // Load saved connections
             for (Direction direction : Direction.values()) {
                 String typeName = NbtCompat.getString(connectionsNbt, direction.name().toLowerCase(), "none");
                 connectionTypes[direction.ordinal()] = PipeConnection.Type.fromSerializedName(typeName);
             }
-        }
+        });
 
         long durationMs = (System.nanoTime() - readStart) / 1_000_000L;
         if (durationMs >= 2L && Boolean.getBoolean("logistics.timing")) {
@@ -303,7 +298,7 @@ public class PipeBlockEntity extends BaseBlockEntity implements PipeConnection, 
         if (!moduleState.contains(key)) {
             moduleState.put(key, new CompoundTag());
         }
-        return moduleState.getCompound(key).orElseThrow();
+        return NbtCompat.getCompoundOrEmpty(moduleState, key);
     }
 
     public PipeContext createContext() {

--- a/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.runtime.TravelingItem;
@@ -97,10 +98,7 @@ public class ExtractionModule implements Module {
 
     private @Nullable Direction getExtractionDirection(PipeContext ctx) {
         CompoundTag state = ctx.moduleState(getStateKey());
-        if (!state.contains(EXTRACT_FROM)) {
-            return null;
-        }
-        String directionStr = state.getString(EXTRACT_FROM).orElse("");
+        String directionStr = NbtCompat.getString(state, EXTRACT_FROM, "");
         if (directionStr.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
@@ -1,5 +1,6 @@
 package com.logistics.pipe.modules;
 
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.runtime.RoutePlan;
@@ -103,11 +104,7 @@ public class ItemFilterModule implements Module {
         if (listOpt.isPresent()) {
             ListTag list = listOpt.get();
             for (int i = 0; i < FILTER_SLOTS_PER_SIDE; i++) {
-                if (i < list.size()) {
-                    slots.add(list.getString(i).orElse(""));
-                } else {
-                    slots.add("");
-                }
+                slots.add(NbtCompat.getStringAt(list, i, ""));
             }
         } else {
             // No saved filters - fill with empty strings

--- a/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
@@ -100,17 +100,9 @@ public class ItemFilterModule implements Module {
         CompoundTag filters = ctx.getCompoundTag(this, FILTERS);
         List<String> slots = new ArrayList<>(FILTER_SLOTS_PER_SIDE);
 
-        var listOpt = filters.getList(direction.getName());
-        if (listOpt.isPresent()) {
-            ListTag list = listOpt.get();
-            for (int i = 0; i < FILTER_SLOTS_PER_SIDE; i++) {
-                slots.add(NbtCompat.getStringAt(list, i, ""));
-            }
-        } else {
-            // No saved filters - fill with empty strings
-            for (int i = 0; i < FILTER_SLOTS_PER_SIDE; i++) {
-                slots.add("");
-            }
+        ListTag list = NbtCompat.getListOrEmpty(filters, direction.getName());
+        for (int i = 0; i < FILTER_SLOTS_PER_SIDE; i++) {
+            slots.add(NbtCompat.getStringAt(list, i, ""));
         }
         return slots;
     }

--- a/src/main/java/com/logistics/pipe/modules/MergerModule.java
+++ b/src/main/java/com/logistics/pipe/modules/MergerModule.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.runtime.RoutePlan;
 import java.util.List;
@@ -70,10 +71,7 @@ public class MergerModule implements Module {
 
     private @Nullable Direction getOutputDirection(PipeContext ctx) {
         CompoundTag state = ctx.moduleState(getStateKey());
-        if (!state.contains(OUTPUT_DIRECTION)) {
-            return null;
-        }
-        String directionStr = state.getString(OUTPUT_DIRECTION).orElse("");
+        String directionStr = NbtCompat.getString(state, OUTPUT_DIRECTION, "");
         if (directionStr.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
### Summary
- Improved NBT read compatibility across Minecraft versions by introducing a small helper layer and switching key call sites to use it.

### Changes
- Added new `NbtCompat` helpers for safer/optional reads of:
- Compound tags (get-or-empty, conditional access)
- List tags (get-or-empty, conditional access, indexed reads)
- Int arrays (conditional access)
- Updated pipe, marker, and module NBT loading to use the compatibility helpers, reducing reliance on version-specific Optional-style NBT APIs.

### Notes
- No gameplay/config changes intended; this is focused on more robust world-data loading and smoother backporting between MC versions.