### PR TITLE
feat: clear module state when modules are removed from pipes

### DIFF
--- a/src/main/java/com/logistics/LogisticsPipe.java
+++ b/src/main/java/com/logistics/LogisticsPipe.java
@@ -283,7 +283,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
             PROVIDER_MODULE = INSTANCE.registerItem("provider_module",
                     props -> new ModuleItem(props, () -> new ProviderModule(8, 1)));
             PROVIDER_MODULE_MKII = INSTANCE.registerItem("provider_mkii_module",
-                    props -> new ModuleItem(props, () -> new ProviderModule(128, 8)));
+                    props -> new ModuleItem(props, () -> new ProviderModule(64, 4)));
             EXTRACTOR_MODULE = INSTANCE.registerItem("extractor_module",
                     props -> new ModuleItem(props, () -> new BasicExtractorModule(1, 100)));
             EXTRACTOR_MODULE_MKII = INSTANCE.registerItem("extractor_module_mkii",
@@ -299,9 +299,9 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
             CRAFTER_MODULE = INSTANCE.registerItem("crafter_module",
                     props -> new ModuleItem(props, () -> new CraftingModule(1, 1)));
             CRAFTER_MODULE_MKII = INSTANCE.registerItem("crafter_mkii_module",
-                    props -> new ModuleItem(props, () -> new CraftingModule(64, 1)));
+                    props -> new ModuleItem(props, () -> new CraftingModule(16, 1)));
             CRAFTER_MODULE_MKIII = INSTANCE.registerItem("crafter_mkiii_module",
-                    props -> new ModuleItem(props, () -> new CraftingModule(128, 8)));
+                    props -> new ModuleItem(props, () -> new CraftingModule(64, 4)));
             QUICKSORT_MODULE = INSTANCE.registerItem("quicksort_module",
                     props -> new ModuleItem(props, QuickSortModule::new));
             TERMINUS_MODULE = INSTANCE.registerItem("terminus_module",

--- a/src/main/java/com/logistics/pipe/PipeContext.java
+++ b/src/main/java/com/logistics/pipe/PipeContext.java
@@ -60,6 +60,11 @@ public record PipeContext(Level world, BlockPos pos, BlockState state, PipeBlock
         moduleState(module.getStateKey()).remove(key);
     }
 
+    public void clearModuleState(Module module) {
+        blockEntity.clearModuleState(module.getStateKey());
+        markDirtyAndSync();
+    }
+
     // Convenience methods for energy access
     public long getEnergy() {
         EnergyComponent energy = blockEntity().getEnergy();

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -366,6 +366,10 @@ public class PipeBlockEntity extends BaseBlockEntity
         return NbtCompat.getCompoundOrEmpty(moduleState, key);
     }
 
+    public void clearModuleState(String key) {
+        moduleState.remove(key);
+    }
+
     public PipeContext createContext() {
         return new PipeContext(level, worldPosition, getBlockState(), this);
     }

--- a/src/main/java/com/logistics/pipe/item/ModuleItem.java
+++ b/src/main/java/com/logistics/pipe/item/ModuleItem.java
@@ -1,7 +1,12 @@
 package com.logistics.pipe.item;
 
 import com.logistics.pipe.modules.Module;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
 
 import java.util.function.Supplier;
 
@@ -20,5 +25,12 @@ public class ModuleItem extends Item {
 
     public Module createModule() {
         return factory.get();
+    }
+
+    @Override
+    public InteractionResult use(Level level, Player player, InteractionHand hand) {
+        if (level.isClientSide()) return InteractionResult.PASS;
+        if (!(player instanceof ServerPlayer serverPlayer)) return InteractionResult.PASS;
+        return createModule().openItemConfig(serverPlayer, hand, player.getItemInHand(hand));
     }
 }

--- a/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
+++ b/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
@@ -19,6 +19,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.player.Player;
@@ -42,8 +43,8 @@ import java.util.List;
 public class AdvancedExtractorModule implements Module {
     private static final String EXTRACT_DIRECTION = "extract_direction";
     private static final String TICKS_SINCE_PULL = "ticks_since_pull";
-    private static final String FILTER_ITEMS = "filter_items";
-    private static final String FILTER_INVERTED = "filter_inverted";
+    public static final String FILTER_ITEMS = "filter_items";
+    public static final String FILTER_INVERTED = "filter_inverted";
     public static final int MAX_FILTER_SLOTS = 9;
 
     private final int itemsPerPull;
@@ -143,6 +144,14 @@ public class AdvancedExtractorModule implements Module {
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, playerInventory, p) -> new AdvancedExtractorScreenHandler(
                         syncId, playerInventory, ctx.blockEntity()),
+                Component.translatable("screen.logistics.advanced_extractor")));
+        return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    public InteractionResult openItemConfig(ServerPlayer player, InteractionHand hand, ItemStack stack) {
+        player.openMenu(new SimpleMenuProvider(
+                (syncId, inv, p) -> new AdvancedExtractorScreenHandler(syncId, inv, player, hand),
                 Component.translatable("screen.logistics.advanced_extractor")));
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -70,13 +70,13 @@ public class CraftingModule implements Module {
         this.stackLimit = stackLimit;
     }
 
-    // NBT keys — recipe config
-    private static final String RECIPE_ITEMS = "recipe_items";
-    private static final String RECIPE_COUNTS = "recipe_counts";
-    private static final String RESULT_ITEM = "result_item";
-    private static final String RESULT_COUNT = "result_count";
-    // NBT keys — behavior
-    private static final String BLOCKING = "blocking";
+    // NBT keys — recipe config (public for item-mode access)
+    public static final String RECIPE_ITEMS = "recipe_items";
+    public static final String RECIPE_COUNTS = "recipe_counts";
+    public static final String RESULT_ITEM = "result_item";
+    public static final String RESULT_COUNT = "result_count";
+    // NBT keys — behavior (public for item-mode access)
+    public static final String BLOCKING = "blocking";
     // NBT keys — timing
     private static final String TICKS_SCAN = "ticks_scan";
     private static final String TICKS_PULSE = "ticks_pulse";
@@ -152,6 +152,37 @@ public class CraftingModule implements Module {
             ctx.saveInt(this, RESULT_COUNT, Math.max(1, count));
         }
         ctx.markDirtyAndSync();
+    }
+
+    // ==================== Static Tag Helpers (for item-mode) ====================
+
+    public static String getIngredientItemFromTag(CompoundTag tag, int slot) {
+        CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, RECIPE_ITEMS);
+        return NbtCompat.getString(items, String.valueOf(slot), "");
+    }
+
+    public static int getIngredientCountFromTag(CompoundTag tag, int slot) {
+        CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, RECIPE_COUNTS);
+        return NbtCompat.getInt(counts, String.valueOf(slot), 1);
+    }
+
+    public static String getResultItemFromTag(CompoundTag tag) {
+        return NbtCompat.getString(tag, RESULT_ITEM, "");
+    }
+
+    public static int getResultCountFromTag(CompoundTag tag) {
+        return NbtCompat.getInt(tag, RESULT_COUNT, 1);
+    }
+
+    // ==================== Item Config ====================
+
+    @Override
+    public InteractionResult openItemConfig(
+            ServerPlayer player, net.minecraft.world.InteractionHand hand, ItemStack stack) {
+        player.openMenu(new SimpleMenuProvider(
+                (syncId, inv, p) -> new CraftingScreenHandler(syncId, inv, player, hand),
+                Component.translatable("block.logistics.crafting_logistics_pipe")));
+        return InteractionResult.SUCCESS;
     }
 
     // ==================== Queue Accessors ====================

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -181,7 +181,7 @@ public class CraftingModule implements Module {
             ServerPlayer player, net.minecraft.world.InteractionHand hand, ItemStack stack) {
         player.openMenu(new SimpleMenuProvider(
                 (syncId, inv, p) -> new CraftingScreenHandler(syncId, inv, player, hand),
-                Component.translatable("block.logistics.crafting_logistics_pipe")));
+                stack.getHoverName()));
         return InteractionResult.SUCCESS;
     }
 

--- a/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
@@ -16,8 +16,10 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 /**
@@ -26,7 +28,7 @@ import net.minecraft.world.level.Level;
  * Otherwise, route to any side with no filters.
  */
 public class ItemFilterModule implements Module {
-    private static final String FILTERS = "filters"; // NBT key for save compatibility
+    public static final String FILTERS = "filters"; // NBT key for save compatibility
     public static final int FILTER_SLOTS_PER_SIDE = 8;
     public static final Direction[] FILTER_ORDER = {
         Direction.NORTH, Direction.SOUTH, Direction.WEST, Direction.EAST, Direction.UP, Direction.DOWN
@@ -76,6 +78,14 @@ public class ItemFilterModule implements Module {
                             world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null;
                     return new ItemFilterScreenHandler(syncId, inventory, pipeEntity);
                 },
+                Component.translatable("screen.logistics.item_filter")));
+        return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    public InteractionResult openItemConfig(ServerPlayer player, InteractionHand hand, ItemStack stack) {
+        player.openMenu(new net.minecraft.world.SimpleMenuProvider(
+                (syncId, inv, p) -> new ItemFilterScreenHandler(syncId, inv, player, hand),
                 Component.translatable("screen.logistics.item_filter")));
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/com/logistics/pipe/modules/Module.java
+++ b/src/main/java/com/logistics/pipe/modules/Module.java
@@ -14,7 +14,9 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
@@ -111,6 +113,10 @@ public interface Module {
     }
 
     default InteractionResult onWrench(PipeContext ctx, Player player) {
+        return InteractionResult.PASS;
+    }
+
+    default InteractionResult openItemConfig(ServerPlayer player, InteractionHand hand, ItemStack stack) {
         return InteractionResult.PASS;
     }
 

--- a/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -254,7 +254,7 @@ public class ProviderModule implements Module {
             head = queue.peekHead();
             if (head == null) break;
 
-            long toExtract = Math.min(head.remaining(), itemsLeft);
+            long toExtract = Math.min(head.remaining(), Math.min(itemsLeft, item.toStack(1).getMaxStackSize()));
             long extracted = 0;
             Direction extractDir = null;
 

--- a/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -21,6 +21,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.item.ItemStack;
@@ -56,9 +57,9 @@ import java.util.UUID;
  */
 public class ProviderModule implements Module {
     private static final String TICKS_SINCE_SCAN = "ticks_since_scan";
-    private static final String MODE = "mode";
-    private static final String FILTER_ITEMS = "filter_items";
-    private static final String FILTER_INVERTED = "filter_inverted";
+    public static final String MODE = "mode";
+    public static final String FILTER_ITEMS = "filter_items";
+    public static final String FILTER_INVERTED = "filter_inverted";
     // Dispatch queue NBT keys (values kept short to minimise NBT size)
     private static final String DISPATCH_QUEUE = "dispatch_queue";
     private static final String DQ_ITEM = "i";  // item registry key string
@@ -386,6 +387,14 @@ public class ProviderModule implements Module {
                         syncId, playerInventory, ctx.blockEntity()),
                 Component.translatable("screen.logistics.provider")));
 
+        return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    public InteractionResult openItemConfig(ServerPlayer player, InteractionHand hand, ItemStack stack) {
+        player.openMenu(new SimpleMenuProvider(
+                (syncId, inv, p) -> new ProviderScreenHandler(syncId, inv, player, hand),
+                Component.translatable("screen.logistics.provider")));
         return InteractionResult.SUCCESS;
     }
 

--- a/src/main/java/com/logistics/pipe/modules/SinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SinkModule.java
@@ -19,6 +19,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.player.Player;
@@ -38,8 +39,8 @@ import java.util.List;
  * <p>This is the Basic Logistics Pipe from LogisticsPipes - pulls items out of the network.
  */
 public class SinkModule implements Module {
-    private static final String FILTERS = "filters";
-    private static final String DEFAULT_ROUTE = "default_route";
+    public static final String FILTERS = "filters";
+    public static final String DEFAULT_ROUTE = "default_route";
     private static final String SINK_DIRECTION = "sink_direction";
     private static final String TICKS_SINCE_SYNC = "ticks_since_sync";
     private static final int SYNC_INTERVAL = 20; // Re-register with network every second to recover from splits
@@ -128,6 +129,14 @@ public class SinkModule implements Module {
                 ),
                 Component.translatable("screen.logistics.sink.requested_items")
         ));
+        return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    public InteractionResult openItemConfig(ServerPlayer player, InteractionHand hand, ItemStack stack) {
+        player.openMenu(new SimpleMenuProvider(
+                (syncId, inv, p) -> new SinkScreenHandler(syncId, inv, player, hand),
+                Component.translatable("screen.logistics.sink.requested_items")));
         return InteractionResult.SUCCESS;
     }
 

--- a/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -21,6 +21,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -54,10 +56,10 @@ public class SupplierModule implements Module {
         BULK100     // ordinal 4 - request whenever any amount is missing (appended to preserve existing ordinals)
     }
 
-    private static final String SUPPLIES = "supplies"; // NBT key for supply configurations
+    public static final String SUPPLIES = "supplies"; // NBT key for supply configurations
     private static final String SUPPLIER_DIRECTION = "supplier_direction";
     private static final String TICKS_SINCE_CHECK = "ticks_since_check";
-    private static final String MODE = "mode"; // Supply mode
+    public static final String MODE = "mode"; // Supply mode
     private static final int CHECK_INTERVAL = 20;
     public static final int MAX_SUPPLY_SLOTS = 9;
 
@@ -114,6 +116,14 @@ public class SupplierModule implements Module {
                             world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null;
                     return new SupplierScreenHandler(syncId, inventory, pipeEntity);
                 },
+                net.minecraft.network.chat.Component.translatable("screen.logistics.supplier.items_to_keep_stocked")));
+        return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    public InteractionResult openItemConfig(ServerPlayer player, InteractionHand hand, ItemStack stack) {
+        player.openMenu(new net.minecraft.world.SimpleMenuProvider(
+                (syncId, inv, p) -> new SupplierScreenHandler(syncId, inv, player, hand),
                 net.minecraft.network.chat.Component.translatable("screen.logistics.supplier.items_to_keep_stocked")));
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorFilterInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorFilterInventory.java
@@ -1,15 +1,19 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.AdvancedExtractorModule;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 
 import java.util.List;
 
@@ -94,6 +98,24 @@ public class AdvancedExtractorFilterInventory implements Container {
             var itemHolder = BuiltInRegistries.ITEM.get(resourceId.toIdentifier());
             if (itemHolder.isEmpty()) continue;
             stacks.set(i, new ItemStack(itemHolder.get().value()));
+        }
+    }
+
+    public void loadFromItem(ItemStack stack) {
+        for (int i = 0; i < FILTER_SLOT_COUNT; i++) stacks.set(i, ItemStack.EMPTY);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData == null) return;
+        CompoundTag tag = customData.copyTag();
+        CompoundTag filterItems = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
+        int displaySlot = 0;
+        for (int i = 0; i < FILTER_SLOT_COUNT && displaySlot < FILTER_SLOT_COUNT; i++) {
+            String itemId = NbtCompat.getString(filterItems, String.valueOf(i), "");
+            if (itemId.isEmpty()) continue;
+            ResourceId rid = ResourceId.tryParse(itemId);
+            if (rid == null) continue;
+            var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
+            if (holder.isEmpty()) continue;
+            stacks.set(displaySlot++, new ItemStack(holder.get().value()));
         }
     }
 

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorFilterInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorFilterInventory.java
@@ -107,19 +107,19 @@ public class AdvancedExtractorFilterInventory implements Container {
         if (customData == null) return;
         CompoundTag tag = customData.copyTag();
         CompoundTag filterItems = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
-        int displaySlot = 0;
-        for (int i = 0; i < FILTER_SLOT_COUNT && displaySlot < FILTER_SLOT_COUNT; i++) {
+        for (int i = 0; i < FILTER_SLOT_COUNT; i++) {
             String itemId = NbtCompat.getString(filterItems, String.valueOf(i), "");
             if (itemId.isEmpty()) continue;
             ResourceId rid = ResourceId.tryParse(itemId);
             if (rid == null) continue;
             var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
             if (holder.isEmpty()) continue;
-            stacks.set(displaySlot++, new ItemStack(holder.get().value()));
+            stacks.set(i, new ItemStack(holder.get().value()));
         }
     }
 
     public void refresh() {
+        if (pipeEntity == null) return;
         loadFromModule();
     }
 }

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -134,7 +134,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                 filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     final int s = slotIndex;
-                    writeToItemTag(tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
                         fi.remove(String.valueOf(s));
                         tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
@@ -152,7 +152,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
             if (itemConfigPlayer != null) {
                 final int s = slotIndex;
-                writeToItemTag(tag -> {
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
                     fi.putString(String.valueOf(s), itemId);
                     tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
@@ -174,7 +174,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             int newInverted = data.get(0) == 0 ? 1 : 0;
             data.set(0, newInverted);
             if (itemConfigPlayer != null) {
-                writeToItemTag(tag -> tag.putInt(AdvancedExtractorModule.FILTER_INVERTED, newInverted));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(AdvancedExtractorModule.FILTER_INVERTED, newInverted));
             } else {
                 PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
                         module.setFilterInverted(ctx, newInverted == 1));
@@ -202,16 +202,6 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
         PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
                 data.set(0, module.isFilterInverted(ctx) ? 1 : 0));
         super.broadcastChanges();
-    }
-
-    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
-        if (itemConfigPlayer == null) return;
-        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
-        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
-        modifier.accept(tag);
-        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
-        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class FilterSlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -137,9 +137,9 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             ItemStack cursor = getCarried();
 
             if (button == 1 || cursor.isEmpty()) {
-                filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     if (!isPinnedItemStillHeld()) return;
+                    filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
@@ -147,6 +147,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                         tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
                     });
                 } else {
+                    filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                     PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
                             module.setFilterItem(ctx, slotIndex, ""));
                 }
@@ -156,9 +157,9 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
 
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM
                     .getKey(cursor.getItem()).toString();
-            filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
             if (itemConfigPlayer != null) {
                 if (!isPinnedItemStillHeld()) return;
+                filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
@@ -166,6 +167,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                     tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
                 });
             } else {
+                filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
                 PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
                         module.setFilterItem(ctx, slotIndex, itemId));
             }

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -1,9 +1,15 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.AdvancedExtractorModule;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
@@ -12,6 +18,8 @@ import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Screen handler for the Advanced Extractor filter GUI.
@@ -30,6 +38,8 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
     private final ContainerData data;
     private final AdvancedExtractorFilterInventory filterInventory;
     private final ContainerLevelAccess context;
+    @Nullable private final ServerPlayer itemConfigPlayer;
+    @Nullable private final InteractionHand itemConfigHand;
 
     public AdvancedExtractorScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(1));
@@ -39,10 +49,30 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
         this(syncId, playerInventory, pipeEntity, new SimpleContainerData(1));
     }
 
+    public AdvancedExtractorScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
+        super(LogisticsPipe.SCREEN.ADVANCED_EXTRACTOR, syncId);
+        this.data = new SimpleContainerData(1);
+        this.itemConfigPlayer = player;
+        this.itemConfigHand = hand;
+        this.context = ContainerLevelAccess.NULL;
+        ItemStack stack = player.getItemInHand(hand);
+        this.filterInventory = new AdvancedExtractorFilterInventory(null);
+        this.filterInventory.loadFromItem(stack);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData != null) {
+            data.set(0, NbtCompat.getInt(customData.copyTag(), AdvancedExtractorModule.FILTER_INVERTED, 0));
+        }
+        addFilterSlots(filterInventory);
+        addPlayerInventorySlots(playerInventory);
+        addDataSlots(data);
+    }
+
     private AdvancedExtractorScreenHandler(
             int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
         super(LogisticsPipe.SCREEN.ADVANCED_EXTRACTOR, syncId);
         this.data = data;
+        this.itemConfigPlayer = null;
+        this.itemConfigHand = null;
         this.filterInventory = new AdvancedExtractorFilterInventory(pipeEntity);
 
         if (pipeEntity != null) {
@@ -81,6 +111,10 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        if (itemConfigPlayer != null) {
+            ItemStack held = player.getItemInHand(itemConfigHand);
+            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+        }
         return context.evaluate(
                 (level, pos) -> player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) <= 64.0,
                 true);
@@ -98,8 +132,17 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
 
             if (button == 1 || cursor.isEmpty()) {
                 filterInventory.setItem(slotIndex, ItemStack.EMPTY);
-                PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
-                        module.setFilterItem(ctx, slotIndex, ""));
+                if (itemConfigPlayer != null) {
+                    final int s = slotIndex;
+                    writeToItemTag(tag -> {
+                        CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
+                        fi.remove(String.valueOf(s));
+                        tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
+                    });
+                } else {
+                    PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
+                            module.setFilterItem(ctx, slotIndex, ""));
+                }
                 broadcastChanges();
                 return;
             }
@@ -107,8 +150,17 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM
                     .getKey(cursor.getItem()).toString();
             filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
-            PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
-                    module.setFilterItem(ctx, slotIndex, itemId));
+            if (itemConfigPlayer != null) {
+                final int s = slotIndex;
+                writeToItemTag(tag -> {
+                    CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
+                    fi.putString(String.valueOf(s), itemId);
+                    tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
+                });
+            } else {
+                PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
+                        module.setFilterItem(ctx, slotIndex, itemId));
+            }
             broadcastChanges();
             return;
         }
@@ -121,8 +173,12 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
         if (id == 0) {
             int newInverted = data.get(0) == 0 ? 1 : 0;
             data.set(0, newInverted);
-            PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
-                    module.setFilterInverted(ctx, newInverted == 1));
+            if (itemConfigPlayer != null) {
+                writeToItemTag(tag -> tag.putInt(AdvancedExtractorModule.FILTER_INVERTED, newInverted));
+            } else {
+                PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
+                        module.setFilterInverted(ctx, newInverted == 1));
+            }
             return true;
         }
         return false;
@@ -134,9 +190,28 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
 
     @Override
     public void broadcastChanges() {
+        if (itemConfigPlayer != null) {
+            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+            if (customData != null) {
+                data.set(0, NbtCompat.getInt(customData.copyTag(), AdvancedExtractorModule.FILTER_INVERTED, 0));
+            }
+            super.broadcastChanges();
+            return;
+        }
         PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
                 data.set(0, module.isFilterInverted(ctx) ? 1 : 0));
         super.broadcastChanges();
+    }
+
+    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
+        if (itemConfigPlayer == null) return;
+        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
+        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
+        modifier.accept(tag);
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class FilterSlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -207,6 +207,8 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                 CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
                 if (customData != null) {
                     data.set(0, NbtCompat.getInt(customData.copyTag(), AdvancedExtractorModule.FILTER_INVERTED, 0));
+                } else {
+                    data.set(0, 0);
                 }
             }
             super.broadcastChanges();

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -3,7 +3,6 @@ package com.logistics.pipe.ui;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.AdvancedExtractorModule;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -40,6 +39,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
     private final ContainerLevelAccess context;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
+    @Nullable private final ItemStack pinnedStack;
 
     public AdvancedExtractorScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(1));
@@ -56,6 +56,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
         ItemStack stack = player.getItemInHand(hand);
+        this.pinnedStack = stack;
         this.filterInventory = new AdvancedExtractorFilterInventory(null);
         this.filterInventory.loadFromItem(stack);
         CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
@@ -73,6 +74,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
         this.data = data;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
+        this.pinnedStack = null;
         this.filterInventory = new AdvancedExtractorFilterInventory(pipeEntity);
 
         if (pipeEntity != null) {
@@ -109,11 +111,15 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
         }
     }
 
+    private boolean isPinnedItemStillHeld() {
+        return pinnedStack != null && itemConfigPlayer != null
+                && itemConfigPlayer.getItemInHand(itemConfigHand) == pinnedStack;
+    }
+
     @Override
     public boolean stillValid(Player player) {
         if (itemConfigPlayer != null) {
-            ItemStack held = player.getItemInHand(itemConfigHand);
-            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+            return isPinnedItemStillHeld();
         }
         return context.evaluate(
                 (level, pos) -> player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) <= 64.0,
@@ -133,6 +139,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             if (button == 1 || cursor.isEmpty()) {
                 filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
+                    if (!isPinnedItemStillHeld()) return;
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
@@ -151,6 +158,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                     .getKey(cursor.getItem()).toString();
             filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return;
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
@@ -174,6 +182,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             int newInverted = data.get(0) == 0 ? 1 : 0;
             data.set(0, newInverted);
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(AdvancedExtractorModule.FILTER_INVERTED, newInverted));
             } else {
                 PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
@@ -191,10 +200,12 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
     @Override
     public void broadcastChanges() {
         if (itemConfigPlayer != null) {
-            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
-            if (customData != null) {
-                data.set(0, NbtCompat.getInt(customData.copyTag(), AdvancedExtractorModule.FILTER_INVERTED, 0));
+            if (isPinnedItemStillHeld()) {
+                ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+                CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+                if (customData != null) {
+                    data.set(0, NbtCompat.getInt(customData.copyTag(), AdvancedExtractorModule.FILTER_INVERTED, 0));
+                }
             }
             super.broadcastChanges();
             return;

--- a/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -141,7 +141,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                     if (!isPinnedItemStillHeld()) return;
                     filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
-                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
                         CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
                         fi.remove(String.valueOf(s));
                         tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
@@ -161,7 +161,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                 if (!isPinnedItemStillHeld()) return;
                 filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
                 final int s = slotIndex;
-                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
                     CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, AdvancedExtractorModule.FILTER_ITEMS);
                     fi.putString(String.valueOf(s), itemId);
                     tag.put(AdvancedExtractorModule.FILTER_ITEMS, fi);
@@ -185,7 +185,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             data.set(0, newInverted);
             if (itemConfigPlayer != null) {
                 if (!isPinnedItemStillHeld()) return true;
-                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(AdvancedExtractorModule.FILTER_INVERTED, newInverted));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> tag.putInt(AdvancedExtractorModule.FILTER_INVERTED, newInverted));
             } else {
                 PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
                         module.setFilterInverted(ctx, newInverted == 1));

--- a/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
@@ -140,6 +140,9 @@ public class ChassisInventory implements Container {
         if (existing.isEmpty()) items.set(slot, ItemStack.EMPTY);
         if (existing.isEmpty()) {
             detachModule(result);
+            if (pipeEntity != null && result.getItem() instanceof ModuleItem moduleItem) {
+                pipeEntity.clearModuleState(moduleItem.createModule().getStateKey());
+            }
             items.set(slot, ItemStack.EMPTY);
         }
         saveToEntity();
@@ -160,6 +163,12 @@ public class ChassisInventory implements Container {
         if (slot < 0 || slot >= items.size()) return;
         ItemStack previous = items.get(slot);
         if (!previous.isEmpty() && (stack.isEmpty() || !ItemStack.isSameItem(previous, stack))) {
+            if (pipeEntity != null) {
+                syncStateToItem(previous);
+                if (previous.getItem() instanceof ModuleItem moduleItem) {
+                    pipeEntity.clearModuleState(moduleItem.createModule().getStateKey());
+                }
+            }
             detachModule(previous);
         }
         items.set(slot, stack);

--- a/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
@@ -7,9 +7,12 @@ import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.CraftingModule;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 
 /**
  * Inventory for the Crafting Logistics Pipe GUI.
@@ -111,6 +114,34 @@ public class CraftingRecipeInventory implements Container {
             ItemStack stack = resolveItem(resultId, count);
             if (!stack.isEmpty()) {
                 stacks.set(9, stack);
+            }
+        }
+    }
+
+    public void loadFromItem(ItemStack stack) {
+        for (int i = 0; i < SLOT_COUNT; i++) {
+            stacks.set(i, ItemStack.EMPTY);
+        }
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData == null) return;
+        CompoundTag tag = customData.copyTag();
+
+        for (int slot = 0; slot < 9; slot++) {
+            String itemId = CraftingModule.getIngredientItemFromTag(tag, slot);
+            if (itemId.isEmpty()) continue;
+            int count = CraftingModule.getIngredientCountFromTag(tag, slot);
+            ItemStack itemStack = resolveItem(itemId, count);
+            if (!itemStack.isEmpty()) {
+                stacks.set(slot, itemStack);
+            }
+        }
+
+        String resultId = CraftingModule.getResultItemFromTag(tag);
+        if (!resultId.isEmpty()) {
+            int count = CraftingModule.getResultCountFromTag(tag);
+            ItemStack itemStack = resolveItem(resultId, count);
+            if (!itemStack.isEmpty()) {
+                stacks.set(9, itemStack);
             }
         }
     }

--- a/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -3,7 +3,6 @@ package com.logistics.pipe.ui;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.CraftingModule;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -42,6 +41,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
     private final ContainerData data;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
+    @Nullable private final ItemStack pinnedStack;
 
     public CraftingScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(2));
@@ -60,6 +60,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         this.context = ContainerLevelAccess.NULL;
 
         ItemStack stack = player.getItemInHand(hand);
+        this.pinnedStack = stack;
         this.recipeInventory = new CraftingRecipeInventory(null);
         this.recipeInventory.loadFromItem(stack);
 
@@ -80,6 +81,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         this.data = data;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
+        this.pinnedStack = null;
         this.recipeInventory = new CraftingRecipeInventory(pipeEntity);
 
         if (pipeEntity != null) {
@@ -129,11 +131,15 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         }
     }
 
+    private boolean isPinnedItemStillHeld() {
+        return pinnedStack != null && itemConfigPlayer != null
+                && itemConfigPlayer.getItemInHand(itemConfigHand) == pinnedStack;
+    }
+
     @Override
     public boolean stillValid(Player player) {
         if (itemConfigPlayer != null) {
-            ItemStack held = player.getItemInHand(itemConfigHand);
-            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+            return isPinnedItemStillHeld();
         }
         return context.evaluate(
                 (level, pos) -> player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) <= 64.0,
@@ -157,6 +163,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             if (button == 1 || cursor.isEmpty()) {
                 recipeInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
+                    if (!isPinnedItemStillHeld()) return;
                     if (isResultSlot) {
                         ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                             tag.remove(CraftingModule.RESULT_ITEM);
@@ -189,6 +196,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             recipeInventory.setItem(slotIndex, cursor.copyWithCount(count));
 
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return;
                 if (isResultSlot) {
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         tag.putString(CraftingModule.RESULT_ITEM, itemId);
@@ -225,6 +233,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             int newBlocking = data.get(DATA_BLOCKING) == 0 ? 1 : 0;
             data.set(DATA_BLOCKING, newBlocking);
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(CraftingModule.BLOCKING, newBlocking));
             } else {
                 PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
@@ -239,11 +248,13 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
     @Override
     public void broadcastChanges() {
         if (itemConfigPlayer != null) {
-            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
-            if (customData != null) {
-                CompoundTag tag = customData.copyTag();
-                data.set(DATA_BLOCKING, NbtCompat.getInt(tag, CraftingModule.BLOCKING, 0));
+            if (isPinnedItemStillHeld()) {
+                ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+                CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+                if (customData != null) {
+                    CompoundTag tag = customData.copyTag();
+                    data.set(DATA_BLOCKING, NbtCompat.getInt(tag, CraftingModule.BLOCKING, 0));
+                }
             }
             super.broadcastChanges();
             return;

--- a/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -158,13 +158,13 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
                 recipeInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     if (isResultSlot) {
-                        writeToItemTag(tag -> {
+                        ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                             tag.remove(CraftingModule.RESULT_ITEM);
                             tag.remove(CraftingModule.RESULT_COUNT);
                         });
                     } else {
                         final int s = slotIndex;
-                        writeToItemTag(tag -> {
+                        ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                             CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
                             CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
                             items.remove(String.valueOf(s));
@@ -190,13 +190,13 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
 
             if (itemConfigPlayer != null) {
                 if (isResultSlot) {
-                    writeToItemTag(tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         tag.putString(CraftingModule.RESULT_ITEM, itemId);
                         tag.putInt(CraftingModule.RESULT_COUNT, count);
                     });
                 } else {
                     final int s = slotIndex;
-                    writeToItemTag(tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
                         CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
                         items.putString(String.valueOf(s), itemId);
@@ -218,16 +218,6 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         super.clicked(slotIndex, button, actionType, player);
     }
 
-    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
-        if (itemConfigPlayer == null) return;
-        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
-        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
-        modifier.accept(tag);
-        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
-        itemConfigPlayer.getInventory().setChanged();
-    }
-
     @Override
     public boolean clickMenuButton(Player player, int id) {
         if (id == 0) {
@@ -235,7 +225,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             int newBlocking = data.get(DATA_BLOCKING) == 0 ? 1 : 0;
             data.set(DATA_BLOCKING, newBlocking);
             if (itemConfigPlayer != null) {
-                writeToItemTag(tag -> tag.putInt(CraftingModule.BLOCKING, newBlocking));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(CraftingModule.BLOCKING, newBlocking));
             } else {
                 PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
                     module.setBlocking(ctx, newBlocking == 1);
@@ -248,7 +238,6 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
 
     @Override
     public void broadcastChanges() {
-        super.broadcastChanges();
         if (itemConfigPlayer != null) {
             ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
             CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
@@ -256,12 +245,14 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
                 CompoundTag tag = customData.copyTag();
                 data.set(DATA_BLOCKING, NbtCompat.getInt(tag, CraftingModule.BLOCKING, 0));
             }
+            super.broadcastChanges();
             return;
         }
         PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
             data.set(DATA_CRAFT_STATE, module.isActive(ctx) ? 1 : 0);
             data.set(DATA_BLOCKING, module.isBlocking(ctx) ? 1 : 0);
         });
+        super.broadcastChanges();
     }
 
     public int getCraftState() {

--- a/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -1,10 +1,16 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.CraftingModule;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
@@ -13,6 +19,8 @@ import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Screen handler for the Crafting Logistics Pipe GUI.
@@ -32,6 +40,8 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
     private final CraftingRecipeInventory recipeInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final ServerPlayer itemConfigPlayer;
+    @Nullable private final InteractionHand itemConfigHand;
 
     public CraftingScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(2));
@@ -41,10 +51,35 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         this(syncId, playerInventory, pipeEntity, new SimpleContainerData(2));
     }
 
+    /** Item-mode constructor: backs the screen with a module item in the player's hand. */
+    public CraftingScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
+        super(LogisticsPipe.SCREEN.CRAFTING, syncId);
+        this.data = new SimpleContainerData(2);
+        this.itemConfigPlayer = player;
+        this.itemConfigHand = hand;
+        this.context = ContainerLevelAccess.NULL;
+
+        ItemStack stack = player.getItemInHand(hand);
+        this.recipeInventory = new CraftingRecipeInventory(null);
+        this.recipeInventory.loadFromItem(stack);
+
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData != null) {
+            CompoundTag tag = customData.copyTag();
+            data.set(DATA_BLOCKING, NbtCompat.getInt(tag, CraftingModule.BLOCKING, 0));
+        }
+
+        addGhostSlots(recipeInventory);
+        addPlayerInventorySlots(playerInventory);
+        addDataSlots(data);
+    }
+
     private CraftingScreenHandler(
             int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
         super(LogisticsPipe.SCREEN.CRAFTING, syncId);
         this.data = data;
+        this.itemConfigPlayer = null;
+        this.itemConfigHand = null;
         this.recipeInventory = new CraftingRecipeInventory(pipeEntity);
 
         if (pipeEntity != null) {
@@ -96,6 +131,10 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        if (itemConfigPlayer != null) {
+            ItemStack held = player.getItemInHand(itemConfigHand);
+            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+        }
         return context.evaluate(
                 (level, pos) -> player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) <= 64.0,
                 true);
@@ -117,15 +156,28 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             // Right-click or empty cursor clears slot
             if (button == 1 || cursor.isEmpty()) {
                 recipeInventory.setItem(slotIndex, ItemStack.EMPTY);
-                if (isResultSlot) {
-                    PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
-                        module.setResult(ctx, "", 1);
-                    });
+                if (itemConfigPlayer != null) {
+                    if (isResultSlot) {
+                        writeToItemTag(tag -> {
+                            tag.remove(CraftingModule.RESULT_ITEM);
+                            tag.remove(CraftingModule.RESULT_COUNT);
+                        });
+                    } else {
+                        final int s = slotIndex;
+                        writeToItemTag(tag -> {
+                            CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
+                            CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
+                            items.remove(String.valueOf(s));
+                            counts.remove(String.valueOf(s));
+                            tag.put(CraftingModule.RECIPE_ITEMS, items);
+                            tag.put(CraftingModule.RECIPE_COUNTS, counts);
+                        });
+                    }
+                } else if (isResultSlot) {
+                    PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, "", 1));
                 } else {
                     final int s = slotIndex;
-                    PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
-                        module.setIngredient(ctx, s, "", 1);
-                    });
+                    PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, s, "", 1));
                 }
                 broadcastChanges();
                 return;
@@ -134,18 +186,30 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             // Left-click with item: place ghost item
             String itemId = BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
             int count = cursor.getCount();
-            ItemStack ghost = cursor.copyWithCount(count);
-            recipeInventory.setItem(slotIndex, ghost);
+            recipeInventory.setItem(slotIndex, cursor.copyWithCount(count));
 
-            if (isResultSlot) {
-                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
-                    module.setResult(ctx, itemId, count);
-                });
+            if (itemConfigPlayer != null) {
+                if (isResultSlot) {
+                    writeToItemTag(tag -> {
+                        tag.putString(CraftingModule.RESULT_ITEM, itemId);
+                        tag.putInt(CraftingModule.RESULT_COUNT, count);
+                    });
+                } else {
+                    final int s = slotIndex;
+                    writeToItemTag(tag -> {
+                        CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
+                        CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
+                        items.putString(String.valueOf(s), itemId);
+                        counts.putInt(String.valueOf(s), Math.max(1, count));
+                        tag.put(CraftingModule.RECIPE_ITEMS, items);
+                        tag.put(CraftingModule.RECIPE_COUNTS, counts);
+                    });
+                }
+            } else if (isResultSlot) {
+                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, itemId, count));
             } else {
                 final int s = slotIndex;
-                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
-                    module.setIngredient(ctx, s, itemId, count);
-                });
+                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, s, itemId, count));
             }
             broadcastChanges();
             return;
@@ -154,15 +218,29 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         super.clicked(slotIndex, button, actionType, player);
     }
 
+    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
+        if (itemConfigPlayer == null) return;
+        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
+        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
+        modifier.accept(tag);
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        itemConfigPlayer.getInventory().setChanged();
+    }
+
     @Override
     public boolean clickMenuButton(Player player, int id) {
         if (id == 0) {
             // Toggle blocking mode
             int newBlocking = data.get(DATA_BLOCKING) == 0 ? 1 : 0;
             data.set(DATA_BLOCKING, newBlocking);
-            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
-                module.setBlocking(ctx, newBlocking == 1);
-            });
+            if (itemConfigPlayer != null) {
+                writeToItemTag(tag -> tag.putInt(CraftingModule.BLOCKING, newBlocking));
+            } else {
+                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
+                    module.setBlocking(ctx, newBlocking == 1);
+                });
+            }
             return true;
         }
         return false;
@@ -171,6 +249,15 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
     @Override
     public void broadcastChanges() {
         super.broadcastChanges();
+        if (itemConfigPlayer != null) {
+            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+            if (customData != null) {
+                CompoundTag tag = customData.copyTag();
+                data.set(DATA_BLOCKING, NbtCompat.getInt(tag, CraftingModule.BLOCKING, 0));
+            }
+            return;
+        }
         PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
             data.set(DATA_CRAFT_STATE, module.isActive(ctx) ? 1 : 0);
             data.set(DATA_BLOCKING, module.isBlocking(ctx) ? 1 : 0);

--- a/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -159,33 +159,9 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             ItemStack cursor = getCarried();
             boolean isResultSlot = slotIndex == RESULT_SLOT;
 
-            // Right-click or empty cursor clears slot
             if (button == 1 || cursor.isEmpty()) {
-                recipeInventory.setItem(slotIndex, ItemStack.EMPTY);
-                if (itemConfigPlayer != null) {
-                    if (!isPinnedItemStillHeld()) return;
-                    if (isResultSlot) {
-                        ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                            tag.remove(CraftingModule.RESULT_ITEM);
-                            tag.remove(CraftingModule.RESULT_COUNT);
-                        });
-                    } else {
-                        final int s = slotIndex;
-                        ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                            CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
-                            CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
-                            items.remove(String.valueOf(s));
-                            counts.remove(String.valueOf(s));
-                            tag.put(CraftingModule.RECIPE_ITEMS, items);
-                            tag.put(CraftingModule.RECIPE_COUNTS, counts);
-                        });
-                    }
-                } else if (isResultSlot) {
-                    PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, "", 1));
-                } else {
-                    final int s = slotIndex;
-                    PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, s, "", 1));
-                }
+                if (isResultSlot) clearResultSlot();
+                else clearIngredientSlot(slotIndex);
                 broadcastChanges();
                 return;
             }
@@ -193,37 +169,77 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             // Left-click with item: place ghost item
             String itemId = BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
             int count = cursor.getCount();
-            recipeInventory.setItem(slotIndex, cursor.copyWithCount(count));
-
-            if (itemConfigPlayer != null) {
-                if (!isPinnedItemStillHeld()) return;
-                if (isResultSlot) {
-                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                        tag.putString(CraftingModule.RESULT_ITEM, itemId);
-                        tag.putInt(CraftingModule.RESULT_COUNT, count);
-                    });
-                } else {
-                    final int s = slotIndex;
-                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                        CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
-                        CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
-                        items.putString(String.valueOf(s), itemId);
-                        counts.putInt(String.valueOf(s), Math.max(1, count));
-                        tag.put(CraftingModule.RECIPE_ITEMS, items);
-                        tag.put(CraftingModule.RECIPE_COUNTS, counts);
-                    });
-                }
-            } else if (isResultSlot) {
-                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, itemId, count));
-            } else {
-                final int s = slotIndex;
-                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, s, itemId, count));
-            }
+            if (isResultSlot) setResultSlot(cursor.copyWithCount(count), itemId, count);
+            else setIngredientSlot(slotIndex, cursor.copyWithCount(count), itemId, count);
             broadcastChanges();
             return;
         }
 
         super.clicked(slotIndex, button, actionType, player);
+    }
+
+    private void clearResultSlot() {
+        if (itemConfigPlayer != null) {
+            if (!isPinnedItemStillHeld()) return;
+            recipeInventory.setItem(RESULT_SLOT, ItemStack.EMPTY);
+            ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                tag.remove(CraftingModule.RESULT_ITEM);
+                tag.remove(CraftingModule.RESULT_COUNT);
+            });
+        } else {
+            recipeInventory.setItem(RESULT_SLOT, ItemStack.EMPTY);
+            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, "", 1));
+        }
+    }
+
+    private void clearIngredientSlot(int slot) {
+        if (itemConfigPlayer != null) {
+            if (!isPinnedItemStillHeld()) return;
+            recipeInventory.setItem(slot, ItemStack.EMPTY);
+            ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
+                CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
+                items.remove(String.valueOf(slot));
+                counts.remove(String.valueOf(slot));
+                tag.put(CraftingModule.RECIPE_ITEMS, items);
+                tag.put(CraftingModule.RECIPE_COUNTS, counts);
+            });
+        } else {
+            recipeInventory.setItem(slot, ItemStack.EMPTY);
+            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, slot, "", 1));
+        }
+    }
+
+    private void setResultSlot(ItemStack display, String itemId, int count) {
+        if (itemConfigPlayer != null) {
+            if (!isPinnedItemStillHeld()) return;
+            recipeInventory.setItem(RESULT_SLOT, display);
+            ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                tag.putString(CraftingModule.RESULT_ITEM, itemId);
+                tag.putInt(CraftingModule.RESULT_COUNT, count);
+            });
+        } else {
+            recipeInventory.setItem(RESULT_SLOT, display);
+            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, itemId, count));
+        }
+    }
+
+    private void setIngredientSlot(int slot, ItemStack display, String itemId, int count) {
+        if (itemConfigPlayer != null) {
+            if (!isPinnedItemStillHeld()) return;
+            recipeInventory.setItem(slot, display);
+            ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                CompoundTag items = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_ITEMS);
+                CompoundTag counts = NbtCompat.getCompoundOrEmpty(tag, CraftingModule.RECIPE_COUNTS);
+                items.putString(String.valueOf(slot), itemId);
+                counts.putInt(String.valueOf(slot), Math.max(1, count));
+                tag.put(CraftingModule.RECIPE_ITEMS, items);
+                tag.put(CraftingModule.RECIPE_COUNTS, counts);
+            });
+        } else {
+            recipeInventory.setItem(slot, display);
+            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, slot, itemId, count));
+        }
     }
 
     @Override

--- a/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -270,6 +270,8 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
                 if (customData != null) {
                     CompoundTag tag = customData.copyTag();
                     data.set(DATA_BLOCKING, NbtCompat.getInt(tag, CraftingModule.BLOCKING, 0));
+                } else {
+                    data.set(DATA_BLOCKING, 0);
                 }
             }
             super.broadcastChanges();

--- a/src/main/java/com/logistics/pipe/ui/FilterInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/FilterInventory.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.ItemFilterModule;
@@ -8,11 +9,15 @@ import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.Level;
 
 public class FilterInventory implements Container {
@@ -137,6 +142,32 @@ public class FilterInventory implements Container {
                     }
                 }
                 stacks.set(slotIndex++, stack);
+            }
+        }
+    }
+
+    public void loadFromItem(ItemStack stack) {
+        for (int i = 0; i < stacks.size(); i++) stacks.set(i, ItemStack.EMPTY);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData == null) return;
+        CompoundTag tag = customData.copyTag();
+        CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, ItemFilterModule.FILTERS);
+        int slotIndex = 0;
+        for (Direction direction : ItemFilterModule.FILTER_ORDER) {
+            ListTag list = NbtCompat.getListOrEmpty(filters, direction.getName());
+            for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
+                String itemId = NbtCompat.getStringAt(list, i, "");
+                ItemStack resolved = ItemStack.EMPTY;
+                if (!itemId.isEmpty()) {
+                    ResourceId rid = ResourceId.tryParse(itemId);
+                    if (rid != null) {
+                        var itemOpt = BuiltInRegistries.ITEM.get(rid.toIdentifier());
+                        if (itemOpt.isPresent() && itemOpt.get().value() != Items.AIR) {
+                            resolved = new ItemStack(itemOpt.get().value());
+                        }
+                    }
+                }
+                stacks.set(slotIndex++, resolved);
             }
         }
     }

--- a/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
@@ -2,14 +2,24 @@ package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.ItemFilterModule;
+import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.inventory.ClickType;
-import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemFilterScreenHandler extends AbstractContainerMenu {
     private static final int FILTER_SLOT_COUNT =
@@ -23,10 +33,14 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
 
     private final FilterInventory filterInventory;
     private final ContainerLevelAccess context;
+    @Nullable private final ServerPlayer itemConfigPlayer;
+    @Nullable private final InteractionHand itemConfigHand;
 
     public ItemFilterScreenHandler(int syncId, Container playerInventory) {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
         this.context = ContainerLevelAccess.NULL;
+        this.itemConfigPlayer = null;
+        this.itemConfigHand = null;
         this.filterInventory = new FilterInventory(null);
 
         addFilterSlots(filterInventory);
@@ -35,12 +49,26 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
 
     public ItemFilterScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
+        this.itemConfigPlayer = null;
+        this.itemConfigHand = null;
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
         } else {
             this.context = ContainerLevelAccess.NULL;
         }
         this.filterInventory = new FilterInventory(pipeEntity);
+
+        addFilterSlots(filterInventory);
+        addPlayerInventorySlots(playerInventory);
+    }
+
+    public ItemFilterScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
+        super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
+        this.itemConfigPlayer = player;
+        this.itemConfigHand = hand;
+        this.context = ContainerLevelAccess.NULL;
+        this.filterInventory = new FilterInventory(null);
+        this.filterInventory.loadFromItem(player.getItemInHand(hand));
 
         addFilterSlots(filterInventory);
         addPlayerInventorySlots(playerInventory);
@@ -75,6 +103,10 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        if (itemConfigPlayer != null) {
+            ItemStack held = player.getItemInHand(itemConfigHand);
+            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+        }
         return true;
     }
 
@@ -91,6 +123,11 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
             } else {
                 filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
             }
+
+            if (itemConfigPlayer != null) {
+                syncFiltersToItem();
+            }
+
             broadcastChanges();
             return;
         }
@@ -101,6 +138,33 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
     @Override
     public ItemStack quickMoveStack(Player player, int slot) {
         return ItemStack.EMPTY;
+    }
+
+    /** Writes the full filter state to the held item's CUSTOM_DATA. */
+    private void syncFiltersToItem() {
+        if (itemConfigPlayer == null) return;
+        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
+        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
+
+        CompoundTag filtersTag = new CompoundTag();
+        int slotIndex = 0;
+        for (Direction direction : ItemFilterModule.FILTER_ORDER) {
+            ListTag list = new ListTag();
+            for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
+                ItemStack slotItem = filterInventory.getItem(slotIndex++);
+                String itemId = slotItem.isEmpty()
+                        ? ""
+                        : net.minecraft.core.registries.BuiltInRegistries.ITEM
+                                .getKey(slotItem.getItem()).toString();
+                list.add(StringTag.valueOf(itemId));
+            }
+            filtersTag.put(direction.getName(), list);
+        }
+        tag.put(ItemFilterModule.FILTERS, filtersTag);
+
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class FilterSlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
@@ -2,7 +2,6 @@ package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.ItemFilterModule;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponents;
@@ -35,12 +34,14 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
     private final ContainerLevelAccess context;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
+    @Nullable private final ItemStack originalStack;
 
     public ItemFilterScreenHandler(int syncId, Container playerInventory) {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
         this.context = ContainerLevelAccess.NULL;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
+        this.originalStack = null;
         this.filterInventory = new FilterInventory(null);
 
         addFilterSlots(filterInventory);
@@ -51,6 +52,7 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
+        this.originalStack = null;
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
         } else {
@@ -66,9 +68,10 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
+        this.originalStack = player.getItemInHand(hand);
         this.context = ContainerLevelAccess.NULL;
         this.filterInventory = new FilterInventory(null);
-        this.filterInventory.loadFromItem(player.getItemInHand(hand));
+        this.filterInventory.loadFromItem(this.originalStack);
 
         addFilterSlots(filterInventory);
         addPlayerInventorySlots(playerInventory);
@@ -104,8 +107,7 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
     @Override
     public boolean stillValid(Player player) {
         if (itemConfigPlayer != null) {
-            ItemStack held = player.getItemInHand(itemConfigHand);
-            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+            return player.getItemInHand(itemConfigHand) == originalStack;
         }
         return true;
     }
@@ -142,8 +144,8 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
 
     /** Writes the full filter state to the held item's CUSTOM_DATA. */
     private void syncFiltersToItem() {
-        if (itemConfigPlayer == null) return;
-        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+        if (itemConfigPlayer == null || itemConfigPlayer.getItemInHand(itemConfigHand) != originalStack) return;
+        ItemStack stack = originalStack;
         CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
         CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
 

--- a/src/main/java/com/logistics/pipe/ui/ItemTagUtils.java
+++ b/src/main/java/com/logistics/pipe/ui/ItemTagUtils.java
@@ -1,0 +1,25 @@
+package com.logistics.pipe.ui;
+
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+
+import java.util.function.Consumer;
+
+/** Shared utility for writing to an item's CUSTOM_DATA in item-mode screen handlers. */
+public final class ItemTagUtils {
+    private ItemTagUtils() {}
+
+    public static void writeToItemTag(ServerPlayer player, InteractionHand hand, Consumer<CompoundTag> modifier) {
+        if (player == null) return;
+        ItemStack stack = player.getItemInHand(hand);
+        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
+        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
+        modifier.accept(tag);
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        player.getInventory().setChanged();
+    }
+}

--- a/src/main/java/com/logistics/pipe/ui/ProviderFilterInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/ProviderFilterInventory.java
@@ -161,6 +161,7 @@ public class ProviderFilterInventory implements Container {
      * Refresh the inventory from the module.
      */
     public void refresh() {
+        if (pipeEntity == null) return;
         loadFromModule();
     }
 }

--- a/src/main/java/com/logistics/pipe/ui/ProviderFilterInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/ProviderFilterInventory.java
@@ -1,15 +1,20 @@
 package com.logistics.pipe.ui;
 
+import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.ProviderModule;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 
 import java.util.List;
 
@@ -130,6 +135,25 @@ public class ProviderFilterInventory implements Container {
             ItemStack displayStack = new ItemStack(item);
             displayStack.setCount(1);
             stacks.set(slotIndex++, displayStack);
+        }
+    }
+
+    public void loadFromItem(ItemStack stack) {
+        for (int i = 0; i < FILTER_SLOT_COUNT; i++) stacks.set(i, ItemStack.EMPTY);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData == null) return;
+        CompoundTag tag = customData.copyTag();
+        CompoundTag filterItems = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
+        int displaySlot = 0;
+        for (int i = 0; i < FILTER_SLOT_COUNT && displaySlot < FILTER_SLOT_COUNT; i++) {
+            String itemId = NbtCompat.getString(filterItems, String.valueOf(i), "");
+            if (itemId.isEmpty()) continue;
+            ResourceId rid = ResourceId.tryParse(itemId);
+            if (rid == null) continue;
+            var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
+            if (holder.isEmpty()) continue;
+            Item item = holder.get().value();
+            stacks.set(displaySlot++, new ItemStack(item));
         }
     }
 

--- a/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
@@ -137,52 +137,58 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     @Override
     public void clicked(int slotIndex, int button, ClickType actionType, Player player) {
         if (slotIndex >= 0 && slotIndex < FILTER_SLOT_COUNT) {
-            // Prevent shift-click
-            if (actionType == ClickType.QUICK_MOVE) {
-                return;
-            }
+            if (actionType == ClickType.QUICK_MOVE) return;
 
             ItemStack cursor = getCarried();
 
-            // Right-click or left-click with empty cursor: Clear slot
             if (button == 1 || cursor.isEmpty()) {
-                if (itemConfigPlayer != null) {
-                    if (!isPinnedItemStillHeld()) return;
-                    filterInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    final int s = slotIndex;
-                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                        CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
-                        fi.remove(String.valueOf(s));
-                        tag.put(ProviderModule.FILTER_ITEMS, fi);
-                    });
-                } else {
-                    filterInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, ""));
-                }
+                if (itemConfigPlayer != null) handleClearSlotForPlayer(slotIndex);
+                else handleClearSlotForModule(slotIndex);
                 broadcastChanges();
                 return;
             }
 
-            // Left-click with item: Place ghost item
-            String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
-            if (itemConfigPlayer != null) {
-                if (!isPinnedItemStillHeld()) return;
-                filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
-                final int s = slotIndex;
-                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                    CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
-                    fi.putString(String.valueOf(s), itemId);
-                    tag.put(ProviderModule.FILTER_ITEMS, fi);
-                });
-            } else {
-                filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
-                PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, itemId));
-            }
+            if (itemConfigPlayer != null) handlePlaceItemForPlayer(slotIndex, cursor);
+            else handlePlaceItemForModule(slotIndex, cursor);
             broadcastChanges();
             return;
         }
 
         super.clicked(slotIndex, button, actionType, player);
+    }
+
+    private void handleClearSlotForPlayer(int slotIndex) {
+        if (!isPinnedItemStillHeld()) return;
+        filterInventory.setItem(slotIndex, ItemStack.EMPTY);
+        final int s = slotIndex;
+        ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
+            CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
+            fi.remove(String.valueOf(s));
+            tag.put(ProviderModule.FILTER_ITEMS, fi);
+        });
+    }
+
+    private void handleClearSlotForModule(int slotIndex) {
+        filterInventory.setItem(slotIndex, ItemStack.EMPTY);
+        PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, ""));
+    }
+
+    private void handlePlaceItemForPlayer(int slotIndex, ItemStack cursor) {
+        if (!isPinnedItemStillHeld()) return;
+        String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
+        filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
+        final int s = slotIndex;
+        ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
+            CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
+            fi.putString(String.valueOf(s), itemId);
+            tag.put(ProviderModule.FILTER_ITEMS, fi);
+        });
+    }
+
+    private void handlePlaceItemForModule(int slotIndex, ItemStack cursor) {
+        String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
+        filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
+        PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, itemId));
     }
 
     @Override
@@ -229,6 +235,9 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
                     CompoundTag tag = customData.copyTag();
                     data.set(0, NbtCompat.getInt(tag, ProviderModule.MODE, 0));
                     data.set(1, NbtCompat.getInt(tag, ProviderModule.FILTER_INVERTED, 0));
+                } else {
+                    data.set(0, 0);
+                    data.set(1, 0);
                 }
             }
             super.broadcastChanges();

--- a/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
@@ -3,7 +3,6 @@ package com.logistics.pipe.ui;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.ProviderModule;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -38,6 +37,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     private final ContainerData data;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
+    @Nullable private final ItemStack pinnedItemStack;
 
     public ProviderScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(2));
@@ -54,6 +54,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
         ItemStack stack = player.getItemInHand(hand);
+        this.pinnedItemStack = stack;
         this.filterInventory = new ProviderFilterInventory(null);
         this.filterInventory.loadFromItem(stack);
         CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
@@ -72,6 +73,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
         this.data = data;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
+        this.pinnedItemStack = null;
         this.filterInventory = new ProviderFilterInventory(pipeEntity);
 
         if (pipeEntity != null) {
@@ -114,11 +116,15 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
         }
     }
 
+    private boolean isPinnedItemStillHeld() {
+        return pinnedItemStack != null && itemConfigPlayer != null
+                && itemConfigPlayer.getItemInHand(itemConfigHand) == pinnedItemStack;
+    }
+
     @Override
     public boolean stillValid(Player player) {
         if (itemConfigPlayer != null) {
-            ItemStack held = player.getItemInHand(itemConfigHand);
-            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+            return isPinnedItemStillHeld();
         }
         return true;
     }
@@ -142,6 +148,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             if (button == 1 || cursor.isEmpty()) {
                 filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
+                    if (!isPinnedItemStillHeld()) return;
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
@@ -159,6 +166,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
             filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return;
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
@@ -181,6 +189,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             int nextMode = (data.get(0) + 1) % ProviderModule.ProviderMode.values().length;
             data.set(0, nextMode);
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(ProviderModule.MODE, nextMode));
             } else {
                 PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setModeFromOrdinal(ctx, nextMode));
@@ -190,6 +199,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             int newInverted = data.get(1) == 0 ? 1 : 0;
             data.set(1, newInverted);
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(ProviderModule.FILTER_INVERTED, newInverted));
             } else {
                 PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterInverted(ctx, newInverted == 1));
@@ -210,12 +220,14 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     @Override
     public void broadcastChanges() {
         if (itemConfigPlayer != null) {
-            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
-            if (customData != null) {
-                CompoundTag tag = customData.copyTag();
-                data.set(0, NbtCompat.getInt(tag, ProviderModule.MODE, 0));
-                data.set(1, NbtCompat.getInt(tag, ProviderModule.FILTER_INVERTED, 0));
+            if (isPinnedItemStillHeld()) {
+                ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+                CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+                if (customData != null) {
+                    CompoundTag tag = customData.copyTag();
+                    data.set(0, NbtCompat.getInt(tag, ProviderModule.MODE, 0));
+                    data.set(1, NbtCompat.getInt(tag, ProviderModule.FILTER_INVERTED, 0));
+                }
             }
             super.broadcastChanges();
             return;

--- a/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
@@ -143,7 +143,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
                 filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     final int s = slotIndex;
-                    writeToItemTag(tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
                         fi.remove(String.valueOf(s));
                         tag.put(ProviderModule.FILTER_ITEMS, fi);
@@ -160,7 +160,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
             if (itemConfigPlayer != null) {
                 final int s = slotIndex;
-                writeToItemTag(tag -> {
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
                     fi.putString(String.valueOf(s), itemId);
                     tag.put(ProviderModule.FILTER_ITEMS, fi);
@@ -181,7 +181,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             int nextMode = (data.get(0) + 1) % ProviderModule.ProviderMode.values().length;
             data.set(0, nextMode);
             if (itemConfigPlayer != null) {
-                writeToItemTag(tag -> tag.putInt(ProviderModule.MODE, nextMode));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(ProviderModule.MODE, nextMode));
             } else {
                 PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setModeFromOrdinal(ctx, nextMode));
             }
@@ -190,7 +190,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             int newInverted = data.get(1) == 0 ? 1 : 0;
             data.set(1, newInverted);
             if (itemConfigPlayer != null) {
-                writeToItemTag(tag -> tag.putInt(ProviderModule.FILTER_INVERTED, newInverted));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(ProviderModule.FILTER_INVERTED, newInverted));
             } else {
                 PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterInverted(ctx, newInverted == 1));
             }
@@ -225,16 +225,6 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             data.set(1, module.isFilterInverted(ctx) ? 1 : 0);
         });
         super.broadcastChanges();
-    }
-
-    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
-        if (itemConfigPlayer == null) return;
-        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
-        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
-        modifier.accept(tag);
-        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
-        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class FilterSlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
@@ -146,9 +146,9 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
 
             // Right-click or left-click with empty cursor: Clear slot
             if (button == 1 || cursor.isEmpty()) {
-                filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     if (!isPinnedItemStillHeld()) return;
+                    filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
@@ -156,6 +156,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
                         tag.put(ProviderModule.FILTER_ITEMS, fi);
                     });
                 } else {
+                    filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                     PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, ""));
                 }
                 broadcastChanges();
@@ -164,9 +165,9 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
 
             // Left-click with item: Place ghost item
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
-            filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
             if (itemConfigPlayer != null) {
                 if (!isPinnedItemStillHeld()) return;
+                filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
@@ -174,6 +175,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
                     tag.put(ProviderModule.FILTER_ITEMS, fi);
                 });
             } else {
+                filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
                 PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, itemId));
             }
             broadcastChanges();

--- a/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
@@ -1,8 +1,15 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.ProviderModule;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
@@ -10,8 +17,9 @@ import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Screen handler for the Provider GUI.
@@ -28,6 +36,8 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     private final ProviderFilterInventory filterInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final ServerPlayer itemConfigPlayer;
+    @Nullable private final InteractionHand itemConfigHand;
 
     public ProviderScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(2));
@@ -37,14 +47,35 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
         this(syncId, playerInventory, pipeEntity, new SimpleContainerData(2));
     }
 
+    public ProviderScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
+        super(LogisticsPipe.SCREEN.PROVIDER, syncId);
+        this.data = new SimpleContainerData(2);
+        this.itemConfigPlayer = player;
+        this.itemConfigHand = hand;
+        this.context = ContainerLevelAccess.NULL;
+        ItemStack stack = player.getItemInHand(hand);
+        this.filterInventory = new ProviderFilterInventory(null);
+        this.filterInventory.loadFromItem(stack);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData != null) {
+            CompoundTag tag = customData.copyTag();
+            data.set(0, NbtCompat.getInt(tag, ProviderModule.MODE, 0));
+            data.set(1, NbtCompat.getInt(tag, ProviderModule.FILTER_INVERTED, 0));
+        }
+        addFilterSlots(filterInventory);
+        addPlayerInventorySlots(playerInventory);
+        addDataSlots(data);
+    }
+
     private ProviderScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
         super(LogisticsPipe.SCREEN.PROVIDER, syncId);
         this.data = data;
+        this.itemConfigPlayer = null;
+        this.itemConfigHand = null;
         this.filterInventory = new ProviderFilterInventory(pipeEntity);
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
-            // Load current mode and filter inversion from module
             PipeModuleHelper.withModule(pipeEntity, ProviderModule.class, (ctx, module) -> {
                 data.set(0, module.getModeOrdinal(ctx));
                 data.set(1, module.isFilterInverted(ctx) ? 1 : 0);
@@ -85,6 +116,10 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        if (itemConfigPlayer != null) {
+            ItemStack held = player.getItemInHand(itemConfigHand);
+            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+        }
         return true;
     }
 
@@ -106,23 +141,33 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             // Right-click or left-click with empty cursor: Clear slot
             if (button == 1 || cursor.isEmpty()) {
                 filterInventory.setItem(slotIndex, ItemStack.EMPTY);
-                PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> {
-                    module.setFilterItem(ctx, slotIndex, "");
-                });
+                if (itemConfigPlayer != null) {
+                    final int s = slotIndex;
+                    writeToItemTag(tag -> {
+                        CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
+                        fi.remove(String.valueOf(s));
+                        tag.put(ProviderModule.FILTER_ITEMS, fi);
+                    });
+                } else {
+                    PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, ""));
+                }
                 broadcastChanges();
                 return;
             }
 
             // Left-click with item: Place ghost item
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
-            ItemStack ghostItem = cursor.copyWithCount(1);
-            filterInventory.setItem(slotIndex, ghostItem);
-
-            // Save to module configuration
-            PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> {
-                module.setFilterItem(ctx, slotIndex, itemId);
-            });
-
+            filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
+            if (itemConfigPlayer != null) {
+                final int s = slotIndex;
+                writeToItemTag(tag -> {
+                    CompoundTag fi = NbtCompat.getCompoundOrEmpty(tag, ProviderModule.FILTER_ITEMS);
+                    fi.putString(String.valueOf(s), itemId);
+                    tag.put(ProviderModule.FILTER_ITEMS, fi);
+                });
+            } else {
+                PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, itemId));
+            }
             broadcastChanges();
             return;
         }
@@ -133,26 +178,22 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     @Override
     public boolean clickMenuButton(Player player, int id) {
         if (id == 0) {
-            // Cycle through modes: Supply(0) -> Reserve(1) -> Guarded(2) -> Seeded(3) -> Sample(4) -> wrap to Supply
-            int currentMode = data.get(0);
-            int nextMode = (currentMode + 1) % ProviderModule.ProviderMode.values().length;
+            int nextMode = (data.get(0) + 1) % ProviderModule.ProviderMode.values().length;
             data.set(0, nextMode);
-
-            // Save mode to module
-            PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> {
-                module.setModeFromOrdinal(ctx, nextMode);
-            });
+            if (itemConfigPlayer != null) {
+                writeToItemTag(tag -> tag.putInt(ProviderModule.MODE, nextMode));
+            } else {
+                PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setModeFromOrdinal(ctx, nextMode));
+            }
             return true;
         } else if (id == 1) {
-            // Toggle filter inversion
-            int currentInverted = data.get(1);
-            int newInverted = currentInverted == 0 ? 1 : 0;
+            int newInverted = data.get(1) == 0 ? 1 : 0;
             data.set(1, newInverted);
-
-            // Save to module
-            PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> {
-                module.setFilterInverted(ctx, newInverted == 1);
-            });
+            if (itemConfigPlayer != null) {
+                writeToItemTag(tag -> tag.putInt(ProviderModule.FILTER_INVERTED, newInverted));
+            } else {
+                PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterInverted(ctx, newInverted == 1));
+            }
             return true;
         }
         return false;
@@ -168,12 +209,32 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
 
     @Override
     public void broadcastChanges() {
-        // Sync module state into data slots before super sends them to the client
+        if (itemConfigPlayer != null) {
+            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+            if (customData != null) {
+                CompoundTag tag = customData.copyTag();
+                data.set(0, NbtCompat.getInt(tag, ProviderModule.MODE, 0));
+                data.set(1, NbtCompat.getInt(tag, ProviderModule.FILTER_INVERTED, 0));
+            }
+            super.broadcastChanges();
+            return;
+        }
         PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> {
             data.set(0, module.getModeOrdinal(ctx));
             data.set(1, module.isFilterInverted(ctx) ? 1 : 0);
         });
         super.broadcastChanges();
+    }
+
+    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
+        if (itemConfigPlayer == null) return;
+        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
+        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
+        modifier.accept(tag);
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class FilterSlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/SinkInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkInventory.java
@@ -1,15 +1,19 @@
 package com.logistics.pipe.ui;
 
+import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.core.lib.storage.NbtCompat;
+import com.logistics.pipe.Pipe;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.SinkModule;
-import com.logistics.pipe.Pipe;
-import com.logistics.core.lib.resource.ResourceId;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 
 /**
  * Inventory wrapper for the Sink GUI.
@@ -95,5 +99,23 @@ public class SinkInventory implements Container {
     @Override
     public void clearContent() {
         items.clear();
+    }
+
+    public void loadFromItem(ItemStack stack) {
+        for (int i = 0; i < SinkModule.MAX_FILTER_SLOTS; i++) items.set(i, ItemStack.EMPTY);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData == null) return;
+        CompoundTag tag = customData.copyTag();
+        CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
+        int displaySlot = 0;
+        for (int i = 0; i < SinkModule.MAX_FILTER_SLOTS && displaySlot < SinkModule.MAX_FILTER_SLOTS; i++) {
+            String itemId = NbtCompat.getString(filters, String.valueOf(i), "");
+            if (itemId.isEmpty()) continue;
+            ResourceId rid = ResourceId.tryParse(itemId);
+            if (rid == null) continue;
+            var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
+            if (holder.isEmpty()) continue;
+            items.set(displaySlot++, new ItemStack(holder.get()));
+        }
     }
 }

--- a/src/main/java/com/logistics/pipe/ui/SinkInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkInventory.java
@@ -107,15 +107,14 @@ public class SinkInventory implements Container {
         if (customData == null) return;
         CompoundTag tag = customData.copyTag();
         CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
-        int displaySlot = 0;
-        for (int i = 0; i < SinkModule.MAX_FILTER_SLOTS && displaySlot < SinkModule.MAX_FILTER_SLOTS; i++) {
+        for (int i = 0; i < SinkModule.MAX_FILTER_SLOTS; i++) {
             String itemId = NbtCompat.getString(filters, String.valueOf(i), "");
             if (itemId.isEmpty()) continue;
             ResourceId rid = ResourceId.tryParse(itemId);
             if (rid == null) continue;
             var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
             if (holder.isEmpty()) continue;
-            items.set(displaySlot++, new ItemStack(holder.get()));
+            items.set(i, new ItemStack(holder.get()));
         }
     }
 }

--- a/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -155,7 +155,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                 sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     final int s = slotIndex;
-                    writeToItemTag(tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
                         filters.remove(String.valueOf(s));
                         tag.put(SinkModule.FILTERS, filters);
@@ -181,7 +181,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             // Save to module configuration
             if (itemConfigPlayer != null) {
                 final int s = slotIndex;
-                writeToItemTag(tag -> {
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
                     filters.putString(String.valueOf(s), itemId);
                     tag.put(SinkModule.FILTERS, filters);
@@ -212,7 +212,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             data.set(0, newValue ? 1 : 0);
 
             if (itemConfigPlayer != null) {
-                writeToItemTag(tag -> tag.putInt(SinkModule.DEFAULT_ROUTE, newValue ? 1 : 0));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(SinkModule.DEFAULT_ROUTE, newValue ? 1 : 0));
             } else {
                 PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
                     module.setDefaultRoute(ctx, newValue);
@@ -225,16 +225,6 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
     public boolean isDefaultRoute() {
         return data.get(0) == 1;
-    }
-
-    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
-        if (itemConfigPlayer == null) return;
-        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
-        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
-        modifier.accept(tag);
-        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
-        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class FilterSlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -1,17 +1,25 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.SinkModule;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.inventory.ClickType;
-import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Screen handler for the Sink GUI (Basic Logistics Pipe).
@@ -28,6 +36,8 @@ public class SinkScreenHandler extends AbstractContainerMenu {
     private final SinkInventory sinkInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final ServerPlayer itemConfigPlayer;
+    @Nullable private final InteractionHand itemConfigHand;
 
     public SinkScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(1));
@@ -37,9 +47,29 @@ public class SinkScreenHandler extends AbstractContainerMenu {
         this(syncId, playerInventory, pipeEntity, new SimpleContainerData(1));
     }
 
+    public SinkScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
+        super(LogisticsPipe.SCREEN.SINK, syncId);
+        this.data = new SimpleContainerData(1);
+        this.itemConfigPlayer = player;
+        this.itemConfigHand = hand;
+        this.context = ContainerLevelAccess.NULL;
+        ItemStack stack = player.getItemInHand(hand);
+        this.sinkInventory = new SinkInventory(null);
+        this.sinkInventory.loadFromItem(stack);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData != null) {
+            data.set(0, NbtCompat.getInt(customData.copyTag(), SinkModule.DEFAULT_ROUTE, 0));
+        }
+        addFilterSlots(sinkInventory);
+        addPlayerInventorySlots(playerInventory);
+        addDataSlots(data);
+    }
+
     private SinkScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
         super(LogisticsPipe.SCREEN.SINK, syncId);
         this.data = data;
+        this.itemConfigPlayer = null;
+        this.itemConfigHand = null;
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
@@ -60,12 +90,20 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
     @Override
     public void broadcastChanges() {
-        super.broadcastChanges();
-
+        if (itemConfigPlayer != null) {
+            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+            if (customData != null) {
+                data.set(0, NbtCompat.getInt(customData.copyTag(), SinkModule.DEFAULT_ROUTE, 0));
+            }
+            super.broadcastChanges();
+            return;
+        }
         // Sync default route value from module to data slot
         PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
             data.set(0, module.isDefaultRoute(ctx) ? 1 : 0);
         });
+        super.broadcastChanges();
     }
 
     private void addFilterSlots(Container inventory) {
@@ -95,6 +133,10 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        if (itemConfigPlayer != null) {
+            ItemStack held = player.getItemInHand(itemConfigHand);
+            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+        }
         return true;
     }
 
@@ -111,9 +153,18 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             // Right-click: Clear slot
             if (button == 1) {
                 sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
-                PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
-                    module.setFilter(ctx, slotIndex, "");
-                });
+                if (itemConfigPlayer != null) {
+                    final int s = slotIndex;
+                    writeToItemTag(tag -> {
+                        CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
+                        filters.remove(String.valueOf(s));
+                        tag.put(SinkModule.FILTERS, filters);
+                    });
+                } else {
+                    PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
+                        module.setFilter(ctx, slotIndex, "");
+                    });
+                }
                 broadcastChanges();
                 return;
             }
@@ -128,9 +179,18 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             sinkInventory.setItem(slotIndex, ghostItem);
 
             // Save to module configuration
-            PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
-                module.setFilter(ctx, slotIndex, itemId);
-            });
+            if (itemConfigPlayer != null) {
+                final int s = slotIndex;
+                writeToItemTag(tag -> {
+                    CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
+                    filters.putString(String.valueOf(s), itemId);
+                    tag.put(SinkModule.FILTERS, filters);
+                });
+            } else {
+                PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
+                    module.setFilter(ctx, slotIndex, itemId);
+                });
+            }
 
             broadcastChanges();
             return;
@@ -151,9 +211,13 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             boolean newValue = data.get(0) == 0;
             data.set(0, newValue ? 1 : 0);
 
-            PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
-                module.setDefaultRoute(ctx, newValue);
-            });
+            if (itemConfigPlayer != null) {
+                writeToItemTag(tag -> tag.putInt(SinkModule.DEFAULT_ROUTE, newValue ? 1 : 0));
+            } else {
+                PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
+                    module.setDefaultRoute(ctx, newValue);
+                });
+            }
             return true;
         }
         return false;
@@ -161,6 +225,16 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
     public boolean isDefaultRoute() {
         return data.get(0) == 1;
+    }
+
+    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
+        if (itemConfigPlayer == null) return;
+        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
+        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
+        modifier.accept(tag);
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class FilterSlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -3,6 +3,7 @@ package com.logistics.pipe.ui;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.SinkModule;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -49,11 +50,14 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
     public SinkScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
         super(LogisticsPipe.SCREEN.SINK, syncId);
+        ItemStack stack = player.getItemInHand(hand);
+        if (stack.isEmpty() || !(stack.getItem() instanceof ModuleItem)) {
+            throw new IllegalArgumentException("Expected a ModuleItem in " + hand + " hand");
+        }
         this.data = new SimpleContainerData(1);
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
-        ItemStack stack = player.getItemInHand(hand);
         this.originalModuleStack = stack;
         this.sinkInventory = new SinkInventory(null);
         this.sinkInventory.loadFromItem(stack);
@@ -164,7 +168,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                     if (!isPinnedItemStillHeld()) return;
                     sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
-                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
                         CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
                         filters.remove(String.valueOf(s));
                         if (filters.isEmpty()) {
@@ -196,7 +200,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                 if (!isPinnedItemStillHeld()) return;
                 sinkInventory.setItem(slotIndex, ghostItem);
                 final int s = slotIndex;
-                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
                     CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
                     filters.putString(String.valueOf(s), itemId);
                     tag.put(SinkModule.FILTERS, filters);
@@ -229,7 +233,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
             if (itemConfigPlayer != null) {
                 if (!isPinnedItemStillHeld()) return true;
-                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(SinkModule.DEFAULT_ROUTE, newValue ? 1 : 0));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> tag.putInt(SinkModule.DEFAULT_ROUTE, newValue ? 1 : 0));
             } else {
                 PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
                     module.setDefaultRoute(ctx, newValue);

--- a/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -102,6 +102,8 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                 CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
                 if (customData != null) {
                     data.set(0, NbtCompat.getInt(customData.copyTag(), SinkModule.DEFAULT_ROUTE, 0));
+                } else {
+                    data.set(0, 0);
                 }
             }
             super.broadcastChanges();

--- a/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -3,7 +3,6 @@ package com.logistics.pipe.ui;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.SinkModule;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -38,6 +37,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
     private final ContainerData data;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
+    @Nullable private final ItemStack originalModuleStack;
 
     public SinkScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(1));
@@ -54,6 +54,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
         ItemStack stack = player.getItemInHand(hand);
+        this.originalModuleStack = stack;
         this.sinkInventory = new SinkInventory(null);
         this.sinkInventory.loadFromItem(stack);
         CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
@@ -70,6 +71,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
         this.data = data;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
+        this.originalModuleStack = null;
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
@@ -91,10 +93,12 @@ public class SinkScreenHandler extends AbstractContainerMenu {
     @Override
     public void broadcastChanges() {
         if (itemConfigPlayer != null) {
-            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
-            if (customData != null) {
-                data.set(0, NbtCompat.getInt(customData.copyTag(), SinkModule.DEFAULT_ROUTE, 0));
+            if (isPinnedItemStillHeld()) {
+                ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+                CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+                if (customData != null) {
+                    data.set(0, NbtCompat.getInt(customData.copyTag(), SinkModule.DEFAULT_ROUTE, 0));
+                }
             }
             super.broadcastChanges();
             return;
@@ -131,11 +135,15 @@ public class SinkScreenHandler extends AbstractContainerMenu {
         }
     }
 
+    private boolean isPinnedItemStillHeld() {
+        return originalModuleStack != null && itemConfigPlayer != null
+                && itemConfigPlayer.getItemInHand(itemConfigHand) == originalModuleStack;
+    }
+
     @Override
     public boolean stillValid(Player player) {
         if (itemConfigPlayer != null) {
-            ItemStack held = player.getItemInHand(itemConfigHand);
-            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+            return isPinnedItemStillHeld();
         }
         return true;
     }
@@ -154,11 +162,16 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             if (button == 1) {
                 sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
+                    if (!isPinnedItemStillHeld()) return;
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
                         filters.remove(String.valueOf(s));
-                        tag.put(SinkModule.FILTERS, filters);
+                        if (filters.isEmpty()) {
+                            tag.remove(SinkModule.FILTERS);
+                        } else {
+                            tag.put(SinkModule.FILTERS, filters);
+                        }
                     });
                 } else {
                     PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
@@ -180,6 +193,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
             // Save to module configuration
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return;
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
@@ -212,6 +226,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             data.set(0, newValue ? 1 : 0);
 
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(SinkModule.DEFAULT_ROUTE, newValue ? 1 : 0));
             } else {
                 PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {

--- a/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -160,9 +160,9 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
             // Right-click: Clear slot
             if (button == 1) {
-                sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     if (!isPinnedItemStillHeld()) return;
+                    sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
@@ -174,6 +174,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                         }
                     });
                 } else {
+                    sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
                     PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
                         module.setFilter(ctx, slotIndex, "");
                     });
@@ -189,11 +190,11 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
             ItemStack ghostItem = cursor.copyWithCount(1); // Filters don't need count
-            sinkInventory.setItem(slotIndex, ghostItem);
 
             // Save to module configuration
             if (itemConfigPlayer != null) {
                 if (!isPinnedItemStillHeld()) return;
+                sinkInventory.setItem(slotIndex, ghostItem);
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, SinkModule.FILTERS);
@@ -201,6 +202,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                     tag.put(SinkModule.FILTERS, filters);
                 });
             } else {
+                sinkInventory.setItem(slotIndex, ghostItem);
                 PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
                     module.setFilter(ctx, slotIndex, itemId);
                 });

--- a/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -1,17 +1,25 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.SupplierModule;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.inventory.ClickType;
-import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Screen handler for the Supplier GUI.
@@ -28,6 +36,8 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
     private final SupplyInventory supplyInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final ServerPlayer itemConfigPlayer;
+    @Nullable private final InteractionHand itemConfigHand;
 
     public SupplierScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(1));
@@ -37,9 +47,29 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         this(syncId, playerInventory, pipeEntity, new SimpleContainerData(1));
     }
 
+    public SupplierScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
+        super(LogisticsPipe.SCREEN.SUPPLIER, syncId);
+        this.data = new SimpleContainerData(1);
+        this.itemConfigPlayer = player;
+        this.itemConfigHand = hand;
+        this.context = ContainerLevelAccess.NULL;
+        ItemStack stack = player.getItemInHand(hand);
+        this.supplyInventory = new SupplyInventory(null);
+        this.supplyInventory.loadFromItem(stack);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData != null) {
+            data.set(0, NbtCompat.getInt(customData.copyTag(), SupplierModule.MODE, 0));
+        }
+        addSupplySlots(supplyInventory);
+        addPlayerInventorySlots(playerInventory);
+        addDataSlots(data);
+    }
+
     private SupplierScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
         super(LogisticsPipe.SCREEN.SUPPLIER, syncId);
         this.data = data;
+        this.itemConfigPlayer = null;
+        this.itemConfigHand = null;
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
@@ -84,6 +114,10 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        if (itemConfigPlayer != null) {
+            ItemStack held = player.getItemInHand(itemConfigHand);
+            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+        }
         return true;
     }
 
@@ -101,9 +135,18 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             // Right-click: Clear slot
             if (button == 1) {
                 supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
-                PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
-                    module.setSupplyConfig(ctx, slotIndex, "", 0);
-                });
+                if (itemConfigPlayer != null) {
+                    final int s = slotIndex;
+                    writeToItemTag(tag -> {
+                        CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
+                        supplies.remove(String.valueOf(s));
+                        tag.put(SupplierModule.SUPPLIES, supplies);
+                    });
+                } else {
+                    PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
+                        module.setSupplyConfig(ctx, slotIndex, "", 0);
+                    });
+                }
                 broadcastChanges();
                 return;
             }
@@ -111,9 +154,18 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             // Left-click with empty cursor: Clear slot
             if (cursor.isEmpty()) {
                 supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
-                PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
-                    module.setSupplyConfig(ctx, slotIndex, "", 0);
-                });
+                if (itemConfigPlayer != null) {
+                    final int s = slotIndex;
+                    writeToItemTag(tag -> {
+                        CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
+                        supplies.remove(String.valueOf(s));
+                        tag.put(SupplierModule.SUPPLIES, supplies);
+                    });
+                } else {
+                    PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
+                        module.setSupplyConfig(ctx, slotIndex, "", 0);
+                    });
+                }
                 broadcastChanges();
                 return;
             }
@@ -139,9 +191,21 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
 
             // Save to module configuration
             int finalAmount = newAmount;
-            PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
-                module.setSupplyConfig(ctx, slotIndex, itemId, finalAmount);
-            });
+            if (itemConfigPlayer != null) {
+                final int s = slotIndex;
+                writeToItemTag(tag -> {
+                    CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
+                    CompoundTag slotTag = new CompoundTag();
+                    slotTag.putString("item", itemId);
+                    slotTag.putInt("amount", finalAmount);
+                    supplies.put(String.valueOf(s), slotTag);
+                    tag.put(SupplierModule.SUPPLIES, supplies);
+                });
+            } else {
+                PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
+                    module.setSupplyConfig(ctx, slotIndex, itemId, finalAmount);
+                });
+            }
 
             broadcastChanges();
             return;
@@ -160,9 +224,13 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         if (id == 0) {
             int nextMode = (data.get(0) + 1) % SupplierModule.SupplyMode.values().length;
             data.set(0, nextMode);
-            PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
-                module.setModeFromOrdinal(ctx, nextMode);
-            });
+            if (itemConfigPlayer != null) {
+                writeToItemTag(tag -> tag.putInt(SupplierModule.MODE, nextMode));
+            } else {
+                PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
+                    module.setModeFromOrdinal(ctx, nextMode);
+                });
+            }
             return true;
         }
         return false;
@@ -174,7 +242,29 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
 
     @Override
     public void broadcastChanges() {
+        if (itemConfigPlayer != null) {
+            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+            if (customData != null) {
+                data.set(0, NbtCompat.getInt(customData.copyTag(), SupplierModule.MODE, 0));
+            }
+            super.broadcastChanges();
+            return;
+        }
+        PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
+            data.set(0, module.getModeOrdinal(ctx));
+        });
         super.broadcastChanges();
+    }
+
+    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
+        if (itemConfigPlayer == null) return;
+        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
+        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
+        modifier.accept(tag);
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class SupplySlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -140,9 +140,9 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
 
             // Right-click: Clear slot
             if (button == 1) {
-                supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     if (!isPinnedItemStillHeld()) return;
+                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
@@ -150,6 +150,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                         tag.put(SupplierModule.SUPPLIES, supplies);
                     });
                 } else {
+                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                     PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
                         module.setSupplyConfig(ctx, slotIndex, "", 0);
                     });
@@ -160,9 +161,9 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
 
             // Left-click with empty cursor: Clear slot
             if (cursor.isEmpty()) {
-                supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     if (!isPinnedItemStillHeld()) return;
+                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
@@ -170,6 +171,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                         tag.put(SupplierModule.SUPPLIES, supplies);
                     });
                 } else {
+                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                     PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
                         module.setSupplyConfig(ctx, slotIndex, "", 0);
                     });
@@ -194,13 +196,11 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                 newAmount = addAmount;
             }
 
-            ItemStack ghostItem = cursor.copyWithCount(newAmount);
-            supplyInventory.setItem(slotIndex, ghostItem);
-
             // Save to module configuration
             int finalAmount = newAmount;
             if (itemConfigPlayer != null) {
                 if (!isPinnedItemStillHeld()) return;
+                supplyInventory.setItem(slotIndex, cursor.copyWithCount(newAmount));
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
@@ -211,6 +211,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                     tag.put(SupplierModule.SUPPLIES, supplies);
                 });
             } else {
+                supplyInventory.setItem(slotIndex, cursor.copyWithCount(newAmount));
                 PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
                     module.setSupplyConfig(ctx, slotIndex, itemId, finalAmount);
                 });

--- a/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -130,52 +130,14 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
     @Override
     public void clicked(int slotIndex, int button, ClickType actionType, Player player) {
         if (slotIndex >= 0 && slotIndex < SUPPLY_SLOT_COUNT) {
-            // Prevent shift-click
-            if (actionType == ClickType.QUICK_MOVE) {
-                return;
-            }
+            if (actionType == ClickType.QUICK_MOVE) return;
+            if (itemConfigPlayer != null && !isPinnedItemStillHeld()) return;
 
             ItemStack cursor = getCarried();
             ItemStack slotItem = supplyInventory.getItem(slotIndex);
 
-            // Right-click: Clear slot
-            if (button == 1) {
-                if (itemConfigPlayer != null) {
-                    if (!isPinnedItemStillHeld()) return;
-                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    final int s = slotIndex;
-                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                        CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
-                        supplies.remove(String.valueOf(s));
-                        tag.put(SupplierModule.SUPPLIES, supplies);
-                    });
-                } else {
-                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
-                        module.setSupplyConfig(ctx, slotIndex, "", 0);
-                    });
-                }
-                broadcastChanges();
-                return;
-            }
-
-            // Left-click with empty cursor: Clear slot
-            if (cursor.isEmpty()) {
-                if (itemConfigPlayer != null) {
-                    if (!isPinnedItemStillHeld()) return;
-                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    final int s = slotIndex;
-                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                        CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
-                        supplies.remove(String.valueOf(s));
-                        tag.put(SupplierModule.SUPPLIES, supplies);
-                    });
-                } else {
-                    supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
-                        module.setSupplyConfig(ctx, slotIndex, "", 0);
-                    });
-                }
+            if (button == 1 || cursor.isEmpty()) {
+                clearSupplySlot(slotIndex);
                 broadcastChanges();
                 return;
             }
@@ -186,42 +148,53 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             int newAmount;
 
             if (slotItem.isEmpty()) {
-                // Place new item
                 newAmount = addAmount;
             } else if (ItemStack.isSameItemSameComponents(cursor, slotItem)) {
-                // Same item - add to existing count
                 newAmount = Math.min(slotItem.getCount() + addAmount, 999); // Cap at 999
             } else {
-                // Different item - replace
                 newAmount = addAmount;
             }
 
-            // Save to module configuration
-            int finalAmount = newAmount;
-            if (itemConfigPlayer != null) {
-                if (!isPinnedItemStillHeld()) return;
-                supplyInventory.setItem(slotIndex, cursor.copyWithCount(newAmount));
-                final int s = slotIndex;
-                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
-                    CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
-                    CompoundTag slotTag = new CompoundTag();
-                    slotTag.putString("item", itemId);
-                    slotTag.putInt("amount", finalAmount);
-                    supplies.put(String.valueOf(s), slotTag);
-                    tag.put(SupplierModule.SUPPLIES, supplies);
-                });
-            } else {
-                supplyInventory.setItem(slotIndex, cursor.copyWithCount(newAmount));
-                PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
-                    module.setSupplyConfig(ctx, slotIndex, itemId, finalAmount);
-                });
-            }
-
+            supplyInventory.setItem(slotIndex, cursor.copyWithCount(newAmount));
+            saveSupplySlot(slotIndex, itemId, newAmount);
             broadcastChanges();
             return;
         }
 
         super.clicked(slotIndex, button, actionType, player);
+    }
+
+    private void clearSupplySlot(int slotIndex) {
+        if (itemConfigPlayer != null) {
+            supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
+            final int s = slotIndex;
+            ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
+                CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
+                supplies.remove(String.valueOf(s));
+                tag.put(SupplierModule.SUPPLIES, supplies);
+            });
+        } else {
+            supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
+            PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) ->
+                    module.setSupplyConfig(ctx, slotIndex, "", 0));
+        }
+    }
+
+    private void saveSupplySlot(int slotIndex, String itemId, int amount) {
+        if (itemConfigPlayer != null) {
+            final int s = slotIndex;
+            ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
+                CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
+                CompoundTag slotTag = new CompoundTag();
+                slotTag.putString("item", itemId);
+                slotTag.putInt("amount", amount);
+                supplies.put(String.valueOf(s), slotTag);
+                tag.put(SupplierModule.SUPPLIES, supplies);
+            });
+        } else {
+            PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) ->
+                    module.setSupplyConfig(ctx, slotIndex, itemId, amount));
+        }
     }
 
     @Override
@@ -233,11 +206,12 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
     public boolean clickMenuButton(Player player, int id) {
         if (id == 0) {
             int nextMode = (data.get(0) + 1) % SupplierModule.SupplyMode.values().length;
-            data.set(0, nextMode);
             if (itemConfigPlayer != null) {
                 if (!isPinnedItemStillHeld()) return true;
-                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(SupplierModule.MODE, nextMode));
+                data.set(0, nextMode);
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> tag.putInt(SupplierModule.MODE, nextMode));
             } else {
+                data.set(0, nextMode);
                 PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
                     module.setModeFromOrdinal(ctx, nextMode);
                 });

--- a/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -137,7 +137,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                 supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     final int s = slotIndex;
-                    writeToItemTag(tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
                         supplies.remove(String.valueOf(s));
                         tag.put(SupplierModule.SUPPLIES, supplies);
@@ -156,7 +156,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                 supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
                     final int s = slotIndex;
-                    writeToItemTag(tag -> {
+                    ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
                         supplies.remove(String.valueOf(s));
                         tag.put(SupplierModule.SUPPLIES, supplies);
@@ -193,7 +193,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             int finalAmount = newAmount;
             if (itemConfigPlayer != null) {
                 final int s = slotIndex;
-                writeToItemTag(tag -> {
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
                     CompoundTag slotTag = new CompoundTag();
                     slotTag.putString("item", itemId);
@@ -225,7 +225,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             int nextMode = (data.get(0) + 1) % SupplierModule.SupplyMode.values().length;
             data.set(0, nextMode);
             if (itemConfigPlayer != null) {
-                writeToItemTag(tag -> tag.putInt(SupplierModule.MODE, nextMode));
+                ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(SupplierModule.MODE, nextMode));
             } else {
                 PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
                     module.setModeFromOrdinal(ctx, nextMode);
@@ -255,16 +255,6 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             data.set(0, module.getModeOrdinal(ctx));
         });
         super.broadcastChanges();
-    }
-
-    private void writeToItemTag(java.util.function.Consumer<CompoundTag> modifier) {
-        if (itemConfigPlayer == null) return;
-        ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-        CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
-        CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
-        modifier.accept(tag);
-        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
-        itemConfigPlayer.getInventory().setChanged();
     }
 
     private static class SupplySlot extends Slot {

--- a/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -233,6 +233,8 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                 CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
                 if (customData != null) {
                     data.set(0, NbtCompat.getInt(customData.copyTag(), SupplierModule.MODE, 0));
+                } else {
+                    data.set(0, 0);
                 }
             }
             super.broadcastChanges();

--- a/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -3,7 +3,6 @@ package com.logistics.pipe.ui;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.SupplierModule;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -38,6 +37,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
     private final ContainerData data;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
+    @Nullable private final ItemStack originalStack;
 
     public SupplierScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null, new SimpleContainerData(1));
@@ -54,6 +54,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
         ItemStack stack = player.getItemInHand(hand);
+        this.originalStack = stack;
         this.supplyInventory = new SupplyInventory(null);
         this.supplyInventory.loadFromItem(stack);
         CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
@@ -70,6 +71,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         this.data = data;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
+        this.originalStack = null;
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
@@ -112,11 +114,15 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         }
     }
 
+    private boolean isPinnedItemStillHeld() {
+        return originalStack != null && itemConfigPlayer != null
+                && itemConfigPlayer.getItemInHand(itemConfigHand) == originalStack;
+    }
+
     @Override
     public boolean stillValid(Player player) {
         if (itemConfigPlayer != null) {
-            ItemStack held = player.getItemInHand(itemConfigHand);
-            return !held.isEmpty() && held.getItem() instanceof ModuleItem;
+            return isPinnedItemStillHeld();
         }
         return true;
     }
@@ -136,6 +142,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             if (button == 1) {
                 supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
+                    if (!isPinnedItemStillHeld()) return;
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
@@ -155,6 +162,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             if (cursor.isEmpty()) {
                 supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
                 if (itemConfigPlayer != null) {
+                    if (!isPinnedItemStillHeld()) return;
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                         CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
@@ -192,6 +200,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             // Save to module configuration
             int finalAmount = newAmount;
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return;
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> {
                     CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
@@ -225,6 +234,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             int nextMode = (data.get(0) + 1) % SupplierModule.SupplyMode.values().length;
             data.set(0, nextMode);
             if (itemConfigPlayer != null) {
+                if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(SupplierModule.MODE, nextMode));
             } else {
                 PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
@@ -243,10 +253,12 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
     @Override
     public void broadcastChanges() {
         if (itemConfigPlayer != null) {
-            ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
-            CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
-            if (customData != null) {
-                data.set(0, NbtCompat.getInt(customData.copyTag(), SupplierModule.MODE, 0));
+            if (isPinnedItemStillHeld()) {
+                ItemStack stack = itemConfigPlayer.getItemInHand(itemConfigHand);
+                CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+                if (customData != null) {
+                    data.set(0, NbtCompat.getInt(customData.copyTag(), SupplierModule.MODE, 0));
+                }
             }
             super.broadcastChanges();
             return;

--- a/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
@@ -1,15 +1,20 @@
 package com.logistics.pipe.ui;
 
+import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.SupplierModule;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 
 import java.util.List;
 
@@ -135,6 +140,29 @@ public class SupplyInventory implements Container {
             // Show target amount as stack count (capped at 64 for display)
             displayStack.setCount((int) Math.min(config.amount(), 64));
             stacks.set(slotIndex++, displayStack);
+        }
+    }
+
+    public void loadFromItem(ItemStack stack) {
+        for (int i = 0; i < SupplierModule.MAX_SUPPLY_SLOTS; i++) stacks.set(i, ItemStack.EMPTY);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData == null) return;
+        CompoundTag tag = customData.copyTag();
+        CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
+        int displaySlot = 0;
+        for (int i = 0; i < SupplierModule.MAX_SUPPLY_SLOTS && displaySlot < SupplierModule.MAX_SUPPLY_SLOTS; i++) {
+            CompoundTag slotTag = NbtCompat.getCompoundOrEmpty(supplies, String.valueOf(i));
+            String itemId = NbtCompat.getString(slotTag, "item", "");
+            int amount = NbtCompat.getInt(slotTag, "amount", 0);
+            if (itemId.isEmpty() || amount <= 0) continue;
+            ResourceId rid = ResourceId.tryParse(itemId);
+            if (rid == null) continue;
+            var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
+            if (holder.isEmpty()) continue;
+            Item item = holder.get().value();
+            ItemStack display = new ItemStack(item);
+            display.setCount((int) Math.min(amount, 64));
+            stacks.set(displaySlot++, display);
         }
     }
 

--- a/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
@@ -149,8 +149,7 @@ public class SupplyInventory implements Container {
         if (customData == null) return;
         CompoundTag tag = customData.copyTag();
         CompoundTag supplies = NbtCompat.getCompoundOrEmpty(tag, SupplierModule.SUPPLIES);
-        int displaySlot = 0;
-        for (int i = 0; i < SupplierModule.MAX_SUPPLY_SLOTS && displaySlot < SupplierModule.MAX_SUPPLY_SLOTS; i++) {
+        for (int i = 0; i < SupplierModule.MAX_SUPPLY_SLOTS; i++) {
             CompoundTag slotTag = NbtCompat.getCompoundOrEmpty(supplies, String.valueOf(i));
             String itemId = NbtCompat.getString(slotTag, "item", "");
             int amount = NbtCompat.getInt(slotTag, "amount", 0);
@@ -162,7 +161,7 @@ public class SupplyInventory implements Container {
             Item item = holder.get().value();
             ItemStack display = new ItemStack(item);
             display.setCount((int) Math.min(amount, 64));
-            stacks.set(displaySlot++, display);
+            stacks.set(i, display);
         }
     }
 


### PR DESCRIPTION
## Summary
This update introduces significant enhancements to the module management system within the logistics pipe framework. The newly added functionality to clear module states upon removal improves resource handling and overall performance for users, ensuring that the state of each module is managed more effectively.

## Changes
- **Module State Management:**
  - Added a method to clear the state of modules when they are removed from the system, allowing the associated state information to be reset effectively.
    
- **Item Configuration Handling:**
  - Enhanced item configuration processes for modules, providing players with improved organizational structures when managing module settings.

- **User Interface Improvements:**
  - Updated UI elements for various modules (including Advanced Extractor, Crafting, and Item Filter modules) to ensure smoother interactions, particularly when adjusting settings via player-held items.
    
- **Data Handling Enhancements:**
  - Introduced mechanisms to load module states directly from item stacks, maintaining consistency between in-game items and their respective module configurations.

## Notes
- Players interacting with modules will experience an immediate effect when removing them, with old states no longer persisting erroneously. This change should streamline gameplay and enhance the overall user experience. 
- Ensure that any existing modules are reviewed for state clearing functionality when removed to maintain the intended game logic.