### PR TITLE
refactor: introduce explicit dispatch commands for network actions

### DIFF
--- a/src/main/java/com/logistics/pipe/network/CommandResult.java
+++ b/src/main/java/com/logistics/pipe/network/CommandResult.java
@@ -1,0 +1,25 @@
+package com.logistics.pipe.network;
+
+/**
+ * Result of executing a {@link NetworkCommand} via {@link NetworkCommandExecutor}.
+ *
+ * @param itemsHandled number of items the command successfully processed (0 on failure)
+ * @param success      {@code true} if the command was accepted and produced a meaningful result
+ */
+public record CommandResult(long itemsHandled, boolean success) {
+
+    /** Successful result with the given item count. */
+    public static CommandResult ok(long itemsHandled) {
+        return new CommandResult(itemsHandled, true);
+    }
+
+    /** Failed result — command could not be executed or produced no output. */
+    public static CommandResult failed() {
+        return new CommandResult(0L, false);
+    }
+
+    /** Alias for {@link #success()} — reads more naturally in conditional expressions. */
+    public boolean isSuccess() {
+        return success;
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/NetworkCommand.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkCommand.java
@@ -1,0 +1,71 @@
+package com.logistics.pipe.network;
+
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.minecraft.core.BlockPos;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Typed command describing a single network action to be executed against the Minecraft world.
+ *
+ * <p>Sealed hierarchy — exactly three concrete forms:
+ * <ul>
+ *   <li>{@link ExtractCommand}           — pull items from a provider pipe</li>
+ *   <li>{@link InsertCrafterInputsCommand} — push ingredients into a crafter's input buffer</li>
+ *   <li>{@link DeliverCommand}           — route items directly to a destination (future use)</li>
+ * </ul>
+ *
+ * <p>Commands are value objects produced by the network domain layer and consumed by
+ * {@link NetworkCommandExecutor}, which bridges them to the Minecraft world.
+ * The domain layer remains Minecraft-free; all world interaction is in the executor.
+ */
+public sealed interface NetworkCommand
+        permits NetworkCommand.ExtractCommand,
+                NetworkCommand.InsertCrafterInputsCommand,
+                NetworkCommand.DeliverCommand {
+
+    // ───────────────────────────────────────────────────────────────────────
+
+    /**
+     * Ask the provider pipe at {@code provider} to extract {@code amount} of {@code item}
+     * and begin routing it toward {@code requester}.
+     *
+     * @param deliveryId UUID attached to the resulting {@link com.logistics.pipe.runtime.TravelingItem}
+     *                   for delivery accounting via
+     *                   {@link ILogisticsNetwork#notifyDelivery}
+     */
+    record ExtractCommand(
+            BlockPos provider,
+            BlockPos requester,
+            ItemVariant item,
+            long amount,
+            UUID deliveryId) implements NetworkCommand {}
+
+    // ───────────────────────────────────────────────────────────────────────
+
+    /**
+     * Insert a set of ingredients directly into the input buffer of the crafter at
+     * {@code crafter}.
+     *
+     * <p>Reserved for explicit ingredient routing; not yet used in the main dispatch path
+     * (ingredients currently arrive via normal {@link ExtractCommand} routing).
+     */
+    record InsertCrafterInputsCommand(
+            BlockPos crafter,
+            Map<ItemVariant, Long> ingredients) implements NetworkCommand {}
+
+    // ───────────────────────────────────────────────────────────────────────
+
+    /**
+     * Deliver {@code amount} of {@code item} directly to {@code destination}, bypassing the
+     * normal {@link com.logistics.pipe.runtime.TravelingItem} routing pipeline.
+     *
+     * <p>Reserved for future use (e.g., instant delivery in creative networks).
+     */
+    record DeliverCommand(
+            BlockPos destination,
+            ItemVariant item,
+            long amount,
+            UUID deliveryId) implements NetworkCommand {}
+}

--- a/src/main/java/com/logistics/pipe/network/NetworkCommandExecutor.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkCommandExecutor.java
@@ -1,0 +1,59 @@
+package com.logistics.pipe.network;
+
+import com.logistics.core.lib.network.IWorldView;
+
+/**
+ * Executes {@link NetworkCommand} objects against the Minecraft world via {@link IWorldView}.
+ *
+ * <p>This is the single boundary point where typed network commands cross from the pure-Java
+ * domain layer into world-coupled code. All Minecraft API interaction is delegated to
+ * {@link IWorldView}; the domain layer remains free of world coupling.
+ *
+ * <p>One executor instance is created per network tick and used for all commands in that tick.
+ * Executors are stateless beyond their {@link IWorldView} reference.
+ */
+public class NetworkCommandExecutor {
+
+    private final IWorldView worldView;
+
+    public NetworkCommandExecutor(IWorldView worldView) {
+        this.worldView = worldView;
+    }
+
+    /**
+     * Execute a network command and return the result.
+     *
+     * @param command the command to execute
+     * @return result describing what was accomplished ({@link CommandResult#failed()} if the
+     *         command could not be executed or the provider returned nothing)
+     */
+    public CommandResult execute(NetworkCommand command) {
+        return switch (command) {
+            case NetworkCommand.ExtractCommand cmd -> executeExtract(cmd);
+            case NetworkCommand.InsertCrafterInputsCommand cmd -> executeInsertCrafterInputs(cmd);
+            case NetworkCommand.DeliverCommand cmd -> executeDeliver(cmd);
+        };
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+
+    private CommandResult executeExtract(NetworkCommand.ExtractCommand cmd) {
+        long shipped = worldView.dispatch(
+                cmd.provider(), cmd.requester(), cmd.item(), cmd.amount(), cmd.deliveryId());
+        return shipped > 0 ? CommandResult.ok(shipped) : CommandResult.failed();
+    }
+
+    private CommandResult executeInsertCrafterInputs(NetworkCommand.InsertCrafterInputsCommand cmd) {
+        // Phase 9 placeholder: crafter input insertion is currently handled by
+        // CraftingModule.onDispatch() via the normal ExtractCommand path.
+        // This command type is reserved for explicit ingredient routing in a future phase.
+        return CommandResult.failed();
+    }
+
+    private CommandResult executeDeliver(NetworkCommand.DeliverCommand cmd) {
+        // Phase 9 placeholder: item delivery is driven by TravelingItem movement in the
+        // pipe runtime. This command type is reserved for direct delivery bypass (e.g.
+        // creative networks) in a future phase.
+        return CommandResult.failed();
+    }
+}

--- a/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -197,18 +197,20 @@ public class PipeNetwork implements ILogisticsNetwork {
      */
     public void tick(long gameTime) {
         if (worldView == null) return;
+        NetworkCommandExecutor executor = new NetworkCommandExecutor(worldView);
         NetworkController.DispatchCommand cmd;
         while ((cmd = controller.nextDispatchable()) != null) {
             NetDbg.out("[Network {}] Dispatch: {} | provider={} → requester={} | {}x {}",
                     getNetworkIdShort(id), cmd.orderId().toString().substring(0, 8),
                     cmd.provider(), cmd.requester(), cmd.amount(), cmd.item().toStack().getItem());
             try {
-                long shipped = worldView.dispatch(
-                        cmd.provider(), cmd.requester(), cmd.item(), cmd.amount(), cmd.orderId());
-                if (shipped > 0) {
+                CommandResult result = executor.execute(new NetworkCommand.ExtractCommand(
+                        cmd.provider(), cmd.requester(), cmd.item(), cmd.amount(), cmd.orderId()));
+                if (result.isSuccess()) {
                     NetDbg.out("[Network {}] Shipped: {} | {} items",
-                            getNetworkIdShort(id), cmd.orderId().toString().substring(0, 8), shipped);
-                    controller.recordDispatched(cmd.orderId(), shipped);
+                            getNetworkIdShort(id), cmd.orderId().toString().substring(0, 8),
+                            result.itemsHandled());
+                    controller.recordDispatched(cmd.orderId(), result.itemsHandled());
                 } else {
                     controller.markSupplyUnavailable(cmd.provider());
                 }


### PR DESCRIPTION
## Summary
This update introduces a new command structure for managing network interactions more explicitly within the logistics system. By implementing `CommandResult` and `NetworkCommand`, we are enhancing the clarity and reliability of network actions, while separating the domain logic from Minecraft interactions.

## Changes
- **New Command Structures**
  - Introduced `CommandResult`: A lightweight object that provides the outcome of executing a command, indicating success or failure along with the number of items handled.
  - Added `NetworkCommand` interface with three specific implementations:
    - `ExtractCommand`: Responsible for extracting items from provider pipes.
    - `InsertCrafterInputsCommand`: Pushes ingredients into a crafter's input buffer (currently reserved for future enhancements).
    - `DeliverCommand`: A placeholder command for future implementation targeting direct item delivery.
  
- **Network Command Execution**
  - Created `NetworkCommandExecutor`: A single boundary point where typed network commands cross from the domain layer into the Minecraft environment, ensuring a clean separation of concerns while managing the execution of commands.

- **Refactored `PipeNetwork` Integration**
  - Updated the `PipeNetwork` class to utilize the new command structures during the tick process, improving how network actions are dispatched and results are handled.

## Notes
- This refactor essentially sets the groundwork for more robust handling of network commands and prepares for future enhancements related to crafting and direct delivery functionalities.