### PR TITLE
fix: update beta build workflow for new release-please branch naming

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -3,7 +3,7 @@ name: Build (Beta)
 on:
   push:
     branches:
-      - 'release-please--mc-**'
+      - 'release-please--branches*/**'
 
 jobs:
   build:
@@ -34,9 +34,9 @@ jobs:
           BASE_VERSION=$(jq -r '."."' .release-please-manifest.json)
 
           # Extract base branch name from release-please branch
-          # release-please--mc-1.21.11 → mc/1.21.11
-          BASE_BRANCH=${GITHUB_REF_NAME#release-please--}
-          BASE_BRANCH=${BASE_BRANCH//-/\/}
+          # release-please--branches--mc/1.21.11--components--mc1.21.11 → mc/1.21.11
+          BASE_BRANCH=${GITHUB_REF_NAME#release-please--branches--}
+          BASE_BRANCH=${BASE_BRANCH%%--components--*}
 
           # Count commits on this branch since divergence from base branch
           # Verify base ref exists before using it


### PR DESCRIPTION
## Summary
- Restores automatic beta build triggers for release-please branches after the upstream branch naming format changed.

## Changes
- Updated `Build (Beta)` workflow branch filters to match the new `release-please` “branches/…” naming scheme.
- Adjusted base-branch extraction logic so beta builds correctly resolve the originating branch (e.g., `mc/1.21.11`) from the new release-please branch format.

## Notes
- No gameplay/runtime changes—this only affects CI behavior for beta builds.