### PR TITLE
refactor: remove unnecessary buffer handling from crafting module

### DIFF
--- a/src/main/java/com/logistics/LogisticsPipe.java
+++ b/src/main/java/com/logistics/LogisticsPipe.java
@@ -301,7 +301,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
             CRAFTER_MODULE_MKII = INSTANCE.registerItem("crafter_mkii_module",
                     props -> new ModuleItem(props, () -> new CraftingModule(64, 1)));
             CRAFTER_MODULE_MKIII = INSTANCE.registerItem("crafter_mkiii_module",
-                    props -> new ModuleItem(props, () -> new CraftingModule(128, 8, 16)));
+                    props -> new ModuleItem(props, () -> new CraftingModule(128, 8)));
             QUICKSORT_MODULE = INSTANCE.registerItem("quicksort_module",
                     props -> new ModuleItem(props, QuickSortModule::new));
             TERMINUS_MODULE = INSTANCE.registerItem("terminus_module",

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -30,7 +30,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.CrafterBlock;
 import net.minecraft.world.level.block.entity.CrafterBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -65,17 +64,10 @@ public class CraftingModule implements Module {
     private final int itemLimit;
     /** Max output stacks to dispatch per cycle (future use; stored for tier identity). */
     private final int stackLimit;
-    /** Internal ingredient buffer slots (MK3+). 0 = no buffer. */
-    private final int bufferSlots;
 
     public CraftingModule(int itemLimit, int stackLimit) {
-        this(itemLimit, stackLimit, 0);
-    }
-
-    public CraftingModule(int itemLimit, int stackLimit, int bufferSlots) {
         this.itemLimit = itemLimit;
         this.stackLimit = stackLimit;
-        this.bufferSlots = bufferSlots;
     }
 
     // NBT keys — recipe config
@@ -94,9 +86,6 @@ public class CraftingModule implements Module {
     private static final String ENTRY_DLV = "dlv";   // UUID as string
     private static final String ENTRY_AMT = "amt";   // remaining amount (long)
     private static final String ENTRY_IDS = "ids";   // ingredient order IDs (CompoundTag)
-    // NBT keys — ingredient buffer (MK3+)
-    private static final String INGREDIENT_BUFFER = "ingredient_buffer"; // CompoundTag: itemId → longCount
-
     // Timing constants
     private static final int SCAN_INTERVAL = 20;    // Update crafter supply every 20 ticks
     private static final int CRAFT_INTERVAL = 6;    // Execute direct crafts every 6 ticks
@@ -196,51 +185,6 @@ public class CraftingModule implements Module {
         } catch (Exception e) {
             return null;
         }
-    }
-
-    // ==================== Ingredient Buffer (MK3+) ====================
-
-    private CompoundTag getBufferTag(PipeContext ctx) {
-        return NbtCompat.getCompoundOrEmpty(ctx.moduleState(getStateKey()), INGREDIENT_BUFFER);
-    }
-
-    private long getBufferCount(PipeContext ctx, String ingredientId) {
-        return NbtCompat.getLong(getBufferTag(ctx), ingredientId, 0L);
-    }
-
-    /** Max items this buffer can hold for one ingredient: bufferSlots × maxStackSize. */
-    private long bufferCapacity(String ingredientId) {
-        if (bufferSlots <= 0) return 0;
-        ItemStack ingredient = resolveItem(ingredientId);
-        int maxStack = ingredient.isEmpty() ? 64 : ingredient.getMaxStackSize();
-        return (long) bufferSlots * maxStack;
-    }
-
-    /** Add up to {@code count} of {@code ingredientId} to the buffer. Returns amount actually added. */
-    private long addToBuffer(PipeContext ctx, String ingredientId, long count) {
-        long capacity = bufferCapacity(ingredientId);
-        long current = getBufferCount(ctx, ingredientId);
-        long toBuffer = Math.min(count, Math.max(0, capacity - current));
-        if (toBuffer <= 0) return 0;
-        CompoundTag buffer = getBufferTag(ctx);
-        buffer.putLong(ingredientId, current + toBuffer);
-        ctx.moduleState(getStateKey()).put(INGREDIENT_BUFFER, buffer);
-        ctx.markDirtyAndSync();
-        return toBuffer;
-    }
-
-    /** Remove up to {@code count} of {@code ingredientId} from the buffer. Returns amount removed. */
-    private long removeFromBuffer(PipeContext ctx, String ingredientId, long count) {
-        long current = getBufferCount(ctx, ingredientId);
-        long toRemove = Math.min(count, current);
-        if (toRemove <= 0) return 0;
-        CompoundTag buffer = getBufferTag(ctx);
-        long remaining = current - toRemove;
-        if (remaining <= 0) buffer.remove(ingredientId);
-        else buffer.putLong(ingredientId, remaining);
-        ctx.moduleState(getStateKey()).put(INGREDIENT_BUFFER, buffer);
-        ctx.markDirtyAndSync();
-        return toRemove;
     }
 
     // ==================== Autocrafter Detection ====================
@@ -402,67 +346,6 @@ public class CraftingModule implements Module {
                 ctx.world().setBlock(ctx.pos(), pipeState.setValue(PipeBlock.CRAFTING, true), 2);
             }
         }
-
-        // Refill autocrafter slots from the internal ingredient buffer (MK3+)
-        if (bufferSlots > 0) {
-            refillAutocrafterFromBuffer(ctx, crafter);
-        }
-    }
-
-    /**
-     * Drain items from the internal ingredient buffer into matching recipe slots in the autocrafter.
-     * Called every craft cycle (regardless of whether crafting succeeded) so the autocrafter stays
-     * loaded as fast as possible.
-     */
-    private void refillAutocrafterFromBuffer(PipeContext ctx, CrafterBlockEntity crafter) {
-        CompoundTag buffer = getBufferTag(ctx);
-        if (buffer.isEmpty()) return;
-
-        boolean crafterChanged = false;
-        boolean bufferChanged = false;
-
-        for (String ingredientId : new ArrayList<>(buffer.keySet())) {
-            long inBuffer = NbtCompat.getLong(buffer, ingredientId, 0L);
-            if (inBuffer <= 0) continue;
-
-            ItemStack ingredient = resolveItem(ingredientId);
-            if (ingredient.isEmpty()) continue;
-
-            int maxStack = ingredient.getMaxStackSize();
-
-            for (int slot = 0; slot < 9 && inBuffer > 0; slot++) {
-                if (!ingredientId.equals(getIngredientItem(ctx, slot))) continue;
-                ItemStack inSlot = crafter.getItem(slot);
-                // Skip slots that already hold a different item — applySlotCount would corrupt them.
-                if (!inSlot.isEmpty()
-                        && !ingredientId.equals(BuiltInRegistries.ITEM.getKey(inSlot.getItem()).toString())) {
-                    continue;
-                }
-                int current = inSlot.isEmpty() ? 0 : inSlot.getCount();
-                int space = Math.max(0, maxStack - current);
-                if (space <= 0) continue;
-
-                int toMove = (int) Math.min(inBuffer, space);
-                applySlotCount(crafter, slot, ingredient, current + toMove);
-                inBuffer -= toMove;
-                crafterChanged = true;
-            }
-
-            long original = NbtCompat.getLong(buffer, ingredientId, 0L);
-            if (inBuffer != original) {
-                bufferChanged = true;
-                if (inBuffer <= 0) buffer.remove(ingredientId);
-                else buffer.putLong(ingredientId, inBuffer);
-            }
-        }
-
-        if (bufferChanged) {
-            ctx.moduleState(getStateKey()).put(INGREDIENT_BUFFER, buffer);
-            ctx.markDirtyAndSync();
-        }
-        if (crafterChanged) {
-            crafter.setChanged();
-        }
     }
 
     /**
@@ -555,9 +438,8 @@ public class CraftingModule implements Module {
             String ingredientId = entry.getKey();
             long needed = entry.getValue();
 
-            // Physical stock = items in the autocrafter slots + items parked in the pipe buffer.
-            // Both pools will eventually be consumed by crafting, so both count as available.
-            long physicalStock = getBufferCount(ctx, ingredientId);
+            // Physical stock = items currently in the autocrafter slots.
+            long physicalStock = 0;
             if (crafterEntity != null) {
                 for (int slot = 0; slot < 9; slot++) {
                     if (!ingredientId.equals(getIngredientItem(ctx, slot))) continue;
@@ -656,15 +538,6 @@ public class CraftingModule implements Module {
             agg[1] += recipeCount;
         }
         if (!hasRecipeSlots) return CrafterBufferState.FULL;
-
-        // Add internal buffer free space so the network knows it can send more batches
-        if (bufferSlots > 0) {
-            for (Map.Entry<String, long[]> entry : perIngredient.entrySet()) {
-                String ingredientId = entry.getKey();
-                long bufferFree = Math.max(0, bufferCapacity(ingredientId) - getBufferCount(ctx, ingredientId));
-                entry.getValue()[0] += bufferFree;
-            }
-        }
 
         int minBatchCapacity = Integer.MAX_VALUE;
         for (Map.Entry<String, long[]> entry : perIngredient.entrySet()) {
@@ -815,9 +688,6 @@ public class CraftingModule implements Module {
             if (entry != null) cancelEntryOrders(ctx, entry);
         }
 
-        // Drop any buffered ingredients into the world (autocrafter disappeared while active)
-        dropBufferedIngredients(ctx);
-
         ctx.moduleState(getStateKey()).remove(QUEUE);
         ctx.saveInt(this, TICKS_PULSE, 0);
         ctx.markDirtyAndSync();
@@ -888,28 +758,17 @@ public class CraftingModule implements Module {
 
         int placed = distributeIngredient(ctx, autocrafterDir, item);
 
-        // Overflow any items that didn't fit in the autocrafter into the pipe's internal buffer
-        int buffered = 0;
-        if (bufferSlots > 0) {
-            int overflow = item.getStack().getCount() - placed;
-            if (overflow > 0) {
-                String ingredientId = BuiltInRegistries.ITEM.getKey(item.getStack().getItem()).toString();
-                buffered = (int) addToBuffer(ctx, ingredientId, overflow);
-            }
-        }
-
-        int totalHandled = placed + buffered;
-        if (totalHandled <= 0) return item;
+        if (placed <= 0) return item;
 
         // Accounting
         if (item.getDeliveryId() != null) {
             ILogisticsNetwork network = NetworkRegistry.getNetwork(ctx.world(), ctx.pos());
             if (network != null) {
-                network.notifyDelivery(ctx.pos(), ItemVariant.of(item.getStack()), totalHandled);
+                network.notifyDelivery(ctx.pos(), ItemVariant.of(item.getStack()), placed);
             }
         }
 
-        item.getStack().shrink(totalHandled);
+        item.getStack().shrink(placed);
         return item.getStack().isEmpty() ? null : item;
     }
 
@@ -1111,9 +970,6 @@ public class CraftingModule implements Module {
             if (entry != null) cancelEntryOrders(ctx, entry);
         }
 
-        // Drop any buffered ingredients into the world
-        dropBufferedIngredients(ctx);
-
         // Clear queue and tick counters so stale state doesn't survive a re-attach
         ctx.moduleState(getStateKey()).remove(QUEUE);
         ctx.saveInt(this, TICKS_PULSE, 0);
@@ -1135,45 +991,6 @@ public class CraftingModule implements Module {
             ctx.world().setBlock(ctx.pos(), currentState.setValue(PipeBlock.CRAFTING, false), 2);
         }
 
-        ctx.markDirtyAndSync();
-    }
-
-    /**
-     * Drop all items stored in the ingredient buffer as item entities at the pipe's position.
-     * Clears the buffer NBT entry afterward. No-op when the buffer is empty or disabled.
-     */
-    private void dropBufferedIngredients(PipeContext ctx) {
-        if (bufferSlots <= 0) return;
-        CompoundTag buffer = getBufferTag(ctx);
-        if (buffer.isEmpty()) return;
-
-        // Build a new buffer containing only entries whose item ID could not be resolved.
-        // Unresolved entries are preserved (with a log warning) so the count isn't silently lost.
-        CompoundTag unresolved = new CompoundTag();
-        for (String ingredientId : buffer.keySet()) {
-            long count = NbtCompat.getLong(buffer, ingredientId, 0L);
-            if (count <= 0) continue;
-            ItemStack ingredient = resolveItem(ingredientId);
-            if (ingredient.isEmpty()) {
-                LogisticsPipe.LOGGER.warn(
-                        "[Crafter @ {}] Cannot drop {} buffered '{}' — item ID not in registry",
-                        ctx.pos(), count, ingredientId);
-                unresolved.putLong(ingredientId, count);
-                continue;
-            }
-            int maxStack = ingredient.getMaxStackSize();
-            while (count > 0) {
-                int batch = (int) Math.min(count, maxStack);
-                Block.popResource(ctx.world(), ctx.pos(), ingredient.copyWithCount(batch));
-                count -= batch;
-            }
-        }
-
-        if (unresolved.isEmpty()) {
-            ctx.moduleState(getStateKey()).remove(INGREDIENT_BUFFER);
-        } else {
-            ctx.moduleState(getStateKey()).put(INGREDIENT_BUFFER, unresolved);
-        }
         ctx.markDirtyAndSync();
     }
 


### PR DESCRIPTION
### Summary
The crafting module has undergone a significant refactor with the removal of its internal ingredient buffering system. This change simplifies the module's functionality, potentially improving performance and usability by focusing on direct crafting operations without intermediary storage.

### Changes
- **Removed Buffer Logic**: 
  - Eliminated the internal ingredient buffer slots that were previously earmarked for MK3+ crafting modules.
  - Simplified logic that dealt with ingredient buffering and retrieval, streamlining the crafting process.

- **Updated Crafting Module Constructor**:
  - Refactored the constructor to remove buffer slot parameters, aligning with the removal of the buffering feature.

- **Changed Item Delivery Notification**:
  - Adjusted item handling to notify logistics networks only for directly crafted items, eliminating references to any buffered materials.

### Notes
- This change may affect users who relied on the ingredient buffer for crafting operations. It is advisable to review crafting strategies to adapt to its removal. 
- Ensure to check for any potential impacts on associated mods or systems that interacted with the previously available buffer functionality.