### PR TITLE
ci: use GitHub release body as changelog when publishing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -170,4 +170,4 @@ jobs:
 
           files: build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
-          changelog-file: CHANGELOG.md
+          changelog: ${{ github.event.release.body || format('Release {0}', steps.version.outputs.full_version) }}


### PR DESCRIPTION
### Summary
- Release publishing now uses the GitHub Release description as the changelog content.

### Changes
- Updated the release workflow to pull changelog text from `github.event.release.body`.
- Falls back to a simple “Release <version>” message when no release body is provided.

### Notes
- This keeps published release notes aligned with what’s written in the GitHub Release UI, without requiring `CHANGELOG.md` to be used for the publish step.