### PR TITLE
ci: enforce Spotless formatting via hooks and PR checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.java]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize text, keep repo LF
+* text=auto eol=lf
+
+# Common text file types
+*.java  text eol=lf
+*.kt    text eol=lf
+*.gradle text eol=lf
+*.properties text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.toml  text eol=lf
+
+# Images/binaries
+*.png binary
+*.jpg binary
+*.gif binary
+*.jar binary

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,40 +1,17 @@
-#!/bin/bash
-# Pre-commit hook to run Spotless formatting on staged files only
+#!/bin/sh
+# Pre-commit hook to check Spotless formatting
 
-set -e
+echo "Checking code formatting..."
 
-# Get list of staged files
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
-
-if [ -z "$STAGED_FILES" ]; then
-    echo "No staged files to check"
-    exit 0
+if ! ./gradlew spotlessCheck --daemon --quiet; then
+    echo ""
+    echo "❌ Code formatting check failed!"
+    echo ""
+    echo "Run './gradlew spotlessApply' to fix formatting, then commit again."
+    echo "Or use 'git commit --no-verify' to skip this check."
+    echo ""
+    exit 1
 fi
 
-echo "Running Spotless formatting on staged files..."
-
-# Stash unstaged changes to avoid formatting them
-STASH_NAME="pre-commit-$(date +%s)"
-git stash push --keep-index --include-untracked -m "$STASH_NAME" > /dev/null 2>&1
-STASHED=$?
-
-# Run spotlessApply to format code
-./gradlew spotlessApply --quiet
-
-# Re-stage any files that were modified by spotless (only if they were originally staged)
-MODIFIED_FILES=$(git diff --name-only)
-if [ -n "$MODIFIED_FILES" ]; then
-    echo "$MODIFIED_FILES" | while read -r file; do
-        if echo "$STAGED_FILES" | grep -q "^${file}$"; then
-            git add "$file"
-            echo "  ✨ Formatted: $file"
-        fi
-    done
-fi
-
-# Restore stashed changes if we stashed anything
-if [ $STASHED -eq 0 ]; then
-    git stash pop --index > /dev/null 2>&1 || true
-fi
-
-echo "✅ Pre-commit checks passed"
+echo "✅ Code formatting check passed"
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,22 +3,35 @@
 
 echo "Formatting code with Spotless..."
 
-# Get list of staged files before formatting
+# Exit early if no staged files
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
-
 if [ -z "$STAGED_FILES" ]; then
     exit 0
 fi
 
-# Run spotlessApply to format all files
-./gradlew spotlessApply --daemon --quiet || exit 1
+# Stash unstaged changes, keeping staged changes in working tree
+git stash push --keep-index -u -m "pre-commit-auto-format" --quiet
+STASH_RESULT=$?
 
-# Re-stage only the files that were originally staged
-echo "$STAGED_FILES" | while read -r file; do
-    if [ -f "$file" ]; then
-        git add "$file"
+# Run spotlessApply to format staged files
+if ! ./gradlew spotlessApply --daemon --quiet; then
+    # Restore stashed changes on failure
+    if [ $STASH_RESULT -eq 0 ]; then
+        git stash pop --quiet 2>/dev/null || true
     fi
-done
+    exit 1
+fi
+
+# Stage all formatted files (only originally staged files are in working tree after stash)
+git add -u
+
+# Restore unstaged changes
+if [ $STASH_RESULT -eq 0 ]; then
+    if ! git stash pop --quiet 2>/dev/null; then
+        echo "⚠️  Warning: Could not restore unstaged changes automatically."
+        echo "   Run 'git stash pop' to restore them manually."
+    fi
+fi
 
 echo "✅ Code formatted and staged"
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Pre-commit hook to run Spotless formatting on staged files only
+
+set -e
+
+# Get list of staged files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+    echo "No staged files to check"
+    exit 0
+fi
+
+echo "Running Spotless formatting on staged files..."
+
+# Stash unstaged changes to avoid formatting them
+STASH_NAME="pre-commit-$(date +%s)"
+git stash push --keep-index --include-untracked -m "$STASH_NAME" > /dev/null 2>&1
+STASHED=$?
+
+# Run spotlessApply to format code
+./gradlew spotlessApply --quiet
+
+# Re-stage any files that were modified by spotless (only if they were originally staged)
+MODIFIED_FILES=$(git diff --name-only)
+if [ -n "$MODIFIED_FILES" ]; then
+    echo "$MODIFIED_FILES" | while read -r file; do
+        if echo "$STAGED_FILES" | grep -q "^${file}$"; then
+            git add "$file"
+            echo "  ✨ Formatted: $file"
+        fi
+    done
+fi
+
+# Restore stashed changes if we stashed anything
+if [ $STASHED -eq 0 ]; then
+    git stash pop --index > /dev/null 2>&1 || true
+fi
+
+echo "✅ Pre-commit checks passed"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,17 +1,24 @@
 #!/bin/sh
-# Pre-commit hook to check Spotless formatting
+# Pre-commit hook to auto-format code with Spotless
 
-echo "Checking code formatting..."
+echo "Formatting code with Spotless..."
 
-if ! ./gradlew spotlessCheck --daemon --quiet; then
-    echo ""
-    echo "❌ Code formatting check failed!"
-    echo ""
-    echo "Run './gradlew spotlessApply' to fix formatting, then commit again."
-    echo "Or use 'git commit --no-verify' to skip this check."
-    echo ""
-    exit 1
+# Get list of staged files before formatting
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
 fi
 
-echo "✅ Code formatting check passed"
+# Run spotlessApply to format all files
+./gradlew spotlessApply --daemon --quiet
+
+# Re-stage only the files that were originally staged
+echo "$STAGED_FILES" | while read -r file; do
+    if [ -f "$file" ]; then
+        git add "$file"
+    fi
+done
+
+echo "✅ Code formatted and staged"
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,7 @@ if [ -z "$STAGED_FILES" ]; then
 fi
 
 # Run spotlessApply to format all files
-./gradlew spotlessApply --daemon --quiet
+./gradlew spotlessApply --daemon --quiet || exit 1
 
 # Re-stage only the files that were originally staged
 echo "$STAGED_FILES" | while read -r file; do

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,47 +26,8 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Check formatting on changed files
-        run: |
-          set -e
-
-          # Get the list of changed files in this PR
-          git fetch origin ${{ github.base_ref }}
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No files changed in this PR"
-            exit 0
-          fi
-
-          echo "Files changed in this PR:"
-          echo "$CHANGED_FILES"
-          echo ""
-
-          # Run spotlessApply to format code
-          ./gradlew spotlessApply --console=plain
-
-          # Check if any changed files were modified by spotless
-          UNFORMATTED_FILES=""
-          for file in $CHANGED_FILES; do
-            if git diff --exit-code --quiet -- "$file"; then
-              # File unchanged by spotless
-              continue
-            else
-              # File was modified by spotless - not properly formatted
-              UNFORMATTED_FILES="$UNFORMATTED_FILES\n  - $file"
-            fi
-          done
-
-          if [ -n "$UNFORMATTED_FILES" ]; then
-            echo "❌ The following files are not properly formatted:"
-            echo -e "$UNFORMATTED_FILES"
-            echo ""
-            echo "Please run './gradlew spotlessApply' locally and commit the changes."
-            exit 1
-          fi
-
-          echo "✅ All changed files are properly formatted"
+      - name: Check formatting
+        run: ./gradlew spotlessCheck --console=plain
 
       - name: Compute version
         id: version

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,48 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - name: Check formatting on changed files
+        run: |
+          set -e
+
+          # Get the list of changed files in this PR
+          git fetch origin ${{ github.base_ref }}
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No files changed in this PR"
+            exit 0
+          fi
+
+          echo "Files changed in this PR:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          # Run spotlessApply to format code
+          ./gradlew spotlessApply --console=plain
+
+          # Check if any changed files were modified by spotless
+          UNFORMATTED_FILES=""
+          for file in $CHANGED_FILES; do
+            if git diff --exit-code --quiet -- "$file"; then
+              # File unchanged by spotless
+              continue
+            else
+              # File was modified by spotless - not properly formatted
+              UNFORMATTED_FILES="$UNFORMATTED_FILES\n  - $file"
+            fi
+          done
+
+          if [ -n "$UNFORMATTED_FILES" ]; then
+            echo "❌ The following files are not properly formatted:"
+            echo -e "$UNFORMATTED_FILES"
+            echo ""
+            echo "Please run './gradlew spotlessApply' locally and commit the changes."
+            exit 1
+          fi
+
+          echo "✅ All changed files are properly formatted"
+
       - name: Compute version
         id: version
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,13 +263,20 @@ This project uses Spotless for minimal automated formatting to ensure consistenc
 ./gradlew installGitHooks
 ```
 
-This installs a pre-commit hook that automatically formats code before each commit.
+This installs a pre-commit hook that checks formatting before each commit.
 
 **Manual formatting:**
 ```bash
 ./gradlew spotlessApply    # Format all files
 ./gradlew spotlessCheck    # Check formatting without changes
 ```
+
+**Skipping the hook:**
+```bash
+git commit --no-verify     # Skip pre-commit formatting check
+```
+
+Use `--no-verify` when making infrastructure commits (like the initial spotless setup) or when you plan to format in a separate commit.
 
 **CI Enforcement:** Pull requests must pass `spotlessCheck` before merging.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ This project uses Spotless for minimal automated formatting to ensure consistenc
 ./gradlew installGitHooks
 ```
 
-This installs a pre-commit hook that checks formatting before each commit.
+This installs a pre-commit hook that automatically formats code before each commit.
 
 **Manual formatting:**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,12 +247,33 @@ Domains are initialized using a two-phase pattern (server/common + client):
 
 ## Code Style
 
-- **Formatting:** Manual - prioritize minimal diffs across branches over strict style
-- **No automated linting** - focus on readable, maintainable code
+- **Formatting:** Automated via Spotless (minimal rules for consistency)
 - **Single-line if/for allowed** but braces preferred for multi-line
 - Keep nesting depth reasonable (prefer max 3 levels)
 
-**Note:** Automated formatters (Spotless) and linters (Checkstyle) were removed to maintain minimal diffs between branches. This makes cross-version maintenance and cherry-picking easier.
+### Code Formatting (Spotless)
+
+This project uses Spotless for minimal automated formatting to ensure consistency:
+- Remove unused imports
+- Trim trailing whitespace
+- End files with newline
+
+**Setup (one-time per developer):**
+```bash
+./gradlew installGitHooks
+```
+
+This installs a pre-commit hook that automatically formats code before each commit.
+
+**Manual formatting:**
+```bash
+./gradlew spotlessApply    # Format all files
+./gradlew spotlessCheck    # Check formatting without changes
+```
+
+**CI Enforcement:** Pull requests must pass `spotlessCheck` before merging.
+
+**Note:** The formatting rules are intentionally minimal to avoid churny diffs and maintain easy cherry-picking between branches.
 
 ## Commit Messages
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,58 @@ tasks.named('check') {
 	dependsOn 'spotlessCheck'
 }
 
+// Task to install Git hooks for developers
+tasks.register('installGitHooks') {
+	description = 'Install Git hooks for code formatting'
+	group = 'build setup'
+
+	doLast {
+		def hooksDir = file('.githooks')
+
+		// Find the git hooks directory (handles worktrees)
+		def gitDir = file('.git')
+		def gitHooksDir
+
+		if (gitDir.isFile()) {
+			// This is a worktree - read the gitdir path
+			def gitDirPath = gitDir.text.trim().replaceFirst('gitdir: ', '')
+			// For worktrees, hooks are in the main repo's .git/hooks
+			def worktreeGitDir = file(gitDirPath)
+			// Navigate up to find the main .git directory
+			def commonDir = new File(worktreeGitDir, 'commondir')
+			if (commonDir.exists()) {
+				def commonPath = commonDir.text.trim()
+				gitHooksDir = file("${worktreeGitDir}/${commonPath}/hooks")
+			} else {
+				gitHooksDir = file("${worktreeGitDir}/hooks")
+			}
+		} else {
+			// Regular git repository
+			gitHooksDir = file('.git/hooks')
+		}
+
+		if (!gitHooksDir.exists()) {
+			gitHooksDir.mkdirs()
+		}
+
+		println "Installing hooks to: ${gitHooksDir}"
+
+		hooksDir.listFiles()?.each { hookFile ->
+			if (hookFile.isFile()) {
+				def targetFile = new File(gitHooksDir, hookFile.name)
+				targetFile.text = hookFile.text
+				targetFile.setExecutable(true)
+				println "  ✓ Installed: ${hookFile.name}"
+			}
+		}
+	}
+}
+
+// Automatically install hooks on build
+tasks.named('build') {
+	dependsOn 'installGitHooks'
+}
+
 java {
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 	// if it is present.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'net.fabricmc.fabric-loom-remap' version "${loom_version}"
 	id 'maven-publish'
+	id 'com.diffplug.spotless' version '6.25.0'
 }
 
 version = System.getenv("MOD_VERSION") ?: project.mod_version
@@ -12,6 +13,23 @@ base {
 
 repositories {
 	maven { url = "https://maven.terraformersmc.com/releases/" }
+}
+
+spotless {
+	// Keep this intentionally minimal to avoid churny formatting diffs.
+	java {
+		target 'src/**/*.java'
+		removeUnusedImports()
+		trimTrailingWhitespace()
+		endWithNewline()
+	}
+
+	// Whitespace hygiene for common text files.
+	format('misc') {
+		target '*.gradle', '*.md', '*.yml', '*.yaml', '*.json', '*.properties', '.gitignore'
+		trimTrailingWhitespace()
+		endWithNewline()
+	}
 }
 
 loom {
@@ -49,6 +67,10 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.release = 21
+}
+
+tasks.named('check') {
+	dependsOn 'spotlessCheck'
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ tasks.register('installGitHooks') {
 
 		if (gitDir.isFile()) {
 			// This is a worktree - read the gitdir path
-			def gitDirPath = gitDir.text.trim().replaceFirst('gitdir: ', '')
+			def gitDirPath = gitDir.text.trim().replace('gitdir: ', '')
 			// For worktrees, hooks are in the main repo's .git/hooks
 			def worktreeGitDir = file(gitDirPath)
 			// Navigate up to find the main .git directory
@@ -96,7 +96,7 @@ tasks.register('installGitHooks') {
 				def commonPath = commonDir.text.trim()
 				gitHooksDir = file("${worktreeGitDir}/${commonPath}/hooks")
 			} else {
-				gitHooksDir = file("${worktreeGitDir}/hooks")
+				gitHooksDir = new File(worktreeGitDir, commonPath).canonicalFile.toPath().resolve("hooks").toFile()
 			}
 		} else {
 			// Regular git repository


### PR DESCRIPTION
### Summary
- Standardize formatting across the repo and ensure PRs can’t merge with inconsistent whitespace/imports.

### Changes
- Add Spotless to the Gradle build with minimal, low-churn rules (unused imports + whitespace/newline hygiene).
- Add a pre-commit hook to auto-format staged files before committing.
- Update PR workflow to run `spotlessCheck` (validation) rather than applying formatting automatically.
- Add `.editorconfig` and `.gitattributes` to normalize editor behavior and line endings across platforms.
- Document the formatting workflow and setup steps in `CLAUDE.md`.

### Notes
- Contributors should run `./gradlew installGitHooks` once to enable the pre-commit formatter.
- CI now requires `spotlessCheck` to pass before merging.