### PR TITLE
refactor: relocate DirectionSerializer and NetworkTickHandler

### DIFF
--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -19,7 +19,6 @@ import com.logistics.core.fluids.MoltenGlassFluid;
 import com.logistics.core.loot.ChestLootModifier;
 import com.logistics.core.marker.MarkerBlock;
 import com.logistics.core.marker.MarkerBlockEntity;
-import com.logistics.core.network.NetworkTickHandler;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
@@ -87,7 +86,6 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         addVanillaCreativeTabEntries();
         registerWorldgen();
         ChestLootModifier.register();
-        NetworkTickHandler.register();
         LogisticsCommands.register();
     }
 

--- a/src/main/java/com/logistics/LogisticsPipe.java
+++ b/src/main/java/com/logistics/LogisticsPipe.java
@@ -6,6 +6,7 @@ import com.logistics.core.bootstrap.DomainBootstrap;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.pipe.modules.*;
 import com.logistics.pipe.network.NetDbg;
+import com.logistics.pipe.network.NetworkTickHandler;
 import com.logistics.pipe.Pipe;
 import com.logistics.pipe.PipeApi;
 import com.logistics.pipe.PipeTypes;
@@ -67,6 +68,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
         SCREEN.register();
         registerMarkingFluidItems();
         registerNetworkPackets();
+        NetworkTickHandler.register();
 
         registerLegacyAliases();
         addCreativeTabEntries();

--- a/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
+++ b/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
@@ -2,7 +2,6 @@ package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.core.lib.storage.FilterSlots;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;

--- a/src/main/java/com/logistics/pipe/modules/BasicExtractorModule.java
+++ b/src/main/java/com/logistics/pipe/modules/BasicExtractorModule.java
@@ -2,7 +2,6 @@ package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.runtime.TravelingItem;

--- a/src/main/java/com/logistics/pipe/modules/DirectionSerializer.java
+++ b/src/main/java/com/logistics/pipe/modules/DirectionSerializer.java
@@ -1,10 +1,11 @@
-package com.logistics.core.lib.storage;
+package com.logistics.pipe.modules;
 
-import com.logistics.pipe.PipeContext;
-import com.logistics.pipe.modules.Module;
+import com.logistics.core.lib.storage.NbtCompat;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.Nullable;
+
+import com.logistics.pipe.PipeContext;
 
 /**
  * Utility for serializing/deserializing Direction values in module storage.

--- a/src/main/java/com/logistics/pipe/modules/EnchantmentSinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/EnchantmentSinkModule.java
@@ -2,7 +2,6 @@ package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.pipe.network.NetworkRegistry;

--- a/src/main/java/com/logistics/pipe/modules/ModSinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ModSinkModule.java
@@ -2,7 +2,6 @@ package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.network.ILogisticsNetwork;

--- a/src/main/java/com/logistics/pipe/modules/PolymorphicSinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/PolymorphicSinkModule.java
@@ -2,7 +2,6 @@ package com.logistics.pipe.modules;
 
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.pipe.network.NetDbg;

--- a/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -4,7 +4,6 @@ import com.logistics.LogisticsPipe;
 import com.logistics.pipe.network.FulfillmentMode;
 import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;

--- a/src/main/java/com/logistics/pipe/modules/SinkModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SinkModule.java
@@ -4,7 +4,6 @@ import com.logistics.LogisticsPipe;
 import com.logistics.pipe.network.NetDbg;
 import com.logistics.pipe.network.ILogisticsNetwork;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.DirectionSerializer;
 import com.logistics.core.lib.storage.FilterSlots;
 import com.logistics.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;

--- a/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -381,11 +381,11 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
 
     @Nullable
     protected Direction getSupplierDirection(PipeContext ctx) {
-        return com.logistics.core.lib.storage.DirectionSerializer.load(ctx, this, SUPPLIER_DIRECTION);
+        return DirectionSerializer.load(ctx, this, SUPPLIER_DIRECTION);
     }
 
     private void setSupplierDirection(PipeContext ctx, @Nullable Direction direction) {
-        com.logistics.core.lib.storage.DirectionSerializer.save(ctx, this, SUPPLIER_DIRECTION, direction);
+        DirectionSerializer.save(ctx, this, SUPPLIER_DIRECTION, direction);
     }
 
     private boolean isSupplierFace(PipeContext ctx, Direction direction) {

--- a/src/main/java/com/logistics/pipe/network/NetworkTickHandler.java
+++ b/src/main/java/com/logistics/pipe/network/NetworkTickHandler.java
@@ -1,6 +1,5 @@
-package com.logistics.core.network;
+package com.logistics.pipe.network;
 
-import com.logistics.pipe.network.NetworkRegistry;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 


### PR DESCRIPTION
# Summary
This update enhances the network handling mechanism by reorganizing the structure of core components, specifically the `DirectionSerializer` and `NetworkTickHandler`. This change aims to improve future maintainability and understanding of the codebase as well as reduce potential system overhead in pipe network operations.

# Changes
- **Refactored Network Components:**
  - Relocated `DirectionSerializer` from the storage library to the pipe modules for better relevance and access.
  - Moved `NetworkTickHandler` to the pipe network package, streamlining network-related functionalities.

- **Minor Adjustments in Pipe Modules:**
  - Removed unnecessary imports of `DirectionSerializer` in various extractor and sink modules, ensuring cleaner code.
  - Updated instances of `DirectionSerializer` calls in the `SupplierModule` to reference the new location.

- **Code Cleanup:**
  - Removed unused references and imports in multiple files to improve overall readability and maintainability.

# Notes
No breaking changes or compatibility issues are associated with this update. Existing functionality remains intact while code organization is improved for future development work.