### PR TITLE
fix: update build script to check Gradle task by MC version

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -53,12 +53,16 @@ jobs:
           # Example: dev-pr.123+mc26.1.sha.a1b2c3d
           BUILD_VERSION="dev-pr.${PR_NUM}+mc${MC_VERSION}.sha.${SHA7}"
 
-          # Determine Gradle task based on target branch
-          # main branch uses 'jar' (MC 26.1+ is not obfuscated)
-          # mc/** branches use 'remapJar' (MC 1.21.11 and earlier are obfuscated)
-          if [[ "$TARGET_BRANCH" == "main" ]]; then
-            GRADLE_TASK="jar"
+          # Determine Gradle task based on MC version (MC 26.1+ is not obfuscated)
+          if [[ "$MC_VERSION" =~ ^([0-9]+)\. ]]; then
+            MC_MAJOR="${BASH_REMATCH[1]}"
+            if (( MC_MAJOR >= 26 )); then
+              GRADLE_TASK="jar"
+            else
+              GRADLE_TASK="remapJar"
+            fi
           else
+            # Fallback for unexpected version format
             GRADLE_TASK="remapJar"
           fi
 


### PR DESCRIPTION
## Summary
The build script has been updated to determine the appropriate Gradle task based on the Minecraft (MC) version. This change streamlines the build process by automatically selecting `jar` for MC versions 26.1 and above, while retaining `remapJar` for versions below this threshold, thus enhancing compatibility and efficiency.

## Changes
- **Build Script Update:**
  - The Gradle task selection is now based on the MC version instead of the target branch.
  - Automatically sets `GRADLE_TASK` to `jar` for MC version 26.1 and above, ensuring a more straightforward build process for newer versions.
  - Maintains the use of `remapJar` for MC versions below 26.1, preserving the functionality for older versions.

## Notes
- This update will enhance the build process and ensure smoother integration for developers working with various Minecraft versions. Please double-check your build configurations to ensure compatibility.