### PR TITLE
feat: introduce pure Java value objects for network states

### DIFF
--- a/src/main/java/com/logistics/pipe/network/CrafterBufferState.java
+++ b/src/main/java/com/logistics/pipe/network/CrafterBufferState.java
@@ -1,0 +1,26 @@
+package com.logistics.pipe.network;
+
+/**
+ * Current buffer capacity of an autocrafter adjacent to a crafting pipe.
+ * Used to limit how many batches can be submitted without overflowing the crafter's
+ * input or output inventory.
+ *
+ * <p>Pure value object — no Minecraft world coupling.
+ */
+public record CrafterBufferState(int maxInsertsNow, int maxCraftsFromOutputSpace) {
+    public CrafterBufferState {
+        if (maxInsertsNow < 0) throw new IllegalArgumentException("maxInsertsNow must not be negative");
+        if (maxCraftsFromOutputSpace < 0) throw new IllegalArgumentException("maxCraftsFromOutputSpace must not be negative");
+    }
+
+    /** A state where the crafter has no capacity — used when the buffer cannot be queried. */
+    public static final CrafterBufferState FULL = new CrafterBufferState(0, 0);
+
+    /** A state representing effectively unlimited capacity (creative/test use). */
+    public static final CrafterBufferState UNLIMITED = new CrafterBufferState(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+    /** How many batches can safely be submitted right now (minimum of the two limits). */
+    public int safeBatchCapacity() {
+        return Math.min(maxInsertsNow, maxCraftsFromOutputSpace);
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/CrafterSnapshot.java
+++ b/src/main/java/com/logistics/pipe/network/CrafterSnapshot.java
@@ -1,0 +1,34 @@
+package com.logistics.pipe.network;
+
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.minecraft.core.BlockPos;
+
+import java.util.List;
+
+/**
+ * Immutable snapshot of a crafting pipe's state at the moment of capture.
+ * Contains the output item, the per-batch output count, the recipe ingredients,
+ * and the autocrafter's current buffer capacity.
+ *
+ * <p>Pure value object — no Minecraft world coupling beyond BlockPos/ItemVariant.
+ */
+public record CrafterSnapshot(
+        BlockPos pos,
+        ItemVariant output,
+        long outputCount,
+        List<RecipeIngredient> ingredients,
+        CrafterBufferState buffer) {
+
+    public CrafterSnapshot {
+        if (pos == null) throw new NullPointerException("pos must not be null");
+        if (output == null) throw new NullPointerException("output must not be null");
+        if (outputCount <= 0) throw new IllegalArgumentException("outputCount must be positive, got: " + outputCount);
+        if (buffer == null) throw new NullPointerException("buffer must not be null");
+        ingredients = List.copyOf(ingredients); // defensive immutable copy
+    }
+
+    /** How many complete batches can be submitted right now given buffer capacity. */
+    public int availableBatchCapacity() {
+        return buffer.safeBatchCapacity();
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/NetworkSnapshot.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkSnapshot.java
@@ -1,0 +1,29 @@
+package com.logistics.pipe.network;
+
+import net.minecraft.core.BlockPos;
+
+import java.util.Map;
+
+/**
+ * Immutable point-in-time view of the full logistics network state.
+ * Aggregates snapshots of all providers, suppliers, and crafters in the network.
+ *
+ * <p>Built by {@link NetworkSnapshotBuilder}. Used by planning and reconciliation
+ * services to reason about the network without querying live Minecraft world state.
+ *
+ * <p>Pure value object — no Minecraft world coupling beyond BlockPos.
+ */
+public record NetworkSnapshot(
+        Map<BlockPos, ProviderSnapshot> providers,
+        Map<BlockPos, SupplierSnapshot> suppliers,
+        Map<BlockPos, CrafterSnapshot> crafters) {
+
+    public NetworkSnapshot {
+        providers = Map.copyOf(providers);
+        suppliers = Map.copyOf(suppliers);
+        crafters = Map.copyOf(crafters);
+    }
+
+    /** An empty snapshot — no nodes registered. */
+    public static final NetworkSnapshot EMPTY = new NetworkSnapshot(Map.of(), Map.of(), Map.of());
+}

--- a/src/main/java/com/logistics/pipe/network/NetworkSnapshotBuilder.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkSnapshotBuilder.java
@@ -1,0 +1,72 @@
+package com.logistics.pipe.network;
+
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.minecraft.core.BlockPos;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Accumulates snapshot data registered by modules and builds a {@link NetworkSnapshot}.
+ *
+ * <p>Modules call the {@code register*} methods (analogous to
+ * {@link ILogisticsNetwork#registerSupply}) to contribute their current state.
+ * Once all modules have reported, {@link #build()} produces an immutable snapshot.
+ *
+ * <p>A new builder should be created each snapshot cycle; builders are not thread-safe
+ * and are not reused across ticks.
+ */
+public class NetworkSnapshotBuilder {
+
+    private final Map<BlockPos, ProviderSnapshot> providers = new HashMap<>();
+    private final Map<BlockPos, SupplierSnapshot> suppliers = new HashMap<>();
+    private final Map<BlockPos, CrafterSnapshot> crafters = new HashMap<>();
+
+    /**
+     * Register or replace the provider snapshot for a position.
+     *
+     * @param pos      provider pipe position
+     * @param stock    current available items
+     * @param priority dispatch priority (1 = real stock, 5 = crafter/on-demand)
+     */
+    public void registerProvider(BlockPos pos, Map<ItemVariant, Long> stock, int priority) {
+        providers.put(pos, new ProviderSnapshot(pos, stock, priority));
+    }
+
+    /**
+     * Register or replace the supplier snapshot for a position.
+     *
+     * @param pos   supplier pipe position
+     * @param slots current state of each configured supply slot
+     */
+    public void registerSupplier(BlockPos pos, List<SupplySlotState> slots) {
+        suppliers.put(pos, new SupplierSnapshot(pos, slots));
+    }
+
+    /**
+     * Register or replace the crafter snapshot for a position.
+     *
+     * @param pos         crafting pipe position
+     * @param output      item the crafter produces
+     * @param outputCount items produced per batch
+     * @param ingredients recipe ingredients
+     * @param buffer      current autocrafter buffer capacity
+     */
+    public void registerCrafter(BlockPos pos, ItemVariant output, long outputCount,
+                                List<RecipeIngredient> ingredients, CrafterBufferState buffer) {
+        crafters.put(pos, new CrafterSnapshot(pos, output, outputCount, ingredients, buffer));
+    }
+
+    /** Remove all snapshot entries for a position (e.g. when a pipe is removed). */
+    public void unregister(BlockPos pos) {
+        providers.remove(pos);
+        suppliers.remove(pos);
+        crafters.remove(pos);
+    }
+
+    /** Build an immutable {@link NetworkSnapshot} from the current registered state. */
+    public NetworkSnapshot build() {
+        return new NetworkSnapshot(providers, suppliers, crafters);
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/ProviderSnapshot.java
+++ b/src/main/java/com/logistics/pipe/network/ProviderSnapshot.java
@@ -1,0 +1,22 @@
+package com.logistics.pipe.network;
+
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.minecraft.core.BlockPos;
+
+import java.util.Map;
+
+/**
+ * Immutable snapshot of what a provider pipe has available at the moment of capture.
+ * Pure value object — no Minecraft world coupling.
+ */
+public record ProviderSnapshot(BlockPos pos, Map<ItemVariant, Long> stock, int priority) {
+    public ProviderSnapshot {
+        if (pos == null) throw new NullPointerException("pos must not be null");
+        stock = Map.copyOf(stock); // defensive immutable copy
+    }
+
+    /** Total available amount of a specific item in this snapshot. */
+    public long available(ItemVariant item) {
+        return stock.getOrDefault(item, 0L);
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/RecipeIngredient.java
+++ b/src/main/java/com/logistics/pipe/network/RecipeIngredient.java
@@ -1,0 +1,14 @@
+package com.logistics.pipe.network;
+
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+
+/**
+ * A single ingredient in a crafting recipe: the item required and how many per batch.
+ * Pure value object — no Minecraft world coupling.
+ */
+public record RecipeIngredient(ItemVariant item, long amountPerBatch) {
+    public RecipeIngredient {
+        if (item == null) throw new NullPointerException("item must not be null");
+        if (amountPerBatch <= 0) throw new IllegalArgumentException("amountPerBatch must be positive, got: " + amountPerBatch);
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/SupplierSnapshot.java
+++ b/src/main/java/com/logistics/pipe/network/SupplierSnapshot.java
@@ -1,0 +1,22 @@
+package com.logistics.pipe.network;
+
+import net.minecraft.core.BlockPos;
+
+import java.util.List;
+
+/**
+ * Immutable snapshot of a supplier pipe's full demand state.
+ * Contains one {@link SupplySlotState} per configured supply slot.
+ * Pure value object — no Minecraft world coupling.
+ */
+public record SupplierSnapshot(BlockPos pos, List<SupplySlotState> slots) {
+    public SupplierSnapshot {
+        if (pos == null) throw new NullPointerException("pos must not be null");
+        slots = List.copyOf(slots); // defensive immutable copy
+    }
+
+    /** {@code true} if any slot needs restocking. */
+    public boolean needsRestock() {
+        return slots.stream().anyMatch(SupplySlotState::shouldRestock);
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/SupplySlotState.java
+++ b/src/main/java/com/logistics/pipe/network/SupplySlotState.java
@@ -1,0 +1,41 @@
+package com.logistics.pipe.network;
+
+/**
+ * State of a single configured slot in a supplier pipe.
+ * Captures the full demand picture: desired target, current on-hand, items already in transit,
+ * items with outstanding orders, and the mode config that governs when to restock.
+ *
+ * <p>The demand formula expressed as data:
+ * <pre>  needed = desired - onHand - inbound - ordered</pre>
+ * (where {@code inbound} is items already traveling toward this supplier but not yet delivered,
+ * and {@code ordered} is the amount tracked by the network as pending but not yet dispatched)
+ *
+ * <p>Pure value object — no Minecraft world coupling.
+ */
+public record SupplySlotState(
+        String itemId,
+        long desired,
+        long onHand,
+        long inbound,
+        long ordered,
+        SupplierModeConfig config) {
+
+    public SupplySlotState {
+        if (itemId == null || itemId.isEmpty()) throw new IllegalArgumentException("itemId must not be blank");
+        if (desired < 0) throw new IllegalArgumentException("desired must not be negative");
+        if (onHand < 0) throw new IllegalArgumentException("onHand must not be negative");
+        if (inbound < 0) throw new IllegalArgumentException("inbound must not be negative");
+        if (ordered < 0) throw new IllegalArgumentException("ordered must not be negative");
+        if (config == null) throw new NullPointerException("config must not be null");
+    }
+
+    /** How many more items are needed to satisfy this slot's target. */
+    public long needed() {
+        return Math.max(0L, desired - onHand - inbound - ordered);
+    }
+
+    /** Whether a restock request should be placed given current on-hand stock. */
+    public boolean shouldRestock() {
+        return needed() > 0 && config.isTriggerMet(onHand, desired);
+    }
+}


### PR DESCRIPTION
## Summary
This update introduces a set of pure Java value objects to encapsulate key data structures related to crafting and logistics network states. This enhancement improves modularity and clarity of the code, facilitating maintenance and supporting future feature expansions.

## Changes
- **Crafter Buffer State:**
  - Added `CrafterBufferState` to track the capacity of autocrafters, preventing overflow during crafting operations.
  
- **Crafting Snapshot:**
  - Introduced `CrafterSnapshot`, capturing the current state of crafting pipes including output, ingredients, and buffer capacity.
  
- **Network Snapshot:**
  - Created `NetworkSnapshot`, which aggregates the states of all network nodes (providers, suppliers, crafters) for effective querying without direct world access.
  
- **Snapshot Builder:**
  - Implemented `NetworkSnapshotBuilder` for constructing `NetworkSnapshot` instances, supporting modular state registration from various network components.

- **Provider and Supplier Snapshots:**
  - Added `ProviderSnapshot` for detailing the stock status of provider pipes.
  - Introduced `SupplierSnapshot` to capture the demand states of supply slots, indicating restocking needs.

- **Recipe Ingredient Structure:**
  - Defined `RecipeIngredient` to represent items required for crafting, including the quantity needed per batch.

- **Supply Slot State:**
  - Established `SupplySlotState`, detailing demand calculations and restocking conditions for individual supply slots.

## Notes
All new classes are designed as immutable value objects, enhancing thread safety and reducing the risk of unintended side effects. No changes in the existing API or functionality affecting backward compatibility were introduced.