### PR TITLE
feat: add import button for autocrafter recipes in crafting screen

### DIFF
--- a/src/client/java/com/logistics/pipe/screen/CraftingScreen.java
+++ b/src/client/java/com/logistics/pipe/screen/CraftingScreen.java
@@ -36,16 +36,18 @@ public class CraftingScreen extends AbstractContainerScreen<CraftingScreenHandle
     protected void init() {
         super.init();
 
-        // Import recipe from adjacent autocrafter
-        addRenderableWidget(Button.builder(
-                Component.translatable("gui.logistics.crafting.import"),
-                button -> {
-                    if (minecraft != null && minecraft.gameMode != null) {
-                        minecraft.gameMode.handleInventoryButtonClick(menu.containerId, 1);
-                    }
-                })
-                .bounds(leftPos + 100, topPos + 15, 68, 14)
-                .build());
+        // Import recipe from adjacent autocrafter (only when backed by a pipe entity)
+        if (menu.supportsAutocrafterImport()) {
+            addRenderableWidget(Button.builder(
+                    Component.translatable("gui.logistics.crafting.import"),
+                    button -> {
+                        if (minecraft != null && minecraft.gameMode != null) {
+                            minecraft.gameMode.handleInventoryButtonClick(menu.containerId, 1);
+                        }
+                    })
+                    .bounds(leftPos + 100, topPos + 15, 68, 14)
+                    .build());
+        }
 
         // Blocking mode toggle button
         this.blockingButton = Button.builder(

--- a/src/client/java/com/logistics/pipe/screen/CraftingScreen.java
+++ b/src/client/java/com/logistics/pipe/screen/CraftingScreen.java
@@ -36,6 +36,17 @@ public class CraftingScreen extends AbstractContainerScreen<CraftingScreenHandle
     protected void init() {
         super.init();
 
+        // Import recipe from adjacent autocrafter
+        addRenderableWidget(Button.builder(
+                Component.translatable("gui.logistics.crafting.import"),
+                button -> {
+                    if (minecraft != null && minecraft.gameMode != null) {
+                        minecraft.gameMode.handleInventoryButtonClick(menu.containerId, 1);
+                    }
+                })
+                .bounds(leftPos + 100, topPos + 15, 68, 14)
+                .build());
+
         // Blocking mode toggle button
         this.blockingButton = Button.builder(
                 getBlockingText(),

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -242,32 +242,40 @@ public class CraftingModule implements Module {
         BlockPos autocrafterPos = ctx.pos().relative(dir);
         if (!(serverLevel.getBlockEntity(autocrafterPos) instanceof CrafterBlockEntity crafter)) return;
 
-        // Import ingredients from crafter input slots
+        // Collect all ingredient data locally before touching NBT
+        CompoundTag items = new CompoundTag();
+        CompoundTag counts = new CompoundTag();
         for (int slot = 0; slot < 9; slot++) {
             ItemStack stack = crafter.getItem(slot);
-            if (stack.isEmpty()) {
-                setIngredient(ctx, slot, "", 1);
-            } else {
+            if (!stack.isEmpty()) {
                 String itemId = BuiltInRegistries.ITEM.getKey(stack.getItem()).toString();
-                setIngredient(ctx, slot, itemId, stack.getCount());
+                items.putString(String.valueOf(slot), itemId);
+                counts.putInt(String.valueOf(slot), Math.max(1, stack.getCount()));
             }
         }
+        ctx.putCompoundTag(this, RECIPE_ITEMS, items);
+        ctx.putCompoundTag(this, RECIPE_COUNTS, counts);
 
-        // Compute recipe result and import it
+        // Compute and store recipe result
         CraftingInput craftInput = crafter.asCraftInput();
         Optional<RecipeHolder<CraftingRecipe>> recipeOpt = CrafterBlock.getPotentialResults(serverLevel, craftInput);
+        CompoundTag state = ctx.moduleState(getStateKey());
         if (recipeOpt.isPresent()) {
             CraftingRecipe recipe = recipeOpt.get().value();
             ItemStack result = recipe.assemble(craftInput, serverLevel.registryAccess());
             if (!result.isEmpty()) {
-                String resultId = BuiltInRegistries.ITEM.getKey(result.getItem()).toString();
-                setResult(ctx, resultId, result.getCount());
+                state.putString(RESULT_ITEM, BuiltInRegistries.ITEM.getKey(result.getItem()).toString());
+                state.putInt(RESULT_COUNT, Math.max(1, result.getCount()));
             } else {
-                setResult(ctx, "", 1);
+                state.remove(RESULT_ITEM);
+                state.remove(RESULT_COUNT);
             }
         } else {
-            setResult(ctx, "", 1);
+            state.remove(RESULT_ITEM);
+            state.remove(RESULT_COUNT);
         }
+
+        ctx.markDirtyAndSync();
     }
 
     // ==================== Module Interface ====================

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -231,6 +231,45 @@ public class CraftingModule implements Module {
         return null;
     }
 
+    /**
+     * Reads the adjacent autocrafter's current slot contents and recipe result, and writes them
+     * into this module's ghost recipe config. Clears any slots in the crafter that are empty.
+     */
+    public void importFromAutocrafter(PipeContext ctx) {
+        if (!(ctx.world() instanceof ServerLevel serverLevel)) return;
+        Direction dir = findAutocrafterDirection(ctx);
+        if (dir == null) return;
+        BlockPos autocrafterPos = ctx.pos().relative(dir);
+        if (!(serverLevel.getBlockEntity(autocrafterPos) instanceof CrafterBlockEntity crafter)) return;
+
+        // Import ingredients from crafter input slots
+        for (int slot = 0; slot < 9; slot++) {
+            ItemStack stack = crafter.getItem(slot);
+            if (stack.isEmpty()) {
+                setIngredient(ctx, slot, "", 1);
+            } else {
+                String itemId = BuiltInRegistries.ITEM.getKey(stack.getItem()).toString();
+                setIngredient(ctx, slot, itemId, stack.getCount());
+            }
+        }
+
+        // Compute recipe result and import it
+        CraftingInput craftInput = crafter.asCraftInput();
+        Optional<RecipeHolder<CraftingRecipe>> recipeOpt = CrafterBlock.getPotentialResults(serverLevel, craftInput);
+        if (recipeOpt.isPresent()) {
+            CraftingRecipe recipe = recipeOpt.get().value();
+            ItemStack result = recipe.assemble(craftInput, serverLevel.registryAccess());
+            if (!result.isEmpty()) {
+                String resultId = BuiltInRegistries.ITEM.getKey(result.getItem()).toString();
+                setResult(ctx, resultId, result.getCount());
+            } else {
+                setResult(ctx, "", 1);
+            }
+        } else {
+            setResult(ctx, "", 1);
+        }
+    }
+
     // ==================== Module Interface ====================
 
     @Override

--- a/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
@@ -87,6 +87,7 @@ public class CraftingRecipeInventory implements Container {
             stacks.set(i, ItemStack.EMPTY);
         }
 
+        if (pipeEntity == null) return;
         if (pipeEntity.getLevel() == null || pipeEntity.getLevel().isClientSide()) return;
 
         PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();

--- a/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
@@ -82,7 +82,7 @@ public class CraftingRecipeInventory implements Container {
         }
     }
 
-    private void loadFromModule() {
+    void loadFromModule() {
         for (int i = 0; i < SLOT_COUNT; i++) {
             stacks.set(i, ItemStack.EMPTY);
         }

--- a/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -299,6 +299,11 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         return data.get(DATA_BLOCKING) == 1;
     }
 
+    /** Returns true when this screen is backed by a pipe entity with an adjacent autocrafter. */
+    public boolean supportsAutocrafterImport() {
+        return itemConfigPlayer == null;
+    }
+
     private static class GhostSlot extends Slot {
         GhostSlot(Container inventory, int index, int x, int y) {
             super(inventory, index, x, y);

--- a/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -258,6 +258,13 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             }
             return true;
         }
+        if (id == 1 && itemConfigPlayer == null) {
+            // Import recipe from adjacent autocrafter
+            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.importFromAutocrafter(ctx));
+            recipeInventory.loadFromModule();
+            broadcastChanges();
+            return true;
+        }
         return false;
     }
 

--- a/src/main/resources/assets/logistics/lang/en_us.json
+++ b/src/main/resources/assets/logistics/lang/en_us.json
@@ -130,6 +130,7 @@
   "gui.logistics.requester.search": "Search...",
   "gui.logistics.requester.amount": "Amount:",
   "gui.logistics.requester.request": "Request",
+  "gui.logistics.crafting.import": "Import",
   "gui.logistics.crafting.blocking.on": "Blocking: ON",
   "gui.logistics.crafting.blocking.off": "Blocking: OFF",
   "gui.logistics.crafting.state.idle": "Idle",


### PR DESCRIPTION
## Summary
This update introduces a new import feature on the crafting screen, allowing users to easily import recipes and ingredients from adjacent autocrafters. This functionality enhances user experience by streamlining the crafting process, minimizing the need for manual entry.

## Changes
- **Crafting Screen Update**: 
  - Added an "Import" button to the crafting screen for importing recipes from adjacent autocrafters.
  
- **New Functionality in Crafting Module**:
  - Implemented logic to read slot contents and recipe results from an adjacent autocrafter, populating the local crafting module with these details.
  
- **Recipe Inventory Integration**:
  - Updated the recipe inventory system to load data from the crafting module after an import operation.

- **Localization**:
  - Added translation support for the new "Import" button in the console interface through the `en_us.json` language file.

## Notes
- Ensure any existing gameplay strategies involving crafting modules are updated according to the use of the new import feature.