### PR TITLE
feat: implement recipe book for macerator crafting interface

### DIFF
--- a/src/client/java/com/logistics/core/macerator/MaceratorRecipeBookComponent.java
+++ b/src/client/java/com/logistics/core/macerator/MaceratorRecipeBookComponent.java
@@ -1,0 +1,67 @@
+package com.logistics.core.macerator;
+
+import com.logistics.LogisticsCore;
+import net.minecraft.client.gui.components.WidgetSprites;
+import net.minecraft.client.gui.screens.recipebook.GhostSlots;
+import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
+import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.context.ContextMap;
+import net.minecraft.world.entity.player.StackedItemContents;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.crafting.display.RecipeDisplay;
+
+import java.util.List;
+
+/**
+ * Recipe book component for the Macerator screen.
+ * Shows all macerator recipes in a single custom tab.
+ */
+public class MaceratorRecipeBookComponent extends RecipeBookComponent<MaceratorScreenHandler> {
+
+    private static final WidgetSprites FILTER_SPRITES = new WidgetSprites(
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_enabled"),
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_disabled"),
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_enabled_highlighted"),
+        Identifier.withDefaultNamespace("recipe_book/furnace_filter_disabled_highlighted")
+    );
+
+    private static final Component FILTER_NAME = Component.translatable("gui.recipebook.toggleRecipes.smeltable");
+
+    private static final List<TabInfo> TABS = List.of(
+        new TabInfo(LogisticsCore.BLOCK.MACERATOR.asItem(), LogisticsCore.RECIPE.MACERATOR_CATEGORY)
+    );
+
+    public MaceratorRecipeBookComponent(MaceratorScreenHandler handler) {
+        super(handler, TABS);
+    }
+
+    @Override
+    protected WidgetSprites getFilterButtonTextures() {
+        return FILTER_SPRITES;
+    }
+
+    @Override
+    protected boolean isCraftingSlot(Slot slot) {
+        return slot.index == 0 || slot.index == 1;
+    }
+
+    @Override
+    protected void selectMatchingRecipes(RecipeCollection collection, StackedItemContents contents) {
+        collection.selectRecipes(contents, d -> d instanceof MaceratorRecipeDisplay);
+    }
+
+    @Override
+    protected Component getRecipeFilterName() {
+        return FILTER_NAME;
+    }
+
+    @Override
+    protected void fillGhostRecipe(GhostSlots ghostSlots, RecipeDisplay display, ContextMap context) {
+        ghostSlots.setResult(this.menu.getSlot(1), context, display.result());
+        if (display instanceof MaceratorRecipeDisplay md) {
+            ghostSlots.setInput(this.menu.getSlot(0), context, md.ingredient());
+        }
+    }
+}

--- a/src/client/java/com/logistics/core/macerator/MaceratorScreen.java
+++ b/src/client/java/com/logistics/core/macerator/MaceratorScreen.java
@@ -3,7 +3,8 @@ package com.logistics.core.macerator;
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.resource.ResourceId;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.navigation.ScreenPosition;
+import net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
@@ -11,14 +12,14 @@ import net.minecraft.world.entity.player.Inventory;
 /**
  * Client-side GUI screen for the Iron Macerator.
  */
-public class MaceratorScreen extends AbstractContainerScreen<MaceratorScreenHandler> {
+public class MaceratorScreen extends AbstractRecipeBookScreen<MaceratorScreenHandler> {
 
     private static final ResourceId TEXTURE = LogisticsMod.modId("textures/gui/core/macerator.png");
     private static final int TEXTURE_WIDTH = 256;
     private static final int TEXTURE_HEIGHT = 256;
 
     public MaceratorScreen(MaceratorScreenHandler handler, Inventory inventory, Component title) {
-        super(handler, inventory, title);
+        super(handler, new MaceratorRecipeBookComponent(handler), inventory, title);
         this.imageWidth = 176;
         this.imageHeight = 166;
     }
@@ -27,6 +28,11 @@ public class MaceratorScreen extends AbstractContainerScreen<MaceratorScreenHand
     protected void init() {
         super.init();
         this.titleLabelX = (this.imageWidth - this.font.width(this.title)) / 2;
+    }
+
+    @Override
+    protected ScreenPosition getRecipeBookButtonPosition() {
+        return new ScreenPosition(this.leftPos + 20, this.height / 2 - 49);
     }
 
     @Override
@@ -65,11 +71,5 @@ public class MaceratorScreen extends AbstractContainerScreen<MaceratorScreenHand
                 7, energyHeight,
                 TEXTURE_WIDTH, TEXTURE_HEIGHT);
         }
-    }
-
-    @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        super.render(graphics, mouseX, mouseY, delta);
-        renderTooltip(graphics, mouseX, mouseY);
     }
 }

--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -6,6 +6,7 @@ import com.logistics.core.item.ProbeItem;
 import com.logistics.core.item.WrenchItem;
 import com.logistics.core.macerator.MaceratorBlock;
 import com.logistics.core.macerator.MaceratorBlockEntity;
+import com.logistics.core.macerator.MaceratorRecipeDisplay;
 import com.logistics.core.macerator.MaceratorRecipeManager;
 import com.logistics.core.macerator.MaceratorRecipeSerializer;
 import com.logistics.core.macerator.MaceratorRecipeWrapper;
@@ -23,8 +24,10 @@ import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.crafting.display.RecipeDisplay;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.core.Registry;
@@ -184,6 +187,8 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
 
         public static RecipeType<MaceratorRecipeWrapper> MACERATOR_RECIPE_TYPE;
         public static RecipeSerializer<MaceratorRecipeWrapper> MACERATOR_RECIPE_SERIALIZER;
+        public static RecipeBookCategory MACERATOR_CATEGORY;
+        public static RecipeDisplay.Type<MaceratorRecipeDisplay> MACERATOR_DISPLAY_TYPE;
 
         static void register() {
             MACERATOR_RECIPE_TYPE = Registry.register(
@@ -200,6 +205,16 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
                 BuiltInRegistries.RECIPE_SERIALIZER,
                 LogisticsMod.modId("macerator").toIdentifier(),
                 new MaceratorRecipeSerializer()
+            );
+            MACERATOR_CATEGORY = Registry.register(
+                BuiltInRegistries.RECIPE_BOOK_CATEGORY,
+                LogisticsMod.modId("macerator").toIdentifier(),
+                new RecipeBookCategory()
+            );
+            MACERATOR_DISPLAY_TYPE = Registry.register(
+                BuiltInRegistries.RECIPE_DISPLAY,
+                LogisticsMod.modId("macerator").toIdentifier(),
+                MaceratorRecipeDisplay.TYPE
             );
         }
     }

--- a/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
+++ b/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
@@ -93,7 +93,7 @@ public class KilnScreenHandler extends RecipeBookMenu {
     @Override
     @SuppressWarnings("unchecked")
     public PostPlaceAction handlePlacement(boolean placeAll, boolean isCreative, RecipeHolder<?> recipe, ServerLevel level, Inventory playerInventory) {
-        List<Slot> relevant = List.of(this.getSlot(0), this.getSlot(1));
+        List<Slot> relevant = List.of(this.getSlot(0));
         return ServerPlaceRecipe.placeRecipe(
             new ServerPlaceRecipe.CraftingMenuAccess<AbstractCookingRecipe>() {
                 @Override

--- a/src/main/java/com/logistics/core/macerator/MaceratorRecipeDisplay.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorRecipeDisplay.java
@@ -1,0 +1,48 @@
+package com.logistics.core.macerator;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.crafting.display.RecipeDisplay;
+import net.minecraft.world.item.crafting.display.SlotDisplay;
+
+/**
+ * Recipe display for the Macerator, used by the recipe book to render recipe entries.
+ */
+public record MaceratorRecipeDisplay(
+    SlotDisplay ingredient,
+    SlotDisplay result,
+    SlotDisplay craftingStation,
+    int grindingTime,
+    float experience
+) implements RecipeDisplay {
+
+    public static final MapCodec<MaceratorRecipeDisplay> MAP_CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
+        SlotDisplay.CODEC.fieldOf("ingredient").forGetter(MaceratorRecipeDisplay::ingredient),
+        SlotDisplay.CODEC.fieldOf("result").forGetter(MaceratorRecipeDisplay::result),
+        SlotDisplay.CODEC.fieldOf("crafting_station").forGetter(MaceratorRecipeDisplay::craftingStation),
+        Codec.INT.fieldOf("duration").forGetter(MaceratorRecipeDisplay::grindingTime),
+        Codec.FLOAT.fieldOf("experience").forGetter(MaceratorRecipeDisplay::experience)
+    ).apply(i, MaceratorRecipeDisplay::new));
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, MaceratorRecipeDisplay> STREAM_CODEC =
+        StreamCodec.composite(
+            SlotDisplay.STREAM_CODEC, MaceratorRecipeDisplay::ingredient,
+            SlotDisplay.STREAM_CODEC, MaceratorRecipeDisplay::result,
+            SlotDisplay.STREAM_CODEC, MaceratorRecipeDisplay::craftingStation,
+            ByteBufCodecs.VAR_INT, MaceratorRecipeDisplay::grindingTime,
+            ByteBufCodecs.FLOAT, MaceratorRecipeDisplay::experience,
+            MaceratorRecipeDisplay::new
+        );
+
+    public static final RecipeDisplay.Type<MaceratorRecipeDisplay> TYPE =
+        new RecipeDisplay.Type<>(MAP_CODEC, STREAM_CODEC);
+
+    @Override
+    public RecipeDisplay.Type<MaceratorRecipeDisplay> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/com/logistics/core/macerator/MaceratorRecipeSerializer.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorRecipeSerializer.java
@@ -4,30 +4,43 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
 /**
  * Recipe serializer for macerator recipes.
- * Registered with Minecraft's recipe system to prevent parse errors.
- * Actual loading is handled by MaceratorRecipeManager.
+ * Handles bare item ID strings ("minecraft:iron_ore") and standard ingredient objects.
+ * Note: {"tag":"..."} object format is not supported by vanilla's Ingredient.CODEC;
+ * those recipes are handled exclusively by MaceratorRecipeManager.
  */
 public class MaceratorRecipeSerializer implements RecipeSerializer<MaceratorRecipeWrapper> {
 
+    private static final MapCodec<MaceratorRecipeWrapper> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
+        Ingredient.CODEC.fieldOf("ingredient").forGetter(MaceratorRecipeWrapper::ingredient),
+        ItemStack.STRICT_CODEC.fieldOf("result").forGetter(MaceratorRecipeWrapper::result),
+        Codec.INT.fieldOf("grindingtime").forGetter(MaceratorRecipeWrapper::grindingTime),
+        Codec.FLOAT.optionalFieldOf("experience", MaceratorRecipe.DEFAULT_EXPERIENCE).forGetter(MaceratorRecipeWrapper::experience)
+    ).apply(i, MaceratorRecipeWrapper::new));
+
+    private static final StreamCodec<RegistryFriendlyByteBuf, MaceratorRecipeWrapper> STREAM_CODEC =
+        StreamCodec.composite(
+            Ingredient.CONTENTS_STREAM_CODEC, MaceratorRecipeWrapper::ingredient,
+            ItemStack.STREAM_CODEC, MaceratorRecipeWrapper::result,
+            ByteBufCodecs.VAR_INT, MaceratorRecipeWrapper::grindingTime,
+            ByteBufCodecs.FLOAT, MaceratorRecipeWrapper::experience,
+            MaceratorRecipeWrapper::new
+        );
+
     @Override
     public MapCodec<MaceratorRecipeWrapper> codec() {
-        return RecordCodecBuilder.mapCodec(instance ->
-            instance.group(
-                Codec.STRING.optionalFieldOf("type", "").forGetter(recipe -> "logistics:macerator")
-            ).apply(instance, type -> new MaceratorRecipeWrapper())
-        );
+        return CODEC;
     }
 
     @Override
     public StreamCodec<RegistryFriendlyByteBuf, MaceratorRecipeWrapper> streamCodec() {
-        return StreamCodec.of(
-            (buf, recipe) -> {},
-            buf -> new MaceratorRecipeWrapper()
-        );
+        return STREAM_CODEC;
     }
 }

--- a/src/main/java/com/logistics/core/macerator/MaceratorRecipeWrapper.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorRecipeWrapper.java
@@ -3,30 +3,65 @@ package com.logistics.core.macerator;
 import com.logistics.LogisticsCore;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.PlacementInfo;
 import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeBookCategories;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
-import net.minecraft.world.item.crafting.RecipeInput;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.crafting.SingleRecipeInput;
+import net.minecraft.world.item.crafting.display.RecipeDisplay;
+import net.minecraft.world.item.crafting.display.SlotDisplay;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
- * Minimal Recipe wrapper to satisfy Minecraft's recipe system.
- * Actual recipe matching is handled by MaceratorRecipeManager.
+ * Recipe wrapper integrating macerator recipes into Minecraft's recipe system.
+ * Carries real ingredient/result data for recipe book display and placement.
+ * Actual machine operation still uses MaceratorRecipeManager.
  */
-public class MaceratorRecipeWrapper implements Recipe<RecipeInput> {
+public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
 
-    @Override
-    public boolean matches(@NotNull RecipeInput input, @NotNull Level level) {
-        return false;
+    private final Ingredient ingredient;
+    private final ItemStack result;
+    private final int grindingTime;
+    private final float experience;
+    @Nullable private PlacementInfo placementInfo;
+
+    public MaceratorRecipeWrapper(Ingredient ingredient, ItemStack result, int grindingTime, float experience) {
+        this.ingredient = ingredient;
+        this.result = result;
+        this.grindingTime = grindingTime;
+        this.experience = experience;
+    }
+
+    public Ingredient ingredient() {
+        return ingredient;
+    }
+
+    public ItemStack result() {
+        return result;
+    }
+
+    public int grindingTime() {
+        return grindingTime;
+    }
+
+    public float experience() {
+        return experience;
     }
 
     @Override
-    public @NotNull ItemStack assemble(@NotNull RecipeInput input, HolderLookup.@NotNull Provider provider) {
-        return ItemStack.EMPTY;
+    public boolean matches(@NotNull SingleRecipeInput input, @NotNull Level level) {
+        return ingredient.test(input.item());
+    }
+
+    @Override
+    public @NotNull ItemStack assemble(@NotNull SingleRecipeInput input, HolderLookup.@NotNull Provider provider) {
+        return result.copy();
     }
 
     @Override
@@ -41,16 +76,30 @@ public class MaceratorRecipeWrapper implements Recipe<RecipeInput> {
 
     @Override
     public boolean isSpecial() {
-        return true;
+        return false;
     }
 
     @Override
     public @NotNull PlacementInfo placementInfo() {
-        return PlacementInfo.NOT_PLACEABLE;
+        if (placementInfo == null) {
+            placementInfo = PlacementInfo.create(ingredient);
+        }
+        return placementInfo;
     }
 
     @Override
     public @NotNull RecipeBookCategory recipeBookCategory() {
-        return RecipeBookCategories.FURNACE_MISC;
+        return LogisticsCore.RECIPE.MACERATOR_CATEGORY;
+    }
+
+    @Override
+    public @NotNull List<RecipeDisplay> display() {
+        return List.of(new MaceratorRecipeDisplay(
+            ingredient.display(),
+            new SlotDisplay.ItemStackSlotDisplay(result),
+            new SlotDisplay.ItemSlotDisplay(LogisticsCore.BLOCK.MACERATOR.asItem()),
+            grindingTime,
+            experience
+        ));
     }
 }

--- a/src/main/java/com/logistics/core/macerator/MaceratorScreenHandler.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorScreenHandler.java
@@ -1,21 +1,29 @@
 package com.logistics.core.macerator;
 
 import com.logistics.LogisticsCore;
+import net.minecraft.recipebook.ServerPlaceRecipe;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.entity.player.StackedItemContents;
 import net.minecraft.world.inventory.ContainerData;
+import net.minecraft.world.inventory.RecipeBookMenu;
+import net.minecraft.world.inventory.RecipeBookType;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.SingleRecipeInput;
+
+import java.util.List;
 
 /**
  * Screen handler for the Iron Macerator GUI.
  * Manages input/output slots and syncs progress/energy data to the client.
  */
-public class MaceratorScreenHandler extends AbstractContainerMenu {
+public class MaceratorScreenHandler extends RecipeBookMenu {
 
     private static final int MACHINE_SLOT_COUNT = 2;
     private static final int PLAYER_INVENTORY_START = MACHINE_SLOT_COUNT;
@@ -64,6 +72,50 @@ public class MaceratorScreenHandler extends AbstractContainerMenu {
         }
 
         this.addDataSlots(data);
+    }
+
+    @Override
+    public RecipeBookType getRecipeBookType() {
+        return RecipeBookType.FURNACE;
+    }
+
+    @Override
+    public void fillCraftSlotsStackedContents(StackedItemContents contents) {
+        ItemStack input = inventory.getItem(MaceratorBlockEntity.INPUT_SLOT);
+        if (!input.isEmpty()) {
+            contents.accountSimpleStack(input);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public PostPlaceAction handlePlacement(boolean placeAll, boolean isCreative, RecipeHolder<?> recipe, ServerLevel level, Inventory playerInventory) {
+        List<Slot> relevant = List.of(this.getSlot(0), this.getSlot(1));
+        return ServerPlaceRecipe.placeRecipe(
+            new ServerPlaceRecipe.CraftingMenuAccess<MaceratorRecipeWrapper>() {
+                @Override
+                public void fillCraftSlotsStackedContents(StackedItemContents contents) {
+                    MaceratorScreenHandler.this.fillCraftSlotsStackedContents(contents);
+                }
+
+                @Override
+                public void clearCraftingContent() {
+                    relevant.forEach(s -> s.set(ItemStack.EMPTY));
+                }
+
+                @Override
+                public boolean recipeMatches(RecipeHolder<MaceratorRecipeWrapper> r) {
+                    return r.value().matches(new SingleRecipeInput(inventory.getItem(MaceratorBlockEntity.INPUT_SLOT)), level);
+                }
+            },
+            1, 1,
+            List.of(this.getSlot(0)),
+            relevant,
+            playerInventory,
+            (RecipeHolder<MaceratorRecipeWrapper>) recipe,
+            placeAll,
+            isCreative
+        );
     }
 
     @Override

--- a/src/main/java/com/logistics/core/macerator/MaceratorScreenHandler.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorScreenHandler.java
@@ -90,7 +90,7 @@ public class MaceratorScreenHandler extends RecipeBookMenu {
     @Override
     @SuppressWarnings("unchecked")
     public PostPlaceAction handlePlacement(boolean placeAll, boolean isCreative, RecipeHolder<?> recipe, ServerLevel level, Inventory playerInventory) {
-        List<Slot> relevant = List.of(this.getSlot(0), this.getSlot(1));
+        List<Slot> relevant = List.of(this.getSlot(0));
         return ServerPlaceRecipe.placeRecipe(
             new ServerPlaceRecipe.CraftingMenuAccess<MaceratorRecipeWrapper>() {
                 @Override


### PR DESCRIPTION
## Summary
This update introduces a new recipe book feature specifically for the Macerator, enhancing the crafting interface and providing players with clear visibility of available recipes. The addition improves user experience by streamlining recipe access and management for the Macerator, which is crucial for efficient gameplay.

## Changes
- **Macerator Recipe Book Component**: Added a dedicated recipe book component that displays all Macerator recipes in a custom tab, making it easier for players to browse and select recipes.
- **Macerator Screen Integration**: Updated the Macerator screen to extend from `AbstractRecipeBookScreen`, integrating the recipe book functionality directly into the crafting interface.
- **Macerator Recipe Display**: Introduced a new `MaceratorRecipeDisplay` class to handle the representation of recipes specific to the Macerator, including ingredient and result slots as well as grinding time and experience information.
- **Recipe Book Category**: Registered a new recipe book category for Macerator recipes to categorize them effectively within the broader crafting system of the game.
- **Recipe Serializer and Wrapper Updates**: Enhanced `MaceratorRecipeSerializer` and `MaceratorRecipeWrapper` to support the new recipe book features, ensuring correct loading and display of Macerator recipes.

## Notes
- This update may require players to refresh their crafting interfaces to see the new recipe book feature in operation. No backward compatibility issues were identified, as the new changes build upon existing functionality.