### PR TITLE
fix: show craftable items as 0 stock and stabilize requester search sorting

### DIFF
--- a/src/client/java/com/logistics/pipe/screen/widget/NetworkItemButton.java
+++ b/src/client/java/com/logistics/pipe/screen/widget/NetworkItemButton.java
@@ -69,13 +69,12 @@ public class NetworkItemButton extends AbstractWidget {
                     item,
                     getX() + 4,
                     getY() + 4,
-                    availableAmount > 1 ? formatAmount(availableAmount) : null
+                    formatAmount(availableAmount)
             );
         }
     }
 
     private String formatAmount(long amount) {
-        if (amount == Long.MAX_VALUE) return "x";
         if (amount >= 1_000_000) {
             long millions = amount / 1_000_000;
             long tenths = (amount % 1_000_000) / 100_000;

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -331,9 +331,9 @@ public class CraftingModule implements Module {
             return;
         }
 
-        // Advertise Long.MAX_VALUE — on-demand crafting supply
+        // Advertise 0 — signals "craftable on demand" (no stock, but can fulfill any order)
         Map<ItemVariant, Long> craftable = new HashMap<>();
-        craftable.put(ItemVariant.of(resultStack), Long.MAX_VALUE);
+        craftable.put(ItemVariant.of(resultStack), 0L);
         network.registerSupply(ctx.pos(), craftable, CRAFTER_PRIORITY);
     }
 

--- a/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -70,7 +70,7 @@ public class NetworkController {
 
         // Add fresh entries, maintaining sorted order by priority
         for (Map.Entry<ItemVariant, Long> entry : items.entrySet()) {
-            if (entry.getValue() <= 0) continue;
+            if (entry.getValue() < 0) continue;
             List<SupplyEntry> list = supplyTable.computeIfAbsent(entry.getKey(), k -> new ArrayList<>());
             list.add(new SupplyEntry(pos, entry.getValue(), priority));
             list.sort(Comparator.comparingInt(e -> e.priority));
@@ -139,14 +139,14 @@ public class NetworkController {
 
             for (int i = 0; i < entries.size(); i++) {
                 SupplyEntry supply = entries.get(i);
-                if (supply.available >= order.amount()) {
-                    // Reserve supply (unlimited sources like crafters keep Long.MAX_VALUE)
-                    if (supply.available != Long.MAX_VALUE) {
+                // available == 0 means "craftable on demand" — always matches any order amount
+                if (supply.available == 0 || supply.available >= order.amount()) {
+                    if (supply.available > 0) {
                         supply.available -= order.amount();
-                    }
-                    if (supply.available == 0) {
-                        entries.remove(i);
-                        if (entries.isEmpty()) supplyTable.remove(order.item());
+                        if (supply.available == 0) {
+                            entries.remove(i);
+                            if (entries.isEmpty()) supplyTable.remove(order.item());
+                        }
                     }
                     return new DispatchCommand(
                             order.id(), supply.pos, order.requester(), order.item(), order.amount());
@@ -240,7 +240,7 @@ public class NetworkController {
                     break;
                 }
             }
-            if (total > 0) {
+            if (total >= 0) {
                 result.merge(entry.getKey().toStack(1), total, Long::sum);
             }
         }

--- a/src/main/java/com/logistics/pipe/ui/RequestInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/RequestInventory.java
@@ -105,7 +105,7 @@ public class RequestInventory implements Container {
 
         for (var entry : available.entrySet()) {
             ItemStack display = entry.getKey().copy();
-            display.setCount((int) Math.min(entry.getValue(), 64));
+            display.setCount((int) Math.max(1, Math.min(entry.getValue(), 64)));
             result.add(display);
         }
 
@@ -137,7 +137,7 @@ public class RequestInventory implements Container {
         for (var entry : available.entrySet()) {
             ItemStack display = entry.getKey().copy();
             // Use full amount - Minecraft can display counts > 64
-            int count = (int) Math.min(entry.getValue(), Integer.MAX_VALUE);
+            int count = (int) Math.max(1, Math.min(entry.getValue(), Integer.MAX_VALUE));
             display.setCount(count);
             items.add(display);
             amounts.add(entry.getValue());
@@ -222,7 +222,7 @@ public class RequestInventory implements Container {
             ItemStack displayStack = entry.getKey().copy();
             // Show available amount as stack count (capped at 64 for display)
             long available = entry.getValue();
-            displayStack.setCount((int) Math.min(available, 64));
+            displayStack.setCount((int) Math.max(1, Math.min(available, 64)));
             stacks.set(slotIndex++, displayStack);
         }
     }

--- a/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
@@ -5,6 +5,7 @@ import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.network.SyncRequesterInventoryPacket;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
@@ -12,6 +13,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -114,6 +116,8 @@ public class RequesterScreenHandler extends AbstractContainerMenu {
     public void refreshSearch(String query) {
         this.currentSearch = query;
         this.filteredItems = getFilteredItems(query);
+        this.filteredItems.sort(Comparator.comparing(
+                stack -> BuiltInRegistries.ITEM.getKey(stack.getItem()).toString()));
         this.currentPage = 0;
     }
 

--- a/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
@@ -117,7 +117,8 @@ public class RequesterScreenHandler extends AbstractContainerMenu {
         this.currentSearch = query;
         this.filteredItems = getFilteredItems(query);
         this.filteredItems.sort(Comparator.comparing(
-                stack -> BuiltInRegistries.ITEM.getKey(stack.getItem()).toString()));
+                        (ItemStack stack) -> BuiltInRegistries.ITEM.getKey(stack.getItem()).toString())
+                .thenComparing(stack -> stack.getComponents().toString()));
         this.currentPage = 0;
     }
 


### PR DESCRIPTION
## Summary
- Improves how on-demand craftable items are represented in requester UIs so they no longer display misleading quantities.
- Makes requester search results deterministic by sorting by item ID.

## Changes
- Crafting suppliers now advertise craftable outputs as **0 available** to indicate “craftable on demand” instead of using an “unlimited” sentinel value.
- Requester item buttons always render an amount label, so craftable items show as **0** rather than appearing as “1” or being hidden.
- Requester search results are now sorted by **registry item ID**, producing stable ordering across refreshes.

## Notes
- Items with 0 shown in the requester list are still valid request targets: **0 means no stock on hand, but can be crafted to fulfill orders**.