### PR TITLE
refactor: dispatch partial inventory supply before falling back to crafting

### DIFF
--- a/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
+++ b/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
@@ -148,13 +148,7 @@ public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHand
     private void addOne(Button button) {
         try {
             int currentAmount = Integer.parseInt(amountField.getValue());
-            // Cap at available amount if item is selected
-            int maxAmount = Integer.MAX_VALUE;
-            if (selectedButton != null && !selectedButton.getItem().isEmpty()) {
-                maxAmount = (int) Math.min(selectedButton.getAvailableAmount(), Integer.MAX_VALUE);
-            }
-            int newAmount = Math.min(maxAmount, currentAmount + 1);
-            amountField.setValue(String.valueOf(newAmount));
+            amountField.setValue(String.valueOf(Math.min(576, currentAmount + 1)));
         } catch (NumberFormatException e) {
             amountField.setValue("1");
         }

--- a/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
+++ b/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
@@ -137,9 +137,8 @@ public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHand
 
     private void subOne(Button button) {
         try {
-            int currentAmount = Integer.parseInt(amountField.getValue());
-            int newAmount = Math.max(1, currentAmount - 1);
-            amountField.setValue(String.valueOf(newAmount));
+            int currentAmount = Math.min(576, Integer.parseInt(amountField.getValue()));
+            amountField.setValue(String.valueOf(Math.max(1, currentAmount - 1)));
         } catch (NumberFormatException e) {
             amountField.setValue("1");
         }
@@ -224,7 +223,7 @@ public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHand
     private void onRequestClick(Button button) {
         if (selectedButton != null && !selectedButton.getItem().isEmpty()) {
             try {
-                int amount = Integer.parseInt(amountField.getValue());
+                int amount = Math.min(576, Math.max(1, Integer.parseInt(amountField.getValue())));
                 if (amount > 0) {
                     // Normalize the ItemStack to count=1 (actual amount is sent separately)
                     ItemStack requestStack = selectedButton.getItem().copy();

--- a/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
+++ b/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
@@ -2,6 +2,7 @@ package com.logistics.pipe.screen;
 
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.pipe.modules.RequesterModule;
 import com.logistics.pipe.network.RequestItemPacket;
 import com.logistics.pipe.screen.widget.NetworkItemButton;
 import com.logistics.pipe.screen.widget.PageButton;
@@ -30,8 +31,7 @@ import java.util.List;
 public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHandler> {
     private static final ResourceId BACKGROUND =
             LogisticsMod.modId("textures/gui/pipe/requester-alt.png");
-    /** Absolute upper bound on request amounts (64 stacks × 9 slots). */
-    private static final int MAX_REQUEST_CAP = 576;
+    private static final int MAX_REQUEST_CAP = RequesterModule.MAX_REQUEST_AMOUNT;
 
     private EditBox searchBox;
     private EditBox amountField;

--- a/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
+++ b/src/client/java/com/logistics/pipe/screen/RequesterScreen.java
@@ -30,6 +30,8 @@ import java.util.List;
 public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHandler> {
     private static final ResourceId BACKGROUND =
             LogisticsMod.modId("textures/gui/pipe/requester-alt.png");
+    /** Absolute upper bound on request amounts (64 stacks × 9 slots). */
+    private static final int MAX_REQUEST_CAP = 576;
 
     private EditBox searchBox;
     private EditBox amountField;
@@ -137,7 +139,7 @@ public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHand
 
     private void subOne(Button button) {
         try {
-            int currentAmount = Math.min(576, Integer.parseInt(amountField.getValue()));
+            int currentAmount = Math.min(MAX_REQUEST_CAP, Integer.parseInt(amountField.getValue()));
             amountField.setValue(String.valueOf(Math.max(1, currentAmount - 1)));
         } catch (NumberFormatException e) {
             amountField.setValue("1");
@@ -147,7 +149,7 @@ public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHand
     private void addOne(Button button) {
         try {
             int currentAmount = Integer.parseInt(amountField.getValue());
-            amountField.setValue(String.valueOf(Math.min(576, currentAmount + 1)));
+            amountField.setValue(String.valueOf(Math.min(MAX_REQUEST_CAP, currentAmount + 1)));
         } catch (NumberFormatException e) {
             amountField.setValue("1");
         }
@@ -223,7 +225,8 @@ public class RequesterScreen extends AbstractContainerScreen<RequesterScreenHand
     private void onRequestClick(Button button) {
         if (selectedButton != null && !selectedButton.getItem().isEmpty()) {
             try {
-                int amount = Math.min(576, Math.max(1, Integer.parseInt(amountField.getValue())));
+                int amount = Math.min(MAX_REQUEST_CAP, Math.max(1, Integer.parseInt(amountField.getValue())));
+                amountField.setValue(String.valueOf(amount)); // reflect any clamping visibly
                 if (amount > 0) {
                     // Normalize the ItemStack to count=1 (actual amount is sent separately)
                     ItemStack requestStack = selectedButton.getItem().copy();

--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -249,8 +249,7 @@ public class RequesterModule implements Module {
             return;
         }
 
-        int maxAmount = stack.getMaxStackSize() * 64;
-        if (amount <= 0 || amount > maxAmount) {
+        if (amount <= 0 || amount > 576) {
             return;
         }
 

--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -43,6 +43,7 @@ public class RequesterModule implements Module {
     private static final String TICKS_SINCE_REQUEST = "ticks_since_request";
     private static final int REQUEST_INTERVAL = 20;
     public static final int MAX_REQUEST_SLOTS = 9;
+    public static final int MAX_REQUEST_AMOUNT = 576;
     // TODO(Phase 11): Energy costs
     // private static final int RF_PER_REQUEST_CYCLE = 5;
 
@@ -145,8 +146,9 @@ public class RequesterModule implements Module {
             long alreadyOrdered = network.getOrderedAmountFor(ctx.pos(), stack);
             long needed = config.amount() - alreadyOrdered;
 
-            if (needed > 0) {
-                network.placeOrder(ItemVariant.of(stack), needed, ctx.pos());
+            long clamped = Math.min(needed, MAX_REQUEST_AMOUNT);
+            if (clamped > 0) {
+                network.placeOrder(ItemVariant.of(stack), clamped, ctx.pos());
 
                 // TODO(Phase 11): Consume energy
                 // ctx.setEnergy(ctx.getEnergy() - RF_PER_REQUEST_CYCLE);
@@ -201,9 +203,10 @@ public class RequesterModule implements Module {
         if (itemId.isEmpty() || amount <= 0) {
             requests.remove(key);
         } else {
+            int clamped = Math.min(amount, MAX_REQUEST_AMOUNT);
             CompoundTag slotTag = new CompoundTag();
             slotTag.putString("item", itemId);
-            slotTag.putInt("amount", amount);
+            slotTag.putInt("amount", clamped);
             requests.put(key, slotTag);
         }
 
@@ -249,7 +252,7 @@ public class RequesterModule implements Module {
             return;
         }
 
-        if (amount <= 0 || amount > 576) {
+        if (amount <= 0 || amount > MAX_REQUEST_AMOUNT) {
             return;
         }
 

--- a/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -139,18 +139,32 @@ public class NetworkController {
 
             for (int i = 0; i < entries.size(); i++) {
                 SupplyEntry supply = entries.get(i);
-                // available == 0 means "craftable on demand" — always matches any order amount
-                if (supply.available == 0 || supply.available >= order.amount()) {
-                    if (supply.available > 0) {
-                        supply.available -= order.amount();
-                        if (supply.available == 0) {
-                            entries.remove(i);
-                            if (entries.isEmpty()) supplyTable.remove(order.item());
-                        }
+
+                // On-demand supply (crafter, available == 0): always dispatchable, never decremented
+                if (supply.available == 0) {
+                    return new DispatchCommand(
+                            order.id(), supply.pos, order.requester(), order.item(), order.amount());
+                }
+
+                if (supply.available >= order.amount()) {
+                    // Full fill from real stock
+                    supply.available -= order.amount();
+                    if (supply.available == 0) {
+                        entries.remove(i);
+                        if (entries.isEmpty()) supplyTable.remove(order.item());
                     }
                     return new DispatchCommand(
                             order.id(), supply.pos, order.requester(), order.item(), order.amount());
                 }
+
+                // Partial fill from real stock: dispatch what's available now; the remainder
+                // will be picked up from the next entry (or a crafter) on the next loop iteration.
+                long partialAmount = supply.available;
+                supply.available = 0;
+                entries.remove(i);
+                if (entries.isEmpty()) supplyTable.remove(order.item());
+                return new DispatchCommand(
+                        order.id(), supply.pos, order.requester(), order.item(), partialAmount);
             }
         }
         return null;
@@ -208,16 +222,16 @@ public class NetworkController {
 
     /**
      * Get total available supply for an item across all providers.
-     * Returns Long.MAX_VALUE if any entry has unlimited supply (e.g., crafters).
+     * Returns Long.MAX_VALUE if any crafter entry (available == 0) can produce it on demand,
+     * since the item can always be crafted. Otherwise returns the sum of real-stock amounts.
      */
     public long getAvailableAmount(ItemVariant item) {
         List<SupplyEntry> entries = supplyTable.get(item);
         if (entries == null || entries.isEmpty()) return 0L;
         long total = 0;
         for (SupplyEntry e : entries) {
-            if (e.available == Long.MAX_VALUE) return Long.MAX_VALUE;
+            if (e.available == 0) return Long.MAX_VALUE; // crafter: on-demand, effectively unlimited
             total += e.available;
-            if (total < 0) return Long.MAX_VALUE; // overflow guard
         }
         return total;
     }
@@ -230,19 +244,9 @@ public class NetworkController {
         for (Map.Entry<ItemVariant, List<SupplyEntry>> entry : supplyTable.entrySet()) {
             long total = 0;
             for (SupplyEntry e : entry.getValue()) {
-                if (e.available == Long.MAX_VALUE) {
-                    total = Long.MAX_VALUE;
-                    break;
-                }
-                total += e.available;
-                if (total < 0) {
-                    total = Long.MAX_VALUE;
-                    break;
-                }
+                total += e.available; // 0 for crafters; positive for real stock
             }
-            if (total >= 0) {
-                result.merge(entry.getKey().toStack(1), total, Long::sum);
-            }
+            result.merge(entry.getKey().toStack(1), total, Long::sum);
         }
         return result;
     }

--- a/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
+++ b/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
@@ -73,34 +73,44 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
     // ===== Priority Dispatch =====
 
     @Test
-    void testPriority_lowerPriorityDispatchedFirst() {
-        // Priority 1 (real stock) preferred over priority 5 (crafter)
+    void testDispatch_realStockBeforeCrafter() {
+        // Real stock (32) dispatched before crafter (0) even when crafter is also registered
         controller.registerSupply(PROVIDER1, Map.of(diamond(), 32L), 1); // real stock
-        controller.registerSupply(PROVIDER2, Map.of(diamond(), Long.MAX_VALUE), 5); // crafter
+        controller.registerSupply(PROVIDER2, Map.of(diamond(), 0L), 5);  // crafter
 
         UUID orderId = controller.placeOrder(diamond(), 16L, REQUESTER);
         assertNotNull(orderId);
 
         NetworkController.DispatchCommand cmd = controller.nextDispatchable();
         assertNotNull(cmd);
-        assertEquals(PROVIDER1, cmd.provider(), "Should dispatch from real stock first (priority 1)");
+        assertEquals(PROVIDER1, cmd.provider(), "Should dispatch from real stock first");
         assertEquals(REQUESTER, cmd.requester());
         assertEquals(16L, cmd.amount());
     }
 
     @Test
-    void testDispatch_fallsThroughToHigherPriority() {
-        // Provider 1 doesn't have enough; only crafter has unlimited
-        controller.registerSupply(PROVIDER1, Map.of(diamond(), 5L), 1);   // only 5
-        controller.registerSupply(PROVIDER2, Map.of(diamond(), Long.MAX_VALUE), 5); // crafter
+    void testDispatch_partialStockThenCraft() {
+        // Provider has only 5, order needs 16 — dispatch 5 from stock, then 11 from crafter
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 5L), 1); // real stock (partial)
+        controller.registerSupply(PROVIDER2, Map.of(diamond(), 0L), 5); // crafter
 
         UUID orderId = controller.placeOrder(diamond(), 16L, REQUESTER);
         assertNotNull(orderId);
 
-        NetworkController.DispatchCommand cmd = controller.nextDispatchable();
-        assertNotNull(cmd);
-        // Provider1 has only 5, order needs 16, so it should skip to provider2
-        assertEquals(PROVIDER2, cmd.provider(), "Should fall through to crafter when real stock insufficient");
+        // First dispatch: partial fill from real stock
+        NetworkController.DispatchCommand cmd1 = controller.nextDispatchable();
+        assertNotNull(cmd1);
+        assertEquals(PROVIDER1, cmd1.provider(), "Should dispatch partial stock from provider first");
+        assertEquals(5L, cmd1.amount(), "Should dispatch only what real stock has available");
+
+        // Record the partial dispatch — order amount drops to 11
+        controller.recordDispatched(orderId, 5L);
+
+        // Second dispatch: remainder from crafter
+        NetworkController.DispatchCommand cmd2 = controller.nextDispatchable();
+        assertNotNull(cmd2);
+        assertEquals(PROVIDER2, cmd2.provider(), "Should dispatch remainder from crafter");
+        assertEquals(11L, cmd2.amount(), "Should dispatch exactly the remaining amount");
     }
 
     // ===== Supply Reservation =====


### PR DESCRIPTION
## Summary
- Improves requester fulfillment by allowing orders to be satisfied from available inventory first, then completing the remainder via crafting when needed.

## Changes
- Partial fills are now dispatched from real stock providers instead of skipping straight to a crafter when inventory can only cover part of an order.
- On-demand crafting providers are treated as “always dispatchable” without being decremented, and are used to fulfill any remaining amount after inventory is exhausted.
- Requester amount increment is now capped to a fixed maximum (576) for more predictable request sizing.

## Notes
- Tests have been updated to reflect the new dispatch behavior (stock-first, then craft for the remainder).