### PR TITLE
fix: register menu type for kiln screen handler

### DIFF
--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -73,6 +73,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         ITEM.register();
         ENTITY.register();
         FLUID.register();
+        MENU.register();
         CREATIVE_TAB.register();
         RECIPE.register();
 
@@ -207,10 +208,13 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
     }
 
     public static final class MENU {
-        public static final MenuType<KilnScreenHandler> KILN =
-            INSTANCE.registerMenuType("kiln", KilnScreenHandler::new);
+        public static MenuType<KilnScreenHandler> KILN;
 
         private MENU() {}
+
+        static void register() {
+            KILN = INSTANCE.registerMenuType("kiln", KilnScreenHandler::new);
+        }
     }
 
     public static final class RECIPE {


### PR DESCRIPTION
## Summary
This update introduces important infrastructure enhancements to the logistics mod, particularly focusing on the kiln functionality, which improves user experience and addresses crashes related to the kiln screen handler.

## Changes
- **Menu Type Registration**: 
  - A new menu type for the kiln screen handler has been registered. This addition enhances the user interface for interacting with kiln-related processes.
  
- **Code Base Enhancements**:
  - Adjustments made to streamline the registration process for interactive menu types, ensuring scalability for future features.

## Notes
- Users experiencing crashes related to the kiln screen can expect improved stability and functionality as a result of these updates. Make sure to update to the latest version for a smoother gameplay experience.
- Fixes #197 