### PR TITLE
feat: support multiple concurrent crafting orders

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -261,14 +261,27 @@ public class CraftingModule implements Module {
         // No ingredients configured — reject the dispatch
         if (neededByItem.isEmpty()) return 0;
 
+        // Pre-validate all ingredients before placing any orders — fail fast so we never
+        // queue a craft with a missing ingredient order that will never arrive.
+        Map<String, ItemStack> resolvedIngredients = new LinkedHashMap<>();
+        for (Map.Entry<String, Long> entry : neededByItem.entrySet()) {
+            ItemStack ingredientStack = resolveItem(entry.getKey());
+            if (ingredientStack.isEmpty()) {
+                LogisticsPipe.LOGGER.warn(
+                        "[Crafter @ {}] Cannot fulfil craft of '{}': ingredient '{}' is not a known item."
+                                + " Check the recipe configured in the crafting pipe.",
+                        ctx.pos(), getResultItem(ctx), entry.getKey());
+                return 0;
+            }
+            resolvedIngredients.put(entry.getKey(), ingredientStack);
+        }
+
         // Place ingredient orders immediately — each queued order orders its own ingredients
         // independently so materials arrive in parallel rather than waiting for prior orders.
         CompoundTag ingredientOrderIds = new CompoundTag();
         for (Map.Entry<String, Long> entry : neededByItem.entrySet()) {
-            ItemStack ingredientStack = resolveItem(entry.getKey());
-            if (ingredientStack.isEmpty()) continue;
-            UUID ingredientOrderId =
-                    network.placeOrder(ItemVariant.of(ingredientStack), entry.getValue(), ctx.pos());
+            UUID ingredientOrderId = network.placeOrder(
+                    ItemVariant.of(resolvedIngredients.get(entry.getKey())), entry.getValue(), ctx.pos());
             ingredientOrderIds.putString(entry.getKey(), ingredientOrderId.toString());
         }
 
@@ -541,19 +554,14 @@ public class CraftingModule implements Module {
 
     /**
      * Intercept the autocrafter's result being pushed into this pipe.
-     * Routes the ordered amount to the head entry's requester; dequeues the entry when
-     * fulfilled and starts the pulse cycle for the next entry if one exists.
-     * Surplus beyond the ordered amount flows freely into the network.
+     * Distributes items FIFO across queued entries: satisfies the head entry first,
+     * then continues into subsequent entries if the batch covers more than one order.
+     * Only items remaining after the queue is exhausted flow freely as surplus.
      */
     @Override
     public boolean onExternalInsert(PipeContext ctx, ItemStack stack, Direction fromDirection) {
         ListTag queue = getQueue(ctx);
         if (queue.isEmpty()) return false;
-
-        CompoundTag head = queue.getCompound(0).orElse(null);
-        if (head == null) return false;
-        BlockPos requester = parseBlockPos(NbtCompat.getString(head, ENTRY_REQ, ""));
-        if (requester == null) return false;
 
         Direction autocrafterDir = findAutocrafterDirection(ctx);
         if (autocrafterDir == null || autocrafterDir != fromDirection) return false;
@@ -564,49 +572,62 @@ public class CraftingModule implements Module {
         if (resultStack.isEmpty() || !ItemStack.isSameItemSameComponents(stack, resultStack))
             return false;
 
-        long ordered = NbtCompat.getLong(head, ENTRY_AMT, 0L);
-        UUID deliveryId = parseUUID(NbtCompat.getString(head, ENTRY_DLV, ""));
+        // Consume items FIFO across the queue: satisfy as many queued entries as possible
+        // before treating any remainder as surplus. This prevents leaking items when the
+        // autocrafter outputs a batch that covers more than one queued order.
+        int available = stack.getCount();
+        boolean headChanged = false;
 
-        // Ordered portion: routed to requester with delivery tracking
-        long orderedCount = Math.min(stack.getCount(), ordered);
-        ItemStack orderedStack = stack.copyWithCount((int) orderedCount);
-        TravelingItem orderedItem = new TravelingItem(
-                orderedStack, fromDirection.getOpposite(), LogisticsPipe.CONFIG.ITEM_MIN_SPEED, requester);
-        if (deliveryId != null) orderedItem.setDeliveryId(deliveryId);
-        ctx.blockEntity().forceAddItem(orderedItem, fromDirection);
+        while (available > 0 && !queue.isEmpty()) {
+            CompoundTag entry = queue.getCompound(0).orElse(null);
+            if (entry == null) { queue.remove(0); headChanged = true; continue; }
 
-        // Surplus: unrouted, flows freely into the network
-        int surplus = stack.getCount() - (int) orderedCount;
-        if (surplus > 0) {
+            BlockPos entryRequester = parseBlockPos(NbtCompat.getString(entry, ENTRY_REQ, ""));
+            if (entryRequester == null) { queue.remove(0); headChanged = true; continue; }
+
+            long entryOrdered = NbtCompat.getLong(entry, ENTRY_AMT, 0L);
+            UUID entryDeliveryId = parseUUID(NbtCompat.getString(entry, ENTRY_DLV, ""));
+
+            long toSend = Math.min(available, entryOrdered);
+            TravelingItem routed = new TravelingItem(
+                    stack.copyWithCount((int) toSend),
+                    fromDirection.getOpposite(), LogisticsPipe.CONFIG.ITEM_MIN_SPEED, entryRequester);
+            if (entryDeliveryId != null) routed.setDeliveryId(entryDeliveryId);
+            ctx.blockEntity().forceAddItem(routed, fromDirection);
+
+            available -= (int) toSend;
+            if (toSend >= entryOrdered) {
+                queue.remove(0);
+                headChanged = true;
+            } else {
+                entry.putLong(ENTRY_AMT, entryOrdered - toSend);
+                break;
+            }
+        }
+
+        saveQueue(ctx, queue);
+
+        if (queue.isEmpty()) {
+            ctx.saveInt(this, TICKS_PULSE, 0);
+            BlockState currentState = ctx.world().getBlockState(ctx.pos());
+            if (currentState.hasProperty(PipeBlock.CRAFTING)
+                    && currentState.getValue(PipeBlock.CRAFTING)) {
+                BlockState newState = currentState.setValue(PipeBlock.CRAFTING, false);
+                ctx.world().setBlock(ctx.pos(), newState, 3);
+                ctx.world().updateNeighborsAt(ctx.pos(), newState.getBlock());
+            }
+        } else if (headChanged) {
+            // Head was dequeued; reset pulse so the new head starts its craft cycle
+            ctx.saveInt(this, TICKS_PULSE, 0);
+        }
+
+        // Surplus: items not consumed by any queued order flow freely into the network
+        if (available > 0) {
             TravelingItem surplusItem = new TravelingItem(
-                    stack.copyWithCount(surplus),
+                    stack.copyWithCount(available),
                     fromDirection.getOpposite(),
                     LogisticsPipe.CONFIG.ITEM_MIN_SPEED);
             ctx.blockEntity().forceAddItem(surplusItem, fromDirection);
-        }
-
-        long remaining = ordered - orderedCount;
-        if (remaining <= 0) {
-            // Head order fulfilled — dequeue and start next if present
-            queue.remove(0);
-            saveQueue(ctx, queue);
-            if (queue.isEmpty()) {
-                // All orders done — clear block state
-                ctx.saveInt(this, TICKS_PULSE, 0);
-                BlockState currentState = ctx.world().getBlockState(ctx.pos());
-                if (currentState.hasProperty(PipeBlock.CRAFTING)
-                        && currentState.getValue(PipeBlock.CRAFTING)) {
-                    BlockState newState = currentState.setValue(PipeBlock.CRAFTING, false);
-                    ctx.world().setBlock(ctx.pos(), newState, 3);
-                    ctx.world().updateNeighborsAt(ctx.pos(), newState.getBlock());
-                }
-            } else {
-                // Next order's ingredients are already ordered — reset pulse to start crafting
-                ctx.saveInt(this, TICKS_PULSE, 0);
-            }
-        } else {
-            head.putLong(ENTRY_AMT, remaining);
-            saveQueue(ctx, queue);
         }
 
         return true;

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -244,6 +244,8 @@ public class CraftingModule implements Module {
         ItemStack resultStack = resolveItem(resultId);
         if (resultStack.isEmpty() || !item.matches(resultStack)) return 0;
 
+        if (amount <= 0) return 0;
+
         ILogisticsNetwork network = NetworkRegistry.getOrCreateNetwork(ctx.world(), ctx.pos());
         if (network == null) return 0;
 
@@ -335,30 +337,33 @@ public class CraftingModule implements Module {
         network.registerSupply(ctx.pos(), craftable, CRAFTER_PRIORITY);
     }
 
+    /** Cancel all ingredient orders recorded in a single queue {@code entry}. */
+    private void cancelEntryOrders(PipeContext ctx, CompoundTag entry) {
+        ILogisticsNetwork network = NetworkRegistry.getNetwork(ctx.world(), ctx.pos());
+        if (network == null) return;
+        CompoundTag ingredientIds = NbtCompat.getCompoundOrEmpty(entry, ENTRY_IDS);
+        for (String key : ingredientIds.keySet()) {
+            UUID id = parseUUID(NbtCompat.getString(ingredientIds, key, ""));
+            if (id != null) {
+                try {
+                    network.cancelOrder(id);
+                } catch (Exception e) {
+                    LogisticsPipe.LOGGER.warn(
+                            "[Crafter @ {}] Failed to cancel ingredient order {}", ctx.pos(), id, e);
+                }
+            }
+        }
+    }
+
     /**
      * Error reset: cancel all outstanding ingredient orders for every queued entry, clear
      * the queue, and turn off the redstone signal. Called when the autocrafter goes missing.
      */
     private void resetToIdle(PipeContext ctx) {
-        ILogisticsNetwork network = NetworkRegistry.getNetwork(ctx.world(), ctx.pos());
-        if (network != null) {
-            ListTag queue = getQueue(ctx);
-            for (int i = 0; i < queue.size(); i++) {
-                CompoundTag entry = queue.getCompound(i).orElse(null);
-                if (entry == null) continue;
-                CompoundTag ingredientIds = NbtCompat.getCompoundOrEmpty(entry, ENTRY_IDS);
-                for (String key : ingredientIds.keySet()) {
-                    UUID id = parseUUID(NbtCompat.getString(ingredientIds, key, ""));
-                    if (id != null) {
-                        try {
-                            network.cancelOrder(id);
-                        } catch (Exception e) {
-                            LogisticsPipe.LOGGER.warn(
-                                    "[Crafter @ {}] Failed to cancel ingredient order {}", ctx.pos(), id, e);
-                        }
-                    }
-                }
-            }
+        ListTag queue = getQueue(ctx);
+        for (int i = 0; i < queue.size(); i++) {
+            CompoundTag entry = queue.getCompound(i).orElse(null);
+            if (entry != null) cancelEntryOrders(ctx, entry);
         }
 
         ctx.moduleState(getStateKey()).remove(QUEUE);
@@ -585,7 +590,12 @@ public class CraftingModule implements Module {
             if (entry == null) { queue.remove(0); headChanged = true; continue; }
 
             BlockPos entryRequester = parseBlockPos(NbtCompat.getString(entry, ENTRY_REQ, ""));
-            if (entryRequester == null) { queue.remove(0); headChanged = true; continue; }
+            if (entryRequester == null) {
+                cancelEntryOrders(ctx, entry);
+                queue.remove(0);
+                headChanged = true;
+                continue;
+            }
 
             long entryOrdered = NbtCompat.getLong(entry, ENTRY_AMT, 0L);
             UUID entryDeliveryId = parseUUID(NbtCompat.getString(entry, ENTRY_DLV, ""));
@@ -618,6 +628,7 @@ public class CraftingModule implements Module {
                 ctx.world().setBlock(ctx.pos(), newState, 3);
                 ctx.world().updateNeighborsAt(ctx.pos(), newState.getBlock());
             }
+            updateCrafterSupply(ctx);
         } else if (headChanged) {
             // Head was dequeued; reset pulse so the new head starts its craft cycle
             ctx.saveInt(this, TICKS_PULSE, 0);

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -352,7 +352,9 @@ public class CraftingModule implements Module {
                     if (id != null) {
                         try {
                             network.cancelOrder(id);
-                        } catch (Exception ignored) {
+                        } catch (Exception e) {
+                            LogisticsPipe.LOGGER.warn(
+                                    "[Crafter @ {}] Failed to cancel ingredient order {}", ctx.pos(), id, e);
                         }
                     }
                 }

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -15,6 +15,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
@@ -43,6 +44,10 @@ import java.util.UUID;
  *
  * <p>Ingredients are routed to the autocrafter slot that currently holds the fewest of that
  * item type relative to the recipe requirement (fewest-complete-batches-first distribution).
+ *
+ * <p>Orders are queued: a second dispatch is accepted while the first is still crafting, and
+ * ingredient orders for all queued entries are placed immediately so materials arrive in
+ * parallel rather than serially.
  */
 public class CraftingModule implements Module {
     // NBT keys — recipe config
@@ -55,12 +60,12 @@ public class CraftingModule implements Module {
     // NBT keys — timing
     private static final String TICKS_SCAN = "ticks_scan";
     private static final String TICKS_PULSE = "ticks_pulse";
-    // NBT keys — active order state
-    private static final String ACTIVE = "active";
-    private static final String PENDING_REQUESTER = "pending_requester";
-    private static final String PENDING_DELIVERY_ID = "pending_delivery_id";
-    private static final String PENDING_AMOUNT = "pending_amount";
-    private static final String INGREDIENT_ORDER_IDS = "ingredient_order_ids";
+    // NBT keys — order queue (ListTag of CompoundTag entries)
+    private static final String QUEUE = "queue";
+    private static final String ENTRY_REQ = "req";   // BlockPos as "x,y,z"
+    private static final String ENTRY_DLV = "dlv";   // UUID as string
+    private static final String ENTRY_AMT = "amt";   // remaining amount (long)
+    private static final String ENTRY_IDS = "ids";   // ingredient order IDs (CompoundTag)
 
     // Timing constants
     private static final int SCAN_INTERVAL = 20;    // Update crafter supply every 20 ticks
@@ -72,13 +77,9 @@ public class CraftingModule implements Module {
 
     // ==================== NBT State Accessors ====================
 
+    /** True when there is at least one order in the queue. */
     public boolean isActive(PipeContext ctx) {
-        return ctx.getInt(this, ACTIVE, 0) == 1;
-    }
-
-    private void setActive(PipeContext ctx, boolean active) {
-        ctx.saveInt(this, ACTIVE, active ? 1 : 0);
-        ctx.markDirtyAndSync();
+        return !getQueue(ctx).isEmpty();
     }
 
     public boolean isBlocking(PipeContext ctx) {
@@ -135,10 +136,20 @@ public class CraftingModule implements Module {
         ctx.markDirtyAndSync();
     }
 
+    // ==================== Queue Accessors ====================
+
+    private ListTag getQueue(PipeContext ctx) {
+        return NbtCompat.getListOrEmpty(ctx.moduleState(getStateKey()), QUEUE);
+    }
+
+    private void saveQueue(PipeContext ctx, ListTag queue) {
+        ctx.moduleState(getStateKey()).put(QUEUE, queue);
+        ctx.markDirtyAndSync();
+    }
+
     @Nullable
-    private BlockPos getPendingRequester(PipeContext ctx) {
-        String s = ctx.getString(this, PENDING_REQUESTER, "");
-        if (s.isEmpty()) return null;
+    private static BlockPos parseBlockPos(String s) {
+        if (s == null || s.isEmpty()) return null;
         try {
             String[] parts = s.split(",");
             return new BlockPos(
@@ -148,40 +159,14 @@ public class CraftingModule implements Module {
         }
     }
 
-    private void setPendingRequester(PipeContext ctx, @Nullable BlockPos pos) {
-        if (pos == null) {
-            ctx.moduleState(getStateKey()).remove(PENDING_REQUESTER);
-        } else {
-            ctx.saveString(
-                    this, PENDING_REQUESTER, pos.getX() + "," + pos.getY() + "," + pos.getZ());
-        }
-    }
-
     @Nullable
-    private UUID getPendingDeliveryId(PipeContext ctx) {
-        String s = ctx.getString(this, PENDING_DELIVERY_ID, "");
-        if (s.isEmpty()) return null;
+    private static UUID parseUUID(String s) {
+        if (s == null || s.isEmpty()) return null;
         try {
             return UUID.fromString(s);
         } catch (Exception e) {
             return null;
         }
-    }
-
-    private void setPendingDeliveryId(PipeContext ctx, @Nullable UUID id) {
-        if (id == null) {
-            ctx.moduleState(getStateKey()).remove(PENDING_DELIVERY_ID);
-        } else {
-            ctx.saveString(this, PENDING_DELIVERY_ID, id.toString());
-        }
-    }
-
-    private long getPendingAmount(PipeContext ctx) {
-        return ctx.getLong(this, PENDING_AMOUNT, 0L);
-    }
-
-    private void setPendingAmount(PipeContext ctx, long amount) {
-        ctx.saveLong(this, PENDING_AMOUNT, amount);
     }
 
     // ==================== Autocrafter Detection ====================
@@ -243,14 +228,14 @@ public class CraftingModule implements Module {
 
     /**
      * Called by the network to start a crafting run.
-     * Records the delivery promise, places ingredient orders, and activates the module.
-     * Returns {@code amount} immediately as a promise; delivery happens after crafting.
+     * Adds the order to the queue and immediately places ingredient orders so materials
+     * arrive in parallel with any currently-active crafting. Returns {@code amount} as a
+     * promise; delivery happens after crafting completes.
      */
     @Override
     public long onDispatch(
             PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
         if (ctx.world().isClientSide()) return 0;
-        if (isActive(ctx)) return 0;
 
         String resultId = getResultItem(ctx);
         if (resultId.isEmpty()) return 0;
@@ -276,32 +261,33 @@ public class CraftingModule implements Module {
         // No ingredients configured — reject the dispatch
         if (neededByItem.isEmpty()) return 0;
 
-        setPendingRequester(ctx, requester);
-        setPendingDeliveryId(ctx, deliveryId);
-        setPendingAmount(ctx, amount);
-
-        // Blocking mode: remove from supply so new orders don't arrive while crafting
-        if (isBlocking(ctx)) {
-            network.registerSupply(ctx.pos(), new HashMap<>(), CRAFTER_PRIORITY);
-        }
-
-        CompoundTag orderIds = new CompoundTag();
+        // Place ingredient orders immediately — each queued order orders its own ingredients
+        // independently so materials arrive in parallel rather than waiting for prior orders.
+        CompoundTag ingredientOrderIds = new CompoundTag();
         for (Map.Entry<String, Long> entry : neededByItem.entrySet()) {
             ItemStack ingredientStack = resolveItem(entry.getKey());
             if (ingredientStack.isEmpty()) continue;
-
-            long alreadyOrdered = network.getOrderedAmountFor(ctx.pos(), ingredientStack);
-            long needed = entry.getValue() - alreadyOrdered;
-            if (needed <= 0) continue;
-
             UUID ingredientOrderId =
-                    network.placeOrder(ItemVariant.of(ingredientStack), needed, ctx.pos());
-            orderIds.putString(entry.getKey(), ingredientOrderId.toString());
+                    network.placeOrder(ItemVariant.of(ingredientStack), entry.getValue(), ctx.pos());
+            ingredientOrderIds.putString(entry.getKey(), ingredientOrderId.toString());
         }
-        ctx.putCompoundTag(this, INGREDIENT_ORDER_IDS, orderIds);
 
-        setActive(ctx, true);
+        // Append entry to queue
+        CompoundTag queueEntry = new CompoundTag();
+        queueEntry.putString(ENTRY_REQ, requester.getX() + "," + requester.getY() + "," + requester.getZ());
+        queueEntry.putString(ENTRY_DLV, deliveryId.toString());
+        queueEntry.putLong(ENTRY_AMT, amount);
+        queueEntry.put(ENTRY_IDS, ingredientOrderIds);
+
+        ListTag queue = getQueue(ctx);
+        queue.add(queueEntry);
+        saveQueue(ctx, queue);
         ctx.saveInt(this, TICKS_PULSE, 0);
+
+        // Blocking mode: immediately suppress supply so no further orders arrive
+        if (isBlocking(ctx)) {
+            network.registerSupply(ctx.pos(), new HashMap<>(), CRAFTER_PRIORITY);
+        }
 
         return amount; // Promise: delivery happens after crafting completes
     }
@@ -316,7 +302,9 @@ public class CraftingModule implements Module {
             return;
         }
 
-        // Blocking mode while active: don't advertise supply
+        // In blocking mode, suppress supply while the queue is non-empty so no further
+        // orders are accepted. In non-blocking mode, continue advertising so additional
+        // orders can be queued; the queue prevents dispatch loops since dispatches succeed.
         if (isBlocking(ctx) && isActive(ctx)) {
             network.registerSupply(ctx.pos(), new HashMap<>(), CRAFTER_PRIORITY);
             return;
@@ -334,27 +322,33 @@ public class CraftingModule implements Module {
         network.registerSupply(ctx.pos(), craftable, CRAFTER_PRIORITY);
     }
 
+    /**
+     * Error reset: cancel all outstanding ingredient orders for every queued entry, clear
+     * the queue, and turn off the redstone signal. Called when the autocrafter goes missing.
+     */
     private void resetToIdle(PipeContext ctx) {
         ILogisticsNetwork network = NetworkRegistry.getNetwork(ctx.world(), ctx.pos());
         if (network != null) {
-            CompoundTag orderIds = ctx.getCompoundTag(this, INGREDIENT_ORDER_IDS);
-            for (String key : orderIds.keySet()) {
-                String uuidStr = NbtCompat.getString(orderIds, key, "");
-                if (!uuidStr.isEmpty()) {
-                    try {
-                        network.cancelOrder(UUID.fromString(uuidStr));
-                    } catch (Exception ignored) {
+            ListTag queue = getQueue(ctx);
+            for (int i = 0; i < queue.size(); i++) {
+                CompoundTag entry = queue.getCompound(i).orElse(null);
+                if (entry == null) continue;
+                CompoundTag ingredientIds = NbtCompat.getCompoundOrEmpty(entry, ENTRY_IDS);
+                for (String key : ingredientIds.keySet()) {
+                    UUID id = parseUUID(NbtCompat.getString(ingredientIds, key, ""));
+                    if (id != null) {
+                        try {
+                            network.cancelOrder(id);
+                        } catch (Exception ignored) {
+                        }
                     }
                 }
             }
         }
 
-        setActive(ctx, false);
-        setPendingRequester(ctx, null);
-        setPendingDeliveryId(ctx, null);
-        setPendingAmount(ctx, 0L);
-        ctx.moduleState(getStateKey()).remove(INGREDIENT_ORDER_IDS);
+        ctx.moduleState(getStateKey()).remove(QUEUE);
         ctx.saveInt(this, TICKS_PULSE, 0);
+        ctx.markDirtyAndSync();
 
         // Clear CRAFTING block state if stuck on
         BlockState currentState = ctx.world().getBlockState(ctx.pos());
@@ -547,11 +541,18 @@ public class CraftingModule implements Module {
 
     /**
      * Intercept the autocrafter's result being pushed into this pipe.
-     * Ordered amount gets destination=requester with deliveryId; surplus flows freely.
+     * Routes the ordered amount to the head entry's requester; dequeues the entry when
+     * fulfilled and starts the pulse cycle for the next entry if one exists.
+     * Surplus beyond the ordered amount flows freely into the network.
      */
     @Override
     public boolean onExternalInsert(PipeContext ctx, ItemStack stack, Direction fromDirection) {
-        BlockPos requester = getPendingRequester(ctx);
+        ListTag queue = getQueue(ctx);
+        if (queue.isEmpty()) return false;
+
+        CompoundTag head = queue.getCompound(0).orElse(null);
+        if (head == null) return false;
+        BlockPos requester = parseBlockPos(NbtCompat.getString(head, ENTRY_REQ, ""));
         if (requester == null) return false;
 
         Direction autocrafterDir = findAutocrafterDirection(ctx);
@@ -563,8 +564,8 @@ public class CraftingModule implements Module {
         if (resultStack.isEmpty() || !ItemStack.isSameItemSameComponents(stack, resultStack))
             return false;
 
-        long ordered = getPendingAmount(ctx);
-        UUID deliveryId = getPendingDeliveryId(ctx);
+        long ordered = NbtCompat.getLong(head, ENTRY_AMT, 0L);
+        UUID deliveryId = parseUUID(NbtCompat.getString(head, ENTRY_DLV, ""));
 
         // Ordered portion: routed to requester with delivery tracking
         long orderedCount = Math.min(stack.getCount(), ordered);
@@ -585,11 +586,28 @@ public class CraftingModule implements Module {
         }
 
         long remaining = ordered - orderedCount;
-        setPendingAmount(ctx, remaining);
         if (remaining <= 0) {
-            resetToIdle(ctx);
+            // Head order fulfilled — dequeue and start next if present
+            queue.remove(0);
+            saveQueue(ctx, queue);
+            if (queue.isEmpty()) {
+                // All orders done — clear block state
+                ctx.saveInt(this, TICKS_PULSE, 0);
+                BlockState currentState = ctx.world().getBlockState(ctx.pos());
+                if (currentState.hasProperty(PipeBlock.CRAFTING)
+                        && currentState.getValue(PipeBlock.CRAFTING)) {
+                    BlockState newState = currentState.setValue(PipeBlock.CRAFTING, false);
+                    ctx.world().setBlock(ctx.pos(), newState, 3);
+                    ctx.world().updateNeighborsAt(ctx.pos(), newState.getBlock());
+                }
+            } else {
+                // Next order's ingredients are already ordered — reset pulse to start crafting
+                ctx.saveInt(this, TICKS_PULSE, 0);
+            }
+        } else {
+            head.putLong(ENTRY_AMT, remaining);
+            saveQueue(ctx, queue);
         }
-        // Otherwise stay active; the pulse cycle will keep checking for more ingredients
 
         return true;
     }

--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -236,11 +236,13 @@ public class RequesterModule implements Module {
     }
 
     /**
-     * Request an item from the network (GUI-triggered request).
-     * Creates an ItemRequest that will be fulfilled by a provider.
-     * @param ctx Pipe context
-     * @param stack Item to request
-     * @param amount Amount to request
+     * Additive/manual order — places {@code amount} as a new discrete order regardless of
+     * what is already in-flight. Each call creates an independent request, so two calls
+     * will result in two deliveries. Intended for GUI-triggered one-shot requests.
+     *
+     * <p>This differs from {@link #processRequests}, which is top-up ordering: it checks
+     * how much is already ordered and only requests the shortfall to reach the slot target.
+     * Do not consolidate the two — the distinct semantics are intentional.
      */
     public void requestItem(PipeContext ctx, ItemStack stack, int amount) {
         if (ctx.world().isClientSide()) {

--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -259,11 +259,7 @@ public class RequesterModule implements Module {
             return;
         }
 
-        long alreadyOrdered = network.getOrderedAmountFor(ctx.pos(), stack);
-        long needed = amount - alreadyOrdered;
-        if (needed > 0) {
-            network.placeOrder(ItemVariant.of(stack), needed, ctx.pos());
-        }
+        network.placeOrder(ItemVariant.of(stack), amount, ctx.pos());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Crafting pipes can now accept multiple dispatches at once by queueing crafting orders and fulfilling them in order.

## Changes
- Added an order queue for crafting modules so additional requests are accepted while a prior order is still crafting.
- Ingredient orders for newly queued crafting requests are placed immediately, allowing materials to arrive in parallel and reducing end-to-end crafting latency.
- Updated result routing so crafted outputs are attributed to the correct requester/delivery promise based on the head of the queue, then automatically advances to the next queued order.

## Notes
- In blocking mode, crafting supply remains suppressed while the queue is non-empty (prevents additional orders); in non-blocking mode, supply can continue to be advertised while requests queue up.
- Requester pipes now place the full requested amount as an order (no longer subtracting “already ordered” amounts), aligning ordering behavior with parallel/queued deliveries.