### PR TITLE
feat: add macerator recipes for copper, gold, and iron dusts

### DIFF
--- a/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_copper_block.json
+++ b/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_copper_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:copper_block",
+  "result": {
+    "id": "logistics:core/copper_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}

--- a/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_raw_copper_block.json
+++ b/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_raw_copper_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:raw_copper_block",
+  "result": {
+    "id": "logistics:core/copper_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}

--- a/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_gold_block.json
+++ b/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_gold_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:gold_block",
+  "result": {
+    "id": "logistics:core/gold_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}

--- a/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_raw_gold_block.json
+++ b/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_raw_gold_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:raw_gold_block",
+  "result": {
+    "id": "logistics:core/gold_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}

--- a/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_iron_block.json
+++ b/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_iron_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:iron_block",
+  "result": {
+    "id": "logistics:core/iron_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}

--- a/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_raw_iron_block.json
+++ b/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_raw_iron_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:raw_iron_block",
+  "result": {
+    "id": "logistics:core/iron_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}


### PR DESCRIPTION
## Summary
This update introduces new macerator recipes for copper, gold, and iron dusts, enhancing the crafting capabilities within the logistics system. By allowing players to convert blocks of these metals into dust, this change introduces more flexibility and efficiency in the materials processing workflow.

## Changes
- **New Macerator Recipes Added:**
  - **Copper Dust:**
    - Recipe for converting `copper_block` into 9 `copper_dust`.
    - Recipe for converting `raw_copper_block` into 9 `copper_dust`.
  - **Gold Dust:**
    - Recipe for converting `gold_block` into 9 `gold_dust`.
    - Recipe for converting `raw_gold_block` into 9 `gold_dust`.
  - **Iron Dust:**
    - Recipe for converting `iron_block` into 9 `iron_dust`.
    - Recipe for converting `raw_iron_block` into 9 `iron_dust`.

## Notes
- These new recipes will allow players to optimize their resource usage and enhance their crafting options within the logistics framework.