### PR TITLE
perf: gate pipe connection updates behind cache dirty flag

### DIFF
--- a/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -119,10 +119,7 @@ public final class PipeRuntime {
 
         // Update connection cache and notify modules of topology changes
         if (ctx.hasPipe()) {
-            updateConnectionCache(ctx);
-            if (handleConnectionChanges(ctx)) {
-                itemState.markNeedsSync();
-            }
+            updateConnections(ctx, itemState);
             ctx.pipe().onTick(ctx.pipeContext());
         }
 
@@ -139,12 +136,16 @@ public final class PipeRuntime {
         transferCompletedItems(ctx, itemState);
     }
 
-    private static void updateConnectionCache(TickContext ctx) {
-        // Only recalculate connections when topology changes (neighbor updates)
+    private static void updateConnections(TickContext ctx, ItemTickState itemState) {
         if (!ctx.blockEntity().isConnectionCacheDirty()) {
             return;
         }
 
+        updateConnectionCache(ctx);
+        if (handleConnectionChanges(ctx)) itemState.markNeedsSync();
+    }
+
+    private static void updateConnectionCache(TickContext ctx) {
         if (ctx.state().getBlock() instanceof PipeBlock pipeBlock) {
             for (Direction direction : Direction.values()) {
                 PipeConnection.Type type = pipeBlock.getDynamicConnectionType(ctx.world(), ctx.pos(), direction);


### PR DESCRIPTION
### Summary
- Reduced per-tick work in pipe runtimes by skipping connection change checks unless the connection cache is marked dirty.

### Changes
- Pipe ticks now update the connection cache and run topology change handling only when neighbor/topology updates have invalidated the cache.
- Item state sync is triggered only when an actual connection change is detected during a dirty-cache update.

### Notes
- No gameplay or API changes expected; this is a runtime performance improvement that primarily helps in worlds with many pipes.