### PR TITLE
perf: avoid per-tick pipe connection cache recalculation

### DIFF
--- a/src/gametest/java/com/logistics/gametest/pipe/PipeInfrastructureGameTest.java
+++ b/src/gametest/java/com/logistics/gametest/pipe/PipeInfrastructureGameTest.java
@@ -103,4 +103,81 @@ public class PipeInfrastructureGameTest {
 
         context.succeed();
     }
+
+    /**
+     * Test that connection cache is only recalculated when neighbors change.
+     * This verifies the performance optimization that avoids per-tick recalculation.
+     */
+    @GameTest
+    public void testConnectionCacheOptimization(GameTestHelper context) {
+        BlockPos pipePos = new BlockPos(1, 1, 1);
+
+        // Place a pipe
+        context.setBlock(pipePos, LogisticsPipe.BLOCK.COPPER_TRANSPORT_PIPE);
+        PipeBlockEntity pipeEntity = context.getBlockEntity(pipePos, PipeBlockEntity.class);
+        if (pipeEntity == null) {
+            context.fail("Pipe block entity should exist");
+            return;
+        }
+
+        // Cache should be dirty initially
+        context.assertTrue(
+                pipeEntity.isConnectionCacheDirty(),
+                "Connection cache should be dirty on first tick"
+        );
+
+        // Manually tick the pipe - should recalculate connections
+        PipeBlockEntity.tick(
+                context.getLevel(),
+                pipePos,
+                context.getBlockState(pipePos),
+                pipeEntity
+        );
+
+        // After first tick, cache should be clean
+        context.assertFalse(
+                pipeEntity.isConnectionCacheDirty(),
+                "Connection cache should be clean after first tick"
+        );
+
+        // Tick again - cache should remain clean (no topology change)
+        PipeBlockEntity.tick(
+                context.getLevel(),
+                pipePos,
+                context.getBlockState(pipePos),
+                pipeEntity
+        );
+
+        context.assertFalse(
+                pipeEntity.isConnectionCacheDirty(),
+                "Connection cache should remain clean when no neighbors change"
+        );
+
+        // Place a neighbor block
+        context.setBlock(pipePos.north(), Blocks.CHEST);
+
+        // Manually invalidate cache (simulating neighborChanged callback)
+        pipeEntity.invalidateConnectionCache();
+
+        // Cache should be dirty after neighbor change
+        context.assertTrue(
+                pipeEntity.isConnectionCacheDirty(),
+                "Connection cache should be dirty after neighbor change"
+        );
+
+        // Tick - should recalculate and clean cache
+        PipeBlockEntity.tick(
+                context.getLevel(),
+                pipePos,
+                context.getBlockState(pipePos),
+                pipeEntity
+        );
+
+        context.assertFalse(
+                pipeEntity.isConnectionCacheDirty(),
+                "Connection cache should be clean after recalculation"
+        );
+
+        context.succeed();
+    }
 }

--- a/src/gametest/java/com/logistics/gametest/pipe/PipeInfrastructureGameTest.java
+++ b/src/gametest/java/com/logistics/gametest/pipe/PipeInfrastructureGameTest.java
@@ -156,10 +156,8 @@ public class PipeInfrastructureGameTest {
         // Place a neighbor block
         context.setBlock(pipePos.north(), Blocks.CHEST);
 
-        // Manually invalidate cache (simulating neighborChanged callback)
-        pipeEntity.invalidateConnectionCache();
-
         // Cache should be dirty after neighbor change
+        // (neighborChanged should have invalidated it automatically)
         context.assertTrue(
                 pipeEntity.isConnectionCacheDirty(),
                 "Connection cache should be dirty after neighbor change"

--- a/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -275,6 +275,11 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
             if (powered != state.getValue(POWERED)) {
                 world.setBlock(pos, state.setValue(POWERED, powered), Block.UPDATE_CLIENTS);
             }
+
+            // Invalidate connection cache when neighbors change
+            if (world.getBlockEntity(pos) instanceof PipeBlockEntity pipeEntity) {
+                pipeEntity.invalidateConnectionCache();
+            }
         }
         super.neighborChanged(state, world, pos, block, orientation, notify);
     }

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -46,6 +46,7 @@ public class PipeBlockEntity extends BaseBlockEntity
 
     // Connection type cache for rendering (updated when connections change)
     private final PipeConnection.Type[] connectionTypes = new PipeConnection.Type[6];
+    private boolean connectionCacheDirty = true;
 
     // Energy storage (only created for pipes with energy capability)
     @Nullable
@@ -113,6 +114,28 @@ public class PipeBlockEntity extends BaseBlockEntity
 
     public void setConnectionType(Direction direction, PipeConnection.Type type) {
         connectionTypes[direction.ordinal()] = type;
+    }
+
+    /**
+     * Mark the connection cache as dirty, forcing recalculation on next tick.
+     * Called when a neighbor block changes.
+     */
+    public void invalidateConnectionCache() {
+        connectionCacheDirty = true;
+    }
+
+    /**
+     * Check if the connection cache needs recalculation.
+     */
+    public boolean isConnectionCacheDirty() {
+        return connectionCacheDirty;
+    }
+
+    /**
+     * Mark the connection cache as clean after recalculation.
+     */
+    public void markConnectionCacheClean() {
+        connectionCacheDirty = false;
     }
 
     /**

--- a/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -140,11 +140,17 @@ public final class PipeRuntime {
     }
 
     private static void updateConnectionCache(TickContext ctx) {
+        // Only recalculate connections when topology changes (neighbor updates)
+        if (!ctx.blockEntity().isConnectionCacheDirty()) {
+            return;
+        }
+
         if (ctx.state().getBlock() instanceof PipeBlock pipeBlock) {
             for (Direction direction : Direction.values()) {
                 PipeConnection.Type type = pipeBlock.getDynamicConnectionType(ctx.world(), ctx.pos(), direction);
                 ctx.blockEntity().setConnectionType(direction, type);
             }
+            ctx.blockEntity().markConnectionCacheClean();
         }
     }
 


### PR DESCRIPTION
## Summary
- Improves pipe tick performance by only recalculating the connection cache when the surrounding blocks change.

## Changes
- Pipe connection cache updates are now skipped on ticks where no neighbor/topology change occurred.
- Neighbor updates now invalidate the pipe’s connection cache so it refreshes on the next tick.
- Added a GameTest to verify the cache is recalculated once initially and only re-dirtied on neighbor changes.

## Notes
- No gameplay or configuration changes intended; this is a performance-focused optimization aimed at reducing per-tick work in larger pipe networks.