### PR TITLE
feat: add JEI support for macerator recipes integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ base {
 
 repositories {
 	maven { url = "https://maven.terraformersmc.com/releases/" }
+	maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
 }
 
 spotless {
@@ -66,6 +67,10 @@ dependencies {
 
 	// Team Reborn Energy API (Fabric standard energy system)
 	modApi include("teamreborn:energy:${project.energy_version}")
+
+	// JEI - compile against API only; players install JEI separately at runtime
+	modCompileOnly("mezz.jei:jei-${minecraft_version}-fabric-api:${jei_version}")
+	modRuntimeOnly("mezz.jei:jei-${minecraft_version}-fabric:${jei_version}")
 
 	// Test infrastructure
 	testImplementation "org.junit.jupiter:junit-jupiter:${project.junit_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ archives_base_name=logistics
 # Dependencies
 fabric_version=0.141.3+1.21.11
 energy_version=4.2.0
+jei_version=27.4.0.21
 
 # Test Dependencies
 junit_version=5.11.0

--- a/src/client/java/com/logistics/automation/macerator/jei/MaceratorJeiPlugin.java
+++ b/src/client/java/com/logistics/automation/macerator/jei/MaceratorJeiPlugin.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 /**
  * JEI plugin that registers the Macerator recipe category and all macerator recipes.
- * Discovered by JEI via the "jei_plugins" Fabric entrypoint in fabric.mod.json.
+ * Discovered by JEI via the "jei_mod_plugin" Fabric entrypoint in fabric.mod.json.
  */
 @JeiPlugin
 public class MaceratorJeiPlugin implements IModPlugin {

--- a/src/client/java/com/logistics/automation/macerator/jei/MaceratorJeiPlugin.java
+++ b/src/client/java/com/logistics/automation/macerator/jei/MaceratorJeiPlugin.java
@@ -1,0 +1,52 @@
+package com.logistics.automation.macerator.jei;
+
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsMod;
+import com.logistics.automation.macerator.MaceratorRecipeManager;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+import net.minecraft.resources.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * JEI plugin that registers the Macerator recipe category and all macerator recipes.
+ * Discovered by JEI via the "jei_plugins" Fabric entrypoint in fabric.mod.json.
+ */
+@JeiPlugin
+public class MaceratorJeiPlugin implements IModPlugin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("Logistics/JEI");
+    private static final Identifier PLUGIN_ID =
+        LogisticsMod.modId("jei_plugin").toIdentifier();
+
+    @Override
+    public Identifier getPluginUid() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public void registerCategories(IRecipeCategoryRegistration registration) {
+        LOGGER.info("Registering macerator recipe category");
+        registration.addRecipeCategories(
+            new MaceratorRecipeCategory(registration.getJeiHelpers().getGuiHelper()));
+    }
+
+    @Override
+    public void registerRecipes(IRecipeRegistration registration) {
+        var recipes = List.copyOf(MaceratorRecipeManager.getAllRecipes().values());
+        LOGGER.info("Registering {} macerator recipes with JEI", recipes.size());
+        registration.addRecipes(MaceratorRecipeCategory.RECIPE_TYPE, recipes);
+    }
+
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+        registration.addCraftingStation(
+            MaceratorRecipeCategory.RECIPE_TYPE, LogisticsAutomation.BLOCK.MACERATOR);
+    }
+}

--- a/src/client/java/com/logistics/automation/macerator/jei/MaceratorRecipeCategory.java
+++ b/src/client/java/com/logistics/automation/macerator/jei/MaceratorRecipeCategory.java
@@ -1,0 +1,87 @@
+package com.logistics.automation.macerator.jei;
+
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsMod;
+import com.logistics.automation.macerator.MaceratorRecipe;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.types.IRecipeType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * JEI recipe category for the Macerator.
+ * Displays a single input ingredient grinding into an output item.
+ */
+public class MaceratorRecipeCategory implements IRecipeCategory<MaceratorRecipe> {
+
+    public static final IRecipeType<MaceratorRecipe> RECIPE_TYPE =
+        IRecipeType.create(LogisticsMod.MOD_ID, "macerator", MaceratorRecipe.class);
+
+    // Matches MaceratorScreen.TEXTURE
+    private static final Identifier TEXTURE =
+        LogisticsMod.modId("textures/gui/automation/macerator.png").toIdentifier();
+
+    // GUI slot positions: input at (56,35), output at (116,35).
+    // Background region origin: UV (48,27). Relative positions:
+    //   input: (8,8), output: (68,8). Arrow source: UV (180,36) size 25x14 at offset (32,9).
+    private static final int INPUT_X = 8, INPUT_Y = 8;
+    private static final int OUTPUT_X = 68, OUTPUT_Y = 8;
+    private static final int ARROW_X = 32, ARROW_Y = 9;
+
+    private static final int WIDTH = 86;
+    private static final int HEIGHT = 26;
+
+    private final IDrawable icon;
+    private final IDrawable arrow;
+
+    public MaceratorRecipeCategory(IGuiHelper guiHelper) {
+        this.icon = guiHelper.createDrawableItemStack(
+            new ItemStack(LogisticsAutomation.BLOCK.MACERATOR));
+        this.arrow = guiHelper.createDrawable(TEXTURE, 180, 36, 25, 14);
+    }
+
+    @Override
+    public IRecipeType<MaceratorRecipe> getRecipeType() {
+        return RECIPE_TYPE;
+    }
+
+    @Override
+    public Component getTitle() {
+        return Component.translatable("block.logistics.automation.macerator");
+    }
+
+    @Override
+    public int getWidth() {
+        return WIDTH;
+    }
+
+    @Override
+    public int getHeight() {
+        return HEIGHT;
+    }
+
+    @Override
+    public IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void createRecipeExtras(IRecipeExtrasBuilder builder, MaceratorRecipe recipe, IFocusGroup focuses) {
+        builder.addDrawable(arrow, ARROW_X, ARROW_Y);
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, MaceratorRecipe recipe, IFocusGroup focuses) {
+        builder.addSlot(RecipeIngredientRole.INPUT, INPUT_X, INPUT_Y)
+            .add(recipe.getIngredient());
+        builder.addSlot(RecipeIngredientRole.OUTPUT, OUTPUT_X, OUTPUT_Y)
+            .add(recipe.getResultItem());
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,7 +16,8 @@
   "description": "A modern logistics and pipe mod with authentic in-pipe item motion, mod interoperability, and request/autocrafting systems.",
   "entrypoints": {
     "client": ["com.logistics.LogisticsModClient"],
-    "main": ["com.logistics.LogisticsMod"]
+    "main": ["com.logistics.LogisticsMod"],
+    "jei_mod_plugin": ["com.logistics.automation.macerator.jei.MaceratorJeiPlugin"]
   },
   "environment": "*",
   "icon": "assets/logistics/icon.png",
@@ -24,6 +25,8 @@
   "license": "MIT",
   "mixins": ["logistics.mixins.json"],
   "name": "Logistics",
-  "suggests": {},
+  "suggests": {
+    "jei": "*"
+  },
   "version": "${version}"
 }


### PR DESCRIPTION
## Summary
This update introduces support for macerator recipes in Just Enough Items (JEI), enhancing user experience by providing an interface to view and utilize macerator recipes within the logistics mod. This functionality allows players to easily access crafting information directly in JEI, improving usability and workflow efficiency.

## Changes
- **JEI Integration for Macerator Recipes**
  - Added a JEI plugin for the macerator, enabling the registration of macerator recipe categories and their respective recipes. 
  - Implemented a `MaceratorRecipeCategory` class that manages the display of macerator recipes.
  - Integrated logging to track recipe registration events for debugging and user feedback.

- **Gradle Configuration Updates**
  - Updated `build.gradle` to include JEI as a compile-only dependency, ensuring that players must install JEI at runtime for the macerator recipes to work.

- **Resource and Configuration Modifications**
  - Adjusted `fabric.mod.json` to register the JEI plugin entry point and declare it as a suggestion for enhanced mod interoperability.

## Notes
- Users need to ensure they have the latest version of JEI installed to fully access macerator recipe support.
- This update expands crafting capabilities and simplifies recipe discovery, promoting a more integrated modding experience.