### PR TITLE
fix: add translations for tin and bronze item tags

### DIFF
--- a/src/main/resources/assets/logistics/lang/en_us.json
+++ b/src/main/resources/assets/logistics/lang/en_us.json
@@ -197,5 +197,15 @@
   "block.logistics.power.creative_engine": "Creative Engine",
   "block.logistics.power.creative_sink": "Creative Sink",
   "message.logistics.power.creative_sink.drain_rate": "Creative Sink: %s RF/t",
-  "message.logistics.power.creative_engine.output": "Creative Engine: %s RF/t"
+  "message.logistics.power.creative_engine.output": "Creative Engine: %s RF/t",
+
+  "tag.item.c.ingots.tin": "Tin Ingots",
+  "tag.item.c.ingots.bronze": "Bronze Ingots",
+  "tag.item.c.nuggets.tin": "Tin Nuggets",
+  "tag.item.c.nuggets.bronze": "Bronze Nuggets",
+  "tag.item.c.raw_materials.tin": "Raw Tin",
+  "tag.item.c.ores.tin": "Tin Ores",
+  "tag.item.c.storage_blocks.tin": "Tin Storage Blocks",
+  "tag.item.c.storage_blocks.bronze": "Bronze Storage Blocks",
+  "tag.item.c.storage_blocks.raw_tin": "Raw Tin Storage Blocks"
 }


### PR DESCRIPTION
## Summary
Translations for tin and bronze item tags have been added to enhance the user experience for English-speaking players. This change ensures consistent terminology within the game, making it easier for users to identify and use these resources.

## Changes
- **Added Translations:**
  - Introduced translations for tin and bronze item tags in the English locale.
    - Includes names for:
      - Tin Ingots
      - Bronze Ingots
      - Tin Nuggets
      - Bronze Nuggets
      - Raw Tin
      - Tin Ores
      - Tin and Bronze Storage Blocks (including Raw Tin)

## Notes
No compatibility issues or migrations are required. Users can expect improved clarity in item identification without needing to adjust settings or configurations.