### PR TITLE
fix: add supported_formats to pack.mcmeta for compatibility

### DIFF
--- a/src/main/resources/resourcepacks/classic_crafting/pack.mcmeta
+++ b/src/main/resources/resourcepacks/classic_crafting/pack.mcmeta
@@ -3,6 +3,7 @@
     "pack_format": 75,
     "min_format": 75,
     "max_format": 84,
+    "supported_formats": [75, 81],
     "description": "Classic Logistics Pipes crafting recipes"
   }
 }


### PR DESCRIPTION
### Summary
Introducing an update to the `pack.mcmeta` file by adding the `supported_formats` attribute, enhancing compatibility for resource packs within the Logistics mod. This modification ensures that users can more reliably utilize varied resource format versions, fostering better integration with the game environment.

### Changes
- Added `supported_formats` to `pack.mcmeta` for increased resource pack compatibility, allowing the pack to support formats 75 and 81.

### Notes
- Users should ensure their resource packs are updated to utilize the latest format specifications, providing a smoother experience with the Logistics mod.