### PR TITLE
refactor: restructure network package and update related imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,11 @@ The domain architecture applies the **Dependency Inversion Principle** (DIP) - d
 ```
 src/main/java/com/logistics/
 ├── LogisticsMod.java        # Entry point, initializes all domains
+├── api/                     # Public API surface (LogisticsApi, TransportApi)
 ├── core/                    # Shared interfaces and utilities
 │   ├── bootstrap/           # Domain initialization system
 │   └── lib/                 # Interfaces that other domains may import
+│       └── network/         # ILogisticsNetwork, IWorldView, Order, etc.
 ├── pipe/                    # Item transport pipes
 ├── power/                   # Energy generation (engines)
 └── automation/              # Machines (quarry, etc.)
@@ -225,12 +227,17 @@ Domains are initialized using a two-phase pattern (server/common + client):
 - **Key abstractions in `core.lib`**:
   - `AbstractEngineBlockEntity` - base for all engines
   - `DomainBootstrap` - interface for domain initialization
+  - `BaseBlockEntity` - base class for block entities with common NBT/tick patterns
+  - `HasItemStorage`, `HasEnergyStorage`, `HasFluidStorage` - capability interfaces block entities implement
+  - `core.lib.network` - logistics network contracts (`ILogisticsNetwork`, `IWorldView`, `INetworkGraph`, `Order`, `IngredientChecker`, `ProviderCanFulfill`)
   - Shared interfaces that enable cross-domain functionality without coupling
 - Think of `core.lib` as the "contract layer" that keeps domains decoupled
 
 **Pipe Domain** (`com.logistics.pipe`):
 - Module composition: `Pipe` composes `Module` instances for behavior
-- Modules control routing, acceptance, and speed
+- Module types: `ProviderModule`, `SupplierModule`, `RequesterModule`, `SinkModule`, `NetworkRouterModule`, `CraftingModule`
+- Module ordering: CraftingModule runs first, NetworkRouterModule runs last
+- Network layer: `NetworkRegistry`, `PipeNetwork` (implements `ILogisticsNetwork`), `NetworkController`, `NetworkGraph`
 - `TravelingItem` represents items in transit with progress-based movement
 - See DESIGN.md for comprehensive pipe architecture
 

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -1,7 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
-import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;

--- a/src/main/java/com/logistics/pipe/modules/NetworkRouterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/NetworkRouterModule.java
@@ -2,7 +2,7 @@ package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.network.NetworkRegistry;
-import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.runtime.RoutePlan;
 import com.logistics.pipe.runtime.TravelingItem;

--- a/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -1,7 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
-import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.NbtCompat;

--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -1,7 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
-import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.core.lib.storage.NbtCompat;

--- a/src/main/java/com/logistics/pipe/modules/SinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SinkModule.java
@@ -2,7 +2,7 @@ package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.network.NetDbg;
-import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.core.lib.storage.NbtCompat;

--- a/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -3,7 +3,7 @@ package com.logistics.pipe.modules;
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.network.NetDbg;
 import com.logistics.pipe.network.NetworkRegistry;
-import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;

--- a/src/main/java/com/logistics/pipe/network/ILogisticsNetwork.java
+++ b/src/main/java/com/logistics/pipe/network/ILogisticsNetwork.java
@@ -1,4 +1,4 @@
-package com.logistics.core.lib.network;
+package com.logistics.pipe.network;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/logistics/pipe/network/IngredientChecker.java
+++ b/src/main/java/com/logistics/pipe/network/IngredientChecker.java
@@ -1,4 +1,4 @@
-package com.logistics.core.lib.network;
+package com.logistics.pipe.network;
 
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -1,9 +1,6 @@
 package com.logistics.pipe.network;
 
 import com.logistics.LogisticsMod;
-import com.logistics.core.lib.network.IngredientChecker;
-import com.logistics.core.lib.network.Order;
-import com.logistics.core.lib.network.ProviderCanFulfill;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
@@ -18,7 +15,7 @@ import java.util.*;
  * and per-requester ordered-amount tracking (how much is already on the way).
  *
  * <p>Dispatch is synchronous: the network calls {@link #nextDispatchable()} each tick,
- * then calls the provider's {@code onDispatch()} directly via {@link com.logistics.core.lib.network.IWorldView}.
+ * then calls the provider's {@code onDispatch()} directly via {@link com.logistics.core.lib.network.IWorldView IWorldView}.
  * Supply is immediately updated after extraction so subsequent orders in the same tick see accurate stock.
  *
  * <p>Before dispatching to a dynamic provider (crafter, etc.), a dry-run ingredient-chain check

--- a/src/main/java/com/logistics/pipe/network/Order.java
+++ b/src/main/java/com/logistics/pipe/network/Order.java
@@ -1,4 +1,4 @@
-package com.logistics.core.lib.network;
+package com.logistics.pipe.network;
 
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.core.BlockPos;

--- a/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -1,7 +1,9 @@
 package com.logistics.pipe.network;
 
 import com.logistics.LogisticsMod;
-import com.logistics.core.lib.network.*;
+import com.logistics.core.lib.network.INetworkGraph;
+import com.logistics.core.lib.network.IWorldView;
+import com.logistics.core.lib.network.NetworkGraph;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/src/main/java/com/logistics/pipe/network/ProviderCanFulfill.java
+++ b/src/main/java/com/logistics/pipe/network/ProviderCanFulfill.java
@@ -1,4 +1,4 @@
-package com.logistics.core.lib.network;
+package com.logistics.pipe.network;
 
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 


### PR DESCRIPTION
## Summary
This update streamlines the structure of the logistics network package and enhances the documentation for public API surfaces. These changes simplify module imports and improve overall code maintainability, which is crucial for future enhancements and integrations.

## Changes
- **Refactored Network Package Structure:**
  - Restructured the logistics network module by moving core interfaces from `core.lib.network` to `pipe.network`.
  - Updated all related imports across various modules (CraftingModule, ProviderModule, etc.) to align with the new structure.
  
- **Documentation Enhancements:**
  - Added detailed documentation for the public API surface, incorporating abstractions and logistics network concepts.
  - Included a reference guide for new package structures and functionalities.

## Notes
- The reorganization may require users to update their imports if they rely on the previous package structure. Users maintaining custom modules should review and adjust their code to ensure compatibility with the new package paths.