### PR TITLE
feat: add beta build workflow for release branches

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - 'release-please--mc-**'
 
-permissions:
-  contents: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,7 +39,13 @@ jobs:
           BASE_BRANCH=${BASE_BRANCH//-/\/}
 
           # Count commits on this branch since divergence from base branch
-          BUILD_NUM=$(git rev-list --count origin/${BASE_BRANCH}..HEAD)
+          # Verify base ref exists before using it
+          if git rev-parse --verify origin/${BASE_BRANCH} >/dev/null 2>&1; then
+            BUILD_NUM=$(git rev-list --count origin/${BASE_BRANCH}..HEAD)
+          else
+            echo "⚠️  Base branch origin/${BASE_BRANCH} not found, falling back to HEAD commit count"
+            BUILD_NUM=$(git rev-list --count HEAD)
+          fi
 
           # Construct beta version
           BETA_VERSION="${BASE_VERSION}-beta.${BUILD_NUM}"

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,0 +1,141 @@
+name: Build (Beta)
+
+on:
+  push:
+    branches:
+      - 'release-please--mc-**'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        loader: [fabric]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Fetch all history for commit counting
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Extract version information
+        id: version
+        run: |
+          # Extract base version from release-please manifest
+          BASE_VERSION=$(jq -r '."."' .release-please-manifest.json)
+
+          # Extract base branch name from release-please branch
+          # release-please--mc-1.21.11 → mc/1.21.11
+          BASE_BRANCH=${GITHUB_REF_NAME#release-please--}
+          BASE_BRANCH=${BASE_BRANCH//-/\/}
+
+          # Count commits on this branch since divergence from base branch
+          BUILD_NUM=$(git rev-list --count origin/${BASE_BRANCH}..HEAD)
+
+          # Construct beta version
+          BETA_VERSION="${BASE_VERSION}-beta.${BUILD_NUM}"
+
+          # Extract MC version from gradle.properties
+          MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
+
+          # Get loader from matrix
+          LOADER="${{ matrix.loader }}"
+
+          # Build full version string with SemVer build metadata
+          FULL_VERSION="${BETA_VERSION}+mc${MC_VERSION}.${LOADER}"
+
+          # Determine Gradle task based on MC version
+          # MC 26.1+ is not obfuscated (use jar)
+          # MC 1.21.11 and earlier are obfuscated (use remapJar)
+          if [[ "$MC_VERSION" =~ ^([0-9]+)\. ]]; then
+            MC_MAJOR="${BASH_REMATCH[1]}"
+            if (( MC_MAJOR >= 26 )); then
+              GRADLE_TASK="jar"
+            else
+              GRADLE_TASK="remapJar"
+            fi
+          else
+            # Fallback for unexpected version format
+            GRADLE_TASK="remapJar"
+          fi
+
+          # Create potentially shortened version for Modrinth (32 char limit)
+          MODRINTH_VERSION="${FULL_VERSION}"
+          if (( ${#MODRINTH_VERSION} > 32 )); then
+            MODRINTH_VERSION="${MODRINTH_VERSION:0:32}"
+            echo "⚠️  Modrinth version truncated to 32 chars: $MODRINTH_VERSION"
+          fi
+
+          echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "beta_version=$BETA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "modrinth_version=$MODRINTH_VERSION" >> "$GITHUB_OUTPUT"
+          echo "full_version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "minecraft_version=$MC_VERSION" >> "$GITHUB_OUTPUT"
+          echo "loader=$LOADER" >> "$GITHUB_OUTPUT"
+          echo "gradle_task=$GRADLE_TASK" >> "$GITHUB_OUTPUT"
+          echo "📦 Base version: $BASE_VERSION"
+          echo "📦 Beta version: $BETA_VERSION"
+          echo "📦 Build number: $BUILD_NUM"
+          echo "📦 Built for MC: $MC_VERSION"
+          echo "📦 Loader: $LOADER"
+          echo "📦 Full version: $FULL_VERSION (will be passed to Gradle as MOD_VERSION)"
+          echo "📦 Modrinth version: $MODRINTH_VERSION"
+          echo "📦 Expected artifact: logistics-$FULL_VERSION.jar"
+          echo "🔨 Gradle task: $GRADLE_TASK"
+
+      - name: Build with Gradle
+        run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
+        env:
+          MOD_VERSION: ${{ steps.version.outputs.full_version }}
+
+      - name: List build artifacts
+        run: |
+          echo "📦 Build artifacts created:"
+          ls -lh build/libs/
+          echo ""
+          echo "🔍 Looking for: logistics-${{ steps.version.outputs.full_version }}.jar"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: logistics-${{ steps.version.outputs.full_version }}
+          path: build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+          if-no-files-found: error
+
+      - name: Publish to Modrinth and CurseForge
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          modrinth-featured: false
+          modrinth-version: ${{ steps.version.outputs.modrinth_version }}
+
+          curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+
+          version-type: beta
+          name: "Logistics v${{ steps.version.outputs.beta_version }} (BETA) for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"
+          version: "${{ steps.version.outputs.full_version }}"
+
+          files: build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+
+          changelog: |
+            **⚠️ This is a BETA release for testing.**
+
+            This version has not been officially released yet. Please help test and report any issues!
+
+            Based on upcoming release: v${{ steps.version.outputs.base_version }}
+
+            🐛 Found a bug? https://github.com/Indemnity83/logistics/issues

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,9 @@
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" }
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Refactorings" },
+    { "type": "test", "section": "Testing" },
+    { "type": "build", "section": "Build System" }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds automated beta builds and publishing for `release-please--mc-*` branches so upcoming releases can be tested before the final tag.

## Changes
- New **Build (Beta)** GitHub Actions workflow that:
- Builds artifacts on push to `release-please--mc-**` branches.
- Generates a `-beta.N` version based on commits since the base branch.
- Uploads the built JAR as a workflow artifact.
- Publishes beta builds to **Modrinth** and **CurseForge** with clear “BETA” labeling.
- Expands `release-please` changelog sections to include:
- **Refactorings**, **Testing**, and **Build System** (in addition to existing sections).

## Notes
- Intended for pre-release validation; beta builds are marked as non-featured and published as `version-type: beta` to reduce confusion with stable releases.