### PR TITLE
refactor: consolidate traveling item speed physics into dedicated helper with tests

### DIFF
--- a/src/main/java/com/logistics/pipe/runtime/TravelingItem.java
+++ b/src/main/java/com/logistics/pipe/runtime/TravelingItem.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.ItemStack;
  * Items move along pipe edges from one connection point to another.
  */
 public class TravelingItem {
+    private static final TravelingItemPhysics PHYSICS = new TravelingItemPhysics(LogisticsPipe.CONFIG.ITEM_MIN_SPEED);
     /**
      * Progress threshold where routing decisions are made (item reaches pipe center).
      */
@@ -72,28 +73,7 @@ public class TravelingItem {
      * @return true if item reached the end of this pipe segment
      */
     public boolean tick(float accelerationRate, float dragCoefficient, float maxSpeed) {
-        boolean deceleratingToMax = speed > maxSpeed;
-        if (deceleratingToMax) {
-            float remaining = Math.max(1.0e-4f, 1.0f - progress);
-            float targetSquared = maxSpeed * maxSpeed;
-            float currentSquared = speed * speed;
-            float decel = (targetSquared - currentSquared) / (2.0f * remaining);
-            speed += decel;
-            if (speed < maxSpeed) {
-                speed = maxSpeed;
-            }
-        } else if (accelerationRate != 0f) {
-            speed += accelerationRate;
-        } else if (dragCoefficient != 0f) {
-            speed -= speed * dragCoefficient;
-        }
-
-        if (speed < LogisticsPipe.CONFIG.ITEM_MIN_SPEED) {
-            speed = LogisticsPipe.CONFIG.ITEM_MIN_SPEED;
-        } else if (!deceleratingToMax && speed > maxSpeed) {
-            speed = maxSpeed;
-        }
-
+        speed = PHYSICS.updateSpeed(speed, progress, accelerationRate, dragCoefficient, maxSpeed);
         progress += speed;
         return progress >= SERVER_EXIT_THRESHOLD;
     }

--- a/src/main/java/com/logistics/pipe/runtime/TravelingItemPhysics.java
+++ b/src/main/java/com/logistics/pipe/runtime/TravelingItemPhysics.java
@@ -1,0 +1,113 @@
+package com.logistics.pipe.runtime;
+
+/**
+ * Encapsulates physics calculations for traveling items in pipes.
+ * Handles acceleration, drag, and physics-based deceleration to target speeds.
+ */
+public class TravelingItemPhysics {
+    private final float minSpeed;
+
+    /**
+     * Create a physics calculator with the specified minimum speed.
+     *
+     * @param minSpeed Minimum allowed speed (items will not slow below this value)
+     */
+    public TravelingItemPhysics(float minSpeed) {
+        this.minSpeed = minSpeed;
+    }
+
+    /**
+     * Update speed for a traveling item based on current state and pipe properties.
+     * Simulates physics (deceleration/acceleration/drag) and clamps result to valid range.
+     *
+     * @param currentSpeed Current speed in blocks per tick
+     * @param currentProgress Current progress along pipe segment (0.0 to 1.0)
+     * @param accelerationRate Rate of acceleration/deceleration (blocks/tick²)
+     * @param dragCoefficient Fraction of speed lost per tick (0.0 to 1.0)
+     * @param maxSpeed Maximum allowed speed for this segment
+     * @return Next speed value, clamped to valid range
+     */
+    public float updateSpeed(
+            float currentSpeed,
+            float currentProgress,
+            float accelerationRate,
+            float dragCoefficient,
+            float maxSpeed) {
+        float speed = simulate(currentSpeed, currentProgress, accelerationRate, dragCoefficient, maxSpeed);
+        return clampSpeed(speed, maxSpeed, currentSpeed > maxSpeed);
+    }
+
+    /**
+     * Calculate next speed based on current physics mode (priority: deceleration > acceleration > drag).
+     *
+     * @param currentSpeed Current speed in blocks per tick
+     * @param currentProgress Current progress along pipe segment (0.0 to 1.0)
+     * @param accelerationRate Rate of acceleration (blocks/tick²)
+     * @param dragCoefficient Fraction of speed lost per tick (0.0 to 1.0)
+     * @param maxSpeed Maximum allowed speed for this segment
+     * @return Unclamped next speed value
+     */
+    private float simulate(
+            float currentSpeed,
+            float currentProgress,
+            float accelerationRate,
+            float dragCoefficient,
+            float maxSpeed) {
+        boolean isOverspeed = currentSpeed > maxSpeed;
+        boolean hasAcceleration = accelerationRate != 0f;
+        boolean hasDrag = dragCoefficient != 0f;
+
+        if (isOverspeed) return decelerateToTarget(currentSpeed, currentProgress, maxSpeed);
+        if (hasAcceleration) return currentSpeed + accelerationRate;
+        if (hasDrag) return applyDrag(currentSpeed, dragCoefficient);
+        return currentSpeed;
+    }
+
+    /**
+     * Calculate deceleration needed to reach target speed exactly at segment exit.
+     * Uses kinematic equation: v² = u² + 2as, solved for a (deceleration).
+     *
+     * @param currentSpeed Current speed
+     * @param currentProgress Current progress (0.0 to 1.0)
+     * @param targetSpeed Target speed to reach at exit
+     * @return New speed after applying calculated deceleration
+     */
+    private float decelerateToTarget(float currentSpeed, float currentProgress, float targetSpeed) {
+        float remaining = Math.max(1.0e-4f, 1.0f - currentProgress);
+        float targetSquared = targetSpeed * targetSpeed;
+        float currentSquared = currentSpeed * currentSpeed;
+        float deceleration = (targetSquared - currentSquared) / (2.0f * remaining);
+
+        float newSpeed = currentSpeed + deceleration;
+        return Math.max(newSpeed, targetSpeed);
+    }
+
+    /**
+     * Apply drag to current speed as a fraction lost per tick.
+     *
+     * @param currentSpeed Current speed
+     * @param dragCoefficient Fraction of speed to remove (0.0 to 1.0)
+     * @return Speed after drag
+     */
+    private float applyDrag(float currentSpeed, float dragCoefficient) {
+        return currentSpeed - (currentSpeed * dragCoefficient);
+    }
+
+    /**
+     * Clamp speed to valid range [minSpeed, maxSpeed].
+     * When decelerating to max, allows temporary overshoot above maxSpeed.
+     *
+     * @param speed Speed to clamp
+     * @param maxSpeed Maximum allowed speed
+     * @param isDeceleratingToMax Whether currently decelerating from overspeed
+     * @return Clamped speed value
+     */
+    private float clampSpeed(float speed, float maxSpeed, boolean isDeceleratingToMax) {
+        boolean isBelowMinimum = speed < minSpeed;
+        boolean isAboveMaximumWhileNotDecelerating = !isDeceleratingToMax && speed > maxSpeed;
+
+        if (isBelowMinimum) return minSpeed;
+        if (isAboveMaximumWhileNotDecelerating) return maxSpeed;
+        return speed;
+    }
+}

--- a/src/main/java/com/logistics/pipe/runtime/TravelingItemPhysics.java
+++ b/src/main/java/com/logistics/pipe/runtime/TravelingItemPhysics.java
@@ -5,6 +5,7 @@ package com.logistics.pipe.runtime;
  * Handles acceleration, drag, and physics-based deceleration to target speeds.
  */
 public class TravelingItemPhysics {
+    private static final float EPSILON = 1e-6f;
     private final float minSpeed;
 
     /**
@@ -33,8 +34,9 @@ public class TravelingItemPhysics {
             float accelerationRate,
             float dragCoefficient,
             float maxSpeed) {
-        float speed = simulate(currentSpeed, currentProgress, accelerationRate, dragCoefficient, maxSpeed);
-        return clampSpeed(speed, maxSpeed, currentSpeed > maxSpeed);
+        float effectiveMax = Math.max(maxSpeed, minSpeed);
+        float speed = simulate(currentSpeed, currentProgress, accelerationRate, dragCoefficient, effectiveMax);
+        return clampSpeed(speed, effectiveMax, currentSpeed > effectiveMax);
     }
 
     /**
@@ -53,9 +55,10 @@ public class TravelingItemPhysics {
             float accelerationRate,
             float dragCoefficient,
             float maxSpeed) {
+
         boolean isOverspeed = currentSpeed > maxSpeed;
-        boolean hasAcceleration = accelerationRate != 0f;
-        boolean hasDrag = dragCoefficient != 0f;
+        boolean hasAcceleration = Math.abs(accelerationRate) > EPSILON;
+        boolean hasDrag = Math.abs(dragCoefficient) > EPSILON;
 
         if (isOverspeed) return decelerateToTarget(currentSpeed, currentProgress, maxSpeed);
         if (hasAcceleration) return currentSpeed + accelerationRate;

--- a/src/test/java/com/logistics/pipe/runtime/TravelingItemPhysicsTest.java
+++ b/src/test/java/com/logistics/pipe/runtime/TravelingItemPhysicsTest.java
@@ -231,6 +231,20 @@ class TravelingItemPhysicsTest {
         }
 
         @Test
+        @DisplayName("should clamp to minSpeed when at zero speed with drag only")
+        void shouldClampZeroSpeedWithDrag() {
+            float result = physics.updateSpeed(
+                0f,     // currentSpeed
+                0.25f,  // currentProgress
+                0f,     // accelerationRate
+                0.5f,   // dragCoefficient
+                0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(MIN_SPEED, within(EPSILON));
+        }
+
+        @Test
         @DisplayName("should handle progress at start")
         void shouldHandleStartProgress() {
             float result = physics.updateSpeed(

--- a/src/test/java/com/logistics/pipe/runtime/TravelingItemPhysicsTest.java
+++ b/src/test/java/com/logistics/pipe/runtime/TravelingItemPhysicsTest.java
@@ -1,0 +1,261 @@
+package com.logistics.pipe.runtime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DisplayName("TravelingItemPhysics")
+class TravelingItemPhysicsTest {
+    private static final float MIN_SPEED = 0.01f;
+    private static final float EPSILON = 0.0001f;
+
+    private TravelingItemPhysics physics;
+
+    @BeforeEach
+    void setUp() {
+        physics = new TravelingItemPhysics(MIN_SPEED);
+    }
+
+    @Nested
+    @DisplayName("Acceleration mode")
+    class AccelerationMode {
+        @Test
+        @DisplayName("should increase speed when accelerating")
+        void shouldAccelerate() {
+            float result = physics.updateSpeed(
+                    0.05f,  // currentSpeed
+                    0.25f,  // currentProgress
+                    0.02f,  // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.07f, within(EPSILON));
+        }
+
+        @Test
+        @DisplayName("should clamp to maxSpeed when accelerating above max")
+        void shouldClampToMax() {
+            float result = physics.updateSpeed(
+                    0.09f,  // currentSpeed
+                    0.25f,  // currentProgress
+                    0.05f,  // accelerationRate (would go to 0.14)
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.1f, within(EPSILON));
+        }
+
+        @Test
+        @DisplayName("should not accelerate when already at max speed")
+        void shouldNotAccelerateAtMax() {
+            float result = physics.updateSpeed(
+                    0.1f,   // currentSpeed (at max)
+                    0.25f,  // currentProgress
+                    0.02f,  // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.1f, within(EPSILON));
+        }
+    }
+
+    @Nested
+    @DisplayName("Drag mode")
+    class DragMode {
+        @Test
+        @DisplayName("should reduce speed when drag is applied")
+        void shouldApplyDrag() {
+            float result = physics.updateSpeed(
+                    0.1f,   // currentSpeed
+                    0.25f,  // currentProgress
+                    0f,     // accelerationRate
+                    0.2f,   // dragCoefficient (20% reduction)
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.08f, within(EPSILON));
+        }
+
+        @Test
+        @DisplayName("should clamp to minSpeed when drag reduces below minimum")
+        void shouldClampToMin() {
+            float result = physics.updateSpeed(
+                    0.02f,  // currentSpeed
+                    0.25f,  // currentProgress
+                    0f,     // accelerationRate
+                    0.9f,   // dragCoefficient (90% reduction)
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(MIN_SPEED, within(EPSILON));
+        }
+    }
+
+    @Nested
+    @DisplayName("Deceleration mode")
+    class DecelerationMode {
+        @Test
+        @DisplayName("should decelerate when above max speed")
+        void shouldDecelerate() {
+            float result = physics.updateSpeed(
+                    0.15f,  // currentSpeed (above max)
+                    0.5f,   // currentProgress (halfway)
+                    0f,     // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            // Should decelerate toward maxSpeed
+            assertThat(result).isLessThan(0.15f);
+            assertThat(result).isGreaterThan(0.1f);
+        }
+
+        @Test
+        @DisplayName("should reach maxSpeed at segment exit")
+        void shouldReachMaxAtExit() {
+            // Start with overspeed, near exit
+            float result = physics.updateSpeed(
+                    0.15f,  // currentSpeed
+                    0.99f,  // currentProgress (very close to exit)
+                    0f,     // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            // Should be very close to maxSpeed
+            assertThat(result).isCloseTo(0.1f, within(0.01f));
+        }
+
+        @Test
+        @DisplayName("should not go below target speed when decelerating")
+        void shouldNotGoBelowTarget() {
+            float result = physics.updateSpeed(
+                    0.11f,  // currentSpeed (slightly above max)
+                    0.99f,  // currentProgress (near exit)
+                    0f,     // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            // Should clamp to maxSpeed, not go below
+            assertThat(result).isGreaterThanOrEqualTo(0.1f);
+        }
+    }
+
+    @Nested
+    @DisplayName("Physics mode priority")
+    class PhysicsPriority {
+        @Test
+        @DisplayName("deceleration should override acceleration")
+        void decelerationOverridesAcceleration() {
+            float result = physics.updateSpeed(
+                    0.15f,  // currentSpeed (above max)
+                    0.5f,   // currentProgress
+                    0.05f,  // accelerationRate (would increase speed)
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            // Should decelerate despite acceleration being present
+            assertThat(result).isLessThan(0.15f);
+        }
+
+        @Test
+        @DisplayName("deceleration should override drag")
+        void decelerationOverridesDrag() {
+            float result = physics.updateSpeed(
+                    0.15f,  // currentSpeed (above max)
+                    0.5f,   // currentProgress
+                    0f,     // accelerationRate
+                    0.5f,   // dragCoefficient (would reduce to 0.075)
+                    0.1f    // maxSpeed
+            );
+
+            // Should decelerate toward maxSpeed, not apply drag
+            assertThat(result).isGreaterThan(0.075f);
+            assertThat(result).isLessThan(0.15f);
+        }
+
+        @Test
+        @DisplayName("acceleration should override drag")
+        void accelerationOverridesDrag() {
+            float result = physics.updateSpeed(
+                    0.05f,  // currentSpeed
+                    0.25f,  // currentProgress
+                    0.02f,  // accelerationRate
+                    0.5f,   // dragCoefficient (would reduce to 0.025)
+                    0.1f    // maxSpeed
+            );
+
+            // Should accelerate, not apply drag
+            assertThat(result).isCloseTo(0.07f, within(EPSILON));
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    class EdgeCases {
+        @Test
+        @DisplayName("should maintain speed with no forces")
+        void shouldMaintainSpeed() {
+            float result = physics.updateSpeed(
+                    0.05f,  // currentSpeed
+                    0.25f,  // currentProgress
+                    0f,     // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.05f, within(EPSILON));
+        }
+
+        @Test
+        @DisplayName("should handle zero current speed")
+        void shouldHandleZeroSpeed() {
+            float result = physics.updateSpeed(
+                    0f,     // currentSpeed
+                    0.25f,  // currentProgress
+                    0.01f,  // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.01f, within(EPSILON));
+        }
+
+        @Test
+        @DisplayName("should handle progress at start")
+        void shouldHandleStartProgress() {
+            float result = physics.updateSpeed(
+                    0.05f,  // currentSpeed
+                    0f,     // currentProgress (at start)
+                    0.01f,  // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.06f, within(EPSILON));
+        }
+
+        @Test
+        @DisplayName("should handle progress near exit")
+        void shouldHandleNearExitProgress() {
+            float result = physics.updateSpeed(
+                    0.05f,  // currentSpeed
+                    0.99f,  // currentProgress (near exit)
+                    0.01f,  // accelerationRate
+                    0f,     // dragCoefficient
+                    0.1f    // maxSpeed
+            );
+
+            assertThat(result).isCloseTo(0.06f, within(EPSILON));
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Centralized traveling item speed updates into a single physics calculator to make item movement behavior easier to reason about and verify.

### Changes
- Extracted speed update logic from `TravelingItem` into `TravelingItemPhysics`.
- Added comprehensive unit coverage for acceleration, drag, overspeed deceleration, priority rules, and edge cases.

### Notes
- No intended gameplay behavior changes; this is a behavior-preserving refactor aimed at improving testability and future tuning safety.