### PR TITLE
fix: add ender dust macerator recipe

### DIFF
--- a/src/main/resources/data/logistics/recipe/macerator/ender_dust.json
+++ b/src/main/resources/data/logistics/recipe/macerator/ender_dust.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:ender_pearl",
+  "result": {
+    "id": "logistics:core/ender_dust",
+    "count": 1
+  },
+  "grindingtime": 200
+}


### PR DESCRIPTION
Adds missing macerator recipe for grinding ender pearls into ender dust.
The ender dust item already exists and is used in crafting recipes, but there was no way to produce it via the macerator.