### PR TITLE
fix: restore non-overheating engine warm flash and scale piston speed by heat

### DIFF
--- a/src/client/java/com/logistics/LogisticsPowerClient.java
+++ b/src/client/java/com/logistics/LogisticsPowerClient.java
@@ -90,6 +90,11 @@ public final class LogisticsPowerClient implements DomainBootstrap {
     /**
      * Registers block color providers for engines to tint based on heat stage.
      * Uses the STAGE block state property to determine color.
+     *
+     * <p>TODO: The non-overheating flash effect (HOT/WARM oscillation) is driven by block state
+     * changes on the server tick, which causes chunk rebuilds at each half-stroke transition.
+     * The better long-term solution is to render the engine core dynamically in the block entity
+     * renderer, where per-frame animation progress is available for smooth, rebuild-free coloring.
      */
     private void registerEngineBlockColors() {
         ColorProviderRegistry.BLOCK.register((state, level, pos, tintIndex) -> {

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -304,20 +304,23 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
         if (heatLevelRatio < 0.25) return HeatStage.COLD;
         if (heatLevelRatio < 0.50) return HeatStage.COOL;
         if (heatLevelRatio < 0.75) return HeatStage.WARM;
-        if (heatLevelRatio < 1.0 || !canOverheat()) return HeatStage.HOT;
+        if (heatLevelRatio < 1.0 || !canOverheat()) {
+            // Non-overheating engines flash WARM during compression to show max heat without danger
+            if (!canOverheat() && cyclePhase == CyclePhase.COMPRESSION) return HeatStage.WARM;
+            return HeatStage.HOT;
+        }
 
         return HeatStage.OVERHEAT;
     }
 
-    /** Compute the piston speed based on current heat stage. */
+    /** Compute the piston speed based on current heat level. */
     public float getPistonSpeed() {
-        return switch (heatStage) {
-            case COLD -> 0.01f;
-            case COOL -> 0.02f;
-            case WARM -> 0.04f;
-            case HOT -> 0.08f;
-            case OVERHEAT -> 0.0f;
-        };
+        double heatLevel = getHeatLevel();
+        if (heatLevel < 0.25) return 0.01f;
+        if (heatLevel < 0.50) return 0.02f;
+        if (heatLevel < 0.75) return 0.04f;
+        if (heatLevel < 1.0 || !canOverheat()) return 0.08f;
+        return 0.0f; // OVERHEAT
     }
 
     // ==================== Cycle System ====================

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -304,13 +304,10 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
         if (heatLevelRatio < 0.25) return HeatStage.COLD;
         if (heatLevelRatio < 0.50) return HeatStage.COOL;
         if (heatLevelRatio < 0.75) return HeatStage.WARM;
-        if (heatLevelRatio < 1.0 || !canOverheat()) {
-            // Non-overheating engines flash WARM during compression to show max heat without danger
-            if (!canOverheat() && cyclePhase == CyclePhase.COMPRESSION) return HeatStage.WARM;
-            return HeatStage.HOT;
-        }
+        if (heatLevelRatio >= 1.0 && canOverheat()) return HeatStage.OVERHEAT;
 
-        return HeatStage.OVERHEAT;
+        // HOT is the max stage for non-overheating engines; flash WARM during compression as a visual cue
+        return !canOverheat() && cyclePhase == CyclePhase.COMPRESSION ? HeatStage.WARM : HeatStage.HOT;
     }
 
     /** Compute the piston speed based on current heat level. */


### PR DESCRIPTION
## Summary
- Fixes a visual regression where non-overheating engines no longer flashed between WARM/HOT at peak heat.
- Makes piston animation speed respond to actual heat level for more consistent behavior near thresholds.

## Changes
- Non-overheating engines now flash **WARM** during the compression half of the cycle when at max heat, matching prior “hot-but-safe” feedback.
- Piston speed is now computed from the engine’s **heat level** rather than the discrete heat stage.

## Notes
- The WARM/HOT flashing is currently driven by server-side blockstate changes, which can trigger extra chunk rebuilds during the animation.
- Fixes #109 