### PR TITLE
fix: properly set sided inventory for engines and kiln

### DIFF
--- a/src/main/java/com/logistics/core/fabricator/KilnBlockEntity.java
+++ b/src/main/java/com/logistics/core/fabricator/KilnBlockEntity.java
@@ -25,6 +25,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -61,7 +62,7 @@ import org.jetbrains.annotations.Nullable;
  * </ul>
  */
 public class KilnBlockEntity extends BaseBlockEntity
-        implements HasItemStorage, HasFluidStorage, MenuBehavior.HasMenu {
+        implements HasItemStorage, HasFluidStorage, WorldlyContainer, MenuBehavior.HasMenu {
 
     // ==================== Constants ====================
 
@@ -485,6 +486,101 @@ public class KilnBlockEntity extends BaseBlockEntity
         // Molten glass is internal-only - cannot be extracted or inserted from outside
         // (conceptually, molten glass wouldn't stay hot outside the kiln)
         return null;
+    }
+
+    // ==================== WorldlyContainer Implementation (Sided Inventory) ====================
+
+    private static final int[] SLOTS_FOR_TOP = new int[]{GLASS_INPUT_SLOT};        // Glass input only
+    private static final int[] SLOTS_FOR_SIDES = new int[]{FUEL_SLOT};             // Fuel input only
+    private static final int[] SLOTS_FOR_BOTTOM = new int[]{OUTPUT_SLOT};          // Output only
+    private static final int[] SLOTS_EMPTY = new int[]{};                          // No access
+
+    @Override
+    public int[] getSlotsForFace(Direction side) {
+        return switch (side) {
+            case UP -> SLOTS_FOR_TOP;      // Glass input from top
+            case DOWN -> SLOTS_FOR_BOTTOM; // Output extraction from bottom
+            default -> SLOTS_FOR_SIDES;    // Fuel input from sides
+        };
+    }
+
+    @Override
+    public boolean canPlaceItemThroughFace(int slot, ItemStack stack, Direction direction) {
+        // Top: Accept glass input items only
+        if (direction == Direction.UP) {
+            return slot == GLASS_INPUT_SLOT && isGlassInput(stack);
+        }
+
+        // Sides: Accept fuel items only
+        if (direction != Direction.DOWN) {
+            return slot == FUEL_SLOT && isFuel(stack);
+        }
+
+        // Bottom: No insertion allowed
+        return false;
+    }
+
+    @Override
+    public boolean canTakeItemThroughFace(int slot, ItemStack stack, Direction direction) {
+        // Bottom: Extract from output slot only
+        if (direction == Direction.DOWN) {
+            return slot == OUTPUT_SLOT;
+        }
+
+        // Top/Sides: No extraction allowed
+        return false;
+    }
+
+    private boolean isGlassInput(ItemStack stack) {
+        return stack.is(Items.GLASS) || stack.is(Items.SAND) ||
+               stack.is(Items.GLASS_PANE) || stack.is(Items.RED_SAND);
+    }
+
+    private boolean isFuel(ItemStack stack) {
+        if (level == null) return true; // Allow during world load
+        return level.fuelValues().isFuel(stack);
+    }
+
+    // ==================== Container Delegation ====================
+
+    @Override
+    public int getContainerSize() {
+        return inventory.getContainerSize();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return inventory.isEmpty();
+    }
+
+    @Override
+    public ItemStack getItem(int slot) {
+        return inventory.getItem(slot);
+    }
+
+    @Override
+    public ItemStack removeItem(int slot, int amount) {
+        return inventory.removeItem(slot, amount);
+    }
+
+    @Override
+    public ItemStack removeItemNoUpdate(int slot) {
+        return inventory.removeItemNoUpdate(slot);
+    }
+
+    @Override
+    public void setItem(int slot, ItemStack stack) {
+        inventory.setItem(slot, stack);
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return inventory.stillValid(player);
+    }
+
+    @Override
+    public void clearContent() {
+        inventory.clearContent();
     }
 
     // ==================== NBT Persistence ====================

--- a/src/main/java/com/logistics/core/fabricator/KilnBlockEntity.java
+++ b/src/main/java/com/logistics/core/fabricator/KilnBlockEntity.java
@@ -532,8 +532,7 @@ public class KilnBlockEntity extends BaseBlockEntity
     }
 
     private boolean isGlassInput(ItemStack stack) {
-        return stack.is(Items.GLASS) || stack.is(Items.SAND) ||
-               stack.is(Items.GLASS_PANE) || stack.is(Items.RED_SAND);
+        return stack.is(Items.GLASS) || stack.is(Items.SAND) || stack.is(Items.GLASS_PANE);
     }
 
     private boolean isFuel(ItemStack stack) {

--- a/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -424,7 +424,9 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
      */
     @Nullable private PipeConnection.Type checkItemStorage(
             Level world, BlockPos pos, BlockPos neighborPos, Direction direction, Block neighborBlock) {
-        if (ItemStorage.SIDED.find(world, neighborPos, direction.getOpposite()) != null) {
+        var storage = ItemStorage.SIDED.find(world, neighborPos, direction.getOpposite());
+
+        if (storage != null && storage.iterator().hasNext()) {
             PipeConnection.Type candidate = PipeConnection.Type.INVENTORY;
             if (pipe != null) {
                 PipeBlockEntity pipeEntity =

--- a/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -346,6 +346,14 @@ public final class PipeRuntime {
         BlockPos targetPos = pos.relative(direction);
 
         Storage<ItemVariant> storage = ItemStorage.SIDED.find(world, targetPos, direction.getOpposite());
+
+        // Debug: log what storage was found
+        if (world.getBlockEntity(targetPos) instanceof com.logistics.power.engine.block.entity.StirlingEngineBlockEntity) {
+            System.out.println("[PipeRuntime] transferItem - targetPos: " + targetPos +
+                             ", querySide: " + direction.getOpposite() +
+                             ", storage: " + (storage != null ? storage.getClass().getSimpleName() : "null"));
+        }
+
         if (storage != null) {
             try (Transaction transaction = Transaction.openOuter()) {
                 long inserted;

--- a/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -347,13 +347,6 @@ public final class PipeRuntime {
 
         Storage<ItemVariant> storage = ItemStorage.SIDED.find(world, targetPos, direction.getOpposite());
 
-        // Debug: log what storage was found
-        if (world.getBlockEntity(targetPos) instanceof com.logistics.power.engine.block.entity.StirlingEngineBlockEntity) {
-            System.out.println("[PipeRuntime] transferItem - targetPos: " + targetPos +
-                             ", querySide: " + direction.getOpposite() +
-                             ", storage: " + (storage != null ? storage.getClass().getSimpleName() : "null"));
-        }
-
         if (storage != null) {
             try (Transaction transaction = Transaction.openOuter()) {
                 long inserted;

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -26,6 +26,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -55,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
  * When buffer fills up, temperature rises and generation decreases.
  */
 public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
-        implements ExtendedScreenHandlerFactory<BlockPos>, ContainerSingleItem.BlockContainerSingleItem, HasItemStorage, MenuBehavior.HasMenu {
+        implements ExtendedScreenHandlerFactory<BlockPos>, ContainerSingleItem.BlockContainerSingleItem, WorldlyContainer, HasItemStorage, MenuBehavior.HasMenu {
 
     // ==================== Constants ====================
 
@@ -135,6 +136,11 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
     @Override
     public Storage<ItemVariant> itemStorage(@Nullable Direction side) {
+        // Don't expose inventory on the output face (facing direction)
+        if (side != null && isOutputDirection(side)) {
+            return null;
+        }
+
         Storage<ItemVariant> baseStorage = inventory.storage();
 
         // Wrap storage to validate fuel items (matches GUI validation behavior)
@@ -356,6 +362,40 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     @Override
     public boolean isEmpty() {
         return inventory.getItem(0).isEmpty();
+    }
+
+    // ==================== WorldlyContainer Implementation (Sided Inventory) ====================
+
+    private static final int[] SLOTS_FOR_INPUT = new int[]{0};
+    private static final int[] SLOTS_FOR_OUTPUT = new int[]{};
+
+    @Override
+    public int[] getSlotsForFace(Direction side) {
+        Direction outputDir = getOutputDirection();
+        // No slots accessible from output face
+        if (side == outputDir) {
+            return SLOTS_FOR_OUTPUT;
+        }
+        // Fuel slot accessible from all other faces
+        return SLOTS_FOR_INPUT;
+    }
+
+    @Override
+    public boolean canPlaceItemThroughFace(int slot, ItemStack stack, Direction direction) {
+        Direction outputDir = getOutputDirection();
+        // Cannot insert items from output face
+        if (direction == outputDir) {
+            return false;
+        }
+        // Can insert fuel from other faces
+        return isValid(slot, stack);
+    }
+
+    @Override
+    public boolean canTakeItemThroughFace(int slot, ItemStack stack, Direction direction) {
+        Direction outputDir = getOutputDirection();
+        // Cannot extract items from output face
+        return direction != outputDir;
     }
 
     // ==================== ExtendedScreenHandlerFactory Implementation ====================


### PR DESCRIPTION
## Summary
- Fixes item extractor pipes incorrectly connecting to Stirling Engines as if they were valid item inventories, which could cause unexpected routing/diversion.

## Changes
- Stirling Engine now enforces sided inventory access so item insertion/extraction is blocked on the engine’s output face.
- Kiln now exposes proper sided inventory rules (top input, side fuel, bottom output) for consistent automation behavior.
- Pipe inventory-connection checks now require a non-empty sided storage view before marking a neighbor as an inventory connection.

## Notes
- This improves compatibility with hoppers/pipes and reduces accidental item routing into blocks that shouldn’t accept items from certain sides.
- fixes #137 