### PR TITLE
feat: implement recipe book for Kiln with access widener support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ spotless {
 loom {
 	splitEnvironmentSourceSets()
 
+	accessWidenerPath = file("src/main/resources/logistics.accesswidener")
+
 	mods {
 		"logistics" {
 			sourceSet sourceSets.main

--- a/src/client/java/com/logistics/automation/kiln/KilnRecipeBookComponent.java
+++ b/src/client/java/com/logistics/automation/kiln/KilnRecipeBookComponent.java
@@ -1,0 +1,73 @@
+package com.logistics.automation.kiln;
+
+import net.minecraft.client.gui.components.WidgetSprites;
+import net.minecraft.client.gui.screens.recipebook.GhostSlots;
+import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
+import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
+import net.minecraft.client.gui.screens.recipebook.SearchRecipeBookCategory;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.context.ContextMap;
+import net.minecraft.world.entity.player.StackedItemContents;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeBookCategories;
+import net.minecraft.world.item.crafting.display.FurnaceRecipeDisplay;
+import net.minecraft.world.item.crafting.display.RecipeDisplay;
+
+import java.util.List;
+
+/**
+ * Recipe book component for the Kiln screen.
+ * Shows all vanilla smelting recipes using furnace tabs and filter sprites.
+ */
+public class KilnRecipeBookComponent extends RecipeBookComponent<KilnScreenHandler> {
+
+    private static final WidgetSprites FILTER_SPRITES = new WidgetSprites(
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_enabled"),
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_disabled"),
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_enabled_highlighted"),
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_disabled_highlighted")
+    );
+
+    private static final Component FILTER_NAME = Component.translatable("gui.recipebook.toggleRecipes.smeltable");
+
+    private static final List<TabInfo> TABS = List.of(
+        new TabInfo(SearchRecipeBookCategory.FURNACE),
+        new TabInfo(Items.PORKCHOP, RecipeBookCategories.FURNACE_FOOD),
+        new TabInfo(Items.STONE, RecipeBookCategories.FURNACE_BLOCKS),
+        new TabInfo(Items.LAVA_BUCKET, Items.EMERALD, RecipeBookCategories.FURNACE_MISC)
+    );
+
+    public KilnRecipeBookComponent(KilnScreenHandler handler) {
+        super(handler, TABS);
+    }
+
+    @Override
+    protected WidgetSprites getFilterButtonTextures() {
+        return FILTER_SPRITES;
+    }
+
+    @Override
+    protected boolean isCraftingSlot(Slot slot) {
+        return slot.index == 0 || slot.index == 1;
+    }
+
+    @Override
+    protected void selectMatchingRecipes(RecipeCollection collection, StackedItemContents contents) {
+        collection.selectRecipes(contents, d -> d instanceof FurnaceRecipeDisplay);
+    }
+
+    @Override
+    protected Component getRecipeFilterName() {
+        return FILTER_NAME;
+    }
+
+    @Override
+    protected void fillGhostRecipe(GhostSlots ghostSlots, RecipeDisplay display, ContextMap context) {
+        ghostSlots.setResult(this.menu.getSlot(1), context, display.result());
+        if (display instanceof FurnaceRecipeDisplay furnaceDisplay) {
+            ghostSlots.setInput(this.menu.getSlot(0), context, furnaceDisplay.ingredient());
+        }
+    }
+}

--- a/src/client/java/com/logistics/automation/kiln/KilnScreen.java
+++ b/src/client/java/com/logistics/automation/kiln/KilnScreen.java
@@ -3,7 +3,8 @@ package com.logistics.automation.kiln;
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.resource.ResourceId;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.navigation.ScreenPosition;
+import net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
@@ -11,14 +12,14 @@ import net.minecraft.world.entity.player.Inventory;
 /**
  * Client-side GUI screen for the Electric Kiln.
  */
-public class KilnScreen extends AbstractContainerScreen<KilnScreenHandler> {
+public class KilnScreen extends AbstractRecipeBookScreen<KilnScreenHandler> {
 
     private static final ResourceId TEXTURE = LogisticsMod.modId("textures/gui/automation/kiln.png");
     private static final int TEXTURE_WIDTH = 256;
     private static final int TEXTURE_HEIGHT = 256;
 
     public KilnScreen(KilnScreenHandler handler, Inventory inventory, Component title) {
-        super(handler, inventory, title);
+        super(handler, new KilnRecipeBookComponent(handler), inventory, title);
         this.imageWidth = 176;
         this.imageHeight = 166;
     }
@@ -27,6 +28,11 @@ public class KilnScreen extends AbstractContainerScreen<KilnScreenHandler> {
     protected void init() {
         super.init();
         this.titleLabelX = (this.imageWidth - this.font.width(this.title)) / 2;
+    }
+
+    @Override
+    protected ScreenPosition getRecipeBookButtonPosition() {
+        return new ScreenPosition(this.leftPos + 20, this.height / 2 - 49);
     }
 
     @Override
@@ -60,11 +66,5 @@ public class KilnScreen extends AbstractContainerScreen<KilnScreenHandler> {
                 7, energyHeight,
                 TEXTURE_WIDTH, TEXTURE_HEIGHT);
         }
-    }
-
-    @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        super.render(graphics, mouseX, mouseY, delta);
-        renderTooltip(graphics, mouseX, mouseY);
     }
 }

--- a/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
+++ b/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
@@ -1,21 +1,30 @@
 package com.logistics.automation.kiln;
 
 import com.logistics.LogisticsAutomation;
+import net.minecraft.recipebook.ServerPlaceRecipe;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.entity.player.StackedItemContents;
 import net.minecraft.world.inventory.ContainerData;
+import net.minecraft.world.inventory.RecipeBookMenu;
+import net.minecraft.world.inventory.RecipeBookType;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.AbstractCookingRecipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.SingleRecipeInput;
+
+import java.util.List;
 
 /**
  * Screen handler for the Electric Kiln GUI.
  * Manages input/output slots and syncs progress/energy data to the client.
  */
-public class KilnScreenHandler extends AbstractContainerMenu {
+public class KilnScreenHandler extends RecipeBookMenu {
 
     private static final int MACHINE_SLOT_COUNT = 2;
     private static final int PLAYER_INVENTORY_START = MACHINE_SLOT_COUNT;
@@ -65,6 +74,54 @@ public class KilnScreenHandler extends AbstractContainerMenu {
 
         this.addDataSlots(data);
     }
+
+    // ==================== RecipeBookMenu ====================
+
+    @Override
+    public RecipeBookType getRecipeBookType() {
+        return RecipeBookType.FURNACE;
+    }
+
+    @Override
+    public void fillCraftSlotsStackedContents(StackedItemContents contents) {
+        ItemStack input = inventory.getItem(KilnBlockEntity.INPUT_SLOT);
+        if (!input.isEmpty()) {
+            contents.accountSimpleStack(input);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public PostPlaceAction handlePlacement(boolean placeAll, boolean isCreative, RecipeHolder<?> recipe, ServerLevel level, Inventory playerInventory) {
+        List<Slot> relevant = List.of(this.getSlot(0), this.getSlot(1));
+        return ServerPlaceRecipe.placeRecipe(
+            new ServerPlaceRecipe.CraftingMenuAccess<AbstractCookingRecipe>() {
+                @Override
+                public void fillCraftSlotsStackedContents(StackedItemContents contents) {
+                    KilnScreenHandler.this.fillCraftSlotsStackedContents(contents);
+                }
+
+                @Override
+                public void clearCraftingContent() {
+                    relevant.forEach(s -> s.set(ItemStack.EMPTY));
+                }
+
+                @Override
+                public boolean recipeMatches(RecipeHolder<AbstractCookingRecipe> r) {
+                    return r.value().matches(new SingleRecipeInput(inventory.getItem(KilnBlockEntity.INPUT_SLOT)), level);
+                }
+            },
+            1, 1,
+            List.of(this.getSlot(0)),
+            relevant,
+            playerInventory,
+            (RecipeHolder<AbstractCookingRecipe>) recipe,
+            placeAll,
+            isCreative
+        );
+    }
+
+    // ==================== Shift-click ====================
 
     @Override
     public ItemStack quickMoveStack(Player player, int index) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,7 @@
   "icon": "assets/logistics/icon.png",
   "id": "logistics",
   "license": "MIT",
+  "accessWidener": "logistics.accesswidener",
   "mixins": ["logistics.mixins.json"],
   "name": "Logistics",
   "suggests": {

--- a/src/main/resources/logistics.accesswidener
+++ b/src/main/resources/logistics.accesswidener
@@ -1,0 +1,5 @@
+accessWidener v2 named
+
+# Allow RecipeBookComponent subclasses outside the recipebook package to fill ghost slots
+accessible method net/minecraft/client/gui/screens/recipebook/GhostSlots setInput (Lnet/minecraft/world/inventory/Slot;Lnet/minecraft/util/context/ContextMap;Lnet/minecraft/world/item/crafting/display/SlotDisplay;)V
+accessible method net/minecraft/client/gui/screens/recipebook/GhostSlots setResult (Lnet/minecraft/world/inventory/Slot;Lnet/minecraft/util/context/ContextMap;Lnet/minecraft/world/item/crafting/display/SlotDisplay;)V


### PR DESCRIPTION
## Summary
The latest update introduces a new Recipe Book for the Kiln component of the logistics system, enhancing the user experience by simplifying recipe browsing and selection. The addition of access widener support allows broader compatibility with Minecraft's recipe system.

## Changes
- **Kiln Recipe Book Component**
  - Added `KilnRecipeBookComponent` to manage and display Kiln recipes, similar to how smelting recipes are handled in the crafting interface.
  - Implemented filtering functionality to toggle view of smelting recipes.

- **Kiln Screen Enhancements**
  - Updated `KilnScreen` to utilize the new `KilnRecipeBookComponent`, enhancing the graphical user interface (GUI) with access to the recipe book.
  - Adjusted the positioning of the recipe book button for better usability.

- **Kiln Screen Handler Refactoring**
  - Changed `KilnScreenHandler` to extend `RecipeBookMenu`, allowing for crafting slots handling with integrated recipe management.
  - Implemented methods to fill crafting slots and match recipes, improving interaction with the recipe system.

- **Access Widener Configuration**
  - Created `logistics.accesswidener` file to enable access to certain methods within the `GhostSlots` class, ensuring proper functionality of recipe ghosting features in the Kiln interface.

## Notes
- This update may affect existing workflows by introducing new functionality that requires adaptation in how players interact with the Kiln. Users will benefit from an enhanced and intuitive recipe browsing system, enhancing overall gameplay experience.