### PR TITLE
feat: implement capacity limits for crafting module batches

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -1,7 +1,11 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.pipe.network.CraftBatchingService;
+import com.logistics.pipe.network.CrafterBufferState;
+import com.logistics.pipe.network.CrafterSnapshot;
 import com.logistics.pipe.network.ILogisticsNetwork;
+import com.logistics.pipe.network.RecipeIngredient;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;
@@ -239,7 +243,8 @@ public class CraftingModule implements Module {
 
         String resultId = getResultItem(ctx);
         if (resultId.isEmpty()) return 0;
-        if (findAutocrafterDirection(ctx) == null) return 0;
+        Direction autocrafterDir = findAutocrafterDirection(ctx);
+        if (autocrafterDir == null) return 0;
 
         ItemStack resultStack = resolveItem(resultId);
         if (resultStack.isEmpty() || !item.matches(resultStack)) return 0;
@@ -250,9 +255,16 @@ public class CraftingModule implements Module {
         if (network == null) return 0;
 
         int resultCount = getResultCount(ctx);
-        long batchCount = (amount + resultCount - 1L) / resultCount;
+        if (resultCount <= 0) return 0;
 
-        // Aggregate ingredient amounts for all batches
+        // Cap batches to what the autocrafter's input buffer can currently absorb
+        CrafterBufferState bufferState = computeBufferState(ctx, autocrafterDir);
+        long batchCount = new CraftBatchingService().safeBatchCount(amount, resultCount, bufferState);
+        if (batchCount <= 0) return 0; // no buffer capacity right now
+
+        long actualAmount = batchCount * resultCount; // may be less than amount
+
+        // Aggregate ingredient amounts for the capped batch count
         Map<String, Long> neededByItem = new LinkedHashMap<>();
         for (int slot = 0; slot < 9; slot++) {
             String ingredientId = getIngredientItem(ctx, slot);
@@ -287,11 +299,11 @@ public class CraftingModule implements Module {
             ingredientOrderIds.putString(entry.getKey(), ingredientOrderId.toString());
         }
 
-        // Append entry to queue
+        // Append entry to queue (for the capped amount we actually accepted)
         CompoundTag queueEntry = new CompoundTag();
         queueEntry.putString(ENTRY_REQ, requester.getX() + "," + requester.getY() + "," + requester.getZ());
         queueEntry.putString(ENTRY_DLV, deliveryId.toString());
-        queueEntry.putLong(ENTRY_AMT, amount);
+        queueEntry.putLong(ENTRY_AMT, actualAmount);
         queueEntry.put(ENTRY_IDS, ingredientOrderIds);
 
         ListTag queue = getQueue(ctx);
@@ -305,7 +317,65 @@ public class CraftingModule implements Module {
             network.unregisterProviderCheck(ctx.pos());
         }
 
-        return amount; // Promise: delivery happens after crafting completes
+        return actualAmount; // Promise: delivery happens after crafting completes (capped to buffer capacity)
+    }
+
+    /**
+     * Compute the autocrafter's current input buffer capacity: how many batches worth of
+     * ingredients can still fit in the crafter's input slots. Returns {@link CrafterBufferState#FULL}
+     * when the crafter cannot be found.
+     */
+    private CrafterBufferState computeBufferState(PipeContext ctx, Direction autocrafterDir) {
+        BlockPos autocrafterPos = ctx.pos().relative(autocrafterDir);
+        if (!(ctx.world().getBlockEntity(autocrafterPos) instanceof CrafterBlockEntity crafter)) {
+            return CrafterBufferState.FULL;
+        }
+        int minBatchCapacity = Integer.MAX_VALUE;
+        boolean hasRecipeSlots = false;
+        for (int slot = 0; slot < 9; slot++) {
+            String ingredientId = getIngredientItem(ctx, slot);
+            if (ingredientId.isEmpty()) continue;
+            hasRecipeSlots = true;
+            int recipeCount = Math.max(1, getIngredientCount(ctx, slot));
+            ItemStack inSlot = crafter.getItem(slot);
+            int current = inSlot.isEmpty() ? 0 : inSlot.getCount();
+            ItemStack ingredient = resolveItem(ingredientId);
+            int maxStack = ingredient.isEmpty() ? 64 : ingredient.getMaxStackSize();
+            int space = Math.max(0, maxStack - current);
+            minBatchCapacity = Math.min(minBatchCapacity, space / recipeCount);
+        }
+        if (!hasRecipeSlots || minBatchCapacity == Integer.MAX_VALUE) return CrafterBufferState.FULL;
+        // maxCraftsFromOutputSpace = unlimited: the pipe accepts output directly via onExternalInsert
+        return new CrafterBufferState(minBatchCapacity, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Build a {@link CrafterSnapshot} from the current recipe config and autocrafter state.
+     * Returns {@code null} when the recipe or autocrafter is not fully configured.
+     */
+    @Nullable
+    private CrafterSnapshot buildCrafterSnapshot(PipeContext ctx) {
+        String resultId = getResultItem(ctx);
+        if (resultId.isEmpty()) return null;
+        ItemStack resultStack = resolveItem(resultId);
+        if (resultStack.isEmpty()) return null;
+        int resultCount = getResultCount(ctx);
+        if (resultCount <= 0) return null;
+        Direction autocrafterDir = findAutocrafterDirection(ctx);
+        if (autocrafterDir == null) return null;
+
+        List<RecipeIngredient> ingredients = new ArrayList<>();
+        for (int slot = 0; slot < 9; slot++) {
+            String ingredientId = getIngredientItem(ctx, slot);
+            if (ingredientId.isEmpty()) continue;
+            ItemStack ingredientStack = resolveItem(ingredientId);
+            if (ingredientStack.isEmpty()) continue;
+            ingredients.add(new RecipeIngredient(ItemVariant.of(ingredientStack), getIngredientCount(ctx, slot)));
+        }
+        if (ingredients.isEmpty()) return null;
+
+        CrafterBufferState buffer = computeBufferState(ctx, autocrafterDir);
+        return new CrafterSnapshot(ctx.pos(), ItemVariant.of(resultStack), resultCount, ingredients, buffer);
     }
 
     private void updateCrafterSupply(PipeContext ctx) {
@@ -316,6 +386,7 @@ public class CraftingModule implements Module {
         if (resultId.isEmpty() || findAutocrafterDirection(ctx) == null) {
             network.registerSupply(ctx.pos(), new HashMap<>(), CRAFTER_PRIORITY);
             network.unregisterProviderCheck(ctx.pos());
+            network.unregisterCrafterSnapshot(ctx.pos());
             return;
         }
 
@@ -325,6 +396,7 @@ public class CraftingModule implements Module {
         if (isBlocking(ctx) && isActive(ctx)) {
             network.registerSupply(ctx.pos(), new HashMap<>(), CRAFTER_PRIORITY);
             network.unregisterProviderCheck(ctx.pos());
+            network.unregisterCrafterSnapshot(ctx.pos());
             return;
         }
 
@@ -332,6 +404,7 @@ public class CraftingModule implements Module {
         if (resultStack.isEmpty()) {
             network.registerSupply(ctx.pos(), new HashMap<>(), CRAFTER_PRIORITY);
             network.unregisterProviderCheck(ctx.pos());
+            network.unregisterCrafterSnapshot(ctx.pos());
             return;
         }
 
@@ -339,6 +412,15 @@ public class CraftingModule implements Module {
         Map<ItemVariant, Long> craftable = new HashMap<>();
         craftable.put(ItemVariant.of(resultStack), 0L);
         network.registerSupply(ctx.pos(), craftable, CRAFTER_PRIORITY);
+
+        // Register buffer snapshot so RequestPlanner can cap batch sizes
+        CrafterSnapshot snapshot = buildCrafterSnapshot(ctx);
+        if (snapshot != null) {
+            network.registerCrafterSnapshot(ctx.pos(), snapshot);
+        } else {
+            network.unregisterCrafterSnapshot(ctx.pos());
+        }
+
         network.registerProviderCheck(ctx.pos(), (amount, checker) -> {
             int resultCount = getResultCount(ctx);
             if (resultCount <= 0) return List.of();

--- a/src/main/java/com/logistics/pipe/network/CraftBatchingService.java
+++ b/src/main/java/com/logistics/pipe/network/CraftBatchingService.java
@@ -1,0 +1,33 @@
+package com.logistics.pipe.network;
+
+/**
+ * Computes the safe number of crafting batches to submit given a crafter's current buffer state.
+ *
+ * <p>Prevents ingredient overflow when the autocrafter's input slots are nearly full: rather than
+ * ordering ingredients for the entire requested amount at once, callers cap the submission to what
+ * the crafter can currently absorb. The remaining batches are submitted on subsequent ticks once
+ * the crafter has consumed the current batch.
+ *
+ * <p>Zero Minecraft API coupling — 100% testable with pure Java.
+ */
+public class CraftBatchingService {
+
+    /**
+     * Compute the safe number of batches to submit.
+     *
+     * <p>Converts {@code totalNeeded} into batches, then clamps to the crafter's current buffer
+     * capacity. Both limits are respected: if the buffer can only accept 4 batches, at most 4
+     * batches are returned regardless of how many were requested.
+     *
+     * @param totalNeeded    total output items needed
+     * @param outputPerBatch items produced per recipe batch (must be &gt; 0)
+     * @param buffer         current crafter input/output buffer limits
+     * @return safe number of batches to submit now (0 if crafter has no capacity)
+     */
+    public long safeBatchCount(long totalNeeded, long outputPerBatch, CrafterBufferState buffer) {
+        if (outputPerBatch <= 0) return 0;
+        long requestedBatches = (totalNeeded + outputPerBatch - 1) / outputPerBatch;
+        long capacityBatches = buffer.safeBatchCapacity();
+        return Math.min(requestedBatches, capacityBatches);
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/ILogisticsNetwork.java
+++ b/src/main/java/com/logistics/pipe/network/ILogisticsNetwork.java
@@ -136,6 +136,26 @@ public interface ILogisticsNetwork {
      */
     void notifyDelivery(BlockPos requester, ItemVariant item, long amount);
 
+    // ===== Crafter Snapshot =====
+
+    /**
+     * Register (or replace) a crafter buffer snapshot for use by the request planner.
+     * Called by crafter modules each scan cycle so the planner sees current buffer capacity.
+     * Default no-op — implementations override when snapshot storage is available.
+     *
+     * @param pos      crafting pipe position
+     * @param snapshot current crafter state (recipe, output count, buffer capacity)
+     */
+    default void registerCrafterSnapshot(BlockPos pos, CrafterSnapshot snapshot) {}
+
+    /**
+     * Remove the crafter snapshot for a position (e.g. when recipe is cleared or pipe removed).
+     * Default no-op — implementations override when snapshot storage is available.
+     *
+     * @param pos crafting pipe position
+     */
+    default void unregisterCrafterSnapshot(BlockPos pos) {}
+
     // ===== Sink Operations =====
 
     /**

--- a/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -76,6 +76,9 @@ public class NetworkController implements PlanningView {
     // Explicit reservation tracking: replaces implicit SupplyEntry.available mutation
     private final ReservationManager reservationManager = new ReservationManager();
 
+    // Crafter buffer snapshots registered by CraftingModule each scan cycle
+    private final Map<BlockPos, CrafterSnapshot> crafterSnapshots = new HashMap<>();
+
     @Nullable
     private OrderFailureListener failureListener;
 
@@ -397,6 +400,16 @@ public class NetworkController implements PlanningView {
         }
     }
 
+    // ===== Crafter Snapshot Registration =====
+
+    public void registerCrafterSnapshot(BlockPos pos, CrafterSnapshot snapshot) {
+        crafterSnapshots.put(pos, snapshot);
+    }
+
+    public void unregisterCrafterSnapshot(BlockPos pos) {
+        crafterSnapshots.remove(pos);
+    }
+
     // ===== Order Query =====
 
     /** {@code true} if the order is still pending in the queue (not yet fully dispatched). */
@@ -429,6 +442,16 @@ public class NetworkController implements PlanningView {
     @Nullable
     public ProviderCanFulfill getCrafterCheck(BlockPos provider) {
         return providerChecks.get(provider);
+    }
+
+    /**
+     * Return the most recent {@link CrafterSnapshot} for a crafter position, or {@code null}
+     * if none has been registered yet.
+     */
+    @Override
+    @Nullable
+    public CrafterSnapshot getCrafterSnapshot(BlockPos provider) {
+        return crafterSnapshots.get(provider);
     }
 
     // ===== Query =====
@@ -505,6 +528,9 @@ public class NetworkController implements PlanningView {
 
         // Merge reservations
         reservationManager.merge(other.reservationManager);
+
+        // Merge crafter snapshots
+        crafterSnapshots.putAll(other.crafterSnapshots);
     }
 
     // ===== Helpers =====

--- a/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -98,6 +98,7 @@ public class PipeNetwork implements ILogisticsNetwork {
         controller.removeSupply(pos);
         controller.cancelOrdersFor(pos);
         controller.unregisterProviderCheck(pos);
+        controller.unregisterCrafterSnapshot(pos);
         defaultRouteSinks.remove(pos);
         sinkPriorities.remove(pos);
     }
@@ -151,6 +152,16 @@ public class PipeNetwork implements ILogisticsNetwork {
     @Override
     public void cancelOrder(UUID orderId) {
         controller.cancelOrder(orderId);
+    }
+
+    @Override
+    public void registerCrafterSnapshot(BlockPos pos, CrafterSnapshot snapshot) {
+        controller.registerCrafterSnapshot(pos, snapshot);
+    }
+
+    @Override
+    public void unregisterCrafterSnapshot(BlockPos pos) {
+        controller.unregisterCrafterSnapshot(pos);
     }
 
     @Override

--- a/src/main/java/com/logistics/pipe/network/PlanningView.java
+++ b/src/main/java/com/logistics/pipe/network/PlanningView.java
@@ -35,4 +35,12 @@ public interface PlanningView {
      */
     @Nullable
     ProviderCanFulfill getCrafterCheck(BlockPos provider);
+
+    /**
+     * Current buffer snapshot for a crafter at the given position.
+     * Returns {@code null} if no snapshot has been registered (crafter not yet scanned).
+     * When null, callers should treat buffer capacity as unlimited.
+     */
+    @Nullable
+    CrafterSnapshot getCrafterSnapshot(BlockPos provider);
 }

--- a/src/main/java/com/logistics/pipe/network/RequestPlanner.java
+++ b/src/main/java/com/logistics/pipe/network/RequestPlanner.java
@@ -78,12 +78,22 @@ public class RequestPlanner {
             // Try crafters for any remainder
             long remaining = needed - planned;
             if (remaining > 0) {
+                CraftBatchingService batcher = new CraftBatchingService();
                 for (PlanningView.SupplyPoint sp : supply) {
                     if (sp.available() != 0) continue; // skip real-stock entries
                     if (view.getCrafterCheck(sp.provider()) == null) continue; // no check registered
-                    // Phase 6: ingredient deps are not recursed; added as empty list
-                    out.add(new PlanNode.CraftNode(sp.provider(), item, remaining, List.of()));
-                    planned += remaining;
+                    CrafterSnapshot snapshot = view.getCrafterSnapshot(sp.provider());
+                    if (snapshot != null) {
+                        // Cap to what the crafter's buffer can currently absorb
+                        long batches = batcher.safeBatchCount(remaining, snapshot.outputCount(), snapshot.buffer());
+                        if (batches <= 0) continue; // crafter buffer is full — try next
+                        out.add(new PlanNode.CraftNode(sp.provider(), item, batches, List.of()));
+                        planned += batches * snapshot.outputCount();
+                    } else {
+                        // No snapshot yet (first scan not complete): treat as unlimited capacity
+                        out.add(new PlanNode.CraftNode(sp.provider(), item, remaining, List.of()));
+                        planned += remaining;
+                    }
                     break; // use first valid crafter
                 }
             }


### PR DESCRIPTION
## Summary
This update introduces a capacity limiting feature for crafting batches within the module system. By implementing this functionality, the system helps prevent ingredient overflow by ensuring that only the necessary amount of ingredients are requested based on the current state of the autocrafter's input buffer. This enhancement improves crafting efficiency and resource management.

## Changes
- **Capacity Limiting Implementation**
  - Added a capacity limiting mechanism in `CraftingModule` that regulates the number of crafting batches based on the autocrafter's input buffer state.
  - Introduced `CraftBatchingService` to compute the safe number of crafting batches that can be submitted to the autocrafter without exceeding its capacity.
  - Enhanced `ILogisticsNetwork` with methods to register and unregister crafter snapshots, enabling the tracking of the current crafting state and buffer capacity.
  
- **Code Enhancements**
  - Improved internal logic in `CraftingModule` to aggregate ingredient amounts based on the adjusted batch size and the current crafter state.
  - Enhanced error handling and state management by ensuring that the register and unregister functions are called appropriately when changes occur in the crafting module's configuration.

## Notes
- This change introduces a new dependency on the current state of the autocrafter, which may impact existing setups relying on the previous crafting behavior. Users are encouraged to review their crafting configurations to ensure optimal performance with the new capacity limiting feature.