### PR TITLE
fix: move schemaVersion to top of fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "authors": ["Kyle Klaus (@indemnity83)"],
   "contributors": ["Malcolm Riley (textures, CC BY 4.0)"],
   "contact": {
@@ -23,7 +24,6 @@
   "license": "MIT",
   "mixins": ["logistics.mixins.json"],
   "name": "Logistics",
-  "schemaVersion": 1,
   "suggests": {},
   "version": "${version}"
 }


### PR DESCRIPTION
## Summary
- Reordered the `fabric.mod.json` metadata so `schemaVersion` is the first key.

## Changes
- Ensures Fabric’s schema declaration is encountered immediately during metadata parsing.

## Notes
- No gameplay or API changes; this is a metadata-only compatibility/polish fix.