### PR TITLE
fix: resolve crafting order placement logic for missing items

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Requester module - creates requests for items from the network.
@@ -286,8 +287,23 @@ public class RequesterModule implements Module {
             return;
         }
 
-        network.placeOrder(variant, amount, ctx.pos(),
-                com.logistics.pipe.network.FulfillmentMode.FULL);
+        // For craftable items, validate upfront that real stock + crafter output can cover
+        // the full requested amount. getMissingIngredients accounts for existing stock and
+        // asks the crafter only for the remainder, so this mirrors the dispatch logic exactly.
+        if (available == Long.MAX_VALUE) {
+            List<ItemVariant> missing = network.getMissingIngredients(variant, amount);
+            if (!missing.isEmpty()) {
+                String missingNames = missing.stream()
+                        .map(v -> v.toStack().getHoverName().getString())
+                        .collect(Collectors.joining(", "));
+                sendAlert(ctx, Component.literal(
+                        "[Logistics] Cannot fill order for " + itemName
+                                + " \u2014 missing ingredients: " + missingNames));
+                return;
+            }
+        }
+
+        network.placeOrder(variant, amount, ctx.pos());
     }
 
     private void sendAlert(PipeContext ctx, Component msg) {

--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.pipe.network.FulfillmentMode;
 import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.storage.DirectionSerializer;
@@ -303,7 +304,7 @@ public class RequesterModule implements Module {
             }
         }
 
-        network.placeOrder(variant, amount, ctx.pos());
+        network.placeOrder(variant, amount, ctx.pos(), FulfillmentMode.FULL);
     }
 
     private void sendAlert(PipeContext ctx, Component msg) {

--- a/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -276,11 +276,13 @@ public class NetworkController implements PlanningView {
         // (the crafter will be needed to fill the remainder on a subsequent tick)
         boolean crafterExists = entries.stream().anyMatch(e -> e.available == 0);
 
-        // FULL mode: never dispatch a partial fill unless a crafter can supply the remainder.
-        // When a crafter is registered, the full-order guarantee was already validated at
-        // order-placement time (requestItem calls getMissingIngredients before placing), so
-        // we allow the partial real-stock dispatch here and let the crafter handle the rest.
-        if (order.fulfillmentMode() == FulfillmentMode.FULL && !crafterExists) return null;
+        // FULL mode: block partial dispatch only when total available supply is insufficient.
+        // getAvailableAmount sums real stock across all providers (returns Long.MAX_VALUE when
+        // a crafter covers the item), so combined providers or a crafter can together satisfy
+        // the order. !crafterExists alone was too narrow: it would stall when stock is split
+        // across multiple providers even though their combined total is sufficient.
+        if (order.fulfillmentMode() == FulfillmentMode.FULL
+                && getAvailableAmount(order.item()) < order.amount()) return null;
         if (crafterExists) {
             List<ItemVariant> missing = getMissingIngredients(order.item(), order.amount());
             if (!missing.isEmpty()) {

--- a/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -272,12 +272,15 @@ public class NetworkController implements PlanningView {
                     order.id(), supply.pos, order.requester(), order.item(), order.amount());
         }
 
-        // FULL mode: never dispatch a partial fill; wait until supply is sufficient
-        if (order.fulfillmentMode() == FulfillmentMode.FULL) return null;
-
         // Partial fill from real stock — pre-check only when a crafter also covers this item
         // (the crafter will be needed to fill the remainder on a subsequent tick)
         boolean crafterExists = entries.stream().anyMatch(e -> e.available == 0);
+
+        // FULL mode: never dispatch a partial fill unless a crafter can supply the remainder.
+        // When a crafter is registered, the full-order guarantee was already validated at
+        // order-placement time (requestItem calls getMissingIngredients before placing), so
+        // we allow the partial real-stock dispatch here and let the crafter handle the rest.
+        if (order.fulfillmentMode() == FulfillmentMode.FULL && !crafterExists) return null;
         if (crafterExists) {
             List<ItemVariant> missing = getMissingIngredients(order.item(), order.amount());
             if (!missing.isEmpty()) {


### PR DESCRIPTION
## Summary
This update addresses a critical issue where crafting requests could stall due to unverified ingredient availability. By refining the crafting order placement logic, the system now accurately checks for missing ingredients before proceeding with the request, ensuring smoother crafting operations.

## Changes
- **Crafting Order Logic Improvement**: 
  - Enhanced the `RequesterModule` logic to validate that both available stock and crafter output can fulfill the requested amount. This avoids stalled crafting requests.
  - Implemented upfront checks for missing ingredients, providing immediate feedback to users about any unfulfilled requests.

## Notes
- Users may notice improved responsiveness in crafting systems as missing ingredient alerts are provided right at the point of order placement. This enhancement helps streamline crafting workflows and reduce confusion during item requests.