### PR TITLE
refactor: register laser quarry renderer models via ModelLoadingPlugin

### DIFF
--- a/src/client/java/com/logistics/LogisticsAutomationClient.java
+++ b/src/client/java/com/logistics/LogisticsAutomationClient.java
@@ -28,13 +28,6 @@ public final class LogisticsAutomationClient implements DomainBootstrap {
             Identifier display = LogisticsAutomation.blockModelIdentifier("laser_quarry_display");
             Identifier topHatch = LogisticsAutomation.blockModelIdentifier("laser_quarry_top_hatch");
 
-            MODEL.ARM = ExtraModelKey.create(arm::toString);
-            MODEL.DRILL = ExtraModelKey.create(drill::toString);
-            MODEL.LED_GREEN = ExtraModelKey.create(ledGreen::toString);
-            MODEL.LED_RED = ExtraModelKey.create(ledRed::toString);
-            MODEL.DISPLAY = ExtraModelKey.create(display::toString);
-            MODEL.TOP_HATCH = ExtraModelKey.create(topHatch::toString);
-
             pluginContext.addModel(MODEL.ARM, SimpleUnbakedExtraModel.blockStateModel(arm));
             pluginContext.addModel(MODEL.DRILL, SimpleUnbakedExtraModel.blockStateModel(drill));
             pluginContext.addModel(MODEL.LED_GREEN, SimpleUnbakedExtraModel.blockStateModel(ledGreen));
@@ -74,12 +67,18 @@ public final class LogisticsAutomationClient implements DomainBootstrap {
     }
 
     public static final class MODEL {
-        public static ExtraModelKey<BlockStateModel> ARM;
-        public static ExtraModelKey<BlockStateModel> DRILL;
-        public static ExtraModelKey<BlockStateModel> LED_GREEN;
-        public static ExtraModelKey<BlockStateModel> LED_RED;
-        public static ExtraModelKey<BlockStateModel> DISPLAY;
-        public static ExtraModelKey<BlockStateModel> TOP_HATCH;
+        public static final ExtraModelKey<BlockStateModel> ARM =
+                ExtraModelKey.create(() -> LogisticsAutomation.blockModelIdentifier("laser_quarry_gantry_arm").toString());
+        public static final ExtraModelKey<BlockStateModel> DRILL =
+                ExtraModelKey.create(() -> LogisticsAutomation.blockModelIdentifier("laser_quarry_drill").toString());
+        public static final ExtraModelKey<BlockStateModel> LED_GREEN =
+                ExtraModelKey.create(() -> LogisticsAutomation.blockModelIdentifier("laser_quarry_led_green").toString());
+        public static final ExtraModelKey<BlockStateModel> LED_RED =
+                ExtraModelKey.create(() -> LogisticsAutomation.blockModelIdentifier("laser_quarry_led_red").toString());
+        public static final ExtraModelKey<BlockStateModel> DISPLAY =
+                ExtraModelKey.create(() -> LogisticsAutomation.blockModelIdentifier("laser_quarry_display").toString());
+        public static final ExtraModelKey<BlockStateModel> TOP_HATCH =
+                ExtraModelKey.create(() -> LogisticsAutomation.blockModelIdentifier("laser_quarry_top_hatch").toString());
 
         private MODEL() {}
     }

--- a/src/client/java/com/logistics/LogisticsAutomationClient.java
+++ b/src/client/java/com/logistics/LogisticsAutomationClient.java
@@ -6,16 +6,42 @@ import com.logistics.automation.render.LaserQuarryRenderState;
 import com.logistics.core.bootstrap.DomainBootstrap;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.model.loading.v1.ExtraModelKey;
+import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
+import net.fabricmc.fabric.api.client.model.loading.v1.SimpleUnbakedExtraModel;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockRenderLayerMap;
+import net.minecraft.client.renderer.block.model.BlockStateModel;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
+import net.minecraft.resources.Identifier;
 
 import static com.logistics.LogisticsMod.LOGGER;
 
 public final class LogisticsAutomationClient implements DomainBootstrap {
     public LogisticsAutomationClient() {
-        // Public constructor for direct instantiation
+        ModelLoadingPlugin.register(pluginContext -> {
+            Identifier arm = LogisticsAutomation.blockModelIdentifier("laser_quarry_gantry_arm");
+            Identifier drill = LogisticsAutomation.blockModelIdentifier("laser_quarry_drill");
+            Identifier ledGreen = LogisticsAutomation.blockModelIdentifier("laser_quarry_led_green");
+            Identifier ledRed = LogisticsAutomation.blockModelIdentifier("laser_quarry_led_red");
+            Identifier display = LogisticsAutomation.blockModelIdentifier("laser_quarry_display");
+            Identifier topHatch = LogisticsAutomation.blockModelIdentifier("laser_quarry_top_hatch");
+
+            MODEL.ARM = ExtraModelKey.create(arm::toString);
+            MODEL.DRILL = ExtraModelKey.create(drill::toString);
+            MODEL.LED_GREEN = ExtraModelKey.create(ledGreen::toString);
+            MODEL.LED_RED = ExtraModelKey.create(ledRed::toString);
+            MODEL.DISPLAY = ExtraModelKey.create(display::toString);
+            MODEL.TOP_HATCH = ExtraModelKey.create(topHatch::toString);
+
+            pluginContext.addModel(MODEL.ARM, SimpleUnbakedExtraModel.blockStateModel(arm));
+            pluginContext.addModel(MODEL.DRILL, SimpleUnbakedExtraModel.blockStateModel(drill));
+            pluginContext.addModel(MODEL.LED_GREEN, SimpleUnbakedExtraModel.blockStateModel(ledGreen));
+            pluginContext.addModel(MODEL.LED_RED, SimpleUnbakedExtraModel.blockStateModel(ledRed));
+            pluginContext.addModel(MODEL.DISPLAY, SimpleUnbakedExtraModel.blockStateModel(display));
+            pluginContext.addModel(MODEL.TOP_HATCH, SimpleUnbakedExtraModel.blockStateModel(topHatch));
+        });
     }
 
     @Override
@@ -45,5 +71,16 @@ public final class LogisticsAutomationClient implements DomainBootstrap {
         ClientPlayConnectionEvents.DISCONNECT.register(
                 (handler, client) -> ClientRenderCacheHooks.clearAllInterpolationCaches());
         ClientLifecycleEvents.CLIENT_STOPPING.register(client -> ClientRenderCacheHooks.clearAllInterpolationCaches());
+    }
+
+    public static final class MODEL {
+        public static ExtraModelKey<BlockStateModel> ARM;
+        public static ExtraModelKey<BlockStateModel> DRILL;
+        public static ExtraModelKey<BlockStateModel> LED_GREEN;
+        public static ExtraModelKey<BlockStateModel> LED_RED;
+        public static ExtraModelKey<BlockStateModel> DISPLAY;
+        public static ExtraModelKey<BlockStateModel> TOP_HATCH;
+
+        private MODEL() {}
     }
 }

--- a/src/client/java/com/logistics/automation/render/LaserQuarryBlockEntityRenderer.java
+++ b/src/client/java/com/logistics/automation/render/LaserQuarryBlockEntityRenderer.java
@@ -1,13 +1,15 @@
 package com.logistics.automation.render;
 
-import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsAutomationClient;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.automation.laserquarry.LaserQuarryConfig;
 import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
-import com.logistics.core.render.ModelRegistry;
 import com.logistics.pipe.block.PipeBlock;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
+import net.fabricmc.fabric.api.client.model.loading.v1.ExtraModelKey;
+import net.fabricmc.fabric.api.client.model.loading.v1.FabricBakedModelManager;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.model.BlockStateModel;
@@ -19,7 +21,6 @@ import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.state.BlockState;
@@ -31,20 +32,16 @@ import net.minecraft.world.phys.Vec3;
  * that moves smoothly to the current mining position.
  */
 public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<LaserQuarryBlockEntity, LaserQuarryRenderState> {
-    private static final Identifier ARM_MODEL_ID =
-            LogisticsAutomation.blockModelIdentifier("laser_quarry_gantry_arm");
-    private static final Identifier DRILL_MODEL_ID =
-            LogisticsAutomation.blockModelIdentifier("laser_quarry_drill");
-    private static final Identifier LED_GREEN_MODEL_ID =
-            LogisticsAutomation.blockModelIdentifier("laser_quarry_led_green");
-    private static final Identifier LED_RED_MODEL_ID =
-            LogisticsAutomation.blockModelIdentifier("laser_quarry_led_red");
-    private static final Identifier DISPLAY_MODEL_ID =
-            LogisticsAutomation.blockModelIdentifier("laser_quarry_display");
-    private static final Identifier TOP_HATCH_MODEL_ID =
-            LogisticsAutomation.blockModelIdentifier("laser_quarry_top_hatch");
-
     public LaserQuarryBlockEntityRenderer(BlockEntityRendererProvider.Context ctx) {}
+
+    private BlockStateModel getModel(ExtraModelKey<BlockStateModel> key) {
+        FabricBakedModelManager modelManager = (FabricBakedModelManager) Minecraft.getInstance().getModelManager();
+        BlockStateModel model = modelManager.getModel(key);
+        if (model == null || model == Minecraft.getInstance().getModelManager().getMissingBlockStateModel()) {
+            return null;
+        }
+        return model;
+    }
 
     @Override
     public LaserQuarryRenderState createRenderState() {
@@ -165,7 +162,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
             return;
         }
 
-        BlockStateModel armModel = ModelRegistry.getModel(ARM_MODEL_ID);
+        BlockStateModel armModel = getModel(LogisticsAutomationClient.MODEL.ARM);
         if (armModel == null) {
             return;
         }
@@ -228,7 +225,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
         }
 
         // Render drill head at the bottom of the vertical beam
-        BlockStateModel drillModel = ModelRegistry.getModel(DRILL_MODEL_ID);
+        BlockStateModel drillModel = getModel(LogisticsAutomationClient.MODEL.DRILL);
         if (drillModel != null) {
             matrices.pushPose();
             // Position drill at arm location, offset to center the model
@@ -358,7 +355,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
 
         // Green LED - instant on, gradual fade off over 12 ticks
         if (state.greenLedBrightness > 0) {
-            BlockStateModel greenLed = ModelRegistry.getModel(LED_GREEN_MODEL_ID);
+            BlockStateModel greenLed = getModel(LogisticsAutomationClient.MODEL.LED_GREEN);
             if (greenLed != null) {
                 matrices.pushPose();
                 matrices.translate(0.5, 0.5, 0.5);
@@ -375,7 +372,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
 
         // Red LED - brightness proportional to energy level (0-15)
         if (state.energyLevel > 0) {
-            BlockStateModel redLed = ModelRegistry.getModel(LED_RED_MODEL_ID);
+            BlockStateModel redLed = getModel(LogisticsAutomationClient.MODEL.LED_RED);
             if (redLed != null) {
                 matrices.pushPose();
                 matrices.translate(0.5, 0.5, 0.5);
@@ -393,7 +390,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
         // Display overlay - scrolling data screen (animated via .mcmeta)
         // Follows green LED: on when working, fades out when stopped
         if (state.greenLedBrightness > 0) {
-            BlockStateModel display = ModelRegistry.getModel(DISPLAY_MODEL_ID);
+            BlockStateModel display = getModel(LogisticsAutomationClient.MODEL.DISPLAY);
             if (display != null) {
                 matrices.pushPose();
                 matrices.translate(0.5, 0.5, 0.5);
@@ -414,7 +411,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
             return;
         }
 
-        BlockStateModel hatch = ModelRegistry.getModel(TOP_HATCH_MODEL_ID);
+        BlockStateModel hatch = getModel(LogisticsAutomationClient.MODEL.TOP_HATCH);
         if (hatch == null) {
             return;
         }


### PR DESCRIPTION
## Summary
- Moved Laser Quarry renderer model registration to Fabric’s `ModelLoadingPlugin`, avoiding reliance on the project’s model registry.

## Changes
- Laser Quarry extra renderer models (arm, drill, LEDs, display, top hatch) are now registered through Fabric’s model loading pipeline.
- Renderer now resolves these models via Fabric’s baked model manager and gracefully skips rendering when a model is missing.

## Notes
- No gameplay behavior changes intended; this primarily improves client-side model loading reliability and reduces coupling to custom model registry code.