### PR TITLE
fix: add missing particle textures to laser quarry, pipes, and engines

### DIFF
--- a/src/main/resources/assets/logistics/models/block/automation/laser_quarry_display.json
+++ b/src/main/resources/assets/logistics/models/block/automation/laser_quarry_display.json
@@ -1,6 +1,7 @@
 {
   "credit": "Scrolling display overlay for laser quarry",
   "textures": {
+    "particle": "logistics:block/automation/laser_quarry/display",
     "display": "logistics:block/automation/laser_quarry/display"
   },
   "elements": [

--- a/src/main/resources/assets/logistics/models/block/automation/laser_quarry_led_green.json
+++ b/src/main/resources/assets/logistics/models/block/automation/laser_quarry_led_green.json
@@ -1,6 +1,7 @@
 {
   "credit": "LED overlay for laser quarry - emissive",
   "textures": {
+    "particle": "logistics:block/automation/laser_quarry/led_green",
     "led": "logistics:block/automation/laser_quarry/led_green"
   },
   "elements": [

--- a/src/main/resources/assets/logistics/models/block/automation/laser_quarry_led_red.json
+++ b/src/main/resources/assets/logistics/models/block/automation/laser_quarry_led_red.json
@@ -1,6 +1,7 @@
 {
   "credit": "LED overlay for laser quarry - emissive",
   "textures": {
+    "particle": "logistics:block/automation/laser_quarry/led_red",
     "led": "logistics:block/automation/laser_quarry/led_red"
   },
   "elements": [

--- a/src/main/resources/assets/logistics/models/block/automation/laser_quarry_top_hatch.json
+++ b/src/main/resources/assets/logistics/models/block/automation/laser_quarry_top_hatch.json
@@ -1,6 +1,7 @@
 {
   "credit": "Top hatch overlay for laser quarry - shows when pipe connected",
   "textures": {
+    "particle": "logistics:block/automation/laser_quarry/top_hatch",
     "hatch": "logistics:block/automation/laser_quarry/top_hatch"
   },
   "elements": [

--- a/src/main/resources/assets/logistics/models/block/pipe/pipe_markings.json
+++ b/src/main/resources/assets/logistics/models/block/pipe/pipe_markings.json
@@ -39,6 +39,7 @@
   ],
   "parent": "block/block",
   "textures": {
+    "particle": "logistics:block/pipe/pipe_markings",
     "texture": "logistics:block/pipe/pipe_markings"
   }
 }

--- a/src/main/resources/assets/logistics/models/block/power/creative_engine_bellow.json
+++ b/src/main/resources/assets/logistics/models/block/power/creative_engine_bellow.json
@@ -2,6 +2,7 @@
 	"parent": "minecraft:block/cube",
 	"texture_size": [64, 64],
 	"textures": {
+		"particle": "logistics:block/power/creative_engine",
 		"0": "logistics:block/power/creative_engine"
 	},
 	"elements": [

--- a/src/main/resources/assets/logistics/models/block/power/creative_engine_piston.json
+++ b/src/main/resources/assets/logistics/models/block/power/creative_engine_piston.json
@@ -2,6 +2,7 @@
 	"parent": "minecraft:block/cube",
 	"texture_size": [64, 64],
 	"textures": {
+		"particle": "logistics:block/power/creative_engine",
 		"0": "logistics:block/power/creative_engine"
 	},
 	"elements": [

--- a/src/main/resources/assets/logistics/models/block/power/redstone_engine_bellow.json
+++ b/src/main/resources/assets/logistics/models/block/power/redstone_engine_bellow.json
@@ -2,6 +2,7 @@
 	"parent": "minecraft:block/cube",
 	"texture_size": [64, 64],
 	"textures": {
+		"particle": "logistics:block/power/redstone_engine",
 		"0": "logistics:block/power/redstone_engine"
 	},
 	"elements": [

--- a/src/main/resources/assets/logistics/models/block/power/redstone_engine_piston.json
+++ b/src/main/resources/assets/logistics/models/block/power/redstone_engine_piston.json
@@ -2,6 +2,7 @@
 	"parent": "minecraft:block/cube",
 	"texture_size": [64, 64],
 	"textures": {
+		"particle": "logistics:block/power/redstone_engine",
 		"0": "logistics:block/power/redstone_engine"
 	},
 	"elements": [

--- a/src/main/resources/assets/logistics/models/block/power/stirling_engine_bellow.json
+++ b/src/main/resources/assets/logistics/models/block/power/stirling_engine_bellow.json
@@ -2,6 +2,7 @@
 	"parent": "minecraft:block/cube",
 	"texture_size": [64, 64],
 	"textures": {
+		"particle": "logistics:block/power/stirling_engine",
 		"0": "logistics:block/power/stirling_engine"
 	},
 	"elements": [

--- a/src/main/resources/assets/logistics/models/block/power/stirling_engine_piston.json
+++ b/src/main/resources/assets/logistics/models/block/power/stirling_engine_piston.json
@@ -2,6 +2,7 @@
 	"parent": "minecraft:block/cube",
 	"texture_size": [64, 64],
 	"textures": {
+		"particle": "logistics:block/power/stirling_engine",
 		"0": "logistics:block/power/stirling_engine"
 	},
 	"elements": [

--- a/src/main/resources/assets/logistics/models/item/power/creative_engine.json
+++ b/src/main/resources/assets/logistics/models/item/power/creative_engine.json
@@ -2,6 +2,7 @@
   "parent": "minecraft:block/cube",
   "texture_size": [64, 64],
   "textures": {
+    "particle": "logistics:block/power/creative_engine",
     "0": "logistics:block/power/creative_engine"
   },
   "elements": [

--- a/src/main/resources/assets/logistics/models/item/power/redstone_engine.json
+++ b/src/main/resources/assets/logistics/models/item/power/redstone_engine.json
@@ -2,6 +2,7 @@
   "parent": "minecraft:block/cube",
   "texture_size": [64, 64],
   "textures": {
+    "particle": "logistics:block/power/redstone_engine",
     "0": "logistics:block/power/redstone_engine"
   },
   "elements": [

--- a/src/main/resources/assets/logistics/models/item/power/stirling_engine.json
+++ b/src/main/resources/assets/logistics/models/item/power/stirling_engine.json
@@ -2,6 +2,7 @@
   "parent": "minecraft:block/cube",
   "texture_size": [64, 64],
   "textures": {
+    "particle": "logistics:block/power/stirling_engine",
     "0": "logistics:block/power/stirling_engine"
   },
   "elements": [


### PR DESCRIPTION
## Summary
- Fixes missing/incorrect block/item particle textures by ensuring affected models define a proper `particle` texture.

## Changes
- Laser quarry overlay models now specify particle textures (display, LEDs, top hatch).
- Pipe markings model now specifies a particle texture.
- Engine bellow/piston block models and engine item models now specify particle textures (creative, redstone, stirling).

## Notes
- This improves visual consistency for block break particles and related particle-based rendering without changing gameplay behavior.