### PR TITLE
fix: crash caused by jar remapping collision in IPipeAccess

### DIFF
--- a/src/main/java/com/logistics/core/lib/pipe/IPipeAccess.java
+++ b/src/main/java/com/logistics/core/lib/pipe/IPipeAccess.java
@@ -28,7 +28,7 @@ public interface IPipeAccess {
     @Nullable EnergyComponent getEnergy();
 
     /** Mark the block entity as changed so it is saved on the next world save. */
-    void setChanged();
+    void markDirty();
 
     /**
      * Return the cached connection type for the given direction.

--- a/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
+++ b/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
@@ -77,7 +77,7 @@ public record PipeContext(Level world, BlockPos pos, BlockState state, IPipeAcce
     }
 
     public void markDirty() {
-        blockEntity.setChanged();
+        blockEntity.markDirty();
     }
 
     public void markDirtyAndSync() {

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -378,6 +378,11 @@ public class PipeBlockEntity extends BaseBlockEntity
     // ==================== IPipeAccess ====================
 
     @Override
+    public void markDirty() {
+        setChanged();
+    }
+
+    @Override
     public CompoundTag moduleState(String key) {
         return getOrCreateModuleState(key);
     }


### PR DESCRIPTION
## Summary

Fixes a crash on world load caused by a Fabric jar remapping collision between a mod-defined interface method and a Minecraft `BlockEntity` method of the same name.

## Root Cause

`IPipeAccess` declared `void setChanged()` — the same name as Minecraft's `BlockEntity.setChanged()`. During `remapJar`, Minecraft's `setChanged()` is renamed to its intermediary mapping (e.g. `m_6598`). The mod-defined interface method keeps its original name. At runtime in a production JAR, `PipeBlockEntity` only inherits the remapped `m_6598` — nothing satisfies `IPipeAccess.setChanged()`, causing:

```
java.lang.AbstractMethodError: Receiver class PipeBlockEntity does not define or inherit
an implementation of the resolved method 'abstract void setChanged()' of interface IPipeAccess.
```

This does **not** reproduce in dev because the dev launcher re-applies mappings at runtime (`m_6598 → setChanged()`), satisfying the interface. Production JARs skip this step.

## Changes

- Renamed `setChanged()` → `markDirty()` in `IPipeAccess` (no collision with Minecraft's method hierarchy in 1.21.x)
- Updated `PipeContext.markDirty()` to call `blockEntity.markDirty()`
- Added explicit `@Override public void markDirty() { setChanged(); }` in `PipeBlockEntity` — the explicit declaration stays named `markDirty()` after remapping, satisfying the interface contract at runtime while correctly delegating to Minecraft's remapped method

Applied to both `mc/1.21.11` and `mc/26.1`.