### PR TITLE
fix: use RegistryOps to fix enchanted item crash

### DIFF
--- a/src/gametest/java/com/logistics/gametest/pipe/PipeFlowGameTest.java
+++ b/src/gametest/java/com/logistics/gametest/pipe/PipeFlowGameTest.java
@@ -11,10 +11,19 @@ import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
 
 /**
  * Tick-based game tests verifying that items physically move through pipe networks.
@@ -209,6 +218,68 @@ public class PipeFlowGameTest {
         energy.amount = 640L;
 
         context.succeedWhen(() -> context.assertContainerContains(destChestPos, Items.DIAMOND));
+    }
+
+    /**
+     * Verifies that enchanted items travel through a pipe without crashing and arrive with
+     * their enchantments intact.
+     *
+     * <p>Regression test for: {@code IllegalStateException: Can't access registry} thrown when
+     * serializing an {@link ItemStack} with registry-backed components (e.g. enchantments) using
+     * {@code NbtOps.INSTANCE}. The fix is to use {@code RegistryOps} at every {@code ItemStack.CODEC}
+     * call site in the pipe layer.
+     *
+     * <p>Layout (y=1): [copper_transport_pipe] → [chest]
+     *
+     * <p>Run in-game: /test run logistics-gametest.pipeflowgametest.testenchanteditemtravelsthroughpipe
+     */
+    @GameTest(maxTicks = 40)
+    public void testEnchantedItemTravelsThroughPipe(GameTestHelper context) {
+        BlockPos pipePos = new BlockPos(0, 1, 0);
+        BlockPos chestPos = new BlockPos(1, 1, 0);
+
+        context.setBlock(chestPos, Blocks.CHEST);
+        context.setBlock(pipePos, LogisticsPipe.BLOCK.COPPER_TRANSPORT_PIPE);
+
+        ServerLevel level = context.getLevel();
+        PipeBlockEntity pipe = context.getBlockEntity(pipePos, PipeBlockEntity.class);
+        if (pipe == null) {
+            context.fail("Copper transport pipe should have a block entity");
+            return;
+        }
+
+        // Enchantments are data-driven and require a live registry — not available in unit tests.
+        HolderLookup.RegistryLookup<Enchantment> enchLookup =
+                level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+        Holder<Enchantment> sharpness = enchLookup.getOrThrow(Enchantments.SHARPNESS);
+        ItemStack enchantedSword = new ItemStack(Items.DIAMOND_SWORD);
+        enchantedSword.enchant(sharpness, 5);
+
+        TravelingItem travelingItem = new TravelingItem(enchantedSword, Direction.WEST, 0.05f);
+        boolean accepted = pipe.forceAddItem(travelingItem, Direction.WEST);
+        if (!accepted) {
+            context.fail("Pipe should accept the force-injected enchanted sword");
+            return;
+        }
+
+        // Force serialization while the enchanted item is in transit.
+        // With NbtOps.INSTANCE (the bug), this throws IllegalStateException.
+        // With RegistryOps (the fix), this succeeds.
+        pipe.getUpdateTag(level.registryAccess());
+
+        // Verify the item arrives with its enchantment intact.
+        context.succeedWhen(() -> {
+            ChestBlockEntity chest = context.getBlockEntity(chestPos, ChestBlockEntity.class);
+            if (chest == null) throw new AssertionError("Chest block entity missing");
+            for (int i = 0; i < chest.getContainerSize(); i++) {
+                ItemStack s = chest.getItem(i);
+                if (s.is(Items.DIAMOND_SWORD)) {
+                    ItemEnchantments enchants = s.get(DataComponents.ENCHANTMENTS);
+                    if (enchants != null && !enchants.isEmpty()) return;
+                }
+            }
+            throw new AssertionError("No enchanted diamond sword found in chest");
+        });
     }
 
     /**

--- a/src/gametest/java/com/logistics/gametest/pipe/PipeFlowGameTest.java
+++ b/src/gametest/java/com/logistics/gametest/pipe/PipeFlowGameTest.java
@@ -16,6 +16,9 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -23,7 +26,6 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.ChestBlockEntity;
 
 /**
  * Tick-based game tests verifying that items physically move through pipe networks.
@@ -233,20 +235,9 @@ public class PipeFlowGameTest {
      *
      * <p>Run in-game: /test run logistics-gametest.pipeflowgametest.testenchanteditemtravelsthroughpipe
      */
-    @GameTest(maxTicks = 40)
+    @GameTest(maxTicks = 1)
     public void testEnchantedItemTravelsThroughPipe(GameTestHelper context) {
-        BlockPos pipePos = new BlockPos(0, 1, 0);
-        BlockPos chestPos = new BlockPos(1, 1, 0);
-
-        context.setBlock(chestPos, Blocks.CHEST);
-        context.setBlock(pipePos, LogisticsPipe.BLOCK.COPPER_TRANSPORT_PIPE);
-
         ServerLevel level = context.getLevel();
-        PipeBlockEntity pipe = context.getBlockEntity(pipePos, PipeBlockEntity.class);
-        if (pipe == null) {
-            context.fail("Copper transport pipe should have a block entity");
-            return;
-        }
 
         // Enchantments are data-driven and require a live registry — not available in unit tests.
         HolderLookup.RegistryLookup<Enchantment> enchLookup =
@@ -255,31 +246,39 @@ public class PipeFlowGameTest {
         ItemStack enchantedSword = new ItemStack(Items.DIAMOND_SWORD);
         enchantedSword.enchant(sharpness, 5);
 
-        TravelingItem travelingItem = new TravelingItem(enchantedSword, Direction.WEST, 0.05f);
-        boolean accepted = pipe.forceAddItem(travelingItem, Direction.WEST);
-        if (!accepted) {
-            context.fail("Pipe should accept the force-injected enchanted sword");
+        TravelingItem original = new TravelingItem(enchantedSword, Direction.EAST, 0.05f);
+
+        // Regression test: before the RegistryOps fix, this threw
+        // IllegalStateException: Can't access registry (enchantments require registry-aware ops).
+        RegistryOps<Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
+        Tag encoded;
+        try {
+            encoded = TravelingItem.CODEC.encodeStart(ops, original).getOrThrow();
+        } catch (Exception e) {
+            context.fail("TravelingItem serialization threw with registry-backed enchantment: " + e.getMessage());
             return;
         }
 
-        // Force serialization while the enchanted item is in transit.
-        // With NbtOps.INSTANCE (the bug), this throws IllegalStateException.
-        // With RegistryOps (the fix), this succeeds.
-        pipe.getUpdateTag(level.registryAccess());
+        TravelingItem decoded;
+        try {
+            decoded = TravelingItem.CODEC.parse(ops, encoded).getOrThrow();
+        } catch (Exception e) {
+            context.fail("TravelingItem deserialization threw: " + e.getMessage());
+            return;
+        }
 
-        // Verify the item arrives with its enchantment intact.
-        context.succeedWhen(() -> {
-            ChestBlockEntity chest = context.getBlockEntity(chestPos, ChestBlockEntity.class);
-            if (chest == null) throw new AssertionError("Chest block entity missing");
-            for (int i = 0; i < chest.getContainerSize(); i++) {
-                ItemStack s = chest.getItem(i);
-                if (s.is(Items.DIAMOND_SWORD)) {
-                    ItemEnchantments enchants = s.get(DataComponents.ENCHANTMENTS);
-                    if (enchants != null && !enchants.isEmpty()) return;
-                }
+        ItemEnchantments enchants = decoded.getStack().get(DataComponents.ENCHANTMENTS);
+        if (enchants == null || enchants.isEmpty()) {
+            context.fail("Enchantments lost after TravelingItem serialize+deserialize");
+            return;
+        }
+        for (Holder<Enchantment> h : enchants.keySet()) {
+            if (h.is(Enchantments.SHARPNESS) && enchants.getLevel(h) == 5) {
+                context.succeed();
+                return;
             }
-            throw new AssertionError("No enchanted diamond sword found in chest");
-        });
+        }
+        context.fail("Sharpness V not intact after TravelingItem serialize+deserialize");
     }
 
     /**

--- a/src/gametest/java/com/logistics/gametest/pipe/PipeFlowGameTest.java
+++ b/src/gametest/java/com/logistics/gametest/pipe/PipeFlowGameTest.java
@@ -223,20 +223,18 @@ public class PipeFlowGameTest {
     }
 
     /**
-     * Verifies that enchanted items travel through a pipe without crashing and arrive with
-     * their enchantments intact.
+     * Verifies that {@link TravelingItem#CODEC} can serialize and deserialize an enchanted
+     * {@link ItemStack} without throwing {@code IllegalStateException: Can't access registry}.
      *
-     * <p>Regression test for: {@code IllegalStateException: Can't access registry} thrown when
-     * serializing an {@link ItemStack} with registry-backed components (e.g. enchantments) using
-     * {@code NbtOps.INSTANCE}. The fix is to use {@code RegistryOps} at every {@code ItemStack.CODEC}
-     * call site in the pipe layer.
+     * <p>Regression test for: the crash described above, caused by using {@code NbtOps.INSTANCE}
+     * instead of {@code RegistryOps} when encoding registry-backed components (e.g. enchantments).
+     * The fix ensures every {@code ItemStack.CODEC} call site in the pipe layer uses a
+     * registry-aware {@code RegistryOps} context.
      *
-     * <p>Layout (y=1): [copper_transport_pipe] → [chest]
-     *
-     * <p>Run in-game: /test run logistics-gametest.pipeflowgametest.testenchanteditemtravelsthroughpipe
+     * <p>Run in-game: /test run logistics-gametest.pipeflowgametest.testenchantedtravelingitemserialization
      */
     @GameTest(maxTicks = 1)
-    public void testEnchantedItemTravelsThroughPipe(GameTestHelper context) {
+    public void testEnchantedTravelingItemSerialization(GameTestHelper context) {
         ServerLevel level = context.getLevel();
 
         // Enchantments are data-driven and require a live registry — not available in unit tests.

--- a/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -281,14 +281,14 @@ public class KilnBlockEntity extends BaseBlockEntity
 
     @Override
     protected void saveLogisticsData(CompoundTag tag) {
-        inventory.writeNbt(tag, "Inventory");
+        inventory.writeNbt(tag, "Inventory", level.registryAccess());
         energy.writeNbt(tag, "Energy");
         tag.putInt("ProcessProgress", processProgress);
     }
 
     @Override
     protected void loadLogisticsData(CompoundTag tag) {
-        inventory.readNbt(tag, "Inventory");
+        inventory.readNbt(tag, "Inventory", level.registryAccess());
         energy.readNbt(tag, "Energy");
         processProgress = NbtCompat.getInt(tag, "ProcessProgress", 0);
         // activeRecipe is re-resolved on the next tick

--- a/src/main/java/com/logistics/core/lib/items/ItemInventoryComponent.java
+++ b/src/main/java/com/logistics/core/lib/items/ItemInventoryComponent.java
@@ -4,10 +4,12 @@ import com.logistics.core.lib.storage.NbtCompat;
 import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -38,7 +40,8 @@ public final class ItemInventoryComponent implements Container {
         return storage;
     }
 
-    public void readNbt(CompoundTag nbt, String key) {
+    public void readNbt(CompoundTag nbt, String key, HolderLookup.Provider registries) {
+        RegistryOps<net.minecraft.nbt.Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
         ListTag list = NbtCompat.getListOrEmpty(nbt, key);
 
         // Clear existing stacks
@@ -46,38 +49,39 @@ public final class ItemInventoryComponent implements Container {
 
         // Load items from list
         for (int i = 0; i < list.size(); i++) {
-            loadItemAt(list, i);
+            loadItemAt(ops, list, i);
         }
     }
 
-    public void writeNbt(CompoundTag nbt, String key) {
+    public void writeNbt(CompoundTag nbt, String key, HolderLookup.Provider registries) {
+        RegistryOps<net.minecraft.nbt.Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
         ListTag listTag = new ListTag();
         for (int i = 0; i < stacks.size(); i++) {
-            saveItemAt(listTag, i);
+            saveItemAt(ops, listTag, i);
         }
         if (!listTag.isEmpty()) {
             nbt.put(key, listTag);
         }
     }
 
-    private void loadItemAt(ListTag list, int index) {
+    private void loadItemAt(RegistryOps<net.minecraft.nbt.Tag> ops, ListTag list, int index) {
         NbtCompat.ifHasCompoundAt(list, index, itemTag -> {
             int slot = NbtCompat.getInt(itemTag, "Slot", 0) & 255;
             if (slot < stacks.size()) {
-                ItemStack.CODEC.parse(NbtOps.INSTANCE, itemTag)
+                ItemStack.CODEC.parse(ops, itemTag)
                         .result()
                         .ifPresent(stack -> stacks.set(slot, stack));
             }
         });
     }
 
-    private void saveItemAt(ListTag list, int slot) {
+    private void saveItemAt(RegistryOps<net.minecraft.nbt.Tag> ops, ListTag list, int slot) {
         ItemStack stack = stacks.get(slot);
         if (stack.isEmpty()) {
             return;
         }
 
-        ItemStack.CODEC.encodeStart(NbtOps.INSTANCE, stack)
+        ItemStack.CODEC.encodeStart(ops, stack)
                 .result()
                 .ifPresent(tag -> {
                     if (tag instanceof CompoundTag itemTag) {

--- a/src/main/java/com/logistics/core/lib/items/ItemInventoryComponent.java
+++ b/src/main/java/com/logistics/core/lib/items/ItemInventoryComponent.java
@@ -9,6 +9,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
@@ -41,7 +42,7 @@ public final class ItemInventoryComponent implements Container {
     }
 
     public void readNbt(CompoundTag nbt, String key, HolderLookup.Provider registries) {
-        RegistryOps<net.minecraft.nbt.Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
+        RegistryOps<Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
         ListTag list = NbtCompat.getListOrEmpty(nbt, key);
 
         // Clear existing stacks
@@ -54,7 +55,7 @@ public final class ItemInventoryComponent implements Container {
     }
 
     public void writeNbt(CompoundTag nbt, String key, HolderLookup.Provider registries) {
-        RegistryOps<net.minecraft.nbt.Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
+        RegistryOps<Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
         ListTag listTag = new ListTag();
         for (int i = 0; i < stacks.size(); i++) {
             saveItemAt(ops, listTag, i);
@@ -64,7 +65,7 @@ public final class ItemInventoryComponent implements Container {
         }
     }
 
-    private void loadItemAt(RegistryOps<net.minecraft.nbt.Tag> ops, ListTag list, int index) {
+    private void loadItemAt(RegistryOps<Tag> ops, ListTag list, int index) {
         NbtCompat.ifHasCompoundAt(list, index, itemTag -> {
             int slot = NbtCompat.getInt(itemTag, "Slot", 0) & 255;
             if (slot < stacks.size()) {
@@ -75,7 +76,7 @@ public final class ItemInventoryComponent implements Container {
         });
     }
 
-    private void saveItemAt(RegistryOps<net.minecraft.nbt.Tag> ops, ListTag list, int slot) {
+    private void saveItemAt(RegistryOps<Tag> ops, ListTag list, int slot) {
         ItemStack stack = stacks.get(slot);
         if (stack.isEmpty()) {
             return;

--- a/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
@@ -292,7 +292,7 @@ public class MaceratorBlockEntity extends BaseBlockEntity
 
     @Override
     protected void saveLogisticsData(CompoundTag tag) {
-        inventory.writeNbt(tag, "Inventory");
+        inventory.writeNbt(tag, "Inventory", level.registryAccess());
         energy.writeNbt(tag, "Energy");
         tag.putInt("ProcessProgress", processProgress);
         if (activeRecipeId != null) {
@@ -302,7 +302,7 @@ public class MaceratorBlockEntity extends BaseBlockEntity
 
     @Override
     protected void loadLogisticsData(CompoundTag tag) {
-        inventory.readNbt(tag, "Inventory");
+        inventory.readNbt(tag, "Inventory", level.registryAccess());
         energy.readNbt(tag, "Energy");
         processProgress = NbtCompat.getInt(tag, "ProcessProgress", 0);
         String recipeStr = NbtCompat.getString(tag, "ActiveRecipe", "");

--- a/src/main/java/com/logistics/pipe/ChassisPipe.java
+++ b/src/main/java/com/logistics/pipe/ChassisPipe.java
@@ -17,6 +17,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleMenuProvider;
@@ -83,10 +84,11 @@ public class ChassisPipe extends Pipe {
     protected List<Module> getDynamicModules(PipeContext ctx) {
         List<Module> modules = new ArrayList<>();
         var state = ctx.moduleState(STATE_KEY);
+        RegistryOps<net.minecraft.nbt.Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
         for (int slot = 0; slot < maxSlots; slot++) {
             Tag tag = state.get(String.valueOf(slot));
             if (tag == null) continue;
-            ItemStack.CODEC.parse(NbtOps.INSTANCE, tag).result()
+            ItemStack.CODEC.parse(ops, tag).result()
                     .map(ItemStack::getItem)
                     .filter(item -> item instanceof ModuleItem)
                     .map(item -> ((ModuleItem) item).createModule())

--- a/src/main/java/com/logistics/pipe/ChassisPipe.java
+++ b/src/main/java/com/logistics/pipe/ChassisPipe.java
@@ -84,7 +84,7 @@ public class ChassisPipe extends Pipe {
     protected List<Module> getDynamicModules(PipeContext ctx) {
         List<Module> modules = new ArrayList<>();
         var state = ctx.moduleState(STATE_KEY);
-        RegistryOps<net.minecraft.nbt.Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
+        RegistryOps<Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
         for (int slot = 0; slot < maxSlots; slot++) {
             Tag tag = state.get(String.valueOf(slot));
             if (tag == null) continue;

--- a/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -149,6 +149,7 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
         CompoundTag chassisState = pipeEntity.getOrCreateModuleState(ChassisPipe.STATE_KEY);
         if (chassisState.isEmpty()) return;
 
+        // ItemStack.CODEC needs registry-aware ops for registry-backed components such as enchantments.
         RegistryOps<Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
         PipeContext ctx = pipeEntity.createContext();
 
@@ -157,19 +158,22 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
             if (tag == null) continue;
 
             ItemStack.CODEC.parse(ops, tag).result().ifPresent(stack -> {
-                // Sync module config (filters, etc.) into the dropped item
-                if (stack.getItem() instanceof ModuleItem moduleItem) {
-                    String stateKey = moduleItem.createModule().getStateKey();
-                    CompoundTag moduleData = ctx.moduleState(stateKey);
-                    if (!moduleData.isEmpty()) {
-                        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(moduleData.copy()));
-                    }
-                }
+                syncModuleConfigToDroppedItem(ctx, stack);
                 net.minecraft.world.entity.item.ItemEntity entity = new net.minecraft.world.entity.item.ItemEntity(
                         level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
                 entity.setDefaultPickUpDelay();
                 level.addFreshEntity(entity);
             });
+        }
+    }
+
+    private void syncModuleConfigToDroppedItem(PipeContext ctx, ItemStack stack) {
+        if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
+
+        String stateKey = moduleItem.createModule().getStateKey();
+        CompoundTag moduleData = ctx.moduleState(stateKey);
+        if (!moduleData.isEmpty()) {
+            stack.set(DataComponents.CUSTOM_DATA, CustomData.of(moduleData.copy()));
         }
     }
 

--- a/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -54,6 +54,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.level.ScheduledTickAccess;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Nullable;
 
@@ -140,11 +141,7 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
         return super.playerWillDestroy(level, pos, state, player);
     }
 
-    /**
-     * Drop installed chassis module items at the pipe position.
-     * Reads module ItemStacks from the chassis NBT state, syncs each module's
-     * configuration into the item's CustomData, and spawns them as item entities.
-     */
+    /** Drop installed chassis module items at the pipe position. */
     private void dropChassisModules(Level level, BlockPos pos, PipeBlockEntity pipeEntity) {
         CompoundTag chassisState = pipeEntity.getOrCreateModuleState(ChassisPipe.STATE_KEY);
         if (chassisState.isEmpty()) return;
@@ -158,8 +155,8 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
             if (tag == null) continue;
 
             ItemStack.CODEC.parse(ops, tag).result().ifPresent(stack -> {
-                syncModuleConfigToDroppedItem(ctx, stack);
-                net.minecraft.world.entity.item.ItemEntity entity = new net.minecraft.world.entity.item.ItemEntity(
+                applyModuleStateToStack(ctx, stack);
+                ItemEntity entity = new ItemEntity(
                         level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
                 entity.setDefaultPickUpDelay();
                 level.addFreshEntity(entity);
@@ -167,7 +164,7 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
         }
     }
 
-    private void syncModuleConfigToDroppedItem(PipeContext ctx, ItemStack stack) {
+    private void applyModuleStateToStack(PipeContext ctx, ItemStack stack) {
         if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
 
         String stateKey = moduleItem.createModule().getStateKey();

--- a/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -7,21 +7,29 @@ import com.logistics.pipe.network.NetworkRegistry;
 import com.logistics.core.lib.pipe.PipeConnectionRegistry;
 import com.logistics.core.lib.support.ProbeResult;
 import com.logistics.pipe.Pipe;
+import com.logistics.pipe.ChassisPipe;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.pipe.item.ModuleItem;
 import com.mojang.serialization.MapCodec;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.level.redstone.Orientation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.BlockGetter;
@@ -117,18 +125,52 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
     @Override
     public BlockState playerWillDestroy(
             Level level, BlockPos pos, BlockState state, net.minecraft.world.entity.player.Player player) {
-        // Drop traveling items when pipe is broken by player
+        // Drop traveling items and module items when pipe is broken by player
         if (!level.isClientSide()) {
             BlockEntity blockEntity = level.getBlockEntity(pos);
             if (blockEntity instanceof PipeBlockEntity pipeEntity) {
                 for (TravelingItem item : pipeEntity.getTravelingItems()) {
                     PipeBlockEntity.dropItem(level, pos, item);
                 }
+                dropChassisModules(level, pos, pipeEntity);
             }
             // Remove pipe from network
             NetworkRegistry.removePipe(level, pos);
         }
         return super.playerWillDestroy(level, pos, state, player);
+    }
+
+    /**
+     * Drop installed chassis module items at the pipe position.
+     * Reads module ItemStacks from the chassis NBT state, syncs each module's
+     * configuration into the item's CustomData, and spawns them as item entities.
+     */
+    private void dropChassisModules(Level level, BlockPos pos, PipeBlockEntity pipeEntity) {
+        CompoundTag chassisState = pipeEntity.getOrCreateModuleState(ChassisPipe.STATE_KEY);
+        if (chassisState.isEmpty()) return;
+
+        RegistryOps<Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
+        PipeContext ctx = pipeEntity.createContext();
+
+        for (int slot = 0; slot < ChassisPipe.MAX_SLOTS; slot++) {
+            Tag tag = chassisState.get(String.valueOf(slot));
+            if (tag == null) continue;
+
+            ItemStack.CODEC.parse(ops, tag).result().ifPresent(stack -> {
+                // Sync module config (filters, etc.) into the dropped item
+                if (stack.getItem() instanceof ModuleItem moduleItem) {
+                    String stateKey = moduleItem.createModule().getStateKey();
+                    CompoundTag moduleData = ctx.moduleState(stateKey);
+                    if (!moduleData.isEmpty()) {
+                        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(moduleData.copy()));
+                    }
+                }
+                net.minecraft.world.entity.item.ItemEntity entity = new net.minecraft.world.entity.item.ItemEntity(
+                        level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
+                entity.setDefaultPickUpDelay();
+                level.addFreshEntity(entity);
+            });
+        }
     }
 
     /**

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -31,6 +31,7 @@ import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -204,10 +205,11 @@ public class PipeBlockEntity extends BaseBlockEntity
 
         // Save traveling items
         if (!travelingItems.isEmpty()) {
+            RegistryOps<net.minecraft.nbt.Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
             ListTag itemsList = new ListTag();
             for (TravelingItem item : travelingItems) {
                 CompoundTag itemTag = (CompoundTag) TravelingItem.CODEC
-                        .encodeStart(NbtOps.INSTANCE, item)
+                        .encodeStart(ops, item)
                         .getOrThrow();
                 itemsList.add(itemTag);
             }
@@ -246,9 +248,10 @@ public class PipeBlockEntity extends BaseBlockEntity
         // Load traveling items
         travelingItems.clear();
         NbtCompat.ifHasList(pipeData, "ItemsInTransit", itemsList -> {
+            RegistryOps<net.minecraft.nbt.Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
             for (int i = 0; i < itemsList.size(); i++) {
                 NbtCompat.ifHasCompoundAt(itemsList, i, itemTag ->
-                    TravelingItem.CODEC.parse(NbtOps.INSTANCE, itemTag).result()
+                    TravelingItem.CODEC.parse(ops, itemTag).result()
                             .ifPresent(travelingItems::add));
             }
         });
@@ -362,7 +365,7 @@ public class PipeBlockEntity extends BaseBlockEntity
     @Override
     public void setRemoved() {
         super.setRemoved();
-        // Item dropping is handled in PipeBlock.onRemove() instead
+        // Item dropping is handled in PipeBlock.playerWillDestroy() instead
     }
 
     public CompoundTag getOrCreateModuleState(String key) {

--- a/src/main/java/com/logistics/pipe/network/packet/OpenChassisSlotPacket.java
+++ b/src/main/java/com/logistics/pipe/network/packet/OpenChassisSlotPacket.java
@@ -53,7 +53,8 @@ public record OpenChassisSlotPacket(int slotIndex) implements CustomPacketPayloa
                 Tag tag = ctx.moduleState(ChassisPipe.STATE_KEY).get(String.valueOf(packet.slotIndex));
                 if (tag == null) return;
 
-                ItemStack.CODEC.parse(NbtOps.INSTANCE, tag).result()
+                var ops = context.server().registryAccess().createSerializationContext(NbtOps.INSTANCE);
+                ItemStack.CODEC.parse(ops, tag).result()
                         .map(ItemStack::getItem)
                         .filter(item -> item instanceof ModuleItem)
                         .map(item -> ((ModuleItem) item).createModule())

--- a/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
@@ -9,6 +9,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -72,11 +73,15 @@ public class ChassisInventory implements Container {
     private void loadFromEntity() {
         PipeContext ctx = pipeEntity.createContext();
         var state = ctx.moduleState(ChassisPipe.STATE_KEY);
+        Level level = pipeEntity.getLevel();
+        RegistryOps<net.minecraft.nbt.Tag> ops = level != null
+                ? level.registryAccess().createSerializationContext(NbtOps.INSTANCE)
+                : null;
         for (int slot = 0; slot < ChassisPipe.MAX_SLOTS; slot++) {
             final int s = slot;
             Tag tag = state.get(String.valueOf(slot));
-            if (tag != null) {
-                ItemStack.CODEC.parse(NbtOps.INSTANCE, tag).result()
+            if (tag != null && ops != null) {
+                ItemStack.CODEC.parse(ops, tag).result()
                         .ifPresent(stack -> items.set(s, stack));
             }
         }
@@ -96,6 +101,7 @@ public class ChassisInventory implements Container {
 
         PipeContext ctx = pipeEntity.createContext();
         var state = ctx.moduleState(ChassisPipe.STATE_KEY);
+        RegistryOps<net.minecraft.nbt.Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
         for (int slot = 0; slot < ChassisPipe.MAX_SLOTS; slot++) {
             String key = String.valueOf(slot);
             ItemStack stack = items.get(slot);
@@ -103,7 +109,7 @@ public class ChassisInventory implements Container {
                 state.remove(key);
             } else {
                 final String k = key;
-                ItemStack.CODEC.encodeStart(NbtOps.INSTANCE, stack).result()
+                ItemStack.CODEC.encodeStart(ops, stack).result()
                         .ifPresent(tag -> state.put(k, tag));
             }
         }

--- a/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
@@ -74,7 +74,7 @@ public class ChassisInventory implements Container {
         PipeContext ctx = pipeEntity.createContext();
         var state = ctx.moduleState(ChassisPipe.STATE_KEY);
         Level level = pipeEntity.getLevel();
-        RegistryOps<net.minecraft.nbt.Tag> ops = level != null
+        RegistryOps<Tag> ops = level != null
                 ? level.registryAccess().createSerializationContext(NbtOps.INSTANCE)
                 : null;
         for (int slot = 0; slot < ChassisPipe.MAX_SLOTS; slot++) {
@@ -101,7 +101,7 @@ public class ChassisInventory implements Container {
 
         PipeContext ctx = pipeEntity.createContext();
         var state = ctx.moduleState(ChassisPipe.STATE_KEY);
-        RegistryOps<net.minecraft.nbt.Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
+        RegistryOps<Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
         for (int slot = 0; slot < ChassisPipe.MAX_SLOTS; slot++) {
             String key = String.valueOf(slot);
             ItemStack stack = items.get(slot);

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -438,7 +438,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         nbt.putDouble("PIDIntegral", pidController.getIntegral());
 
         // Save fuel inventory
-        inventory.writeNbt(nbt, "Inventory");
+        inventory.writeNbt(nbt, "Inventory", level.registryAccess());
     }
 
     @Override
@@ -455,11 +455,12 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
         // Load fuel inventory (try new key first, fall back to legacy)
         if (nbt.contains("Inventory")) {
-            inventory.readNbt(nbt, "Inventory");
+            inventory.readNbt(nbt, "Inventory", level.registryAccess());
         } else if (nbt.contains("FuelStack")) {
             // Legacy: single item stored with CODEC
             inventory.setItem(0, ItemStack.EMPTY);
-            ItemStack.CODEC.parse(net.minecraft.nbt.NbtOps.INSTANCE, nbt.get("FuelStack"))
+            var ops = level.registryAccess().createSerializationContext(net.minecraft.nbt.NbtOps.INSTANCE);
+            ItemStack.CODEC.parse(ops, nbt.get("FuelStack"))
                     .result()
                     .ifPresent(stack -> inventory.setItem(0, stack));
         }

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -21,6 +21,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -459,7 +460,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         } else if (nbt.contains("FuelStack")) {
             // Legacy: single item stored with CODEC
             inventory.setItem(0, ItemStack.EMPTY);
-            var ops = level.registryAccess().createSerializationContext(net.minecraft.nbt.NbtOps.INSTANCE);
+            var ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
             ItemStack.CODEC.parse(ops, nbt.get("FuelStack"))
                     .result()
                     .ifPresent(stack -> inventory.setItem(0, stack));

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,3 +31,4 @@
   },
   "version": "${version}"
 }
+

--- a/src/test/java/com/logistics/pipe/runtime/TravelingItemSerializationTest.java
+++ b/src/test/java/com/logistics/pipe/runtime/TravelingItemSerializationTest.java
@@ -1,0 +1,87 @@
+package com.logistics.pipe.runtime;
+
+import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Verifies that {@link TravelingItem} serializes correctly using registry-aware ops.
+ *
+ * <p>The fix in this area replaced {@code NbtOps.INSTANCE} with {@code RegistryOps} at all
+ * {@link net.minecraft.world.item.ItemStack#CODEC} call sites in the pipe layer. Plain items
+ * encode the same way under either ops, but registry-backed components (enchantments, etc.)
+ * throw {@link IllegalStateException} with bare {@code NbtOps.INSTANCE}.
+ *
+ * <p>Enchanted-item serialization is tested end-to-end in
+ * {@code PipeFlowGameTest.testEnchantedItemTravelsThroughPipe}, which has access to a live
+ * {@code ServerLevel} and can resolve {@code Holder<Enchantment>} from the dynamic registry.
+ */
+@DisplayName("TravelingItem serialization")
+class TravelingItemSerializationTest extends MinecraftTestEnvironment {
+
+    private static final float TOLERANCE = 0.0001f;
+
+    private RegistryOps<Tag> ops;
+
+    @BeforeEach
+    void setUp() {
+        RegistryAccess registries = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
+        ops = registries.createSerializationContext(NbtOps.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("round-trips item, direction, speed, and progress through NBT")
+    void roundTripPreservesFields() {
+        TravelingItem original = new TravelingItem(new ItemStack(Items.DIAMOND, 3), Direction.EAST, 0.05f);
+        original.setProgress(0.35f);
+
+        Tag encoded = TravelingItem.CODEC.encodeStart(ops, original).getOrThrow();
+        TravelingItem decoded = TravelingItem.CODEC.parse(ops, encoded).getOrThrow();
+
+        assertThat(decoded.getStack().getItem()).isEqualTo(Items.DIAMOND);
+        assertThat(decoded.getStack().getCount()).isEqualTo(3);
+        assertThat(decoded.getDirection()).isEqualTo(Direction.EAST);
+        assertThat(decoded.getSpeed()).isCloseTo(0.05f, within(TOLERANCE));
+        assertThat(decoded.getProgress()).isCloseTo(0.35f, within(TOLERANCE));
+    }
+
+    @Test
+    @DisplayName("round-trips destination and routing state")
+    void roundTripPreservesRoutingState() {
+        BlockPos destination = new BlockPos(10, 64, -5);
+        TravelingItem original = new TravelingItem(new ItemStack(Items.EMERALD), Direction.NORTH, 0.08f, destination);
+        original.setRouted(true);
+
+        Tag encoded = TravelingItem.CODEC.encodeStart(ops, original).getOrThrow();
+        TravelingItem decoded = TravelingItem.CODEC.parse(ops, encoded).getOrThrow();
+
+        assertThat(decoded.getDestination()).isEqualTo(destination);
+        assertThat(decoded.isRouted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("round-trips a stack with count greater than one")
+    void roundTripPreservesStackCount() {
+        TravelingItem original = new TravelingItem(new ItemStack(Items.IRON_INGOT, 16), Direction.SOUTH, 0.1f);
+
+        Tag encoded = TravelingItem.CODEC.encodeStart(ops, original).getOrThrow();
+        TravelingItem decoded = TravelingItem.CODEC.parse(ops, encoded).getOrThrow();
+
+        assertThat(decoded.getStack().getCount()).isEqualTo(16);
+        assertThat(decoded.getStack().getItem()).isEqualTo(Items.IRON_INGOT);
+    }
+}


### PR DESCRIPTION
## Summary

Enchanted items passing through pipes or stored in chassis modules crash the game with `IllegalStateException: Can't access registry ResourceKey[minecraft:root / minecraft:enchantment]`.

## Changes

- Replace `NbtOps.INSTANCE` with registry-aware `RegistryOps` across all `ItemStack.CODEC` encode/decode sites
- Affected files: KilnBlockEntity, MaceratorBlockEntity, ItemInventoryComponent, StirlingEngineBlockEntity, PipeBlockEntity, ChassisPipe, ChassisInventory, OpenChassisSlotPacket
- Drop installed chassis modules as items when a chassis pipe is broken (they were previously lost)