### PR TITLE
fix: prevent kiln recipes from showing up empty

### DIFF
--- a/src/main/java/com/logistics/core/fabricator/KilnRecipeWrapper.java
+++ b/src/main/java/com/logistics/core/fabricator/KilnRecipeWrapper.java
@@ -42,6 +42,11 @@ public class KilnRecipeWrapper implements Recipe<RecipeInput> {
     }
 
     @Override
+    public boolean isSpecial() {
+        return true;
+    }
+
+    @Override
     public @NotNull PlacementInfo placementInfo() {
         return PlacementInfo.NOT_PLACEABLE;
     }


### PR DESCRIPTION
### Summary
- Fixes an issue where kiln recipes could appear as empty/invalid in recipe handling.

### Changes
- Marks `KilnRecipeWrapper` as a special recipe so it won’t be treated like a normal placeable/craftable recipe, avoiding empty recipe edge cases.

### Notes
- No content changes to kiln recipes themselves; this only affects how the wrapper is classified and displayed/processed.