### PR TITLE
feat: add grinding time to macerator recipes

### DIFF
--- a/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
+++ b/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
@@ -59,7 +59,6 @@ public class MaceratorBlockEntity extends BaseBlockEntity
     // Processing constants — tuned so 1 coal in a Stirling Engine (10 RF/t at full temp, 1600 ticks)
     // produces exactly 16,000 RF, enough to macerate 8 items (8 × 2,000 RF each).
     static final int ENERGY_PER_TICK = 10;
-    static final int PROCESS_TIME_TICKS = 200;
 
     private final ItemInventoryComponent inventory = new ItemInventoryComponent(TOTAL_SLOTS, this::setChanged);
     final EnergyComponent energy = new EnergyComponent(ENERGY_CAPACITY, MAX_ENERGY_INPUT, 0, this::setChanged);
@@ -78,7 +77,7 @@ public class MaceratorBlockEntity extends BaseBlockEntity
         public int get(int index) {
             return switch (index) {
                 case DATA_PROGRESS -> processProgress;
-                case DATA_TOTAL_TICKS -> activeRecipeId != null ? PROCESS_TIME_TICKS : 0;
+                case DATA_TOTAL_TICKS -> activeRecipeId != null ? MaceratorRecipeManager.getRecipe(activeRecipeId).getGrindingTime() : 0;
                 case DATA_ENERGY -> (int) Math.min(energy.amount, Integer.MAX_VALUE);
                 default -> 0;
             };
@@ -146,7 +145,7 @@ public class MaceratorBlockEntity extends BaseBlockEntity
         setLit(level, state, true);
         processProgress++;
 
-        if (processProgress >= PROCESS_TIME_TICKS) {
+        if (processProgress >= recipe.getGrindingTime()) {
             completeProcessing(recipe);
         }
 

--- a/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
+++ b/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
@@ -77,7 +77,11 @@ public class MaceratorBlockEntity extends BaseBlockEntity
         public int get(int index) {
             return switch (index) {
                 case DATA_PROGRESS -> processProgress;
-                case DATA_TOTAL_TICKS -> activeRecipeId != null ? MaceratorRecipeManager.getRecipe(activeRecipeId).getGrindingTime() : 0;
+                case DATA_TOTAL_TICKS -> {
+                    if (activeRecipeId == null) yield 0;
+                    MaceratorRecipe r = MaceratorRecipeManager.getRecipe(activeRecipeId);
+                    yield r != null ? r.getGrindingTime() : 0;
+                }
                 case DATA_ENERGY -> (int) Math.min(energy.amount, Integer.MAX_VALUE);
                 default -> 0;
             };

--- a/src/main/java/com/logistics/automation/macerator/MaceratorRecipe.java
+++ b/src/main/java/com/logistics/automation/macerator/MaceratorRecipe.java
@@ -32,6 +32,7 @@ public class MaceratorRecipe {
         if (ingredient == null) throw new IllegalArgumentException("ingredient must not be null");
         if (resultItemId == null) throw new IllegalArgumentException("resultItemId must not be null");
         if (resultCount <= 0) throw new IllegalArgumentException("resultCount must be > 0");
+        if (grindingTime <= 0) throw new IllegalArgumentException("grindingTime must be > 0");
         this.id = id;
         this.ingredient = ingredient;
         this.tagIngredient = null;
@@ -50,6 +51,7 @@ public class MaceratorRecipe {
         if (tagIngredient == null) throw new IllegalArgumentException("tagIngredient must not be null");
         if (resultItemId == null) throw new IllegalArgumentException("resultItemId must not be null");
         if (resultCount <= 0) throw new IllegalArgumentException("resultCount must be > 0");
+        if (grindingTime <= 0) throw new IllegalArgumentException("grindingTime must be > 0");
         this.id = id;
         this.ingredient = null;
         this.tagIngredient = tagIngredient;

--- a/src/main/java/com/logistics/automation/macerator/MaceratorRecipe.java
+++ b/src/main/java/com/logistics/automation/macerator/MaceratorRecipe.java
@@ -11,20 +11,23 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Recipe for the Macerator.
  * Accepts a single input item and produces a result.
- * Processing time and energy cost are global constants on {@link MaceratorBlockEntity}.
  */
 public class MaceratorRecipe {
+    static final int DEFAULT_GRINDING_TIME = 200;
+
     private final ResourceId id;
     @Nullable private final Ingredient ingredient;
     @Nullable private final TagKey<Item> tagIngredient;
     private final ResourceId resultItemId;
     private final int resultCount;
+    private final int grindingTime;
 
     public MaceratorRecipe(
         ResourceId id,
         Ingredient ingredient,
         ResourceId resultItemId,
-        int resultCount
+        int resultCount,
+        int grindingTime
     ) {
         if (ingredient == null) throw new IllegalArgumentException("ingredient must not be null");
         if (resultItemId == null) throw new IllegalArgumentException("resultItemId must not be null");
@@ -34,13 +37,15 @@ public class MaceratorRecipe {
         this.tagIngredient = null;
         this.resultItemId = resultItemId;
         this.resultCount = resultCount;
+        this.grindingTime = grindingTime;
     }
 
     public MaceratorRecipe(
         ResourceId id,
         TagKey<Item> tagIngredient,
         ResourceId resultItemId,
-        int resultCount
+        int resultCount,
+        int grindingTime
     ) {
         if (tagIngredient == null) throw new IllegalArgumentException("tagIngredient must not be null");
         if (resultItemId == null) throw new IllegalArgumentException("resultItemId must not be null");
@@ -50,10 +55,15 @@ public class MaceratorRecipe {
         this.tagIngredient = tagIngredient;
         this.resultItemId = resultItemId;
         this.resultCount = resultCount;
+        this.grindingTime = grindingTime;
     }
 
     public ResourceId getId() {
         return id;
+    }
+
+    public int getGrindingTime() {
+        return grindingTime;
     }
 
     public boolean matches(ItemStack stack) {

--- a/src/main/java/com/logistics/automation/macerator/MaceratorRecipeManager.java
+++ b/src/main/java/com/logistics/automation/macerator/MaceratorRecipeManager.java
@@ -35,9 +35,8 @@ import java.util.concurrent.Executor;
  * <pre>{@code
  * {
  *   "ingredient": "minecraft:raw_iron",
- *   "result": { "id": "logistics:core/iron_dust", "count": 2 },
- *   "processTimeTicks": 100,
- *   "energyPerTick": 20
+ *   "result": { "id": "logistics:automation/iron_powder", "count": 2 },
+ *   "grindingtime": 200
  * }
  * }</pre>
  */

--- a/src/main/java/com/logistics/automation/macerator/MaceratorRecipeManager.java
+++ b/src/main/java/com/logistics/automation/macerator/MaceratorRecipeManager.java
@@ -109,6 +109,10 @@ public class MaceratorRecipeManager {
             throw new IllegalArgumentException("Missing ingredient in recipe: " + recipeId);
         }
 
+        int grindingTime = json.has("grindingtime")
+            ? json.get("grindingtime").getAsInt()
+            : MaceratorRecipe.DEFAULT_GRINDING_TIME;
+
         if (ingredientElement.isJsonObject()) {
             JsonObject ingredientObj = ingredientElement.getAsJsonObject();
             if (!ingredientObj.has("tag") || ingredientObj.get("tag").isJsonNull()) {
@@ -116,13 +120,13 @@ public class MaceratorRecipeManager {
             }
             String tagId = ingredientObj.get("tag").getAsString();
             TagKey<Item> tagKey = TagKey.create(Registries.ITEM, Identifier.parse(tagId));
-            return new MaceratorRecipe(recipeId, tagKey, resultItemId, resultCount);
+            return new MaceratorRecipe(recipeId, tagKey, resultItemId, resultCount, grindingTime);
         } else {
             String ingredientId = ingredientElement.getAsString();
             var itemHolder = BuiltInRegistries.ITEM.get(ResourceId.parse(ingredientId).toIdentifier())
                 .orElseThrow(() -> new IllegalArgumentException("Unknown ingredient item: " + ingredientId));
             Ingredient ingredient = Ingredient.of(itemHolder.value());
-            return new MaceratorRecipe(recipeId, ingredient, resultItemId, resultCount);
+            return new MaceratorRecipe(recipeId, ingredient, resultItemId, resultCount, grindingTime);
         }
     }
 

--- a/src/main/resources/data/logistics/recipe/macerator/amethyst_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/amethyst_dust.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/amethyst_dust",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/blaze_powder.json
+++ b/src/main/resources/data/logistics/recipe/macerator/blaze_powder.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:blaze_powder",
     "count": 4
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/bone_meal.json
+++ b/src/main/resources/data/logistics/recipe/macerator/bone_meal.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:bone_meal",
     "count": 6
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/bronze_powder_from_ingot.json
+++ b/src/main/resources/data/logistics/recipe/macerator/bronze_powder_from_ingot.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/bronze_powder",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/coal_dust_from_charcoal.json
+++ b/src/main/resources/data/logistics/recipe/macerator/coal_dust_from_charcoal.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/coal_dust",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/coal_dust_from_coal.json
+++ b/src/main/resources/data/logistics/recipe/macerator/coal_dust_from_coal.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/coal_dust",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/copper_powder.json
+++ b/src/main/resources/data/logistics/recipe/macerator/copper_powder.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/copper_powder",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/copper_powder_from_deepslate.json
+++ b/src/main/resources/data/logistics/recipe/macerator/copper_powder_from_deepslate.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/copper_powder",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/copper_powder_from_ingot.json
+++ b/src/main/resources/data/logistics/recipe/macerator/copper_powder_from_ingot.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/copper_powder",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/diamond_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/diamond_dust.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/diamond_dust",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/diamond_dust_from_deepslate.json
+++ b/src/main/resources/data/logistics/recipe/macerator/diamond_dust_from_deepslate.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/diamond_dust",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/diamond_dust_from_diamond.json
+++ b/src/main/resources/data/logistics/recipe/macerator/diamond_dust_from_diamond.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/diamond_dust",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_allium.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_allium.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:magenta_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_azure_bluet.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_azure_bluet.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:light_gray_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_blue_orchid.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_blue_orchid.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:light_blue_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_cornflower.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_cornflower.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:blue_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_dandelion.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_dandelion.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:yellow_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_lilac.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_lilac.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:magenta_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_lily_of_the_valley.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_lily_of_the_valley.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:white_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_orange_tulip.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_orange_tulip.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:orange_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_oxeye_daisy.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_oxeye_daisy.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:light_gray_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_peony.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_peony.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:pink_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_pink_tulip.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_pink_tulip.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:pink_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_pitcher_plant.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_pitcher_plant.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:cyan_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_poppy.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_poppy.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:red_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_red_tulip.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_red_tulip.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:red_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_rose_bush.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_rose_bush.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:red_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_sunflower.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_sunflower.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:yellow_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_torchflower.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_torchflower.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:orange_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_white_tulip.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_white_tulip.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:light_gray_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/dye_from_wither_rose.json
+++ b/src/main/resources/data/logistics/recipe/macerator/dye_from_wither_rose.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:black_dye",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/echo_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/echo_dust.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/echo_dust",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/emerald_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/emerald_dust.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/emerald_dust",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/emerald_dust_from_deepslate.json
+++ b/src/main/resources/data/logistics/recipe/macerator/emerald_dust_from_deepslate.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/emerald_dust",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/emerald_dust_from_emerald.json
+++ b/src/main/resources/data/logistics/recipe/macerator/emerald_dust_from_emerald.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/emerald_dust",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/flour.json
+++ b/src/main/resources/data/logistics/recipe/macerator/flour.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/flour",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/glowstone_powder.json
+++ b/src/main/resources/data/logistics/recipe/macerator/glowstone_powder.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:glowstone_dust",
     "count": 4
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/gold_powder.json
+++ b/src/main/resources/data/logistics/recipe/macerator/gold_powder.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/gold_powder",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/gold_powder_from_deepslate.json
+++ b/src/main/resources/data/logistics/recipe/macerator/gold_powder_from_deepslate.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/gold_powder",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/gold_powder_from_ingot.json
+++ b/src/main/resources/data/logistics/recipe/macerator/gold_powder_from_ingot.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/gold_powder",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/iron_powder.json
+++ b/src/main/resources/data/logistics/recipe/macerator/iron_powder.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/iron_powder",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/iron_powder_from_deepslate.json
+++ b/src/main/resources/data/logistics/recipe/macerator/iron_powder_from_deepslate.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/iron_powder",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/iron_powder_from_ingot.json
+++ b/src/main/resources/data/logistics/recipe/macerator/iron_powder_from_ingot.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/iron_powder",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/lapis_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/lapis_dust.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/lapis_dust",
     "count": 8
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/lapis_dust_from_deepslate.json
+++ b/src/main/resources/data/logistics/recipe/macerator/lapis_dust_from_deepslate.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/lapis_dust",
     "count": 8
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/lapis_dust_from_lapis.json
+++ b/src/main/resources/data/logistics/recipe/macerator/lapis_dust_from_lapis.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/lapis_dust",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/nether_quartz_from_block.json
+++ b/src/main/resources/data/logistics/recipe/macerator/nether_quartz_from_block.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:quartz",
     "count": 4
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/prismarine_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/prismarine_dust.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/prismarine_dust",
     "count": 4
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/prismarine_dust_from_bricks.json
+++ b/src/main/resources/data/logistics/recipe/macerator/prismarine_dust_from_bricks.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/prismarine_dust",
     "count": 9
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/prismarine_dust_from_shard.json
+++ b/src/main/resources/data/logistics/recipe/macerator/prismarine_dust_from_shard.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/prismarine_dust",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/quartz_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/quartz_dust.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/quartz_dust",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/quartz_dust_from_nether_quartz.json
+++ b/src/main/resources/data/logistics/recipe/macerator/quartz_dust_from_nether_quartz.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/quartz_dust",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/redstone_from_deepslate.json
+++ b/src/main/resources/data/logistics/recipe/macerator/redstone_from_deepslate.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:redstone",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/redstone_from_ore.json
+++ b/src/main/resources/data/logistics/recipe/macerator/redstone_from_ore.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "minecraft:redstone",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/tin_powder.json
+++ b/src/main/resources/data/logistics/recipe/macerator/tin_powder.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/tin_powder",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/tin_powder_from_ingot.json
+++ b/src/main/resources/data/logistics/recipe/macerator/tin_powder_from_ingot.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/tin_powder",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_logs.json
+++ b/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_logs.json
@@ -1,8 +1,11 @@
 {
   "type": "logistics:macerator",
-  "ingredient": {"tag": "minecraft:logs"},
+  "ingredient": {
+    "tag": "minecraft:logs"
+  },
   "result": {
     "id": "logistics:automation/wood_pulp",
     "count": 8
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_planks.json
+++ b/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_planks.json
@@ -1,8 +1,11 @@
 {
   "type": "logistics:macerator",
-  "ingredient": {"tag": "minecraft:planks"},
+  "ingredient": {
+    "tag": "minecraft:planks"
+  },
   "result": {
     "id": "logistics:automation/wood_pulp",
     "count": 2
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_stick.json
+++ b/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_stick.json
@@ -4,5 +4,6 @@
   "result": {
     "id": "logistics:automation/wood_pulp",
     "count": 1
-  }
+  },
+  "grindingtime": 200
 }

--- a/src/test/java/com/logistics/automation/macerator/MaceratorRecipeTest.java
+++ b/src/test/java/com/logistics/automation/macerator/MaceratorRecipeTest.java
@@ -18,7 +18,8 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
             ResourceId.in("test", "iron_dust"),
             Ingredient.of(Items.RAW_IRON),
             ResourceId.in("minecraft", "iron_ingot"), // using iron_ingot as a valid item for result
-            2
+            2,
+            MaceratorRecipe.DEFAULT_GRINDING_TIME
         );
     }
 

--- a/src/test/java/com/logistics/automation/macerator/MaceratorRecipeTest.java
+++ b/src/test/java/com/logistics/automation/macerator/MaceratorRecipeTest.java
@@ -66,6 +66,19 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    @DisplayName("should preserve non-default grinding time")
+    void grindingTime() {
+        MaceratorRecipe recipe = new MaceratorRecipe(
+            ResourceId.in("test", "iron_dust"),
+            Ingredient.of(Items.RAW_IRON),
+            ResourceId.in("minecraft", "iron_ingot"),
+            2,
+            5
+        );
+        assertThat(recipe.getGrindingTime()).isEqualTo(5);
+    }
+
+    @Test
     @DisplayName("should return correct recipe id")
     void recipeId() {
         MaceratorRecipe recipe = rawIronRecipe();


### PR DESCRIPTION
### Summary
This update introduces a flexible grinding time feature for macerator recipes, enhancing customization of processing efficiency and playstyle.

### Changes
- **Added Grinding Time to Recipes:**
  - Each macerator recipe now has a configurable `grindingtime` property, allowing for varying processing durations.
  - Users can define the grinding time for each item in its corresponding recipe JSON file, improving recipe customization.

- **Updated Recipe Management:**
  - The `MaceratorRecipe` and `MaceratorRecipeManager` classes have been modified to handle the new grinding time attribute.
  - The default grinding time is set to 200 ticks, ensuring backward compatibility and immediate usability for existing recipes.

- **Modified Macerator Processing Logic:**
  - The macerator's processing logic now references the `grindingTime` from the active recipe, making processing speed dynamic per item type.

- **Recipe Data Updates:**
  - All existing macerator recipes have been updated to include the `grindingtime` field in their JSON configurations, ensuring they work with the new feature.

### Notes
- Existing recipes will require an update to include the new `grindingtime` attribute. Default values have been applied for legacy recipes to maintain functionality. Users are encouraged to customize grinding times to optimize their game experience.