### PR TITLE
fix: resolve vanishing filters in diamond pipes serialization

### DIFF
--- a/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -13,6 +13,7 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -280,15 +281,15 @@ public class KilnBlockEntity extends BaseBlockEntity
     // ==================== NBT ====================
 
     @Override
-    protected void saveLogisticsData(CompoundTag tag) {
-        inventory.writeNbt(tag, "Inventory", level.registryAccess());
+    protected void saveLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
+        inventory.writeNbt(tag, "Inventory", registries);
         energy.writeNbt(tag, "Energy");
         tag.putInt("ProcessProgress", processProgress);
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag tag) {
-        inventory.readNbt(tag, "Inventory", level.registryAccess());
+    protected void loadLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
+        inventory.readNbt(tag, "Inventory", registries);
         energy.readNbt(tag, "Energy");
         processProgress = NbtCompat.getInt(tag, "ProcessProgress", 0);
         // activeRecipe is re-resolved on the next tick

--- a/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
@@ -1158,8 +1159,8 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     // NBT serialization
     @Override
-    protected void saveLogisticsData(CompoundTag nbt) {
-        super.saveLogisticsData(nbt);
+    protected void saveLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.saveLogisticsData(nbt, registries);
 
         // Save energy
         energy.writeNbt(nbt, "Energy");
@@ -1194,8 +1195,8 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag nbt) {
-        super.loadLogisticsData(nbt);
+    protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLogisticsData(nbt, registries);
 
         // Load energy (try new key first, fall back to legacy)
         if (nbt.contains("Energy")) {
@@ -1250,8 +1251,8 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     }
 
     @Override
-    protected void loadLegacyData(CompoundTag nbt) {
-        super.loadLegacyData(nbt);
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLegacyData(nbt, registries);
 
         useCustomBounds = false;
         customMinX = 0;

--- a/src/main/java/com/logistics/automation/marker/MarkerBlockEntity.java
+++ b/src/main/java/com/logistics/automation/marker/MarkerBlockEntity.java
@@ -6,6 +6,7 @@ import com.logistics.core.lib.storage.NbtCompat;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
@@ -157,8 +158,8 @@ public class MarkerBlockEntity extends BaseBlockEntity {
     }
 
     @Override
-    protected void saveLogisticsData(CompoundTag data) {
-        super.saveLogisticsData(data);
+    protected void saveLogisticsData(CompoundTag data, HolderLookup.Provider registries) {
+        super.saveLogisticsData(data, registries);
 
         // Save connected markers
         if (!connectedMarkers.isEmpty()) {
@@ -188,8 +189,8 @@ public class MarkerBlockEntity extends BaseBlockEntity {
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag data) {
-        super.loadLogisticsData(data);
+    protected void loadLogisticsData(CompoundTag data, HolderLookup.Provider registries) {
+        super.loadLogisticsData(data, registries);
 
         connectedMarkers.clear();
         boundMin = null;
@@ -204,8 +205,8 @@ public class MarkerBlockEntity extends BaseBlockEntity {
     }
 
     @Override
-    protected void loadLegacyData(CompoundTag nbt) {
-        super.loadLegacyData(nbt);
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLegacyData(nbt, registries);
 
         if (nbt.contains("MarkerData")) {
             CompoundTag data = nbt.getCompound("MarkerData");

--- a/src/main/java/com/logistics/core/lib/BaseBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/BaseBlockEntity.java
@@ -37,11 +37,10 @@ public abstract class BaseBlockEntity extends BlockEntity {
      * Save logistics block entity data to NBT.
      * Override this instead of {@link #saveAdditional(CompoundTag, net.minecraft.core.HolderLookup.Provider)}.
      *
-     * <p>Note: Use {@code level.registryAccess()} to serialize ItemStacks and other registry objects.
-     *
      * @param tag the compound tag to write logistics data into
+     * @param registries registry access for serializing ItemStacks and other registry objects
      */
-    protected void saveLogisticsData(CompoundTag tag) {
+    protected void saveLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
         // Default: no logistics data
     }
 
@@ -49,11 +48,13 @@ public abstract class BaseBlockEntity extends BlockEntity {
      * Load logistics block entity data from NBT.
      * Override this instead of {@link #loadAdditional(CompoundTag, net.minecraft.core.HolderLookup.Provider)}.
      *
-     * <p>Note: Use {@code level.registryAccess()} to deserialize ItemStacks and other registry objects.
+     * <p>Use {@code registries} (not {@code level.registryAccess()}) to deserialize ItemStacks —
+     * {@code level} is null at load time because {@code setLevel} is called after deserialization.
      *
      * @param tag the compound tag to read logistics data from
+     * @param registries registry access for deserializing ItemStacks and other registry objects
      */
-    protected void loadLogisticsData(CompoundTag tag) {
+    protected void loadLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
         // Default: no logistics data
     }
 
@@ -67,8 +68,9 @@ public abstract class BaseBlockEntity extends BlockEntity {
      * <p>TODO: This method should be removed prior to v1.0 release
      *
      * @param nbt the compound tag to read legacy data from
+     * @param registries registry access for deserializing ItemStacks and other registry objects
      */
-    protected void loadLegacyData(CompoundTag nbt) {
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
         // Default: no legacy data migration needed
     }
 
@@ -76,7 +78,7 @@ public abstract class BaseBlockEntity extends BlockEntity {
     protected final void saveAdditional(CompoundTag nbt, HolderLookup.Provider registries) {
         super.saveAdditional(nbt, registries);
         CompoundTag logisticsData = new CompoundTag();
-        saveLogisticsData(logisticsData);
+        saveLogisticsData(logisticsData, registries);
         if (!logisticsData.isEmpty()) {
             nbt.put(DATA_KEY, logisticsData);
         }
@@ -86,9 +88,9 @@ public abstract class BaseBlockEntity extends BlockEntity {
     protected final void loadAdditional(CompoundTag nbt, HolderLookup.Provider registries) {
         super.loadAdditional(nbt, registries);
         if (nbt.contains(DATA_KEY)) {
-            loadLogisticsData(nbt.getCompound(DATA_KEY));
+            loadLogisticsData(nbt.getCompound(DATA_KEY), registries);
         } else {
-            loadLegacyData(nbt);  // Changed signature: CompoundTag instead of ValueInput
+            loadLegacyData(nbt, registries);
         }
     }
 

--- a/src/main/java/com/logistics/core/lib/BaseBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/BaseBlockEntity.java
@@ -20,8 +20,9 @@ import org.jetbrains.annotations.Nullable;
  *   <li>Proper client chunk sync and update packets</li>
  * </ul>
  *
- * <p>Subclasses override {@link #saveLogisticsData(CompoundTag)} and {@link #loadLogisticsData(CompoundTag)}
- * for normal persistence, using the simple NBT tag-based API.
+ * <p>Subclasses override {@link #saveLogisticsData(CompoundTag, HolderLookup.Provider)} and
+ * {@link #loadLogisticsData(CompoundTag, HolderLookup.Provider)} for normal persistence,
+ * using the simple NBT tag-based API.
  */
 public abstract class BaseBlockEntity extends BlockEntity {
 

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
@@ -530,7 +531,7 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveLogisticsData(CompoundTag engineData) {
+    protected void saveLogisticsData(CompoundTag engineData, HolderLookup.Provider registries) {
         engineData.putLong("StoredEnergy", energyStorage.amount);
         engineData.putDouble("Temperature", temperature);
         engineData.putFloat("CycleProgress", progress);
@@ -539,7 +540,7 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag engineData) {
+    protected void loadLogisticsData(CompoundTag engineData, HolderLookup.Provider registries) {
         energyStorage.amount = NbtCompat.getLong(engineData, "StoredEnergy", 0L);
         temperature = NbtCompat.getDouble(engineData, "Temperature", 0.0);
         progress = NbtCompat.getFloat(engineData, "CycleProgress", 0f);
@@ -548,7 +549,7 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
     }
 
     @Override
-    protected void loadLegacyData(CompoundTag nbt) {
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
         if (nbt.contains("Engine")) {
             CompoundTag engineData = nbt.getCompound("Engine");
             // Load old key names (before BaseBlockEntity refactoring)

--- a/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
+++ b/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
@@ -14,6 +14,7 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -291,8 +292,8 @@ public class MaceratorBlockEntity extends BaseBlockEntity
     // ==================== NBT ====================
 
     @Override
-    protected void saveLogisticsData(CompoundTag tag) {
-        inventory.writeNbt(tag, "Inventory", level.registryAccess());
+    protected void saveLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
+        inventory.writeNbt(tag, "Inventory", registries);
         energy.writeNbt(tag, "Energy");
         tag.putInt("ProcessProgress", processProgress);
         if (activeRecipeId != null) {
@@ -301,8 +302,8 @@ public class MaceratorBlockEntity extends BaseBlockEntity
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag tag) {
-        inventory.readNbt(tag, "Inventory", level.registryAccess());
+    protected void loadLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
+        inventory.readNbt(tag, "Inventory", registries);
         energy.readNbt(tag, "Energy");
         processProgress = NbtCompat.getInt(tag, "ProcessProgress", 0);
         String recipeStr = NbtCompat.getString(tag, "ActiveRecipe", "");

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -208,7 +208,7 @@ public class PipeBlockEntity extends BaseBlockEntity
 
         // Save traveling items
         if (!travelingItems.isEmpty()) {
-            RegistryOps<net.minecraft.nbt.Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
+            RegistryOps<Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
             ListTag itemsList = new ListTag();
             for (TravelingItem item : travelingItems) {
                 CompoundTag itemTag = (CompoundTag) TravelingItem.CODEC

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -28,10 +28,12 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
@@ -201,12 +203,12 @@ public class PipeBlockEntity extends BaseBlockEntity
     }
 
     @Override
-    protected void saveLogisticsData(CompoundTag pipeData) {
-        super.saveLogisticsData(pipeData);
+    protected void saveLogisticsData(CompoundTag pipeData, HolderLookup.Provider registries) {
+        super.saveLogisticsData(pipeData, registries);
 
         // Save traveling items
         if (!travelingItems.isEmpty()) {
-            RegistryOps<net.minecraft.nbt.Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
+            RegistryOps<net.minecraft.nbt.Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
             ListTag itemsList = new ListTag();
             for (TravelingItem item : travelingItems) {
                 CompoundTag itemTag = (CompoundTag) TravelingItem.CODEC
@@ -241,15 +243,15 @@ public class PipeBlockEntity extends BaseBlockEntity
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag pipeData) {
-        super.loadLogisticsData(pipeData);
+    protected void loadLogisticsData(CompoundTag pipeData, HolderLookup.Provider registries) {
+        super.loadLogisticsData(pipeData, registries);
 
         long readStart = System.nanoTime();
 
         // Load traveling items
         travelingItems.clear();
         NbtCompat.ifHasList(pipeData, "ItemsInTransit", itemsList -> {
-            RegistryOps<net.minecraft.nbt.Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
+            RegistryOps<Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
             for (int i = 0; i < itemsList.size(); i++) {
                 NbtCompat.ifHasCompoundAt(itemsList, i, itemTag ->
                     TravelingItem.CODEC.parse(ops, itemTag).result()
@@ -295,8 +297,8 @@ public class PipeBlockEntity extends BaseBlockEntity
     }
 
     @Override
-    protected void loadLegacyData(CompoundTag nbt) {
-        super.loadLegacyData(nbt);
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLegacyData(nbt, registries);
 
         if (nbt.contains("PipeData")) {
             CompoundTag oldData = nbt.getCompound("PipeData");
@@ -321,7 +323,7 @@ public class PipeBlockEntity extends BaseBlockEntity
             }
 
             // Now load using the standard loader which expects new keys
-            loadLogisticsData(massaged);
+            loadLogisticsData(massaged, registries);
 
             long durationMs = (System.nanoTime() - readStart) / 1_000_000L;
             if (durationMs >= 2L && Boolean.getBoolean("logistics.timing")) {

--- a/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -10,6 +10,7 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -140,15 +141,15 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveLogisticsData(CompoundTag nbt) {
-        super.saveLogisticsData(nbt);
+    protected void saveLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.saveLogisticsData(nbt, registries);
         nbt.putInt("DrainRateIndex", drainRateIndex);
         // Note: totalEnergyReceived not persisted - testing-only counter, resets on reload
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag nbt) {
-        super.loadLogisticsData(nbt);
+    protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLogisticsData(nbt, registries);
         drainRateIndex = NbtCompat.getInt(nbt, "DrainRateIndex", 4);
         // Clamp to valid range
         if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
@@ -158,8 +159,8 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
     }
 
     @Override
-    protected void loadLegacyData(CompoundTag nbt) {
-        super.loadLegacyData(nbt);
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLegacyData(nbt, registries);
         if (nbt.contains("CreativeSink")) {
             CompoundTag data = nbt.getCompound("CreativeSink");
             // Load old key name (before BaseBlockEntity refactoring)

--- a/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -6,6 +6,7 @@ import com.logistics.power.engine.block.CreativeEngineBlock;
 import com.logistics.LogisticsPower;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -125,14 +126,14 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveLogisticsData(CompoundTag nbt) {
-        super.saveLogisticsData(nbt);
+    protected void saveLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.saveLogisticsData(nbt, registries);
         nbt.putInt("OutputLevelIndex", outputLevelIndex);
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag nbt) {
-        super.loadLogisticsData(nbt);
+    protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLogisticsData(nbt, registries);
         outputLevelIndex = NbtCompat.getInt(nbt, "OutputLevelIndex", 0);
         // Clamp to valid range
         if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
@@ -141,8 +142,8 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     }
 
     @Override
-    protected void loadLegacyData(CompoundTag nbt) {
-        super.loadLegacyData(nbt); // Loads engine data from "Engine" tag
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLegacyData(nbt, registries); // Loads engine data from "Engine" tag
 
         // Load Creative-specific data from old "CreativeData" tag
         if (nbt.contains("CreativeData")) {

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -22,6 +22,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
@@ -429,8 +430,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     // ==================== NBT Serialization ====================
 
     @Override
-    protected void saveLogisticsData(CompoundTag nbt) {
-        super.saveLogisticsData(nbt);
+    protected void saveLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.saveLogisticsData(nbt, registries);
 
         // Save Stirling-specific data
         nbt.putInt("BurnTimeRemaining", burnTime);
@@ -440,12 +441,12 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         nbt.putDouble("PIDIntegral", pidController.getIntegral());
 
         // Save fuel inventory
-        inventory.writeNbt(nbt, "Inventory", level.registryAccess());
+        inventory.writeNbt(nbt, "Inventory", registries);
     }
 
     @Override
-    protected void loadLogisticsData(CompoundTag nbt) {
-        super.loadLogisticsData(nbt);
+    protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLogisticsData(nbt, registries);
 
         // Load Stirling-specific data
         burnTime = NbtCompat.getInt(nbt, "BurnTimeRemaining", 0);
@@ -457,11 +458,11 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
         // Load fuel inventory (try new key first, fall back to legacy)
         if (nbt.contains("Inventory")) {
-            inventory.readNbt(nbt, "Inventory", level.registryAccess());
+            inventory.readNbt(nbt, "Inventory", registries);
         } else if (nbt.contains("FuelStack")) {
             // Legacy: single item stored with CODEC
             inventory.setItem(0, ItemStack.EMPTY);
-            var ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
+            var ops = registries.createSerializationContext(NbtOps.INSTANCE);
             ItemStack.CODEC.parse(ops, nbt.get("FuelStack"))
                     .result()
                     .ifPresent(stack -> inventory.setItem(0, stack));
@@ -469,8 +470,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     }
 
     @Override
-    protected void loadLegacyData(CompoundTag nbt) {
-        super.loadLegacyData(nbt); // Loads engine data from "Engine" tag
+    protected void loadLegacyData(CompoundTag nbt, HolderLookup.Provider registries) {
+        super.loadLegacyData(nbt, registries); // Loads engine data from "Engine" tag
 
         // Load Stirling-specific data from old "StirlingData" tag
         if (nbt.contains("StirlingData")) {

--- a/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -487,7 +487,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         // Load fuel from old "Fuel" tag at root level
         inventory.setItem(0, ItemStack.EMPTY);
         if (nbt.contains("Fuel")) {
-            ItemStack.CODEC.parse(net.minecraft.nbt.NbtOps.INSTANCE, nbt.get("Fuel"))
+            var ops = registries.createSerializationContext(NbtOps.INSTANCE);
+            ItemStack.CODEC.parse(ops, nbt.get("Fuel"))
                     .result()
                     .ifPresent(stack -> inventory.setItem(0, stack));
         }

--- a/src/test/java/com/logistics/core/lib/BaseBlockEntityPersistenceTest.java
+++ b/src/test/java/com/logistics/core/lib/BaseBlockEntityPersistenceTest.java
@@ -1,0 +1,156 @@
+package com.logistics.core.lib;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link BaseBlockEntity} template methods receive a valid
+ * {@link HolderLookup.Provider} during load — even when {@code level} is {@code null}.
+ *
+ * <h2>Regression context (issue #287 / PR #283)</h2>
+ * <p>PR #283 introduced a crash-fix that replaced bare {@code NbtOps.INSTANCE} with
+ * {@code RegistryOps} when serializing {@code ItemStack}s. The call sites inside
+ * {@code loadLogisticsData} used {@code level.registryAccess()} to obtain the ops.
+ *
+ * <p>However, {@code loadAdditional} is called by Minecraft during chunk deserialization,
+ * <em>before</em> {@link net.minecraft.world.level.block.entity.BlockEntity#setLevel setLevel}
+ * is invoked. At that point {@code level} is {@code null}, so every {@code level.registryAccess()}
+ * call threw {@code NullPointerException}, aborting the entire {@code loadLogisticsData} body.
+ *
+ * <p>The symptom was two-fold:
+ * <ol>
+ *   <li>Items in transit were lost after reload (the NPE fired while loading them).</li>
+ *   <li>Filters (module state) disappeared from pipes that had items in transit, because
+ *       filter state was loaded <em>after</em> the items in the same method — the aborted
+ *       body never reached it.</li>
+ * </ol>
+ *
+ * <p>The fix threads {@code HolderLookup.Provider registries} from
+ * {@code loadAdditional}/{@code saveAdditional} into the template methods so subclasses
+ * never need {@code level.registryAccess()}.
+ */
+@DisplayName("BaseBlockEntity persistence")
+class BaseBlockEntityPersistenceTest extends MinecraftTestEnvironment {
+
+    /**
+     * A minimal concrete {@code BaseBlockEntity} with two fields:
+     * <ul>
+     *   <li>{@code storedItem} — an {@code ItemStack}, serialized via {@code ItemStack.CODEC}
+     *       (requires a registry-aware ops context).</li>
+     *   <li>{@code storedLabel} — a plain string, loaded <em>after</em> the item.</li>
+     * </ul>
+     * The ordering mirrors {@code PipeBlockEntity}: items-in-transit are loaded before
+     * module state. If item loading throws, the label is never reached.
+     */
+    private static class TwoFieldEntity extends BaseBlockEntity {
+
+        ItemStack storedItem = ItemStack.EMPTY;
+        String storedLabel = "";
+
+        TwoFieldEntity() {
+            // Use a real type/block pair to satisfy BlockEntity's validateBlockState check.
+            // The type itself is irrelevant to our logic — we only test saveCustomOnly /
+            // loadCustomOnly which call saveAdditional/loadAdditional directly.
+            super(BlockEntityType.CHEST, BlockPos.ZERO, Blocks.CHEST.defaultBlockState());
+        }
+
+        @Override
+        protected void saveLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
+            if (!storedItem.isEmpty()) {
+                RegistryOps<Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
+                ItemStack.CODEC.encodeStart(ops, storedItem).result()
+                        .ifPresent(encoded -> tag.put("Item", encoded));
+            }
+            if (!storedLabel.isEmpty()) {
+                tag.putString("Label", storedLabel);
+            }
+        }
+
+        @Override
+        protected void loadLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
+            // Load item FIRST, then label — intentional ordering to mirror PipeBlockEntity.
+            if (tag.contains("Item")) {
+                RegistryOps<Tag> ops = registries.createSerializationContext(NbtOps.INSTANCE);
+                storedItem = ItemStack.CODEC.parse(ops, tag.get("Item")).result()
+                        .orElse(ItemStack.EMPTY);
+            }
+            storedLabel = tag.contains("Label", Tag.TAG_STRING) ? tag.getString("Label") : "";
+        }
+    }
+
+    private HolderLookup.Provider registries;
+
+    @BeforeEach
+    void setUp() {
+        registries = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
+    }
+
+    @Test
+    @DisplayName("item and label both survive a save/load cycle when level is null")
+    void bothFieldsSurviveSaveLoadWithNullLevel() {
+        TwoFieldEntity writer = new TwoFieldEntity();
+        writer.storedItem = new ItemStack(Items.DIAMOND, 7);
+        writer.storedLabel = "filter-state";
+
+        CompoundTag saved = writer.saveCustomOnly(registries);
+
+        TwoFieldEntity reader = new TwoFieldEntity();
+        assertThat(reader.hasLevel()).as("level must be absent to reproduce the regression").isFalse();
+        reader.loadCustomOnly(saved, registries);
+
+        assertThat(reader.storedItem.getItem()).isEqualTo(Items.DIAMOND);
+        assertThat(reader.storedItem.getCount()).isEqualTo(7);
+        assertThat(reader.storedLabel).isEqualTo("filter-state");
+    }
+
+    @Test
+    @DisplayName("label loads even when item serialization precedes it — regression for issue #287")
+    void labelLoadsEvenWhenItemLoadingPrecedesIt() {
+        // Before the fix, PipeBlockEntity.loadLogisticsData called level.registryAccess()
+        // to build RegistryOps. level was null at load time → NPE → method aborted.
+        // Module state (filters / label here) came AFTER items in the method body and
+        // was therefore never reached, making filters vanish from any pipe that had
+        // items in transit when the world was saved.
+        TwoFieldEntity writer = new TwoFieldEntity();
+        writer.storedItem = new ItemStack(Items.IRON_INGOT);
+        writer.storedLabel = "expected-to-survive";
+
+        CompoundTag saved = writer.saveCustomOnly(registries);
+
+        TwoFieldEntity reader = new TwoFieldEntity();
+        reader.loadCustomOnly(saved, registries);
+
+        assertThat(reader.storedLabel)
+                .as("label (analogous to filter state) must load even though it follows item loading")
+                .isEqualTo("expected-to-survive");
+    }
+
+    @Test
+    @DisplayName("empty state round-trips without error")
+    void emptyStateRoundTrips() {
+        TwoFieldEntity writer = new TwoFieldEntity();
+        CompoundTag saved = writer.saveCustomOnly(registries);
+
+        TwoFieldEntity reader = new TwoFieldEntity();
+        reader.loadCustomOnly(saved, registries);
+
+        assertThat(reader.storedItem.isEmpty()).isTrue();
+        assertThat(reader.storedLabel).isEmpty();
+    }
+}


### PR DESCRIPTION
# Summary
This update introduces a refactor of the NBT serialization methods across various block entities to utilize the `HolderLookup.Provider`, streamlining the way item stacks and other registry objects are saved and loaded. This change is essential to eliminate potential `NullPointerExceptions` during serialization, particularly when the block entity's level is not yet set.

# Changes
- **NBT Serialization Refactor**
  - Updated methods in multiple block entity classes (Kiln, Laser Quarry, Marker, Macerator, Pipes, and Creative Engines) to accept `HolderLookup.Provider` for improved registry access during NBT serialization and deserialization.
  - The previous method relied on `level.registryAccess()`, which could lead to null references since it was called before the block entity's level was assigned.
  
- **Improved Data Preservation**
  - Enhanced the reliability of loading mechanics for data that must not be lost, particularly in scenarios involving items in transit and filter states for pipes.
  - Added unit tests to verify the correct behavior of the updated serialization processes, ensuring that both items and labels persist correctly across save/load cycles, even when the level context is not set.

# Notes
- Users may observe that filters in pipes persist correctly after reloads, addressing issues where filter states were lost due to previous serialization errors.
- This update fixes #287