### PR TITLE
fix: add loot tables for pipes to drop on block break

### DIFF
--- a/src/main/resources/data/logistics/loot_table/blocks/pipe/basic_logistics_pipe.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/pipe/basic_logistics_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:pipe/basic_logistics_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/logistics/loot_table/blocks/pipe/provider_logistics_pipe.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/pipe/provider_logistics_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:pipe/provider_logistics_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/logistics/loot_table/blocks/pipe/requester_logistics_pipe.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/pipe/requester_logistics_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:pipe/requester_logistics_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/logistics/loot_table/blocks/pipe/supplier_logistics_pipe.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/pipe/supplier_logistics_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:pipe/supplier_logistics_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}


### PR DESCRIPTION
## Summary
This update introduces loot tables for logistics pipes, ensuring that they drop their corresponding items when broken. This fix addresses community feedback and enhances the overall gameplay experience by providing players with tangible rewards for breaking logistics pipe blocks.

## Changes
- Added loot tables for logistics pipes on block break events:
  - `basic_logistics_pipe`
  - `provider_logistics_pipe`
  - `requester_logistics_pipe`
  - `supplier_logistics_pipe`
- Ensured that all logistics pipes drop their associated items when destroyed, improving gameplay consistency and player satisfaction.

## Notes
- Players can expect that upon breaking different types of logistics pipes, they will now successfully recover the items rather than losing them or experiencing inconsistent behavior.