### PR TITLE
fix: enchanted items being provided on the network

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/ProviderDispatchQueue.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderDispatchQueue.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayDeque;
@@ -29,12 +30,14 @@ public class ProviderDispatchQueue {
      * A single pending dispatch request.
      *
      * @param itemId     registry key of the item (e.g. "minecraft:iron_ingot")
+     * @param itemTag    full serialized ItemStack tag preserving data components (null = bare item)
      * @param remaining  items still to be extracted and injected into the pipe
      * @param requester  destination pipe position
      * @param deliveryId delivery correlation UUID (may be null)
      */
     public record Entry(
             String itemId,
+            @Nullable CompoundTag itemTag,
             long remaining,
             BlockPos requester,
             @Nullable UUID deliveryId) {}
@@ -45,10 +48,17 @@ public class ProviderDispatchQueue {
 
     /**
      * Add a new dispatch request to the tail of the queue.
+     *
+     * @param itemTag serialized ItemStack tag preserving data components; null for bare items
      */
-    public void enqueue(String itemId, long amount, BlockPos requester, @Nullable UUID deliveryId) {
+    public void enqueue(String itemId, @Nullable CompoundTag itemTag, long amount, BlockPos requester, @Nullable UUID deliveryId) {
         if (amount <= 0) return;
-        entries.addLast(new Entry(itemId, amount, requester, deliveryId));
+        entries.addLast(new Entry(itemId, itemTag, amount, requester, deliveryId));
+    }
+
+    /** Add a bare-item dispatch request (no data components). */
+    public void enqueue(String itemId, long amount, BlockPos requester, @Nullable UUID deliveryId) {
+        enqueue(itemId, null, amount, requester, deliveryId);
     }
 
     /**
@@ -61,7 +71,7 @@ public class ProviderDispatchQueue {
         entries.pollFirst();
         long newRemaining = head.remaining() - consumed;
         if (newRemaining > 0) {
-            entries.addFirst(new Entry(head.itemId(), newRemaining, head.requester(), head.deliveryId()));
+            entries.addFirst(new Entry(head.itemId(), head.itemTag(), newRemaining, head.requester(), head.deliveryId()));
         }
     }
 

--- a/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -25,7 +25,10 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -71,6 +74,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
     // Dispatch queue NBT keys
     private static final String DISPATCH_QUEUE = "dispatch_queue";
     private static final String DQ_ITEM = "item";
+    private static final String DQ_ITEM_TAG = "item_tag";
     private static final String DQ_AMOUNT = "amount";
     private static final String DQ_REQUESTER = "requester";
     private static final String DQ_DELIVERY_ID = "delivery_id";
@@ -217,7 +221,14 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
     private void enqueueDispatch(PipeContext ctx, ItemVariant item, long amount,
             BlockPos requester, @Nullable UUID deliveryId) {
         ProviderDispatchQueue queue = loadQueue(ctx);
-        queue.enqueue(BuiltInRegistries.ITEM.getKey(item.getItem()).toString(), amount, requester, deliveryId);
+        String itemId = BuiltInRegistries.ITEM.getKey(item.getItem()).toString();
+        RegistryOps<Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
+        CompoundTag itemTag = ItemStack.CODEC.encodeStart(ops, item.toStack(1))
+                .result()
+                .filter(t -> t instanceof CompoundTag)
+                .map(t -> (CompoundTag) t)
+                .orElse(null);
+        queue.enqueue(itemId, itemTag, amount, requester, deliveryId);
         saveQueue(ctx, queue);
     }
 
@@ -242,7 +253,15 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
         if (rid == null) { queue.removeHead(); saveQueue(ctx, queue); return; }
         var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
         if (holder.isEmpty()) { queue.removeHead(); saveQueue(ctx, queue); return; }
-        ItemVariant item = ItemVariant.of(new ItemStack(holder.get().value()));
+        ItemVariant item;
+        if (head.itemTag() != null) {
+            RegistryOps<Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
+            ItemStack stack = ItemStack.CODEC.parse(ops, head.itemTag()).result()
+                    .orElse(new ItemStack(holder.get().value()));
+            item = ItemVariant.of(stack);
+        } else {
+            item = ItemVariant.of(new ItemStack(holder.get().value()));
+        }
 
         ProviderMode mode = getMode(ctx);
         long itemsLeft = itemLimit;
@@ -325,7 +344,8 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
             if (!dlvStr.isEmpty()) {
                 try { deliveryId = UUID.fromString(dlvStr); } catch (Exception ignored) {}
             }
-            queue.enqueue(itemId, amount, requester, deliveryId);
+            CompoundTag itemTag = entry.getCompound(DQ_ITEM_TAG).orElse(null);
+            queue.enqueue(itemId, itemTag, amount, requester, deliveryId);
         }
         return queue;
     }
@@ -339,6 +359,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
             for (ProviderDispatchQueue.Entry e : queue.entries()) {
                 CompoundTag entry = new CompoundTag();
                 entry.putString(DQ_ITEM, e.itemId());
+                if (e.itemTag() != null) entry.put(DQ_ITEM_TAG, e.itemTag());
                 entry.putLong(DQ_AMOUNT, e.remaining());
                 entry.putIntArray(DQ_REQUESTER, new int[]{e.requester().getX(), e.requester().getY(), e.requester().getZ()});
                 if (e.deliveryId() != null) entry.putString(DQ_DELIVERY_ID, e.deliveryId().toString());

--- a/src/test/java/com/logistics/pipe/modules/ProviderDispatchQueueSerializationTest.java
+++ b/src/test/java/com/logistics/pipe/modules/ProviderDispatchQueueSerializationTest.java
@@ -1,0 +1,104 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link ProviderDispatchQueue} correctly preserves item data components
+ * (custom names, enchantments, etc.) through enqueue → NBT round-trip → reconstruction.
+ *
+ * <h2>Regression context</h2>
+ * <p>Prior to this fix, {@link ProviderDispatchQueue.Entry} stored only a {@code String itemId}.
+ * When the provider drained the queue, it reconstructed {@code ItemVariant.of(new ItemStack(item))}
+ * — a bare variant with no components. Because {@link net.fabricmc.fabric.api.transfer.v1.item.ItemVariant}
+ * equality includes all data components, the bare variant never matched enchanted (or otherwise
+ * component-bearing) items in storage, so extraction always failed silently.
+ *
+ * <p>The fix adds a {@code @Nullable CompoundTag itemTag} to each entry carrying the full
+ * serialized {@link ItemStack}. This test verifies that the tag survives the round-trip and
+ * that the reconstructed {@link ItemStack} carries the same components.
+ */
+@DisplayName("ProviderDispatchQueue serialization")
+class ProviderDispatchQueueSerializationTest extends MinecraftTestEnvironment {
+
+    private RegistryOps<Tag> ops;
+
+    @BeforeEach
+    void setUp() {
+        ops = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY)
+                .createSerializationContext(NbtOps.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("itemTag round-trips through CompoundTag serialization")
+    void itemTagRoundTrips() {
+        // Encode a stack with a custom display name — a component that doesn't require
+        // a live server registry, unlike enchantments which use dynamic registry holders.
+        ItemStack original = new ItemStack(Items.DIAMOND_SWORD);
+        original.set(DataComponents.CUSTOM_NAME, Component.literal("Vorpal Blade"));
+
+        CompoundTag itemTag = (CompoundTag) ItemStack.CODEC.encodeStart(ops, original)
+                .result()
+                .orElseThrow(() -> new AssertionError("Encode failed"));
+
+        ProviderDispatchQueue queue = new ProviderDispatchQueue();
+        queue.enqueue("minecraft:diamond_sword", itemTag, 1, BlockPos.ZERO, null);
+
+        ProviderDispatchQueue.Entry entry = queue.peekHead();
+        assertThat(entry.itemTag()).isNotNull();
+
+        // Decode back to ItemStack and verify components survived
+        ItemStack decoded = ItemStack.CODEC.parse(ops, entry.itemTag())
+                .result()
+                .orElseThrow(() -> new AssertionError("Decode failed"));
+
+        assertThat(decoded.getItem()).isEqualTo(Items.DIAMOND_SWORD);
+        assertThat(decoded.get(DataComponents.CUSTOM_NAME))
+                .isNotNull()
+                .extracting(Component::getString)
+                .isEqualTo("Vorpal Blade");
+    }
+
+    @Test
+    @DisplayName("itemTag is null for bare items — no unnecessary component storage")
+    void bareItemProducesNullTag() {
+        ProviderDispatchQueue queue = new ProviderDispatchQueue();
+        queue.enqueue("minecraft:diamond", 64, BlockPos.ZERO, null);
+
+        assertThat(queue.peekHead().itemTag()).isNull();
+    }
+
+    @Test
+    @DisplayName("itemTag survives partial consumption")
+    void itemTagSurvivesPartialConsumption() {
+        ItemStack stack = new ItemStack(Items.IRON_SWORD);
+        stack.set(DataComponents.CUSTOM_NAME, Component.literal("Excalibur"));
+
+        CompoundTag tag = (CompoundTag) ItemStack.CODEC.encodeStart(ops, stack)
+                .result()
+                .orElseThrow();
+
+        ProviderDispatchQueue queue = new ProviderDispatchQueue();
+        queue.enqueue("minecraft:iron_sword", tag, 10, BlockPos.ZERO, null);
+        queue.consumeFromHead(3);
+
+        ProviderDispatchQueue.Entry head = queue.peekHead();
+        assertThat(head.remaining()).isEqualTo(7);
+        assertThat(head.itemTag()).isEqualTo(tag);
+    }
+}

--- a/src/test/java/com/logistics/pipe/modules/ProviderDispatchQueueTest.java
+++ b/src/test/java/com/logistics/pipe/modules/ProviderDispatchQueueTest.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -267,5 +268,84 @@ class ProviderDispatchQueueTest {
         snapshot.clear(); // modifying the list must not affect the queue
 
         assertEquals(1, queue.size());
+    }
+
+    // ===== itemTag (component-aware dispatch) =====
+
+    @Test
+    void enqueue_withItemTag_preservesTagInEntry() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id", DIAMOND);
+        tag.putInt("count", 1);
+
+        queue.enqueue(DIAMOND, tag, 5, REQUESTER_A, null);
+
+        ProviderDispatchQueue.Entry head = queue.peekHead();
+        assertNotNull(head);
+        assertEquals(tag, head.itemTag());
+    }
+
+    @Test
+    void enqueue_withNullItemTag_storesNull() {
+        queue.enqueue(DIAMOND, (CompoundTag) null, 5, REQUESTER_A, null);
+
+        assertNull(queue.peekHead().itemTag());
+    }
+
+    @Test
+    void enqueue_bareOverload_storesNullTag() {
+        queue.enqueue(DIAMOND, 5, REQUESTER_A, null);
+
+        assertNull(queue.peekHead().itemTag(), "bare enqueue overload must store null itemTag");
+    }
+
+    @Test
+    void consumeFromHead_partial_preservesItemTag() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id", DIAMOND);
+
+        queue.enqueue(DIAMOND, tag, 10, REQUESTER_A, DELIVERY_1);
+        queue.consumeFromHead(3);
+
+        ProviderDispatchQueue.Entry head = queue.peekHead();
+        assertNotNull(head);
+        assertEquals(7, head.remaining());
+        assertEquals(tag, head.itemTag(), "itemTag must survive partial consumption");
+    }
+
+    @Test
+    void consumeFromHead_full_removesEntry_tagGone() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id", DIAMOND);
+
+        queue.enqueue(DIAMOND, tag, 5, REQUESTER_A, null);
+        queue.consumeFromHead(5);
+
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    void entries_snapshot_preservesItemTag() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id", DIAMOND);
+
+        queue.enqueue(DIAMOND, tag, 8, REQUESTER_A, null);
+
+        var snapshot = queue.entries();
+        assertEquals(1, snapshot.size());
+        assertEquals(tag, snapshot.get(0).itemTag());
+    }
+
+    @Test
+    void getReservations_itemTagDoesNotAffectReservationKey() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("enchantment", "sharpness");
+
+        queue.enqueue(DIAMOND, tag, 3, REQUESTER_A, null);
+        queue.enqueue(DIAMOND, 5, REQUESTER_B, null); // bare, same item type
+
+        // Reservations are keyed by itemId only — components are not factored in
+        Map<String, Long> res = queue.getReservations();
+        assertEquals(8L, res.get(DIAMOND), "enchanted and bare counts should both contribute to item-type reservation");
     }
 }


### PR DESCRIPTION
## Summary
This update introduces support for item tags in the `ProviderDispatchQueue`, enabling comprehensive data handling for enchanted items and other items with complex properties. This enhancement aims to prevent issues with item extraction and improve the overall reliability of the logistics system.

## Changes
- **Added ItemTag Support**: 
  - `ProviderDispatchQueue` and `ProviderModule` now support an optional `itemTag` field to store full serialized `ItemStack` data (e.g., custom names, enchantments).
  - This addition replaces the previous implementation that only tracked the item ID, resolving extraction issues for items with data components.
- **Refactored Enqueue Methods**: 
  - New method overloads added for enqueueing items with or without tags, streamlining item dispatch processes.
- **Enhanced Serialization Testing**: 
  - Introduced comprehensive tests to validate tag handling during enqueue, consumption, and serialization processes. 
  - Validates that item data components are preserved across queue operations.
  
## Notes
- Ensure data compatibility when migrating from earlier versions, as functionalities regarding item data representation have changed significantly.