### PR TITLE
chore: remove outdated versioning configuration option

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,6 @@
       "pull-request-title-pattern": "chore: release ${version} for ${component}",
       "initial-version": "0.3.0",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "bootstrap-sha": "085d95cf5ff6314f0ba83a3733c60a6d36091963"
     }
   },


### PR DESCRIPTION
# Summary
This update introduces a streamlined version numbering scheme by removing the option to bump patches for minor pre-major versions. This change aims to simplify version management and reduce potential confusion among contributors and users.

# Changes
- **Configuration Update**
  - Removed the `bump-patch-for-minor-pre-major` configuration option in the versioning scheme, ensuring a more straightforward increment logic.

# Notes
- This change does not impact existing functionality but adjusts the versioning practices for better clarity moving forward. Users and maintainers should be aware of the updated versioning logic in upcoming releases.