### PR TITLE
fix: register mod content during common initialization

### DIFF
--- a/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/src/main/java/com/logistics/LogisticsAutomation.java
@@ -38,6 +38,9 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     public void initCommon() {
         LOGGER.info("Registering {}", domain());
 
+        BLOCK.register();
+        ENTITY.register();
+
         registerLegacyAliases();
         addCreativeTabEntries();
 
@@ -52,17 +55,26 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     public static final class BLOCK {
         private BLOCK() {}
 
-        public static final Block LASER_QUARRY = INSTANCE.registerBlockWithItem("laser_quarry",
-            props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
-        public static final Block LASER_QUARRY_FRAME = INSTANCE.registerBlock("laser_quarry_frame",
-            props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
+        public static Block LASER_QUARRY;
+        public static Block LASER_QUARRY_FRAME;
+
+        static void register() {
+            LASER_QUARRY = INSTANCE.registerBlockWithItem("laser_quarry",
+                props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
+            LASER_QUARRY_FRAME = INSTANCE.registerBlock("laser_quarry_frame",
+                props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
+        }
     }
 
     public static final class ENTITY {
         private ENTITY() {}
 
-        public static final BlockEntityType<LaserQuarryBlockEntity> LASER_QUARRY_BLOCK_ENTITY =
-            INSTANCE.registerBlockEntity("laser_quarry", LaserQuarryBlockEntity::new, BLOCK.LASER_QUARRY);
+        public static BlockEntityType<LaserQuarryBlockEntity> LASER_QUARRY_BLOCK_ENTITY;
+
+        static void register() {
+            LASER_QUARRY_BLOCK_ENTITY =
+                INSTANCE.registerBlockEntity("laser_quarry", LaserQuarryBlockEntity::new, BLOCK.LASER_QUARRY);
+        }
     }
 
     private static void addCreativeTabEntries() {

--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -57,6 +57,11 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
     public void initCommon() {
         LOGGER.info("Registering {}", domain());
 
+        BLOCK.register();
+        ITEM.register();
+        ENTITY.register();
+        CREATIVE_TAB.register();
+
         registerStorageAccess();
         registerLegacyAliases();
         addCreativeTabEntries();
@@ -103,109 +108,146 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
     }
 
     public static final class BLOCK {
-        public static final Block MARKER = INSTANCE.registerBlockWithItem("marker",
-            props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
-
-        // Tin Ore and Storage Blocks
-        public static final Block TIN_ORE = INSTANCE.registerBlockWithItem("tin_ore",
-            props -> new Block(props.strength(3.0f, 3.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
-        public static final Block DEEPSLATE_TIN_ORE = INSTANCE.registerBlockWithItem("deepslate_tin_ore",
-            props -> new Block(props.strength(4.5f, 3.0f).sound(SoundType.DEEPSLATE).requiresCorrectToolForDrops()));
-        public static final Block TIN_BLOCK = INSTANCE.registerBlockWithItem("tin_block",
-            props -> new Block(props.strength(3.0f, 6.0f).sound(SoundType.METAL).requiresCorrectToolForDrops()));
-        public static final Block RAW_TIN_BLOCK = INSTANCE.registerBlockWithItem("raw_tin_block",
-            props -> new Block(props.strength(5.0f, 6.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
-
-        // Bronze Storage Block
-        public static final Block BRONZE_BLOCK = INSTANCE.registerBlockWithItem("bronze_block",
-            props -> new Block(props.strength(3.0f, 6.0f).sound(SoundType.METAL).requiresCorrectToolForDrops()));
-
-        // Apatite Ore and Storage Block
-        public static final Block APATITE_ORE = INSTANCE.registerBlockWithItem("apatite_ore",
-            props -> new DropExperienceBlock(UniformInt.of(0, 2), props.strength(3.0f, 3.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
-        public static final Block APATITE_BLOCK = INSTANCE.registerBlockWithItem("apatite_block",
-            props -> new Block(props.strength(5.0f, 6.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
+        public static Block MARKER;
+        public static Block TIN_ORE;
+        public static Block DEEPSLATE_TIN_ORE;
+        public static Block TIN_BLOCK;
+        public static Block RAW_TIN_BLOCK;
+        public static Block BRONZE_BLOCK;
+        public static Block APATITE_ORE;
+        public static Block APATITE_BLOCK;
 
         private BLOCK() {}
 
+        static void register() {
+            MARKER = INSTANCE.registerBlockWithItem("marker",
+                props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
+
+            // Tin Ore and Storage Blocks
+            TIN_ORE = INSTANCE.registerBlockWithItem("tin_ore",
+                props -> new Block(props.strength(3.0f, 3.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
+            DEEPSLATE_TIN_ORE = INSTANCE.registerBlockWithItem("deepslate_tin_ore",
+                props -> new Block(props.strength(4.5f, 3.0f).sound(SoundType.DEEPSLATE).requiresCorrectToolForDrops()));
+            TIN_BLOCK = INSTANCE.registerBlockWithItem("tin_block",
+                props -> new Block(props.strength(3.0f, 6.0f).sound(SoundType.METAL).requiresCorrectToolForDrops()));
+            RAW_TIN_BLOCK = INSTANCE.registerBlockWithItem("raw_tin_block",
+                props -> new Block(props.strength(5.0f, 6.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
+
+            // Bronze Storage Block
+            BRONZE_BLOCK = INSTANCE.registerBlockWithItem("bronze_block",
+                props -> new Block(props.strength(3.0f, 6.0f).sound(SoundType.METAL).requiresCorrectToolForDrops()));
+
+            // Apatite Ore and Storage Block
+            APATITE_ORE = INSTANCE.registerBlockWithItem("apatite_ore",
+                props -> new DropExperienceBlock(UniformInt.of(0, 2), props.strength(3.0f, 3.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
+            APATITE_BLOCK = INSTANCE.registerBlockWithItem("apatite_block",
+                props -> new Block(props.strength(5.0f, 6.0f).sound(SoundType.STONE).requiresCorrectToolForDrops()));
+        }
     }
 
     public static final class ENTITY {
-        public static final BlockEntityType<MarkerBlockEntity> MARKER_BLOCK_ENTITY =
-            INSTANCE.registerBlockEntity("marker", MarkerBlockEntity::new, BLOCK.MARKER);
+        public static BlockEntityType<MarkerBlockEntity> MARKER_BLOCK_ENTITY;
 
         private ENTITY() {}
 
+        static void register() {
+            MARKER_BLOCK_ENTITY = INSTANCE.registerBlockEntity("marker", MarkerBlockEntity::new, BLOCK.MARKER);
+        }
     }
 
 
     public static final class ITEM {
-        public static final Item WRENCH = INSTANCE.registerItem("wrench",
-            props -> new WrenchItem(props.stacksTo(1)));
-        public static final Item PROBE = INSTANCE.registerItem("probe",
-            props -> new ProbeItem(props.stacksTo(1)));
-
-        // Tin Materials
-        public static final Item RAW_TIN = INSTANCE.registerItem("raw_tin",
-            props -> new Item(props));
-        public static final Item TIN_INGOT = INSTANCE.registerItem("tin_ingot",
-            props -> new Item(props));
-        public static final Item TIN_NUGGET = INSTANCE.registerItem("tin_nugget",
-            props -> new Item(props));
-
-        // Bronze Materials
-        public static final Item BRONZE_INGOT = INSTANCE.registerItem("bronze_ingot",
-            props -> new Item(props));
-        public static final Item BRONZE_NUGGET = INSTANCE.registerItem("bronze_nugget",
-            props -> new Item(props));
-
-        // Apatite
-        public static final Item APATITE = INSTANCE.registerItem("apatite",
-            props -> new Item(props));
-
-        // Components
-        public static final Item STURDY_CASING = INSTANCE.registerItem("sturdy_casing",
-            props -> new Item(props));
-
-        // Gears
-        public static final Item WOODEN_GEAR = INSTANCE.registerItem("wooden_gear",
-            props -> new Item(props));
-        public static final Item STONE_GEAR = INSTANCE.registerItem("stone_gear",
-            props -> new Item(props));
-        public static final Item COPPER_GEAR = INSTANCE.registerItem("copper_gear",
-            props -> new Item(props));
-        public static final Item TIN_GEAR = INSTANCE.registerItem("tin_gear",
-            props -> new Item(props));
-        public static final Item IRON_GEAR = INSTANCE.registerItem("iron_gear",
-            props -> new Item(props));
-        public static final Item GOLD_GEAR = INSTANCE.registerItem("gold_gear",
-            props -> new Item(props));
-        public static final Item BRONZE_GEAR = INSTANCE.registerItem("bronze_gear",
-            props -> new Item(props));
-        public static final Item DIAMOND_GEAR = INSTANCE.registerItem("diamond_gear",
-            props -> new Item(props));
-        public static final Item NETHERITE_GEAR = INSTANCE.registerItem("netherite_gear",
-            props -> new Item(props));
+        public static Item WRENCH;
+        public static Item PROBE;
+        public static Item RAW_TIN;
+        public static Item TIN_INGOT;
+        public static Item TIN_NUGGET;
+        public static Item BRONZE_INGOT;
+        public static Item BRONZE_NUGGET;
+        public static Item APATITE;
+        public static Item STURDY_CASING;
+        public static Item WOODEN_GEAR;
+        public static Item STONE_GEAR;
+        public static Item COPPER_GEAR;
+        public static Item TIN_GEAR;
+        public static Item IRON_GEAR;
+        public static Item GOLD_GEAR;
+        public static Item BRONZE_GEAR;
+        public static Item DIAMOND_GEAR;
+        public static Item NETHERITE_GEAR;
 
         private ITEM() {}
+
+        static void register() {
+            WRENCH = INSTANCE.registerItem("wrench",
+                props -> new WrenchItem(props.stacksTo(1)));
+            PROBE = INSTANCE.registerItem("probe",
+                props -> new ProbeItem(props.stacksTo(1)));
+
+            // Tin Materials
+            RAW_TIN = INSTANCE.registerItem("raw_tin",
+                props -> new Item(props));
+            TIN_INGOT = INSTANCE.registerItem("tin_ingot",
+                props -> new Item(props));
+            TIN_NUGGET = INSTANCE.registerItem("tin_nugget",
+                props -> new Item(props));
+
+            // Bronze Materials
+            BRONZE_INGOT = INSTANCE.registerItem("bronze_ingot",
+                props -> new Item(props));
+            BRONZE_NUGGET = INSTANCE.registerItem("bronze_nugget",
+                props -> new Item(props));
+
+            // Apatite
+            APATITE = INSTANCE.registerItem("apatite",
+                props -> new Item(props));
+
+            // Components
+            STURDY_CASING = INSTANCE.registerItem("sturdy_casing",
+                props -> new Item(props));
+
+            // Gears
+            WOODEN_GEAR = INSTANCE.registerItem("wooden_gear",
+                props -> new Item(props));
+            STONE_GEAR = INSTANCE.registerItem("stone_gear",
+                props -> new Item(props));
+            COPPER_GEAR = INSTANCE.registerItem("copper_gear",
+                props -> new Item(props));
+            TIN_GEAR = INSTANCE.registerItem("tin_gear",
+                props -> new Item(props));
+            IRON_GEAR = INSTANCE.registerItem("iron_gear",
+                props -> new Item(props));
+            GOLD_GEAR = INSTANCE.registerItem("gold_gear",
+                props -> new Item(props));
+            BRONZE_GEAR = INSTANCE.registerItem("bronze_gear",
+                props -> new Item(props));
+            DIAMOND_GEAR = INSTANCE.registerItem("diamond_gear",
+                props -> new Item(props));
+            NETHERITE_GEAR = INSTANCE.registerItem("netherite_gear",
+                props -> new Item(props));
+        }
     }
 
     public static final class CREATIVE_TAB {
         private CREATIVE_TAB() {}
         private static final List<Consumer<CreativeModeTab.Output>> ENTRIES = new ArrayList<>();
 
-        public static final CreativeModeTab LOGISTICS_TRANSPORT = Registry.register(
-                BuiltInRegistries.CREATIVE_MODE_TAB,
-                LogisticsMod.getIdentifier("logistics_transport"),
-                FabricItemGroup.builder()
-                        .title(Component.literal("Logistics"))
-                        .icon(() -> new ItemStack(ITEM.IRON_GEAR))
-                        .displayItems((params, entries) -> {
-                            for (Consumer<CreativeModeTab.Output> entry : ENTRIES) {
-                                entry.accept(entries);
-                            }
-                        })
-                        .build());
+        public static CreativeModeTab LOGISTICS_TRANSPORT;
+
+        static void register() {
+            LOGISTICS_TRANSPORT = Registry.register(
+                    BuiltInRegistries.CREATIVE_MODE_TAB,
+                    LogisticsMod.getIdentifier("logistics_transport"),
+                    FabricItemGroup.builder()
+                            .title(Component.literal("Logistics"))
+                            .icon(() -> new ItemStack(ITEM.IRON_GEAR))
+                            .displayItems((params, entries) -> {
+                                for (Consumer<CreativeModeTab.Output> entry : ENTRIES) {
+                                    entry.accept(entries);
+                                }
+                            })
+                            .build());
+        }
 
         public static void add(Consumer<CreativeModeTab.Output> entryBuilder) {
             ENTRIES.add(entryBuilder);

--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -185,46 +185,30 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
                 props -> new ProbeItem(props.stacksTo(1)));
 
             // Tin Materials
-            RAW_TIN = INSTANCE.registerItem("raw_tin",
-                props -> new Item(props));
-            TIN_INGOT = INSTANCE.registerItem("tin_ingot",
-                props -> new Item(props));
-            TIN_NUGGET = INSTANCE.registerItem("tin_nugget",
-                props -> new Item(props));
+            RAW_TIN = INSTANCE.registerItem("raw_tin", Item::new);
+            TIN_INGOT = INSTANCE.registerItem("tin_ingot", Item::new);
+            TIN_NUGGET = INSTANCE.registerItem("tin_nugget", Item::new);
 
             // Bronze Materials
-            BRONZE_INGOT = INSTANCE.registerItem("bronze_ingot",
-                props -> new Item(props));
-            BRONZE_NUGGET = INSTANCE.registerItem("bronze_nugget",
-                props -> new Item(props));
+            BRONZE_INGOT = INSTANCE.registerItem("bronze_ingot", Item::new);
+            BRONZE_NUGGET = INSTANCE.registerItem("bronze_nugget", Item::new);
 
             // Apatite
-            APATITE = INSTANCE.registerItem("apatite",
-                props -> new Item(props));
+            APATITE = INSTANCE.registerItem("apatite", Item::new);
 
             // Components
-            STURDY_CASING = INSTANCE.registerItem("sturdy_casing",
-                props -> new Item(props));
+            STURDY_CASING = INSTANCE.registerItem("sturdy_casing", Item::new);
 
             // Gears
-            WOODEN_GEAR = INSTANCE.registerItem("wooden_gear",
-                props -> new Item(props));
-            STONE_GEAR = INSTANCE.registerItem("stone_gear",
-                props -> new Item(props));
-            COPPER_GEAR = INSTANCE.registerItem("copper_gear",
-                props -> new Item(props));
-            TIN_GEAR = INSTANCE.registerItem("tin_gear",
-                props -> new Item(props));
-            IRON_GEAR = INSTANCE.registerItem("iron_gear",
-                props -> new Item(props));
-            GOLD_GEAR = INSTANCE.registerItem("gold_gear",
-                props -> new Item(props));
-            BRONZE_GEAR = INSTANCE.registerItem("bronze_gear",
-                props -> new Item(props));
-            DIAMOND_GEAR = INSTANCE.registerItem("diamond_gear",
-                props -> new Item(props));
-            NETHERITE_GEAR = INSTANCE.registerItem("netherite_gear",
-                props -> new Item(props));
+            WOODEN_GEAR = INSTANCE.registerItem("wooden_gear", Item::new);
+            STONE_GEAR = INSTANCE.registerItem("stone_gear", Item::new);
+            COPPER_GEAR = INSTANCE.registerItem("copper_gear", Item::new);
+            TIN_GEAR = INSTANCE.registerItem("tin_gear", Item::new);
+            IRON_GEAR = INSTANCE.registerItem("iron_gear", Item::new);
+            GOLD_GEAR = INSTANCE.registerItem("gold_gear", Item::new);
+            BRONZE_GEAR = INSTANCE.registerItem("bronze_gear", Item::new);
+            DIAMOND_GEAR = INSTANCE.registerItem("diamond_gear", Item::new);
+            NETHERITE_GEAR = INSTANCE.registerItem("netherite_gear", Item::new);
         }
     }
 

--- a/src/main/java/com/logistics/LogisticsPipe.java
+++ b/src/main/java/com/logistics/LogisticsPipe.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap {
     private static final LogisticsPipe INSTANCE = new LogisticsPipe();
     private static final Map<Item, DyeColor> MARKING_FLUID_ITEM_COLORS = new HashMap<>();
-    private static final Map<DyeColor, Item> MARKING_FLUID_ITEMS = registerMarkingFluidItems();
+    private static Map<DyeColor, Item> MARKING_FLUID_ITEMS = Collections.emptyMap();
 
     @Override
     protected String domain() {
@@ -53,6 +53,12 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
     @Override
     public void initCommon() {
         LOGGER.info("Registering {}", domain());
+
+        BLOCK.register();
+        ENTITY.register();
+        DATA.register();
+        SCREEN.register();
+        registerMarkingFluidItems();
 
         registerLegacyAliases();
         addCreativeTabEntries();
@@ -98,52 +104,72 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
     public static final class BLOCK {
         private BLOCK() {}
 
-        public static final Block STONE_TRANSPORT_PIPE = INSTANCE.registerBlockWithItem("stone_transport_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.STONE_TRANSPORT_PIPE));
-        public static final Block ITEM_PASSTHROUGH_PIPE = INSTANCE.registerBlockWithItem("item_passthrough_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_PASSTHROUGH_PIPE));
-        public static final Block COPPER_TRANSPORT_PIPE = INSTANCE.registerBlockWithItem("copper_transport_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.COPPER_TRANSPORT_PIPE),
-            ModularPipeBlockItem::new);
-        public static final Block ITEM_EXTRACTOR_PIPE = INSTANCE.registerBlockWithItem("item_extractor_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_EXTRACTOR));
-        public static final Block ITEM_MERGER_PIPE = INSTANCE.registerBlockWithItem("item_merger_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_MERGER));
-        public static final Block GOLD_TRANSPORT_PIPE = INSTANCE.registerBlockWithItem("gold_transport_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.GOLD_TRANSPORT));
-        public static final Block ITEM_FILTER_PIPE = INSTANCE.registerBlockWithItem("item_filter_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_FILTER));
-        public static final Block ITEM_INSERTION_PIPE = INSTANCE.registerBlockWithItem("item_insertion_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_INSERTION));
-        public static final Block ITEM_VOID_PIPE = INSTANCE.registerBlockWithItem("item_void_pipe",
-            props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_VOID));
+        public static Block STONE_TRANSPORT_PIPE;
+        public static Block ITEM_PASSTHROUGH_PIPE;
+        public static Block COPPER_TRANSPORT_PIPE;
+        public static Block ITEM_EXTRACTOR_PIPE;
+        public static Block ITEM_MERGER_PIPE;
+        public static Block GOLD_TRANSPORT_PIPE;
+        public static Block ITEM_FILTER_PIPE;
+        public static Block ITEM_INSERTION_PIPE;
+        public static Block ITEM_VOID_PIPE;
+
+        static void register() {
+            STONE_TRANSPORT_PIPE = INSTANCE.registerBlockWithItem("stone_transport_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.STONE_TRANSPORT_PIPE));
+            ITEM_PASSTHROUGH_PIPE = INSTANCE.registerBlockWithItem("item_passthrough_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_PASSTHROUGH_PIPE));
+            COPPER_TRANSPORT_PIPE = INSTANCE.registerBlockWithItem("copper_transport_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.COPPER_TRANSPORT_PIPE),
+                ModularPipeBlockItem::new);
+            ITEM_EXTRACTOR_PIPE = INSTANCE.registerBlockWithItem("item_extractor_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_EXTRACTOR));
+            ITEM_MERGER_PIPE = INSTANCE.registerBlockWithItem("item_merger_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_MERGER));
+            GOLD_TRANSPORT_PIPE = INSTANCE.registerBlockWithItem("gold_transport_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.GOLD_TRANSPORT));
+            ITEM_FILTER_PIPE = INSTANCE.registerBlockWithItem("item_filter_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_FILTER));
+            ITEM_INSERTION_PIPE = INSTANCE.registerBlockWithItem("item_insertion_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_INSERTION));
+            ITEM_VOID_PIPE = INSTANCE.registerBlockWithItem("item_void_pipe",
+                props -> new PipeBlock(createPipeProperties(props), PipeTypes.ITEM_VOID));
+        }
     }
 
     public static final class ENTITY {
-        public static final BlockEntityType<PipeBlockEntity> PIPE_BLOCK_ENTITY = INSTANCE.registerBlockEntity("pipe",
-            PipeBlockEntity::new,
-            BLOCK.STONE_TRANSPORT_PIPE,
-            BLOCK.ITEM_EXTRACTOR_PIPE,
-            BLOCK.ITEM_MERGER_PIPE,
-            BLOCK.GOLD_TRANSPORT_PIPE,
-            BLOCK.ITEM_FILTER_PIPE,
-            BLOCK.COPPER_TRANSPORT_PIPE,
-            BLOCK.ITEM_PASSTHROUGH_PIPE,
-            BLOCK.ITEM_INSERTION_PIPE,
-            BLOCK.ITEM_VOID_PIPE);
+        public static BlockEntityType<PipeBlockEntity> PIPE_BLOCK_ENTITY;
 
         private ENTITY() {}
+
+        static void register() {
+            PIPE_BLOCK_ENTITY = INSTANCE.registerBlockEntity("pipe",
+                PipeBlockEntity::new,
+                BLOCK.STONE_TRANSPORT_PIPE,
+                BLOCK.ITEM_EXTRACTOR_PIPE,
+                BLOCK.ITEM_MERGER_PIPE,
+                BLOCK.GOLD_TRANSPORT_PIPE,
+                BLOCK.ITEM_FILTER_PIPE,
+                BLOCK.COPPER_TRANSPORT_PIPE,
+                BLOCK.ITEM_PASSTHROUGH_PIPE,
+                BLOCK.ITEM_INSERTION_PIPE,
+                BLOCK.ITEM_VOID_PIPE);
+        }
     }
 
     public static final class DATA {
-        public static final DataComponentType<WeatheringState> WEATHERING_STATE = Registry.register(
-                BuiltInRegistries.DATA_COMPONENT_TYPE,
-                LogisticsPipe.identifier("weathering_state"),
-                DataComponentType.<WeatheringState>builder()
-                        .persistent(WeatheringState.CODEC)
-                        .build());
+        public static DataComponentType<WeatheringState> WEATHERING_STATE;
 
         private DATA() {}
+
+        static void register() {
+            WEATHERING_STATE = Registry.register(
+                    BuiltInRegistries.DATA_COMPONENT_TYPE,
+                    LogisticsPipe.identifier("weathering_state"),
+                    DataComponentType.<WeatheringState>builder()
+                            .persistent(WeatheringState.CODEC)
+                            .build());
+        }
     }
 
     public static final class CONFIG {
@@ -172,12 +198,16 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
     }
 
     public static final class SCREEN {
-        public static final MenuType<ItemFilterScreenHandler> ITEM_FILTER = Registry.register(
-                BuiltInRegistries.MENU,
-                LogisticsPipe.identifier("item_filter"),
-                new MenuType<>(ItemFilterScreenHandler::new, FeatureFlagSet.of()));
+        public static MenuType<ItemFilterScreenHandler> ITEM_FILTER;
 
         private SCREEN() {}
+
+        static void register() {
+            ITEM_FILTER = Registry.register(
+                    BuiltInRegistries.MENU,
+                    LogisticsPipe.identifier("item_filter"),
+                    new MenuType<>(ItemFilterScreenHandler::new, FeatureFlagSet.of()));
+        }
     }
 
     private static Block.Properties createPipeProperties(Block.Properties props) {
@@ -187,7 +217,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
                 .noOcclusion();
     }
 
-    private static Map<DyeColor, Item> registerMarkingFluidItems() {
+    private static void registerMarkingFluidItems() {
         Map<DyeColor, Item> items = new EnumMap<>(DyeColor.class);
         for (DyeColor color : DyeColor.values()) {
             String name = "marking_fluid_" + color.getName();
@@ -196,7 +226,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
             items.put(color, item);
             MARKING_FLUID_ITEM_COLORS.put(item, color);
         }
-        return Collections.unmodifiableMap(items);
+        MARKING_FLUID_ITEMS = Collections.unmodifiableMap(items);
     }
 
     public static Item getMarkingFluidItem(DyeColor color) {

--- a/src/main/java/com/logistics/LogisticsPower.java
+++ b/src/main/java/com/logistics/LogisticsPower.java
@@ -46,42 +46,64 @@ public final class LogisticsPower extends LogisticsMod implements DomainBootstra
     public void initCommon() {
         LOGGER.info("Registering {}", domain());
 
+        BLOCK.register();
+        ENTITY.register();
+        SCREEN.register();
+
         addCreativeTabEntries();
     }
 
     public static final class BLOCK {
         private BLOCK() {}
 
-        public static final Block REDSTONE_ENGINE = INSTANCE.registerBlockWithItem("redstone_engine",
-            props -> new RedstoneEngineBlock(props.strength(5.0f).sound(SoundType.WOOD).noOcclusion()));
-        public static final Block STIRLING_ENGINE = INSTANCE.registerBlockWithItem("stirling_engine",
-            props -> new StirlingEngineBlock(props.strength(5.0f).sound(SoundType.COPPER).noOcclusion()));
-        public static final Block CREATIVE_ENGINE = INSTANCE.registerBlockWithItem("creative_engine",
-            props -> new CreativeEngineBlock(props.strength(5.0f).sound(SoundType.STONE).noOcclusion()));
-        public static final Block CREATIVE_SINK = INSTANCE.registerBlockWithItem("creative_sink",
-            props -> new CreativeSinkBlock(props.strength(5.0f).sound(SoundType.STONE)));
+        public static Block REDSTONE_ENGINE;
+        public static Block STIRLING_ENGINE;
+        public static Block CREATIVE_ENGINE;
+        public static Block CREATIVE_SINK;
+
+        static void register() {
+            REDSTONE_ENGINE = INSTANCE.registerBlockWithItem("redstone_engine",
+                props -> new RedstoneEngineBlock(props.strength(5.0f).sound(SoundType.WOOD).noOcclusion()));
+            STIRLING_ENGINE = INSTANCE.registerBlockWithItem("stirling_engine",
+                props -> new StirlingEngineBlock(props.strength(5.0f).sound(SoundType.COPPER).noOcclusion()));
+            CREATIVE_ENGINE = INSTANCE.registerBlockWithItem("creative_engine",
+                props -> new CreativeEngineBlock(props.strength(5.0f).sound(SoundType.STONE).noOcclusion()));
+            CREATIVE_SINK = INSTANCE.registerBlockWithItem("creative_sink",
+                props -> new CreativeSinkBlock(props.strength(5.0f).sound(SoundType.STONE)));
+        }
     }
 
     public static final class ENTITY {
         private ENTITY() {}
 
-        public static final BlockEntityType<RedstoneEngineBlockEntity> REDSTONE_ENGINE_BLOCK_ENTITY =
-            INSTANCE.registerBlockEntity("redstone_engine", RedstoneEngineBlockEntity::new, BLOCK.REDSTONE_ENGINE);
-        public static final BlockEntityType<StirlingEngineBlockEntity> STIRLING_ENGINE_BLOCK_ENTITY =
-            INSTANCE.registerBlockEntity("stirling_engine", StirlingEngineBlockEntity::new, BLOCK.STIRLING_ENGINE);
-        public static final BlockEntityType<CreativeEngineBlockEntity> CREATIVE_ENGINE_BLOCK_ENTITY =
-            INSTANCE.registerBlockEntity("creative_engine", CreativeEngineBlockEntity::new, BLOCK.CREATIVE_ENGINE);
-        public static final BlockEntityType<CreativeSinkBlockEntity> CREATIVE_SINK_BLOCK_ENTITY =
-            INSTANCE.registerBlockEntity("creative_sink", CreativeSinkBlockEntity::new, BLOCK.CREATIVE_SINK);
+        public static BlockEntityType<RedstoneEngineBlockEntity> REDSTONE_ENGINE_BLOCK_ENTITY;
+        public static BlockEntityType<StirlingEngineBlockEntity> STIRLING_ENGINE_BLOCK_ENTITY;
+        public static BlockEntityType<CreativeEngineBlockEntity> CREATIVE_ENGINE_BLOCK_ENTITY;
+        public static BlockEntityType<CreativeSinkBlockEntity> CREATIVE_SINK_BLOCK_ENTITY;
+
+        static void register() {
+            REDSTONE_ENGINE_BLOCK_ENTITY =
+                INSTANCE.registerBlockEntity("redstone_engine", RedstoneEngineBlockEntity::new, BLOCK.REDSTONE_ENGINE);
+            STIRLING_ENGINE_BLOCK_ENTITY =
+                INSTANCE.registerBlockEntity("stirling_engine", StirlingEngineBlockEntity::new, BLOCK.STIRLING_ENGINE);
+            CREATIVE_ENGINE_BLOCK_ENTITY =
+                INSTANCE.registerBlockEntity("creative_engine", CreativeEngineBlockEntity::new, BLOCK.CREATIVE_ENGINE);
+            CREATIVE_SINK_BLOCK_ENTITY =
+                INSTANCE.registerBlockEntity("creative_sink", CreativeSinkBlockEntity::new, BLOCK.CREATIVE_SINK);
+        }
     }
 
     public static final class SCREEN {
-        public static final MenuType<StirlingEngineScreenHandler> STIRLING_ENGINE = Registry.register(
-                BuiltInRegistries.MENU,
-                LogisticsPower.identifier("stirling_engine"),
-                new ExtendedScreenHandlerType<>(StirlingEngineScreenHandler::new, BlockPos.STREAM_CODEC));
+        public static MenuType<StirlingEngineScreenHandler> STIRLING_ENGINE;
 
         private SCREEN() {}
+
+        static void register() {
+            STIRLING_ENGINE = Registry.register(
+                    BuiltInRegistries.MENU,
+                    LogisticsPower.identifier("stirling_engine"),
+                    new ExtendedScreenHandlerType<>(StirlingEngineScreenHandler::new, BlockPos.STREAM_CODEC));
+        }
     }
 
     private static void addCreativeTabEntries() {

--- a/src/main/java/com/logistics/LogisticsPower.java
+++ b/src/main/java/com/logistics/LogisticsPower.java
@@ -94,9 +94,9 @@ public final class LogisticsPower extends LogisticsMod implements DomainBootstra
     }
 
     public static final class SCREEN {
-        public static MenuType<StirlingEngineScreenHandler> STIRLING_ENGINE;
-
         private SCREEN() {}
+
+        public static MenuType<StirlingEngineScreenHandler> STIRLING_ENGINE;
 
         static void register() {
             STIRLING_ENGINE = Registry.register(


### PR DESCRIPTION
### Summary
- Ensures blocks, items, block entities, menus, data components, and creative tabs are registered at the correct time during `initCommon` so content is reliably available at runtime.

### Changes
- Moved static, load-time registrations into explicit `register()` calls invoked from `initCommon` across modules:
- **Core**: blocks, items, block entities, and creative tab
- **Pipe**: blocks, pipe block entity, data component, menu type, and marking fluid items
- **Power**: blocks, block entities, and menu type
- **Automation**: blocks and block entities

### Notes
- This improves startup/registration ordering stability and prevents missing/early-access registration issues caused by static initialization timing.
- Fixes #130 