### PR TITLE
feat: add support for ingredient tags in macerator recipes

### DIFF
--- a/src/main/java/com/logistics/core/macerator/MaceratorRecipeManager.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorRecipeManager.java
@@ -126,6 +126,10 @@ public class MaceratorRecipeManager {
             return new MaceratorRecipe(recipeId, tagKey, resultItemId, resultCount, grindingTime, experience);
         } else {
             String ingredientId = ingredientElement.getAsString();
+            if (ingredientId.startsWith("#")) {
+                TagKey<Item> tagKey = TagKey.create(Registries.ITEM, Identifier.parse(ingredientId.substring(1)));
+                return new MaceratorRecipe(recipeId, tagKey, resultItemId, resultCount, grindingTime, experience);
+            }
             var itemHolder = BuiltInRegistries.ITEM.get(ResourceId.parse(ingredientId).toIdentifier())
                 .orElseThrow(() -> new IllegalArgumentException("Unknown ingredient item: " + ingredientId));
             Ingredient ingredient = Ingredient.of(itemHolder.value());

--- a/src/main/resources/data/logistics/loot_table/blocks/automation/macerator.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/automation/macerator.json
@@ -2,7 +2,7 @@
   "pools": [
     {
       "conditions": [{ "condition": "minecraft:survives_explosion" }],
-      "entries": [{ "name": "logistics:automation/macerator", "type": "minecraft:item" }],
+      "entries": [{ "name": "logistics:core/macerator", "type": "minecraft:item" }],
       "rolls": 1
     }
   ],

--- a/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_logs.json
+++ b/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_logs.json
@@ -1,8 +1,6 @@
 {
   "type": "logistics:macerator",
-  "ingredient": {
-    "tag": "minecraft:logs"
-  },
+  "ingredient": "#minecraft:logs",
   "result": {
     "id": "logistics:core/wood_pulp",
     "count": 8

--- a/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_planks.json
+++ b/src/main/resources/data/logistics/recipe/macerator/wood_pulp_from_planks.json
@@ -1,8 +1,6 @@
 {
   "type": "logistics:macerator",
-  "ingredient": {
-    "tag": "minecraft:planks"
-  },
+  "ingredient": "#minecraft:planks",
   "result": {
     "id": "logistics:core/wood_pulp",
     "count": 2


### PR DESCRIPTION
## Summary
This update enhances the macerator's recipe management by introducing support for ingredient tags, allowing for more flexible recipe configurations. This change streamlines the process of adding new recipes and increases compatibility with modded ingredients, which is vital for maintaining a diverse ecosystem of items within the logistics system.

## Changes
- **Ingredient Tags Support**: 
  - Implemented the ability to use ingredient tags in macerator recipes.
  - Replaced existing JSON recipe definitions to utilize tag syntax (e.g., `"#minecraft:logs"` instead of `"tag": "minecraft:logs"`).
  
- **Loot Table Update**: 
  - Corrected the item identifier in the macerator's loot table to refer to `logistics:core/macerator` instead of `logistics:automation/macerator`.

- **Recipe Definitions Adjustments**: 
  - Updated wood pulp recipes to employ tag-based ingredients, ensuring consistent and simplified recipe management. 

## Notes
- Users using custom or modded recipes should verify compatibility with the new tag system.
- This change might require some adaptation in existing custom recipes to follow the new tag format.