### PR TITLE
feat: add runtime-toggleable network debug logging and /logistics debug command

### DIFF
--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -1,5 +1,6 @@
 package com.logistics;
 
+import com.logistics.core.LogisticsCommands;
 import com.logistics.core.bootstrap.DomainBootstrap;
 import com.logistics.core.fabricator.KilnBlock;
 import com.logistics.core.fabricator.KilnBlockEntity;
@@ -87,6 +88,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         registerWorldgen();
         ChestLootModifier.register();
         NetworkTickHandler.register();
+        LogisticsCommands.register();
     }
 
     private void registerStorageAccess() {

--- a/src/main/java/com/logistics/LogisticsPipe.java
+++ b/src/main/java/com/logistics/LogisticsPipe.java
@@ -1,8 +1,10 @@
 package com.logistics;
 
 import com.logistics.api.LogisticsApi;
+import com.logistics.core.DebugLog;
 import com.logistics.core.bootstrap.DomainBootstrap;
 import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.pipe.network.NetDbg;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeApi;
 import com.logistics.pipe.PipeTypes;
@@ -53,6 +55,8 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
     @Override
     public void initCommon() {
         LOGGER.info("Registering {}", domain());
+
+        DebugLog.register(NetDbg.DOMAIN);
 
         BLOCK.register();
         ENTITY.register();

--- a/src/main/java/com/logistics/core/DebugLog.java
+++ b/src/main/java/com/logistics/core/DebugLog.java
@@ -1,0 +1,46 @@
+package com.logistics.core;
+
+import com.logistics.LogisticsMod;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Runtime-toggleable debug logging by named subsystem.
+ * Domain names are arbitrary strings — no registration required.
+ * Enable via: /logistics debug <domain> true
+ * Output is emitted at INFO level — no log4j configuration needed.
+ */
+public final class DebugLog {
+    private static final Set<String> registered = ConcurrentHashMap.newKeySet();
+    private static final Set<String> enabled = ConcurrentHashMap.newKeySet();
+
+    private DebugLog() {}
+
+    public static void register(String domain) {
+        registered.add(domain);
+    }
+
+    public static Set<String> getRegisteredDomains() {
+        return Collections.unmodifiableSet(registered);
+    }
+
+    public static boolean isEnabled(String domain) {
+        return enabled.contains(domain);
+    }
+
+    public static void setEnabled(String domain, boolean on) {
+        if (on) enabled.add(domain);
+        else enabled.remove(domain);
+    }
+
+    public static Set<String> getEnabledDomains() {
+        return Collections.unmodifiableSet(enabled);
+    }
+
+    public static void debug(String domain, String format, Object... args) {
+        if (enabled.contains(domain)) {
+            LogisticsMod.LOGGER.info("[" + domain + "] " + format, args);
+        }
+    }
+}

--- a/src/main/java/com/logistics/core/LogisticsCommands.java
+++ b/src/main/java/com/logistics/core/LogisticsCommands.java
@@ -1,0 +1,71 @@
+package com.logistics.core;
+
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+
+import java.util.Set;
+
+/**
+ * Registers /logistics commands.
+ * /logistics debug                  — show registered domains and enabled state
+ * /logistics debug <domain> true    — enable debug logging for a named domain
+ * /logistics debug <domain> false   — disable debug logging for a named domain
+ *
+ * Registered domains come from DebugLog.register() calls in bootstrap.
+ * Example: /logistics debug network true
+ */
+public final class LogisticsCommands {
+    private LogisticsCommands() {}
+
+    private static final SuggestionProvider<CommandSourceStack> DOMAIN_SUGGESTIONS =
+        (ctx, builder) -> SharedSuggestionProvider.suggest(DebugLog.getRegisteredDomains(), builder);
+
+    public static void register() {
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
+            dispatcher.register(
+                Commands.literal("logistics")
+                    .then(Commands.literal("debug")
+                        .requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                        .executes(ctx -> {
+                            Set<String> registered = DebugLog.getRegisteredDomains();
+                            Set<String> enabled = DebugLog.getEnabledDomains();
+                            if (registered.isEmpty()) {
+                                ctx.getSource().sendSuccess(
+                                    () -> Component.literal("No debug domains registered."), false);
+                            } else {
+                                StringBuilder sb = new StringBuilder("Debug domains:");
+                                for (String domain : registered) {
+                                    sb.append("\n  ").append(domain).append(": ")
+                                      .append(enabled.contains(domain) ? "ON" : "off");
+                                }
+                                String msg = sb.toString();
+                                ctx.getSource().sendSuccess(() -> Component.literal(msg), false);
+                            }
+                            return 1;
+                        })
+                        .then(Commands.argument("domain", StringArgumentType.word())
+                            .suggests(DOMAIN_SUGGESTIONS)
+                            .then(Commands.argument("state", BoolArgumentType.bool())
+                                .executes(ctx -> {
+                                    String domain = StringArgumentType.getString(ctx, "domain");
+                                    boolean state = BoolArgumentType.getBool(ctx, "state");
+                                    DebugLog.setEnabled(domain, state);
+                                    ctx.getSource().sendSuccess(
+                                        () -> Component.literal(
+                                            domain + " debug logging: " + (state ? "ON" : "OFF")),
+                                        true);
+                                    return 1;
+                                })
+                            )
+                        )
+                    )
+            )
+        );
+    }
+}

--- a/src/main/java/com/logistics/core/LogisticsCommands.java
+++ b/src/main/java/com/logistics/core/LogisticsCommands.java
@@ -9,6 +9,9 @@ import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,7 +27,13 @@ public final class LogisticsCommands {
     private LogisticsCommands() {}
 
     private static final SuggestionProvider<CommandSourceStack> DOMAIN_SUGGESTIONS =
-        (ctx, builder) -> SharedSuggestionProvider.suggest(DebugLog.getRegisteredDomains(), builder);
+        (ctx, builder) -> SharedSuggestionProvider.suggest(sortedDomains(), builder);
+
+    private static List<String> sortedDomains() {
+        List<String> domains = new ArrayList<>(DebugLog.getRegisteredDomains());
+        Collections.sort(domains);
+        return domains;
+    }
 
     public static void register() {
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
@@ -33,7 +42,7 @@ public final class LogisticsCommands {
                     .then(Commands.literal("debug")
                         .requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
                         .executes(ctx -> {
-                            Set<String> registered = DebugLog.getRegisteredDomains();
+                            List<String> registered = sortedDomains();
                             Set<String> enabled = DebugLog.getEnabledDomains();
                             if (registered.isEmpty()) {
                                 ctx.getSource().sendSuccess(
@@ -58,7 +67,7 @@ public final class LogisticsCommands {
                                     if (!DebugLog.getRegisteredDomains().contains(domain)) {
                                         ctx.getSource().sendFailure(Component.literal(
                                             "Unknown debug domain: " + domain
-                                            + ". Known: " + DebugLog.getRegisteredDomains()));
+                                            + ". Known: " + sortedDomains()));
                                         return 0;
                                     }
                                     DebugLog.setEnabled(domain, state);

--- a/src/main/java/com/logistics/core/LogisticsCommands.java
+++ b/src/main/java/com/logistics/core/LogisticsCommands.java
@@ -55,6 +55,12 @@ public final class LogisticsCommands {
                                 .executes(ctx -> {
                                     String domain = StringArgumentType.getString(ctx, "domain");
                                     boolean state = BoolArgumentType.getBool(ctx, "state");
+                                    if (!DebugLog.getRegisteredDomains().contains(domain)) {
+                                        ctx.getSource().sendFailure(Component.literal(
+                                            "Unknown debug domain: " + domain
+                                            + ". Known: " + DebugLog.getRegisteredDomains()));
+                                        return 0;
+                                    }
                                     DebugLog.setEnabled(domain, state);
                                     ctx.getSource().sendSuccess(
                                         () -> Component.literal(

--- a/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -1,8 +1,8 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
-import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;
@@ -251,7 +251,7 @@ public class ProviderModule implements Module {
         Map<ItemStack, Long> availableItems = aggregateInventoryItems(ctx, inventoryFaces, mode);
         network.registerSupply(ctx.pos(), toVariantMap(availableItems), SUPPLY_PRIORITY);
 
-        if (!availableItems.isEmpty()) {
+        if (!availableItems.isEmpty() && NetDbg.isEnabled()) {
             long totalItems = availableItems.values().stream().mapToLong(Long::longValue).sum();
             NetDbg.out("[Provider @ {}] Mode {} - Updated supply: {} item types, {} total",
                     ctx.pos(), mode, availableItems.size(), totalItems);

--- a/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.NbtCompat;
@@ -29,8 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import static com.logistics.LogisticsMod.LOGGER;
 
 /**
  * Provider module - scans all adjacent inventories and fulfills orders from the network.
@@ -254,7 +253,7 @@ public class ProviderModule implements Module {
 
         if (!availableItems.isEmpty()) {
             long totalItems = availableItems.values().stream().mapToLong(Long::longValue).sum();
-            LOGGER.debug("[Provider @ {}] Mode {} - Updated supply: {} item types, {} total",
+            NetDbg.out("[Provider @ {}] Mode {} - Updated supply: {} item types, {} total",
                     ctx.pos(), mode, availableItems.size(), totalItems);
         }
     }

--- a/src/main/java/com/logistics/pipe/modules/SinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SinkModule.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.DirectionSerializer;
@@ -26,8 +27,6 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-
-import static com.logistics.LogisticsMod.LOGGER;
 
 /**
  * Sink module - routes items from the network into an adjacent inventory.
@@ -122,14 +121,14 @@ public class SinkModule implements Module {
 
         // Priority 1: Filter match
         if (matchesFilter(ctx, item.getStack())) {
-            LOGGER.debug("[Sink @ {}] Item {} matches filter, routing to inventory ({})",
+            NetDbg.out("[Sink @ {}] Item {} matches filter, routing to inventory ({})",
                     ctx.pos(), item.getStack().getItem(), sinkDir);
             return RoutePlan.reroute(sinkDir);
         }
 
         // Priority 2: Destination match
         if (item.getDestination() != null && item.getDestination().equals(ctx.pos())) {
-            LOGGER.debug("[Sink @ {}] Item {} arrived at destination, routing to inventory ({})",
+            NetDbg.out("[Sink @ {}] Item {} arrived at destination, routing to inventory ({})",
                     ctx.pos(), item.getStack().getItem(), sinkDir);
             return RoutePlan.reroute(sinkDir);
         }
@@ -138,11 +137,11 @@ public class SinkModule implements Module {
         if (isDefaultRoute(ctx) && item.getDestination() == null) {
             boolean hasOtherOptions = options.stream().anyMatch(dir -> !dir.equals(sinkDir));
             if (!hasOtherOptions) {
-                LOGGER.debug("[Sink @ {}] Default route accepting {} (no other options), routing to inventory ({})",
+                NetDbg.out("[Sink @ {}] Default route accepting {} (no other options), routing to inventory ({})",
                         ctx.pos(), item.getStack().getItem(), sinkDir);
                 return RoutePlan.reroute(sinkDir);
             }
-            LOGGER.debug("[Sink @ {}] Default route passing on {} (other directions available)",
+            NetDbg.out("[Sink @ {}] Default route passing on {} (other directions available)",
                     ctx.pos(), item.getStack().getItem());
         }
 
@@ -256,10 +255,10 @@ public class SinkModule implements Module {
             if (network != null) {
                 if (enabled) {
                     network.registerDefaultRouteSink(ctx.pos(), 0);
-                    LOGGER.debug("[Sink @ {}] Default route enabled and registered with network", ctx.pos());
+                    NetDbg.out("[Sink @ {}] Default route enabled and registered with network", ctx.pos());
                 } else {
                     network.unregisterDefaultRouteSink(ctx.pos());
-                    LOGGER.debug("[Sink @ {}] Default route disabled and unregistered from network", ctx.pos());
+                    NetDbg.out("[Sink @ {}] Default route disabled and unregistered from network", ctx.pos());
                 }
             }
         }

--- a/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.pipe.network.NetDbg;
 import com.logistics.pipe.network.NetworkRegistry;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
@@ -27,8 +28,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.logistics.LogisticsMod.LOGGER;
 
 /**
  * Supplier module - maintains inventory stock levels by requesting items from the network.
@@ -135,7 +134,7 @@ public class SupplierModule implements Module {
             Direction supplierDir = getSupplierDirection(ctx);
             if (supplierDir != null && options.contains(supplierDir)) {
                 if (!ctx.world().isClientSide()) {
-                    LOGGER.debug("[Supplier @ {}] Routing {} x{} to inventory ({})",
+                    NetDbg.out("[Supplier @ {}] Routing {} x{} to inventory ({})",
                             ctx.pos(), item.getStack().getItem(), item.getStack().getCount(), supplierDir);
                 }
                 return RoutePlan.reroute(supplierDir);
@@ -182,7 +181,7 @@ public class SupplierModule implements Module {
 
             long needed = config.amount() - currentAmount - pendingAmount;
 
-            LOGGER.debug("[Supplier @ {}] Checking {} (mode {}): target={}, current={}, pending={}, needed={}",
+            NetDbg.out("[Supplier @ {}] Checking {} (mode {}): target={}, current={}, pending={}, needed={}",
                     ctx.pos(), config.itemId(), mode, config.amount(), currentAmount, pendingAmount, needed);
 
             long available = network.getAvailableAmount(stack);

--- a/src/main/java/com/logistics/pipe/network/NetDbg.java
+++ b/src/main/java/com/logistics/pipe/network/NetDbg.java
@@ -1,0 +1,17 @@
+package com.logistics.pipe.network;
+
+import com.logistics.core.DebugLog;
+
+/**
+ * Debug logger for the pipe network subsystem.
+ * Enable via: /logistics debug network true
+ */
+public final class NetDbg {
+    public static final String DOMAIN = "network";
+
+    private NetDbg() {}
+
+    public static void out(String format, Object... args) {
+        DebugLog.debug(DOMAIN, format, args);
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/NetDbg.java
+++ b/src/main/java/com/logistics/pipe/network/NetDbg.java
@@ -11,6 +11,10 @@ public final class NetDbg {
 
     private NetDbg() {}
 
+    public static boolean isEnabled() {
+        return DebugLog.isEnabled(DOMAIN);
+    }
+
     public static void out(String format, Object... args) {
         DebugLog.debug(DOMAIN, format, args);
     }

--- a/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -99,6 +99,8 @@ public class NetworkController {
         orderedForRequester
                 .computeIfAbsent(requester, k -> new HashMap<>())
                 .merge(item, amount, Long::sum);
+        NetDbg.out("Order placed: {} | {}x {} → {} (requester)",
+                id.toString().substring(0, 8), amount, item.toStack().getItem(), requester);
         return id;
     }
 
@@ -108,6 +110,7 @@ public class NetworkController {
     public void cancelOrder(UUID id) {
         Order order = orderQueue.remove(id);
         if (order != null) {
+            NetDbg.out("Order cancelled: {}", id.toString().substring(0, 8));
             decrementOrdered(order.requester(), order.item(), order.amount());
         }
     }
@@ -164,6 +167,7 @@ public class NetworkController {
         if (shipped <= 0) return;
         Order order = orderQueue.get(orderId);
         if (order == null) return;
+        NetDbg.out("Recorded dispatch: {} | {} items shipped", orderId.toString().substring(0, 8), shipped);
         if (shipped >= order.amount()) {
             orderQueue.remove(orderId);
         } else {
@@ -189,6 +193,7 @@ public class NetworkController {
      */
     public void notifyDelivery(BlockPos requester, ItemVariant item, long amount) {
         if (amount <= 0) return;
+        NetDbg.out("Delivery notified: {} received {}x {}", requester, amount, item.toStack().getItem());
         decrementOrdered(requester, item, amount);
     }
 

--- a/src/main/java/com/logistics/pipe/network/NetworkRegistry.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkRegistry.java
@@ -21,8 +21,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.logistics.LogisticsMod.LOGGER;
-
 /**
  * Global registry for pipe networks.
  * Handles network discovery, merging, and splitting.
@@ -138,7 +136,7 @@ public class NetworkRegistry {
         } else if (neighborNetworks.size() == 1) {
             return joinExistingNetwork(pos, neighborNetworks.iterator().next(), levelNetworks, levelPositions);
         } else {
-            LOGGER.debug("[Network] Merging {} networks at {}", neighborNetworks.size(), pos);
+            NetDbg.out("[Network] Merging {} networks at {}", neighborNetworks.size(), pos);
             return mergeNetworks(pos, neighborNetworks, levelNetworks, levelPositions);
         }
     }
@@ -159,7 +157,7 @@ public class NetworkRegistry {
         network.addPipe(pos);
         levelNetworks.put(networkId, network);
         levelPositions.put(pos, networkId);
-        LOGGER.debug("[Network] Created new network {} with pipe at {}",
+        NetDbg.out("[Network] Created new network {} with pipe at {}",
             PipeNetwork.getNetworkIdShort(networkId), pos);
         return network;
     }
@@ -176,7 +174,7 @@ public class NetworkRegistry {
         PipeNetwork network = levelNetworks.get(networkId);
         network.addPipe(pos);
         levelPositions.put(pos, networkId);
-        LOGGER.debug("[Network {}] Pipe joined at {} (total pipes: {})",
+        NetDbg.out("[Network {}] Pipe joined at {} (total pipes: {})",
             PipeNetwork.getNetworkIdShort(networkId), pos, network.size());
         return network;
     }
@@ -198,7 +196,7 @@ public class NetworkRegistry {
             network.addPipe(unmappedPipe);
             levelPositions.put(unmappedPipe, networkId);
         }
-        LOGGER.debug("[Network {}] Added {} unmapped pipes (total pipes: {})",
+        NetDbg.out("[Network {}] Added {} unmapped pipes (total pipes: {})",
             PipeNetwork.getNetworkIdShort(networkId), unmappedPipes.size(), network.size());
     }
 

--- a/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -151,10 +151,15 @@ public class PipeNetwork implements ILogisticsNetwork {
         if (worldView == null) return;
         NetworkController.DispatchCommand cmd;
         while ((cmd = controller.nextDispatchable()) != null) {
+            NetDbg.out("[Network {}] Dispatch: {} | provider={} → requester={} | {}x {}",
+                    getNetworkIdShort(id), cmd.orderId().toString().substring(0, 8),
+                    cmd.provider(), cmd.requester(), cmd.amount(), cmd.item().toStack().getItem());
             try {
                 long shipped = worldView.dispatch(
                         cmd.provider(), cmd.requester(), cmd.item(), cmd.amount(), cmd.orderId());
                 if (shipped > 0) {
+                    NetDbg.out("[Network {}] Shipped: {} | {} items",
+                            getNetworkIdShort(id), cmd.orderId().toString().substring(0, 8), shipped);
                     controller.recordDispatched(cmd.orderId(), shipped);
                 } else {
                     controller.markSupplyUnavailable(cmd.provider());
@@ -195,7 +200,7 @@ public class PipeNetwork implements ILogisticsNetwork {
             throw new IllegalStateException("Cannot use findSinkFor without IWorldView - update tests to use proper constructor");
         }
 
-        LogisticsMod.LOGGER.debug("[Network {}] Finding sink for {} (members: {}, default routes: {})",
+        NetDbg.out("[Network {}] Finding sink for {} (members: {}, default routes: {})",
                 getNetworkIdShort(id), stack.getItem(), graph.size(), defaultRouteSinks.size());
 
         BlockPos bestSink = findFilteredSink(stack);
@@ -204,7 +209,7 @@ public class PipeNetwork implements ILogisticsNetwork {
         }
 
         if (bestSink == null) {
-            LogisticsMod.LOGGER.warn("[Network {}] No sink found for {}", getNetworkIdShort(id), stack.getItem());
+            NetDbg.out("[Network {}] No sink found for {}", getNetworkIdShort(id), stack.getItem());
         }
 
         return bestSink;
@@ -213,7 +218,7 @@ public class PipeNetwork implements ILogisticsNetwork {
     private BlockPos findFilteredSink(ItemStack stack) {
         for (BlockPos pos : graph.getNodes()) {
             if (worldView.matchesSinkFilter(pos, stack)) {
-                LogisticsMod.LOGGER.debug("[Network {}] Found filtered sink at {}",
+                NetDbg.out("[Network {}] Found filtered sink at {}",
                         getNetworkIdShort(id), pos);
                 return pos;
             }
@@ -222,7 +227,7 @@ public class PipeNetwork implements ILogisticsNetwork {
     }
 
     private BlockPos findDefaultRouteSink() {
-        LogisticsMod.LOGGER.debug("[Network {}] No filtered sink, checking {} default routes",
+        NetDbg.out("[Network {}] No filtered sink, checking {} default routes",
                 getNetworkIdShort(id), defaultRouteSinks.size());
 
         BlockPos bestSink = null;
@@ -233,7 +238,7 @@ public class PipeNetwork implements ILogisticsNetwork {
 
             int priority = sinkPriorities.getOrDefault(sink, DEFAULT_SINK_PRIORITY);
             if (priority > bestPriority) {
-                LogisticsMod.LOGGER.debug("[Network {}] Found default route at {} (priority: {})",
+                NetDbg.out("[Network {}] Found default route at {} (priority: {})",
                         getNetworkIdShort(id), sink, priority);
                 bestSink = sink;
                 bestPriority = priority;
@@ -241,7 +246,7 @@ public class PipeNetwork implements ILogisticsNetwork {
         }
 
         if (bestSink != null) {
-            LogisticsMod.LOGGER.debug("[Network {}] Selected default route at {}",
+            NetDbg.out("[Network {}] Selected default route at {}",
                     getNetworkIdShort(id), bestSink);
         }
 

--- a/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -1,7 +1,7 @@
 package com.logistics.pipe.runtime;
 
 import com.logistics.LogisticsPipe;
-import static com.logistics.LogisticsMod.LOGGER;
+import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
@@ -414,7 +414,7 @@ public final class PipeRuntime {
                                     ItemVariant.of(item.getStack()),
                                     inserted);
                         } else {
-                            LOGGER.debug("[PipeRuntime] notifyDelivery skipped at {}: no network found for {} ({})",
+                            NetDbg.out("[PipeRuntime] notifyDelivery skipped at {}: no network found for {} ({})",
                                     pos, item.getStack().getItem(), item.getDeliveryId());
                         }
                     }


### PR DESCRIPTION
### Summary
- Adds an in-game way to turn detailed pipe/network debug logging on and off at runtime, without requiring log configuration changes.

### Changes
- Introduced runtime-toggleable debug logging by named subsystem (domain-based).
- Added `/logistics debug` command for admins to:
- List available debug domains and their current ON/off state
- Enable/disable a domain (e.g., `network`) while the server is running
- Updated pipe/network-related diagnostics to use the new network debug domain so logs are only emitted when explicitly enabled.

### Notes
- Debug output is emitted at `INFO` level to ensure it’s visible in typical server log setups.
- Command access requires gamemaster-level permissions.