### PR TITLE
refactor: remove default route sink registration and methods

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/SinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SinkModule.java
@@ -74,7 +74,6 @@ public class SinkModule implements Module, TickingModule, RoutingModule, ItemAcc
                         network.registerSinkInterest(ctx.pos(), holder.value()));
             }
             if (isDefaultRoute(ctx)) {
-                network.registerDefaultRouteSink(ctx.pos());
                 network.registerGenericSinkInterest(ctx.pos());
             }
         }
@@ -85,7 +84,6 @@ public class SinkModule implements Module, TickingModule, RoutingModule, ItemAcc
         ILogisticsNetwork network = NetworkRegistry.getNetwork(ctx.world(), ctx.pos());
         if (network != null) {
             network.unregisterSink(ctx.pos()); // also clears both interest maps
-            network.unregisterDefaultRouteSink(ctx.pos());
         }
     }
 
@@ -252,11 +250,11 @@ public class SinkModule implements Module, TickingModule, RoutingModule, ItemAcc
             ILogisticsNetwork network = NetworkRegistry.getNetwork(ctx.world(), ctx.pos());
             if (network != null) {
                 if (enabled) {
-                    network.registerDefaultRouteSink(ctx.pos());
+                    network.registerSink(ctx.pos(), 0);
                     network.registerGenericSinkInterest(ctx.pos());
                     NetDbg.out("[Sink @ {}] Default route enabled and registered with network", ctx.pos());
                 } else {
-                    network.unregisterDefaultRouteSink(ctx.pos());
+                    network.unregisterSink(ctx.pos());
                     network.unregisterGenericSinkInterest(ctx.pos());
                     NetDbg.out("[Sink @ {}] Default route disabled and unregistered from network", ctx.pos());
                 }

--- a/src/main/java/com/logistics/pipe/network/ILogisticsNetwork.java
+++ b/src/main/java/com/logistics/pipe/network/ILogisticsNetwork.java
@@ -178,22 +178,6 @@ public interface ILogisticsNetwork {
     void unregisterSink(BlockPos pos);
 
     /**
-     * Register a position as a default-route (catch-all) sink at priority 0.
-     * Convenience for {@code registerSink(sink, 0)}.
-     */
-    default void registerDefaultRouteSink(BlockPos sink) {
-        registerSink(sink, 0);
-    }
-
-    /**
-     * Unregister a default-route sink.
-     * Convenience for {@code unregisterSink(sink)}.
-     */
-    default void unregisterDefaultRouteSink(BlockPos sink) {
-        unregisterSink(sink);
-    }
-
-    /**
      * Declare that the sink at {@code pos} wants to receive items of this specific type.
      * Called by filtered sinks (SinkModule filter slots, PassiveSupplierModule config items).
      * These are indexed so only interested sinks are considered during lookup.


### PR DESCRIPTION
## Summary
This update focuses on simplifying the routing system by removing the default route sink registration from the SinkModule and ILogisticsNetwork. This change enhances clarity in sink management while maintaining the core functionality of item routing.

## Changes
- **Removed Default Route Sink Registration:**
  - Eliminated the `registerDefaultRouteSink` and `unregisterDefaultRouteSink` methods from the `ILogisticsNetwork` interface.
  - Eliminated related calls to default route registration in `SinkModule`, replacing it with standard sink registration that incorporates explicit priorities.

## Notes
- This change streamlines the sink registration process, making it clearer and more intentional. Users interacting with the sink modules will need to be aware that the default route behavior is now handled through regular sink registrations.