### PR TITLE
fix: preserve copper pipe weathering in item state and models

### DIFF
--- a/src/main/java/com/logistics/pipe/Pipe.java
+++ b/src/main/java/com/logistics/pipe/Pipe.java
@@ -9,6 +9,7 @@ import com.logistics.pipe.runtime.RoutePlan;
 import com.logistics.pipe.runtime.TravelingItem;
 import java.util.ArrayList;
 import java.util.List;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -16,6 +17,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.component.CustomModelData;
 import org.jetbrains.annotations.Nullable;
 
 public class Pipe {
@@ -162,22 +164,38 @@ public class Pipe {
 
     /**
      * Add item components from all modules when the block is broken.
-     * Also adds custom model data component if any module provides model data strings.
-     *
-     * <p><b>MC 1.21.1:</b> No-op stub - component system doesn't exist.
-     * Copper pipes lose oxidation state when picked up in this version.
+     * Also adds custom model data component if any module provides model data.
      */
-    public void addItemComponents(Object builder, PipeContext ctx) {
-        // No-op in MC 1.21.1 - component system doesn't exist
+    public void addItemComponents(DataComponentMap.Builder builder, PipeContext ctx) {
+        for (Module module : modules) {
+            module.addItemComponents(builder, ctx);
+        }
+
+        // Aggregate custom model data integer from all modules (MC 1.21.1 uses int-based CMD)
+        int modelValue = 0;
+        for (Module module : modules) {
+            int v = module.getCustomModelDataValue(ctx);
+            if (v != 0) {
+                modelValue = v;
+                break;
+            }
+        }
+        if (modelValue != 0) {
+            builder.set(net.minecraft.core.component.DataComponents.CUSTOM_MODEL_DATA,
+                    new CustomModelData(modelValue));
+        }
     }
 
     /**
      * Read item components into all modules when the block is placed.
      *
-     * <p><b>MC 1.21.1:</b> No-op stub - component system doesn't exist.
+     * <p><b>Note:</b> The parameter type differs between MC versions.
+     * In MC 1.21.1 it is {@code BlockEntity.DataComponentInput}.
      */
     public void readItemComponents(Object components, PipeContext ctx) {
-        // No-op in MC 1.21.1 - component system doesn't exist
+        for (Module module : modules) {
+            module.readItemComponents(components, ctx);
+        }
     }
 
     /**
@@ -196,11 +214,14 @@ public class Pipe {
     /**
      * Get the item name suffix from item components.
      * Used for item display names when we don't have a block context.
-     *
-     * <p><b>MC 1.21.1:</b> No-op stub - always returns empty string.
      */
     public String getItemNameSuffixFromComponents(Object components) {
-        // No-op in MC 1.21.1 - component system doesn't exist
+        for (Module module : modules) {
+            String suffix = module.getItemNameSuffixFromComponents(components);
+            if (!suffix.isEmpty()) {
+                return suffix;
+            }
+        }
         return "";
     }
 

--- a/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
@@ -299,9 +300,15 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
 
     @Override
     public ItemStack getCloneItemStack(LevelReader world, BlockPos pos, BlockState state) {
-        // MC 1.21.1: Component system doesn't exist, so pipes lose state when picked
-        // This means copper pipes lose oxidation/waxing state when picked with middle click
-        return super.getCloneItemStack(world, pos, state);
+        ItemStack stack = super.getCloneItemStack(world, pos, state);
+
+        // Copy components from block entity to preserve weathering state on pick-block.
+        BlockEntity blockEntity = world.getBlockEntity(pos);
+        if (blockEntity instanceof PipeBlockEntity pipeEntity) {
+            stack.applyComponents(pipeEntity.collectComponents());
+        }
+
+        return stack;
     }
 
     @Override

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -12,6 +12,8 @@ import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
+import com.logistics.pipe.data.PipeDataComponents.WeatheringState;
+import com.logistics.pipe.modules.WeatheringModule;
 import com.logistics.pipe.runtime.PipeRuntime;
 import com.logistics.pipe.runtime.TravelingItem;
 import java.util.ArrayList;
@@ -22,12 +24,14 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
@@ -334,6 +338,42 @@ public class PipeBlockEntity extends BaseBlockEntity
 
     public PipeContext createContext() {
         return new PipeContext(level, worldPosition, getBlockState(), this);
+    }
+
+    // --- Component handling for item drops ---
+
+    @Override
+    protected void collectImplicitComponents(DataComponentMap.Builder builder) {
+        super.collectImplicitComponents(builder);
+
+        BlockState state = getBlockState();
+        if (!(state.getBlock() instanceof PipeBlock pipeBlock)) return;
+
+        Pipe pipe = pipeBlock.getPipe();
+        if (pipe == null) return;
+
+        pipe.addItemComponents(builder, createContext());
+    }
+
+    @Override
+    protected void applyImplicitComponents(BlockEntity.DataComponentInput components) {
+        super.applyImplicitComponents(components);
+
+        BlockState state = getBlockState();
+        if (!(state.getBlock() instanceof PipeBlock pipeBlock)) return;
+
+        Pipe pipe = pipeBlock.getPipe();
+        if (pipe == null) return;
+
+        // Apply weathering state directly - DataComponentInput has protected access
+        // so we handle it here in the BlockEntity subclass rather than in module code.
+        WeatheringState ws = components.get(LogisticsPipe.DATA.WEATHERING_STATE);
+        if (ws != null && !ws.isDefault()) {
+            WeatheringModule wm = pipe.getModule(WeatheringModule.class);
+            if (wm != null) {
+                wm.applyWeatheringState(ws, createContext());
+            }
+        }
     }
 
     public int getLastConnectionsMask() {

--- a/src/main/java/com/logistics/pipe/modules/Module.java
+++ b/src/main/java/com/logistics/pipe/modules/Module.java
@@ -6,6 +6,7 @@ import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.runtime.RoutePlan;
 import java.util.List;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionResult;
@@ -152,20 +153,20 @@ public interface Module {
      * Add components to the item stack when the block is broken.
      * Called for each module to allow adding custom components to dropped items.
      *
-     * <p><b>MC 1.21.1:</b> No-op stub - component system doesn't exist.
-     *
-     * @param builder the component map builder (Object in MC 1.21.1)
+     * @param builder the component map builder
      * @param ctx the pipe context
      */
-    default void addItemComponents(Object builder, PipeContext ctx) {}
+    default void addItemComponents(DataComponentMap.Builder builder, PipeContext ctx) {}
 
     /**
      * Read components from the item stack when the block is placed.
      * Called for each module to allow reading custom components from placed items.
      *
-     * <p><b>MC 1.21.1:</b> No-op stub - component system doesn't exist.
+     * <p><b>Note:</b> The parameter type differs between MC versions:
+     * MC 1.21.1 passes {@code BlockEntity.DataComponentInput};
+     * newer versions pass {@code DataComponentGetter}.
      *
-     * @param components the components from the item (Object in MC 1.21.1)
+     * @param components the components from the item
      * @param ctx the pipe context
      */
     default void readItemComponents(Object components, PipeContext ctx) {}
@@ -179,6 +180,18 @@ public interface Module {
      */
     default List<String> getCustomModelDataStrings(PipeContext ctx) {
         return List.of();
+    }
+
+    /**
+     * Get custom model data integer value for item model selection.
+     * Used in MC 1.21.1 where CustomModelData is an integer, not a string list.
+     * Return 0 for no custom model data.
+     *
+     * @param ctx the pipe context
+     * @return integer model data value, or 0 for none
+     */
+    default int getCustomModelDataValue(PipeContext ctx) {
+        return 0;
     }
 
     /**
@@ -197,9 +210,11 @@ public interface Module {
      * Used for item display names when we don't have a block context.
      * For example, ".exposed" or ".waxed.oxidized" for weathering states.
      *
-     * <p><b>MC 1.21.1:</b> No-op stub - always returns empty string.
+     * <p><b>Note:</b> The parameter is an {@code ItemStack} (which implements
+     * {@code DataComponentHolder} in MC 1.21.1 and {@code DataComponentGetter}
+     * in newer versions). Use {@code DataComponentHolder} cast to read components.
      *
-     * @param components the item components (Object in MC 1.21.1)
+     * @param components the item stack (as Object to bridge version differences)
      * @return the translation key suffix, or empty string for default name
      */
     default String getItemNameSuffixFromComponents(Object components) {

--- a/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
+++ b/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
@@ -9,6 +9,8 @@ import com.logistics.pipe.data.PipeDataComponents.WeatheringState;
 import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -217,27 +219,38 @@ public class WeatheringModule implements Module {
     // --- Item component handling ---
 
     @Override
-    public void addItemComponents(Object builder, PipeContext ctx) {
-        // No-op in MC 1.21.1 - component system doesn't exist
-        // Copper pipes lose oxidation state when picked up
+    public void addItemComponents(DataComponentMap.Builder builder, PipeContext ctx) {
+        int stage = getOxidationStage(ctx);
+        boolean waxed = isWaxed(ctx);
+
+        WeatheringState state = new WeatheringState(stage, waxed);
+        if (!state.isDefault()) {
+            builder.set(LogisticsPipe.DATA.WEATHERING_STATE, state);
+        }
     }
 
     @Override
     public void readItemComponents(Object components, PipeContext ctx) {
-        // No-op in MC 1.21.1 - component system doesn't exist
+        // In MC 1.21.1, BlockEntity.DataComponentInput has protected access,
+        // so reading is handled directly in PipeBlockEntity.applyImplicitComponents.
+    }
+
+    /**
+     * Applies the given weathering state to this module's persistent storage.
+     * Called from PipeBlockEntity where DataComponentInput is accessible.
+     */
+    public void applyWeatheringState(WeatheringState state, PipeContext ctx) {
+        ctx.saveInt(this, OXIDATION_KEY, state.oxidationStage());
+        ctx.saveInt(this, WAXED_KEY, state.waxed() ? 1 : 0);
     }
 
     @Override
-    public List<String> getCustomModelDataStrings(PipeContext ctx) {
+    public int getCustomModelDataValue(PipeContext ctx) {
         int stage = getOxidationStage(ctx);
         boolean waxed = isWaxed(ctx);
-
-        if (stage == STAGE_UNAFFECTED && !waxed) {
-            return List.of();
-        }
-
-        String modelKey = getModelKey(stage, waxed);
-        return List.of(modelKey);
+        // Encode stage + waxed as a single integer: 1-4 = unwaxed stages, 5-8 = waxed stages
+        if (stage == STAGE_UNAFFECTED && !waxed) return 0;
+        return waxed ? stage + 5 : stage;
     }
 
     @Override
@@ -249,14 +262,38 @@ public class WeatheringModule implements Module {
 
     @Override
     public String getItemNameSuffixFromComponents(Object components) {
-        // No-op in MC 1.21.1 - component system doesn't exist
-        return "";
+        // components is an ItemStack (implements DataComponentHolder) in MC 1.21.1
+        if (!(components instanceof DataComponentHolder holder)) return "";
+        WeatheringState state = holder.get(LogisticsPipe.DATA.WEATHERING_STATE);
+        if (state == null || state.isDefault()) return "";
+        return buildItemNameSuffix(state.oxidationStage(), state.waxed());
     }
 
     @Override
     public void appendCreativeMenuVariants(List<ItemStack> stacks, ItemStack baseStack) {
-        // No-op in MC 1.21.1 - component system doesn't exist
-        // Only base (unoxidized) copper pipes appear in creative menu
+        // Add all oxidation stages (unwaxed)
+        for (int stage = STAGE_EXPOSED; stage <= STAGE_OXIDIZED; stage++) {
+            stacks.add(createVariant(baseStack, stage, false));
+        }
+
+        // Add all waxed variants (including waxed unaffected)
+        for (int stage = STAGE_UNAFFECTED; stage <= STAGE_OXIDIZED; stage++) {
+            stacks.add(createVariant(baseStack, stage, true));
+        }
+    }
+
+    private static ItemStack createVariant(ItemStack baseStack, int stage, boolean waxed) {
+        ItemStack stack = baseStack.copy();
+        stack.set(LogisticsPipe.DATA.WEATHERING_STATE, new WeatheringState(stage, waxed));
+
+        // Add integer-based custom model data for item model variant selection
+        int modelValue = waxed ? stage + 5 : stage;
+        if (modelValue != 0) {
+            stack.set(net.minecraft.core.component.DataComponents.CUSTOM_MODEL_DATA,
+                    new CustomModelData(modelValue));
+        }
+
+        return stack;
     }
 
     private static String buildItemNameSuffix(int stage, boolean waxed) {
@@ -274,20 +311,4 @@ public class WeatheringModule implements Module {
         return oxidationSuffix;
     }
 
-    private static String getModelKey(int stage, boolean waxed) {
-        String stageName =
-                switch (stage) {
-                    case STAGE_EXPOSED -> "exposed";
-                    case STAGE_WEATHERED -> "weathered";
-                    case STAGE_OXIDIZED -> "oxidized";
-                    default -> "";
-                };
-
-        if (waxed && !stageName.isEmpty()) {
-            return "waxed_" + stageName;
-        } else if (waxed) {
-            return "waxed";
-        }
-        return stageName;
-    }
 }

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe.json
@@ -34,5 +34,14 @@
     "particle": "logistics:block/pipe/copper_pipe_core",
     "core": "logistics:block/pipe/copper_pipe_core",
     "arm":  "logistics:block/pipe/copper_pipe_arm"
-  }
+  },
+  "overrides": [
+    {"predicate": {"custom_model_data": 1}, "model": "logistics:item/pipe/copper_transport_pipe_exposed"},
+    {"predicate": {"custom_model_data": 2}, "model": "logistics:item/pipe/copper_transport_pipe_weathered"},
+    {"predicate": {"custom_model_data": 3}, "model": "logistics:item/pipe/copper_transport_pipe_oxidized"},
+    {"predicate": {"custom_model_data": 5}, "model": "logistics:item/pipe/copper_transport_pipe_waxed"},
+    {"predicate": {"custom_model_data": 6}, "model": "logistics:item/pipe/copper_transport_pipe_waxed_exposed"},
+    {"predicate": {"custom_model_data": 7}, "model": "logistics:item/pipe/copper_transport_pipe_waxed_weathered"},
+    {"predicate": {"custom_model_data": 8}, "model": "logistics:item/pipe/copper_transport_pipe_waxed_oxidized"}
+  ]
 }

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_exposed.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_exposed.json
@@ -1,0 +1,8 @@
+{
+  "parent": "logistics:item/pipe/copper_transport_pipe",
+  "textures": {
+    "particle": "logistics:block/pipe/copper_pipe_core_exposed",
+    "core": "logistics:block/pipe/copper_pipe_core_exposed",
+    "arm":  "logistics:block/pipe/copper_pipe_arm_exposed"
+  }
+}

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_oxidized.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_oxidized.json
@@ -1,0 +1,8 @@
+{
+  "parent": "logistics:item/pipe/copper_transport_pipe",
+  "textures": {
+    "particle": "logistics:block/pipe/copper_pipe_core_oxidized",
+    "core": "logistics:block/pipe/copper_pipe_core_oxidized",
+    "arm":  "logistics:block/pipe/copper_pipe_arm_oxidized"
+  }
+}

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed.json
@@ -1,0 +1,8 @@
+{
+  "parent": "logistics:item/pipe/copper_transport_pipe",
+  "textures": {
+    "particle": "logistics:block/pipe/copper_pipe_core",
+    "core": "logistics:block/pipe/copper_pipe_core",
+    "arm":  "logistics:block/pipe/copper_pipe_arm"
+  }
+}

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed_exposed.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed_exposed.json
@@ -1,0 +1,8 @@
+{
+  "parent": "logistics:item/pipe/copper_transport_pipe",
+  "textures": {
+    "particle": "logistics:block/pipe/copper_pipe_core_exposed",
+    "core": "logistics:block/pipe/copper_pipe_core_exposed",
+    "arm":  "logistics:block/pipe/copper_pipe_arm_exposed"
+  }
+}

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed_oxidized.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed_oxidized.json
@@ -1,0 +1,8 @@
+{
+  "parent": "logistics:item/pipe/copper_transport_pipe",
+  "textures": {
+    "particle": "logistics:block/pipe/copper_pipe_core_oxidized",
+    "core": "logistics:block/pipe/copper_pipe_core_oxidized",
+    "arm":  "logistics:block/pipe/copper_pipe_arm_oxidized"
+  }
+}

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed_weathered.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_waxed_weathered.json
@@ -1,0 +1,8 @@
+{
+  "parent": "logistics:item/pipe/copper_transport_pipe",
+  "textures": {
+    "particle": "logistics:block/pipe/copper_pipe_core_weathered",
+    "core": "logistics:block/pipe/copper_pipe_core_weathered",
+    "arm":  "logistics:block/pipe/copper_pipe_arm_weathered"
+  }
+}

--- a/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_weathered.json
+++ b/src/main/resources/assets/logistics/models/item/pipe/copper_transport_pipe_weathered.json
@@ -1,0 +1,8 @@
+{
+  "parent": "logistics:item/pipe/copper_transport_pipe",
+  "textures": {
+    "particle": "logistics:block/pipe/copper_pipe_core_weathered",
+    "core": "logistics:block/pipe/copper_pipe_core_weathered",
+    "arm":  "logistics:block/pipe/copper_pipe_arm_weathered"
+  }
+}


### PR DESCRIPTION
## Summary
- Copper transport pipes now retain oxidation and waxing state when converted to an item and when placed back down, preventing accidental loss of progress/appearance.

## Changes
- Persist copper pipe weathering (oxidation stage + waxed) into item components so drops and pick-block keep the correct variant.
- Update item model selection to reflect weathering via `custom_model_data` overrides, adding dedicated models for exposed/weathered/oxidized and waxed variants.
- Expand creative inventory variants so all copper pipe weathering states are available for testing/building.

## Notes
- This primarily affects *item form* presentation and state retention; placed blocks continue to weather as before, but now round-trip correctly through item stacks.