### PR TITLE
fix: correct supplier module UI targeting

### DIFF
--- a/src/main/java/com/logistics/core/lib/pipe/IPipeAccess.java
+++ b/src/main/java/com/logistics/core/lib/pipe/IPipeAccess.java
@@ -21,6 +21,11 @@ public interface IPipeAccess {
     /** Return (or lazily create) the mutable NBT tag for the given module-state key. */
     CompoundTag moduleState(String key);
 
+    /** Return the mutable NBT tag for the given module-state key, if it already exists. */
+    @Nullable default CompoundTag existingModuleState(String key) {
+        return null;
+    }
+
     /** Remove all stored state for the given module-state key. */
     void clearModuleState(String key);
 

--- a/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
+++ b/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
@@ -6,7 +6,9 @@ import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.storage.NbtCompat;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.Nullable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -14,43 +16,80 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
-public record PipeContext(Level world, BlockPos pos, BlockState state, IPipeAccess blockEntity) {
+public record PipeContext(
+        Level world,
+        BlockPos pos,
+        BlockState state,
+        IPipeAccess blockEntity,
+        Map<Module, String> moduleStateKeys) {
+
+    public PipeContext(Level world, BlockPos pos, BlockState state, IPipeAccess blockEntity) {
+        this(world, pos, state, blockEntity, Map.of());
+    }
+
+    public PipeContext withModuleStateKey(Module module, String stateKey) {
+        IdentityHashMap<Module, String> keys = new IdentityHashMap<>(moduleStateKeys);
+        keys.put(module, stateKey);
+        return new PipeContext(world, pos, state, blockEntity, keys);
+    }
+
+    public String moduleStateKey(Module module) {
+        return moduleStateKeys.getOrDefault(module, module.getStateKey());
+    }
 
     public CompoundTag moduleState(String key) {
         return blockEntity.moduleState(key);
     }
 
+    public CompoundTag moduleState(Module module) {
+        String stateKey = moduleStateKey(module);
+        CompoundTag existingScopedState = blockEntity.existingModuleState(stateKey);
+        CompoundTag state = moduleState(stateKey);
+
+        String defaultStateKey = module.getStateKey();
+        if (!stateKey.equals(defaultStateKey) && existingScopedState == null) {
+            CompoundTag legacyState = blockEntity.existingModuleState(defaultStateKey);
+            if (legacyState != null && !legacyState.isEmpty()) {
+                for (String key : legacyState.keySet()) {
+                    state.put(key, legacyState.get(key).copy());
+                }
+            }
+        }
+
+        return state;
+    }
+
     // Convenience methods for module state access (with Module instance)
     public String getString(Module module, String key, String defaultValue) {
-        return NbtCompat.getString(moduleState(module.getStateKey()), key, defaultValue);
+        return NbtCompat.getString(moduleState(module), key, defaultValue);
     }
 
     public void saveString(Module module, String key, String value) {
-        moduleState(module.getStateKey()).putString(key, value);
+        moduleState(module).putString(key, value);
     }
 
     public int getInt(Module module, String key, int defaultValue) {
-        return NbtCompat.getInt(moduleState(module.getStateKey()), key, defaultValue);
+        return NbtCompat.getInt(moduleState(module), key, defaultValue);
     }
 
     public void saveInt(Module module, String key, int value) {
-        moduleState(module.getStateKey()).putInt(key, value);
+        moduleState(module).putInt(key, value);
     }
 
     public long getLong(Module module, String key, long defaultValue) {
-        return NbtCompat.getLong(moduleState(module.getStateKey()), key, defaultValue);
+        return NbtCompat.getLong(moduleState(module), key, defaultValue);
     }
 
     public void saveLong(Module module, String key, long value) {
-        moduleState(module.getStateKey()).putLong(key, value);
+        moduleState(module).putLong(key, value);
     }
 
     public void remove(Module module, String key) {
-        moduleState(module.getStateKey()).remove(key);
+        moduleState(module).remove(key);
     }
 
     public void clearModuleState(Module module) {
-        blockEntity.clearModuleState(module.getStateKey());
+        blockEntity.clearModuleState(moduleStateKey(module));
         markDirtyAndSync();
     }
 
@@ -69,11 +108,11 @@ public record PipeContext(Level world, BlockPos pos, BlockState state, IPipeAcce
     }
 
     public CompoundTag getCompoundTag(Module module, String key) {
-        return NbtCompat.getCompoundOrEmpty(moduleState(module.getStateKey()), key);
+        return NbtCompat.getCompoundOrEmpty(moduleState(module), key);
     }
 
     public void putCompoundTag(Module module, String key, CompoundTag value) {
-        moduleState(module.getStateKey()).put(key, value);
+        moduleState(module).put(key, value);
     }
 
     public void markDirty() {

--- a/src/main/java/com/logistics/core/lib/storage/DirectionSerializer.java
+++ b/src/main/java/com/logistics/core/lib/storage/DirectionSerializer.java
@@ -22,7 +22,7 @@ public class DirectionSerializer {
      */
     @Nullable
     public static Direction load(PipeContext ctx, Module module, String key) {
-        CompoundTag state = ctx.moduleState(module.getStateKey());
+        CompoundTag state = ctx.moduleState(module);
         String directionStr = NbtCompat.getString(state, key, "");
         if (directionStr.isEmpty()) {
             return null;

--- a/src/main/java/com/logistics/pipe/ChassisPipe.java
+++ b/src/main/java/com/logistics/pipe/ChassisPipe.java
@@ -1,5 +1,8 @@
 package com.logistics.pipe;
 
+import com.logistics.LogisticsMod;
+import com.logistics.core.LogisticsConfig;
+import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.pipe.*;
 import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.resource.ResourceId;
@@ -23,6 +26,9 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.block.Block;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +55,16 @@ public class ChassisPipe extends Pipe {
 
     private final int maxSlots;
 
+    public static String moduleStateKey(ItemStack stack, Module module) {
+        return ModuleItem.moduleStateKey(stack, module);
+    }
+
+    private record DynamicModule(Module module, String stateKey) {
+        PipeContext scopedContext(PipeContext ctx) {
+            return ctx.withModuleStateKey(module, stateKey());
+        }
+    }
+
     public ChassisPipe(int maxSlots, Module... fixedModules) {
         super(fixedModules);
         this.maxSlots = maxSlots;
@@ -62,10 +78,28 @@ public class ChassisPipe extends Pipe {
     @Override
     public <T extends Module> T getModule(Class<T> moduleClass, PipeBlockEntity entity) {
         PipeContext ctx = entity.createContext();
-        for (Module m : getDynamicModules(ctx)) {
-            if (moduleClass.isInstance(m)) return moduleClass.cast(m);
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (moduleClass.isInstance(module)) return moduleClass.cast(module);
         }
         return super.getModule(moduleClass);
+    }
+
+    @Override
+    public <T extends Module> T getModule(
+            Class<T> moduleClass, PipeBlockEntity entity, @Nullable String stateKey) {
+        if (stateKey == null) {
+            return getModule(moduleClass, entity);
+        }
+
+        PipeContext ctx = entity.createContext();
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (moduleClass.isInstance(module) && stateKey.equals(entry.stateKey())) {
+                return moduleClass.cast(module);
+            }
+        }
+        return super.getModule(moduleClass, entity, stateKey);
     }
 
     @Override
@@ -83,16 +117,32 @@ public class ChassisPipe extends Pipe {
      */
     protected List<Module> getDynamicModules(PipeContext ctx) {
         List<Module> modules = new ArrayList<>();
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            modules.add(entry.module());
+        }
+        return modules;
+    }
+
+    private List<DynamicModule> getDynamicModuleEntries(PipeContext ctx) {
+        List<DynamicModule> modules = new ArrayList<>();
         var state = ctx.moduleState(STATE_KEY);
         RegistryOps<Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
         for (int slot = 0; slot < maxSlots; slot++) {
-            Tag tag = state.get(String.valueOf(slot));
+            String slotKey = String.valueOf(slot);
+            Tag tag = state.get(slotKey);
             if (tag == null) continue;
-            ItemStack.CODEC.parse(ops, tag).result()
-                    .map(ItemStack::getItem)
-                    .filter(item -> item instanceof ModuleItem)
-                    .map(item -> ((ModuleItem) item).createModule())
-                    .ifPresent(modules::add);
+            ItemStack.CODEC.parse(ops, tag).result().ifPresent(stack -> {
+                if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
+                boolean missingModuleId = ModuleItem.getModuleId(stack).isBlank();
+                Module module = moduleItem.createModule();
+                String stateKey = moduleStateKey(stack, module);
+                if (missingModuleId) {
+                    ItemStack.CODEC.encodeStart(ops, stack).result()
+                            .ifPresent(encoded -> state.put(slotKey, encoded));
+                    ctx.markDirtyAndSync();
+                }
+                modules.add(new DynamicModule(module, stateKey));
+            });
         }
         return modules;
     }
@@ -104,36 +154,55 @@ public class ChassisPipe extends Pipe {
 
     @Override
     public RoutePlan route(PipeContext ctx, TravelingItem item, List<Direction> options) {
-        for (Module m : getDynamicModules(ctx)) {
-            if (m instanceof RoutingModule router) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (module instanceof RoutingModule router) {
+                RoutePlan plan = router.route(entry.scopedContext(ctx), item, options);
+                if (plan.getType() != RoutePlan.Type.PASS) return plan;
+            }
+        }
+        for (Module module : getStaticModules()) {
+            if (module instanceof RoutingModule router) {
                 RoutePlan plan = router.route(ctx, item, options);
                 if (plan.getType() != RoutePlan.Type.PASS) return plan;
             }
         }
-        return super.route(ctx, item, options);
+        return RoutePlan.pass();
     }
 
     @Override
     public void onTick(PipeContext ctx) {
         if (ctx.world().isClientSide()) return;
-        for (Module m : getDynamicModules(ctx)) {
-            if (m instanceof TickingModule ticking) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (module instanceof TickingModule ticking) {
+                ticking.onTick(entry.scopedContext(ctx));
+            }
+        }
+        for (Module module : getStaticModules()) {
+            if (module instanceof TickingModule ticking) {
                 ticking.onTick(ctx);
             }
         }
-        super.onTick(ctx);
     }
 
     @Override
     public long dispatch(PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
         if (ctx.world().isClientSide()) return 0;
-        for (Module m : getDynamicModules(ctx)) {
-            if (m instanceof DispatchableModule dispatchable) {
-                long d = dispatchable.onDispatch(ctx, requester, item, amount, deliveryId);
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (module instanceof DispatchableModule dispatchable) {
+                long d = dispatchable.onDispatch(entry.scopedContext(ctx), requester, item, amount, deliveryId);
                 if (d != 0) return d;
             }
         }
-        return super.dispatch(ctx, requester, item, amount, deliveryId);
+        for (Module module : getStaticModules()) {
+            if (module instanceof DispatchableModule dispatchable) {
+                long dispatched = dispatchable.onDispatch(ctx, requester, item, amount, deliveryId);
+                if (dispatched != 0) return dispatched;
+            }
+        }
+        return 0;
     }
 
     /**
@@ -148,48 +217,103 @@ public class ChassisPipe extends Pipe {
 
     @Override
     public void randomTick(PipeContext ctx, RandomSource random) {
-        for (Module m : getDynamicModules(ctx)) {
-            if (m instanceof RandomTickModule rt) {
-                rt.randomTick(ctx, random);
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (module instanceof RandomTickModule rt) {
+                rt.randomTick(entry.scopedContext(ctx), random);
             }
         }
-        super.randomTick(ctx, random);
+        for (Module module : getStaticModules()) {
+            if (module instanceof RandomTickModule randomTick) {
+                randomTick.randomTick(ctx, random);
+            }
+        }
     }
 
     @Override
     public TravelingItem handleTransfer(PipeContext ctx, TravelingItem item, Direction direction) {
         TravelingItem current = item;
-        for (Module m : getDynamicModules(ctx)) {
-            if (m instanceof TransferHandlerModule handler) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (module instanceof TransferHandlerModule handler) {
+                current = handler.onTransferToStorage(entry.scopedContext(ctx), current, direction);
+                if (current == null) return null;
+            }
+        }
+        for (Module module : getStaticModules()) {
+            if (module instanceof TransferHandlerModule handler) {
                 current = handler.onTransferToStorage(ctx, current, direction);
                 if (current == null) return null;
             }
         }
-        return super.handleTransfer(ctx, current, direction);
+        return current;
+    }
+
+    @Override
+    public boolean matchesSinkFilter(PipeContext ctx, ItemStack stack) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Module module = entry.module();
+            if (module instanceof ItemAcceptingModule sink && sink.acceptsItem(entry.scopedContext(ctx), stack)) {
+                return true;
+            }
+        }
+        for (Module module : getStaticModules()) {
+            if (module instanceof ItemAcceptingModule sink && sink.acceptsItem(ctx, stack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
     public boolean onExternalInsert(PipeContext ctx, ItemStack stack, Direction from) {
-        for (Module m : getDynamicModules(ctx)) {
-            if (m.onExternalInsert(ctx, stack, from)) return true;
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            if (entry.module().onExternalInsert(entry.scopedContext(ctx), stack, from)) return true;
         }
-        return super.onExternalInsert(ctx, stack, from);
+        for (Module module : getStaticModules()) {
+            if (module.onExternalInsert(ctx, stack, from)) return true;
+        }
+        return false;
     }
 
     @Override
     public boolean canAcceptFrom(PipeContext ctx, Direction from, ItemStack stack) {
-        for (Module m : getDynamicModules(ctx)) {
-            if (!m.canAcceptFrom(ctx, from, stack)) return false;
+        if (!ctx.isNeighborPipe(from)) {
+            boolean allowed = false;
+            for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+                if (entry.module().canAcceptFromNonPipe(entry.scopedContext(ctx), from)) {
+                    allowed = true;
+                    break;
+                }
+            }
+            if (!allowed) {
+                for (Module module : getStaticModules()) {
+                    if (module.canAcceptFromNonPipe(ctx, from)) {
+                        allowed = true;
+                        break;
+                    }
+                }
+            }
+            if (!allowed) return false;
         }
-        return super.canAcceptFrom(ctx, from, stack);
+
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            if (!entry.module().canAcceptFrom(entry.scopedContext(ctx), from, stack)) return false;
+        }
+        for (Module module : getStaticModules()) {
+            if (!module.canAcceptFrom(ctx, from, stack)) return false;
+        }
+        return true;
     }
 
     @Override
     public void onConnectionsChanged(PipeContext ctx, List<Direction> connected) {
-        for (Module m : getDynamicModules(ctx)) {
-            m.onConnectionsChanged(ctx, connected);
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            entry.module().onConnectionsChanged(entry.scopedContext(ctx), connected);
         }
-        super.onConnectionsChanged(ctx, connected);
+        for (Module module : getStaticModules()) {
+            module.onConnectionsChanged(ctx, connected);
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -198,29 +322,183 @@ public class ChassisPipe extends Pipe {
 
     @Override
     public List<CoreDecoration> getCoreDecorations(PipeContext ctx) {
-        List<CoreDecoration> result = new ArrayList<>(super.getCoreDecorations(ctx));
-        for (Module m : getDynamicModules(ctx)) {
-            result.addAll(m.getCoreDecorations(ctx));
+        List<CoreDecoration> result = new ArrayList<>();
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            result.addAll(entry.module().getCoreDecorations(entry.scopedContext(ctx)));
+        }
+        for (Module module : getStaticModules()) {
+            result.addAll(module.getCoreDecorations(ctx));
         }
         return result;
     }
 
     @Override
     public List<ResourceId> getPipeDecorations(PipeContext ctx, Direction direction) {
-        List<ResourceId> result = new ArrayList<>(super.getPipeDecorations(ctx, direction));
-        for (Module m : getDynamicModules(ctx)) {
-            result.addAll(m.getPipeDecorations(ctx, direction));
+        List<ResourceId> result = new ArrayList<>();
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            result.addAll(entry.module().getPipeDecorations(entry.scopedContext(ctx), direction));
+        }
+        for (Module module : getStaticModules()) {
+            result.addAll(module.getPipeDecorations(ctx, direction));
         }
         return result;
     }
 
     @Override
     public Integer getArmTint(PipeContext ctx, Direction direction) {
-        for (Module m : getDynamicModules(ctx)) {
-            Integer tint = m.getArmTint(ctx, direction);
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            Integer tint = entry.module().getArmTint(entry.scopedContext(ctx), direction);
             if (tint != null) return tint;
         }
-        return super.getArmTint(ctx, direction);
+        for (Module module : getStaticModules()) {
+            Integer tint = module.getArmTint(ctx, direction);
+            if (tint != null) return tint;
+        }
+        return null;
+    }
+
+    @Override
+    public ResourceId getCoreModelId(PipeContext ctx) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            ResourceId override = entry.module().getCoreModel(entry.scopedContext(ctx));
+            if (override != null) return override;
+        }
+        for (Module module : getStaticModules()) {
+            ResourceId override = module.getCoreModel(ctx);
+            if (override != null) return override;
+        }
+        return LogisticsMod.modId("block/" + getPipeName() + "_core");
+    }
+
+    @Override
+    public ResourceId getPipeArm(PipeContext ctx, Direction direction) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            ResourceId override = entry.module().getPipeArm(entry.scopedContext(ctx), direction);
+            if (override != null) return override;
+        }
+        for (Module module : getStaticModules()) {
+            ResourceId override = module.getPipeArm(ctx, direction);
+            if (override != null) return override;
+        }
+
+        String suffix = ctx.isInventoryConnection(direction) ? "_arm_extended" : "_arm";
+        return LogisticsMod.modId("block/" + getPipeName() + suffix);
+    }
+
+    @Override
+    public float getAccelerationRate(PipeContext ctx) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            float accel = entry.module().getAcceleration(entry.scopedContext(ctx));
+            if (accel > 0f) return accel;
+        }
+        for (Module module : getStaticModules()) {
+            float accel = module.getAcceleration(ctx);
+            if (accel > 0f) return accel;
+        }
+        return 0f;
+    }
+
+    @Override
+    public float getDrag(PipeContext ctx) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            float drag = entry.module().getDrag(entry.scopedContext(ctx));
+            if (drag > 0f) return drag;
+        }
+        for (Module module : getStaticModules()) {
+            float drag = module.getDrag(ctx);
+            if (drag > 0f) return drag;
+        }
+        return LogisticsConfig.get().pipe.drag;
+    }
+
+    @Override
+    public float getMaxSpeed(PipeContext ctx) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            float max = entry.module().getMaxSpeed(entry.scopedContext(ctx));
+            if (max > 0f) return max;
+        }
+        for (Module module : getStaticModules()) {
+            float max = module.getMaxSpeed(ctx);
+            if (max > 0f) return max;
+        }
+        return LogisticsConfig.get().pipe.maxSpeed;
+    }
+
+    @Override
+    public InteractionResult onUseWithItem(PipeContext ctx, UseOnContext usage) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            InteractionResult result = entry.module().onUseWithItem(entry.scopedContext(ctx), usage);
+            if (result != InteractionResult.PASS) return result;
+        }
+        for (Module module : getStaticModules()) {
+            InteractionResult result = module.onUseWithItem(ctx, usage);
+            if (result != InteractionResult.PASS) return result;
+        }
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    public InteractionResult onUseWithoutItem(PipeContext ctx, UseOnContext usage) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            InteractionResult result = entry.module().onUseWithoutItem(entry.scopedContext(ctx), usage);
+            if (result != InteractionResult.PASS) return result;
+        }
+        for (Module module : getStaticModules()) {
+            InteractionResult result = module.onUseWithoutItem(ctx, usage);
+            if (result != InteractionResult.PASS) return result;
+        }
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    public int getComparatorOutput(PipeContext ctx) {
+        int output = 0;
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            output = Math.max(output, entry.module().comparatorOutput(entry.scopedContext(ctx)));
+        }
+        for (Module module : getStaticModules()) {
+            output = Math.max(output, module.comparatorOutput(ctx));
+        }
+        return output;
+    }
+
+    @Override
+    public void randomDisplayTick(PipeContext ctx, RandomSource random) {
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            entry.module().randomDisplayTick(entry.scopedContext(ctx), random);
+        }
+        for (Module module : getStaticModules()) {
+            module.randomDisplayTick(ctx, random);
+        }
+    }
+
+    @Override
+    public PipeConnection.Type filterConnection(
+            @Nullable PipeContext ctx, Direction direction, Block neighborBlock, PipeConnection.Type candidate) {
+        if (candidate == PipeConnection.Type.NONE) return PipeConnection.Type.NONE;
+        if (ctx != null) {
+            for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+                if (!entry.module().allowsConnection(entry.scopedContext(ctx), direction, neighborBlock)) {
+                    return PipeConnection.Type.NONE;
+                }
+            }
+        }
+        for (Module module : getStaticModules()) {
+            if (!module.allowsConnection(ctx, direction, neighborBlock)) return PipeConnection.Type.NONE;
+        }
+        return candidate;
+    }
+
+    @Override
+    public boolean acceptsLowTierEnergyFrom(PipeContext ctx, Direction from) {
+        if (!hasEnergy()) return false;
+        for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
+            if (entry.module().acceptsLowTierEnergyFrom(entry.scopedContext(ctx), from)) return true;
+        }
+        for (Module module : getStaticModules()) {
+            if (module.acceptsLowTierEnergyFrom(ctx, from)) return true;
+        }
+        return false;
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/logistics/pipe/Pipe.java
+++ b/src/main/java/com/logistics/pipe/Pipe.java
@@ -9,6 +9,7 @@ import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.core.lib.pipe.CoreDecoration;
 import com.logistics.core.lib.pipe.DispatchableModule;
+import com.logistics.core.lib.pipe.ItemAcceptingModule;
 import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.pipe.RandomTickModule;
 import com.logistics.core.lib.pipe.TickingModule;
@@ -29,6 +30,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.component.CustomModelData;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +42,10 @@ public class Pipe {
 
     protected Pipe(Module... modules) {
         this.modules = List.of(modules);
+    }
+
+    protected List<Module> getStaticModules() {
+        return modules;
     }
 
     /**
@@ -267,6 +273,29 @@ public class Pipe {
      */
     public <T extends Module> T getModule(Class<T> moduleClass, PipeBlockEntity entity) {
         return getModule(moduleClass);
+    }
+
+    public <T extends Module> T getModule(
+            Class<T> moduleClass, PipeBlockEntity entity, @Nullable String stateKey) {
+        if (stateKey == null) {
+            return getModule(moduleClass, entity);
+        }
+
+        for (Module module : getModules(entity)) {
+            if (moduleClass.isInstance(module) && stateKey.equals(module.getStateKey())) {
+                return moduleClass.cast(module);
+            }
+        }
+        return null;
+    }
+
+    public boolean matchesSinkFilter(PipeContext ctx, ItemStack stack) {
+        for (Module module : getModules(ctx)) {
+            if (module instanceof ItemAcceptingModule sink && sink.acceptsItem(ctx, stack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -29,7 +29,6 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.BlockGetter;
@@ -167,11 +166,9 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
     private void applyModuleStateToStack(PipeContext ctx, ItemStack stack) {
         if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
 
-        String stateKey = moduleItem.createModule().getStateKey();
+        String stateKey = ChassisPipe.moduleStateKey(stack, moduleItem.createModule());
         CompoundTag moduleData = ctx.moduleState(stateKey);
-        if (!moduleData.isEmpty()) {
-            stack.set(DataComponents.CUSTOM_DATA, CustomData.of(moduleData.copy()));
-        }
+        stack.set(DataComponents.CUSTOM_DATA, ModuleItem.customDataWithModuleState(stack, moduleData));
     }
 
     /**

--- a/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -394,6 +394,14 @@ public class PipeBlockEntity extends BaseBlockEntity
     }
 
     @Override
+    public @Nullable CompoundTag existingModuleState(String key) {
+        if (!moduleState.contains(key)) {
+            return null;
+        }
+        return NbtCompat.getCompoundOrEmpty(moduleState, key);
+    }
+
+    @Override
     public PipeConnection.Type getConnectionType(Level world, BlockPos pos, Direction direction) {
         BlockState blockState = getBlockState();
         if (blockState.getBlock() instanceof PipeBlock pipeBlock) {

--- a/src/main/java/com/logistics/pipe/item/ModuleItem.java
+++ b/src/main/java/com/logistics/pipe/item/ModuleItem.java
@@ -1,13 +1,19 @@
 package com.logistics.pipe.item;
 
 import com.logistics.core.lib.pipe.Module;
+import com.logistics.core.lib.storage.NbtCompat;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.Level;
 
+import java.util.UUID;
 import java.util.function.Supplier;
 
 /**
@@ -16,6 +22,8 @@ import java.util.function.Supplier;
  * the module that will be active for that slot.
  */
 public class ModuleItem extends Item {
+    public static final String MODULE_ID_KEY = "logistics_module_id";
+
     private final Supplier<? extends Module> factory;
 
     public ModuleItem(Properties props, Supplier<? extends Module> factory) {
@@ -25,6 +33,41 @@ public class ModuleItem extends Item {
 
     public Module createModule() {
         return factory.get();
+    }
+
+    public static String moduleStateKey(ItemStack stack, Module module) {
+        return "module." + ensureModuleId(stack) + "." + module.getStateKey();
+    }
+
+    public static String ensureModuleId(ItemStack stack) {
+        String moduleId = getModuleId(stack);
+        if (!moduleId.isBlank()) return moduleId;
+
+        moduleId = UUID.randomUUID().toString();
+        CompoundTag tag = copyCustomData(stack);
+        tag.putString(MODULE_ID_KEY, moduleId);
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        return moduleId;
+    }
+
+    public static String getModuleId(ItemStack stack) {
+        return NbtCompat.getString(copyCustomData(stack), MODULE_ID_KEY, "");
+    }
+
+    public static CustomData customDataWithModuleState(ItemStack stack, CompoundTag moduleState) {
+        CompoundTag tag = moduleState.copy();
+        tag.remove(MODULE_ID_KEY);
+        tag.putString(MODULE_ID_KEY, ensureModuleId(stack));
+        return CustomData.of(tag);
+    }
+
+    public static boolean isModuleIdentityKey(String key) {
+        return MODULE_ID_KEY.equals(key);
+    }
+
+    private static CompoundTag copyCustomData(ItemStack stack) {
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        return customData != null ? customData.copyTag() : new CompoundTag();
     }
 
     @Override

--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -152,8 +152,8 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
 
     public void setResult(PipeContext ctx, String itemId, int count) {
         if (itemId == null || itemId.isEmpty()) {
-            ctx.moduleState(getStateKey()).remove(RESULT_ITEM);
-            ctx.moduleState(getStateKey()).remove(RESULT_COUNT);
+            ctx.moduleState(this).remove(RESULT_ITEM);
+            ctx.moduleState(this).remove(RESULT_COUNT);
         } else {
             ctx.saveString(this, RESULT_ITEM, itemId);
             ctx.saveInt(this, RESULT_COUNT, Math.max(1, count));
@@ -195,11 +195,11 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
     // ==================== Queue Accessors ====================
 
     private ListTag getQueue(PipeContext ctx) {
-        return NbtCompat.getListOrEmpty(ctx.moduleState(getStateKey()), QUEUE);
+        return NbtCompat.getListOrEmpty(ctx.moduleState(this), QUEUE);
     }
 
     private void saveQueue(PipeContext ctx, ListTag queue) {
-        ctx.moduleState(getStateKey()).put(QUEUE, queue);
+        ctx.moduleState(this).put(QUEUE, queue);
         ctx.markDirtyAndSync();
     }
 
@@ -266,7 +266,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
         // Compute and store recipe result
         CraftingInput craftInput = crafter.asCraftInput();
         Optional<RecipeHolder<CraftingRecipe>> recipeOpt = CrafterBlock.getPotentialResults(serverLevel, craftInput);
-        CompoundTag state = ctx.moduleState(getStateKey());
+        CompoundTag state = ctx.moduleState(this);
         if (recipeOpt.isPresent()) {
             CraftingRecipe recipe = recipeOpt.get().value();
             ItemStack result = recipe.assemble(craftInput, serverLevel.registryAccess());
@@ -791,7 +791,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
             if (entry != null) cancelEntryOrders(ctx, entry);
         }
 
-        ctx.moduleState(getStateKey()).remove(QUEUE);
+        ctx.moduleState(this).remove(QUEUE);
         ctx.saveInt(this, TICKS_PULSE, 0);
         ctx.markDirtyAndSync();
 
@@ -1074,7 +1074,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
         }
 
         // Clear queue and tick counters so stale state doesn't survive a re-attach
-        ctx.moduleState(getStateKey()).remove(QUEUE);
+        ctx.moduleState(this).remove(QUEUE);
         ctx.saveInt(this, TICKS_PULSE, 0);
         ctx.saveInt(this, TICKS_SCAN, 0);
 

--- a/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
@@ -95,7 +95,7 @@ public class ExtractionModule implements Module, TickingModule {
     }
 
     private @Nullable Direction getExtractionDirection(PipeContext ctx) {
-        CompoundTag state = ctx.moduleState(getStateKey());
+        CompoundTag state = ctx.moduleState(this);
         String directionStr = NbtCompat.getString(state, EXTRACT_FROM, "");
         if (directionStr.isEmpty()) {
             return null;

--- a/src/main/java/com/logistics/pipe/modules/MergerModule.java
+++ b/src/main/java/com/logistics/pipe/modules/MergerModule.java
@@ -76,7 +76,7 @@ public class MergerModule implements Module, RoutingModule {
     }
 
     private @Nullable Direction getOutputDirection(PipeContext ctx) {
-        CompoundTag state = ctx.moduleState(getStateKey());
+        CompoundTag state = ctx.moduleState(this);
         String directionStr = NbtCompat.getString(state, OUTPUT_DIRECTION, "");
         if (directionStr.isEmpty()) {
             return null;

--- a/src/main/java/com/logistics/pipe/modules/ProcessModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProcessModule.java
@@ -129,7 +129,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
     // ==================== Queue Helpers ====================
 
     private ListTag getQueue(PipeContext ctx) {
-        CompoundTag state = ctx.moduleState(getStateKey());
+        CompoundTag state = ctx.moduleState(this);
         ListTag queue = NbtCompat.getListOrEmpty(state, QUEUE);
         if (!queue.isEmpty()) return queue;
 
@@ -159,14 +159,14 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
     }
 
     private void saveQueue(PipeContext ctx, ListTag queue) {
-        ctx.moduleState(getStateKey()).put(QUEUE, queue);
+        ctx.moduleState(this).put(QUEUE, queue);
         ctx.markDirtyAndSync();
     }
 
     // ==================== Private NBT Helpers ====================
 
     private String getEntryString(PipeContext ctx, String listKey, int slot, String field) {
-        ListTag list = NbtCompat.getListOrEmpty(ctx.moduleState(getStateKey()), listKey);
+        ListTag list = NbtCompat.getListOrEmpty(ctx.moduleState(this), listKey);
         if (slot < 0 || slot >= list.size()) return "";
         return list.getCompound(slot)
                 .map(e -> NbtCompat.getString(e, field, ""))
@@ -174,7 +174,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
     }
 
     private int getEntryInt(PipeContext ctx, String listKey, int slot, String field, int def) {
-        ListTag list = NbtCompat.getListOrEmpty(ctx.moduleState(getStateKey()), listKey);
+        ListTag list = NbtCompat.getListOrEmpty(ctx.moduleState(this), listKey);
         if (slot < 0 || slot >= list.size()) return def;
         return list.getCompound(slot)
                 .map(e -> NbtCompat.getInt(e, field, def))
@@ -185,7 +185,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
             @Nullable String dest) {
         int maxSlot = KEY_INPUTS.equals(listKey) ? MAX_INPUTS : MAX_OUTPUTS;
         if (slot < 0 || slot >= maxSlot) return;
-        ListTag list = NbtCompat.getListOrEmpty(ctx.moduleState(getStateKey()), listKey);
+        ListTag list = NbtCompat.getListOrEmpty(ctx.moduleState(this), listKey);
 
         // Expand list to required size
         while (list.size() <= slot) {
@@ -215,7 +215,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
             }
         }
 
-        ctx.moduleState(getStateKey()).put(listKey, list);
+        ctx.moduleState(this).put(listKey, list);
         ctx.markDirtyAndSync();
     }
 
@@ -601,7 +601,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
                 cancelEntryOrders(network, entry);
             }
         }
-        ctx.moduleState(getStateKey()).remove(QUEUE);
+        ctx.moduleState(this).remove(QUEUE);
         ctx.markDirtyAndSync();
     }
 

--- a/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -310,7 +310,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
     /** Load the dispatch queue from NBT state. Returns an empty queue if nothing is stored. */
     private ProviderDispatchQueue loadQueue(PipeContext ctx) {
         ProviderDispatchQueue queue = new ProviderDispatchQueue();
-        ListTag tag = NbtCompat.getListOrEmpty(ctx.moduleState(getStateKey()), DISPATCH_QUEUE);
+        ListTag tag = NbtCompat.getListOrEmpty(ctx.moduleState(this), DISPATCH_QUEUE);
         for (int i = 0; i < tag.size(); i++) {
             CompoundTag entry = tag.getCompound(i).orElse(null);
             if (entry == null) continue;
@@ -333,7 +333,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
     /** Persist the dispatch queue to NBT state. */
     private void saveQueue(PipeContext ctx, ProviderDispatchQueue queue) {
         if (queue.isEmpty()) {
-            ctx.moduleState(getStateKey()).remove(DISPATCH_QUEUE);
+            ctx.moduleState(this).remove(DISPATCH_QUEUE);
         } else {
             ListTag tag = new ListTag();
             for (ProviderDispatchQueue.Entry e : queue.entries()) {
@@ -344,7 +344,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
                 if (e.deliveryId() != null) entry.putString(DQ_DELIVERY_ID, e.deliveryId().toString());
                 tag.add(entry);
             }
-            ctx.moduleState(getStateKey()).put(DISPATCH_QUEUE, tag);
+            ctx.moduleState(this).put(DISPATCH_QUEUE, tag);
         }
         ctx.markDirtyAndSync();
     }

--- a/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -110,11 +110,12 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
 
         net.minecraft.world.level.Level world = ctx.world();
         net.minecraft.core.BlockPos pos = ctx.pos();
+        String moduleStateKey = getStateKey();
         serverPlayer.openMenu(new net.minecraft.world.SimpleMenuProvider(
                 (syncId, inventory, playerEntity) -> {
                     PipeBlockEntity pipeEntity =
                             world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null;
-                    return new SupplierScreenHandler(syncId, inventory, pipeEntity);
+                return new SupplierScreenHandler(syncId, inventory, pipeEntity, moduleStateKey);
                 },
                 net.minecraft.network.chat.Component.translatable("screen.logistics.supplier.items_to_keep_stocked")));
         return InteractionResult.SUCCESS;

--- a/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -110,12 +110,12 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
 
         net.minecraft.world.level.Level world = ctx.world();
         net.minecraft.core.BlockPos pos = ctx.pos();
-        String moduleStateKey = getStateKey();
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new net.minecraft.world.SimpleMenuProvider(
                 (syncId, inventory, playerEntity) -> {
                     PipeBlockEntity pipeEntity =
                             world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null;
-                return new SupplierScreenHandler(syncId, inventory, pipeEntity, moduleStateKey);
+                    return new SupplierScreenHandler(syncId, inventory, pipeEntity, moduleStateKey);
                 },
                 net.minecraft.network.chat.Component.translatable("screen.logistics.supplier.items_to_keep_stocked")));
         return InteractionResult.SUCCESS;

--- a/src/main/java/com/logistics/pipe/network/MinecraftWorldView.java
+++ b/src/main/java/com/logistics/pipe/network/MinecraftWorldView.java
@@ -6,7 +6,6 @@ import com.logistics.pipe.Pipe;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
-import com.logistics.core.lib.pipe.ItemAcceptingModule;
 import com.logistics.core.lib.pipe.Module;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,12 +77,7 @@ public class MinecraftWorldView implements IWorldView {
         Pipe pipe = block.getPipe();
         PipeContext ctx = pipeEntity.createContext();
 
-        for (Module module : pipe.getModules(pipeEntity)) {
-            if (module instanceof ItemAcceptingModule sink && sink.acceptsItem(ctx, stack)) {
-                return true;
-            }
-        }
-        return false;
+        return pipe.matchesSinkFilter(ctx, stack);
     }
 
     @Override

--- a/src/main/java/com/logistics/pipe/network/packet/OpenChassisSlotPacket.java
+++ b/src/main/java/com/logistics/pipe/network/packet/OpenChassisSlotPacket.java
@@ -54,11 +54,19 @@ public record OpenChassisSlotPacket(int slotIndex) implements CustomPacketPayloa
                 if (tag == null) return;
 
                 var ops = context.server().registryAccess().createSerializationContext(NbtOps.INSTANCE);
-                ItemStack.CODEC.parse(ops, tag).result()
-                        .map(ItemStack::getItem)
-                        .filter(item -> item instanceof ModuleItem)
-                        .map(item -> ((ModuleItem) item).createModule())
-                        .ifPresent(module -> module.onWrench(ctx, player));
+                ItemStack.CODEC.parse(ops, tag).result().ifPresent(stack -> {
+                    if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
+                    boolean missingModuleId = ModuleItem.getModuleId(stack).isBlank();
+                    Module module = moduleItem.createModule();
+                    String stateKey = ChassisPipe.moduleStateKey(stack, module);
+                    if (missingModuleId) {
+                        ItemStack.CODEC.encodeStart(ops, stack).result()
+                                .ifPresent(encoded -> ctx.moduleState(ChassisPipe.STATE_KEY)
+                                        .put(String.valueOf(packet.slotIndex), encoded));
+                        ctx.markDirtyAndSync();
+                    }
+                    module.onWrench(ctx.withModuleStateKey(module, stateKey), player);
+                });
             });
         });
     }

--- a/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/ChassisInventory.java
@@ -39,12 +39,13 @@ public class ChassisInventory implements Container {
     private void syncStateFromItem(ItemStack stack) {
         if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
         CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
-        if (customData == null) return;
         PipeContext ctx = pipeEntity.createContext();
-        String stateKey = moduleItem.createModule().getStateKey();
+        String stateKey = ChassisPipe.moduleStateKey(stack, moduleItem.createModule());
         CompoundTag state = ctx.moduleState(stateKey);
+        if (customData == null) return;
         CompoundTag itemState = customData.copyTag();
         for (String key : itemState.keySet()) {
+            if (ModuleItem.isModuleIdentityKey(key)) continue;
             Tag value = itemState.get(key);
             if (value != null) state.put(key, value);
         }
@@ -56,18 +57,17 @@ public class ChassisInventory implements Container {
         Level level = pipeEntity.getLevel();
         if (level == null || level.isClientSide()) return;
         if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
-        moduleItem.createModule().onDetach(pipeEntity.createContext());
+        var module = moduleItem.createModule();
+        module.onDetach(pipeEntity.createContext().withModuleStateKey(module, ChassisPipe.moduleStateKey(stack, module)));
     }
 
     /** Before returning a module item, copy the block entity module state → item's CustomData. */
     private void syncStateToItem(ItemStack stack) {
         if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
         PipeContext ctx = pipeEntity.createContext();
-        String stateKey = moduleItem.createModule().getStateKey();
+        String stateKey = ChassisPipe.moduleStateKey(stack, moduleItem.createModule());
         CompoundTag state = ctx.moduleState(stateKey);
-        if (!state.isEmpty()) {
-            stack.set(DataComponents.CUSTOM_DATA, CustomData.of(state.copy()));
-        }
+        stack.set(DataComponents.CUSTOM_DATA, ModuleItem.customDataWithModuleState(stack, state));
     }
 
     private void loadFromEntity() {
@@ -93,7 +93,8 @@ public class ChassisInventory implements Container {
         if (level == null || level.isClientSide()) return;
 
         // Sync current module state back into each item before persisting
-        for (ItemStack stack : items) {
+        for (int slot = 0; slot < items.size(); slot++) {
+            ItemStack stack = items.get(slot);
             if (!stack.isEmpty()) {
                 syncStateToItem(stack);
             }
@@ -146,7 +147,7 @@ public class ChassisInventory implements Container {
         if (existing.isEmpty()) {
             detachModule(result);
             if (pipeEntity != null && result.getItem() instanceof ModuleItem moduleItem) {
-                pipeEntity.clearModuleState(moduleItem.createModule().getStateKey());
+                pipeEntity.clearModuleState(ChassisPipe.moduleStateKey(result, moduleItem.createModule()));
             }
             items.set(slot, ItemStack.EMPTY);
         }
@@ -167,11 +168,11 @@ public class ChassisInventory implements Container {
     public void setItem(int slot, ItemStack stack) {
         if (slot < 0 || slot >= items.size()) return;
         ItemStack previous = items.get(slot);
-        if (!previous.isEmpty() && (stack.isEmpty() || !ItemStack.isSameItem(previous, stack))) {
+        if (!previous.isEmpty() && (stack.isEmpty() || !ItemStack.isSameItemSameComponents(previous, stack))) {
             if (pipeEntity != null) {
                 syncStateToItem(previous);
                 if (previous.getItem() instanceof ModuleItem moduleItem) {
-                    pipeEntity.clearModuleState(moduleItem.createModule().getStateKey());
+                    pipeEntity.clearModuleState(ChassisPipe.moduleStateKey(previous, moduleItem.createModule()));
                 }
             }
             detachModule(previous);
@@ -208,8 +209,8 @@ public class ChassisInventory implements Container {
 
     @Override
     public void clearContent() {
-        for (ItemStack stack : items) {
-            detachModule(stack);
+        for (int slot = 0; slot < items.size(); slot++) {
+            detachModule(items.get(slot));
         }
         for (int i = 0; i < items.size(); i++) {
             items.set(i, ItemStack.EMPTY);

--- a/src/main/java/com/logistics/pipe/ui/PipeModuleHelper.java
+++ b/src/main/java/com/logistics/pipe/ui/PipeModuleHelper.java
@@ -8,7 +8,6 @@ import com.logistics.core.lib.pipe.Module;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 /**
@@ -46,6 +45,9 @@ public class PipeModuleHelper {
 
                 if (module != null) {
                     PipeContext ctx = pipeEntity.createContext();
+                    if (stateKey != null) {
+                        ctx = ctx.withModuleStateKey(module, stateKey);
+                    }
                     action.accept(ctx, module);
                 }
             }
@@ -80,6 +82,9 @@ public class PipeModuleHelper {
 
             if (module != null) {
                 PipeContext ctx = pipeEntity.createContext();
+                if (stateKey != null) {
+                    ctx = ctx.withModuleStateKey(module, stateKey);
+                }
                 action.accept(ctx, module);
             }
         }
@@ -92,25 +97,6 @@ public class PipeModuleHelper {
     ) {
         PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
         Pipe pipe = block.getPipe();
-
-        if (stateKey == null) {
-            return pipe.getModule(moduleClass, pipeEntity);
-        }
-
-        return findModule(pipe.getModules(pipeEntity), moduleClass, stateKey);
-    }
-
-    static <T extends Module> T findModule(
-        List<Module> modules,
-        Class<T> moduleClass,
-        String stateKey
-    ) {
-        for (Module module : modules) {
-            if (moduleClass.isInstance(module) && stateKey.equals(module.getStateKey())) {
-                return moduleClass.cast(module);
-            }
-        }
-
-        return null;
+        return pipe.getModule(moduleClass, pipeEntity, stateKey);
     }
 }

--- a/src/main/java/com/logistics/pipe/ui/PipeModuleHelper.java
+++ b/src/main/java/com/logistics/pipe/ui/PipeModuleHelper.java
@@ -6,7 +6,9 @@ import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.core.lib.pipe.Module;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.function.BiConsumer;
 
 /**
@@ -29,11 +31,18 @@ public class PipeModuleHelper {
         Class<T> moduleClass,
         BiConsumer<PipeContext, T> action
     ) {
+        withModule(context, moduleClass, null, action);
+    }
+
+    public static <T extends Module> void withModule(
+        ContainerLevelAccess context,
+        Class<T> moduleClass,
+        @Nullable String stateKey,
+        BiConsumer<PipeContext, T> action
+    ) {
         context.execute((world, pos) -> {
             if (world.getBlockEntity(pos) instanceof PipeBlockEntity pipeEntity) {
-                PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-                Pipe pipe = block.getPipe();
-                T module = pipe.getModule(moduleClass, pipeEntity);
+                T module = getModule(pipeEntity, moduleClass, stateKey);
 
                 if (module != null) {
                     PipeContext ctx = pipeEntity.createContext();
@@ -57,15 +66,51 @@ public class PipeModuleHelper {
         Class<T> moduleClass,
         BiConsumer<PipeContext, T> action
     ) {
+        withModule(pipeEntity, moduleClass, null, action);
+    }
+
+    public static <T extends Module> void withModule(
+        PipeBlockEntity pipeEntity,
+        Class<T> moduleClass,
+        @Nullable String stateKey,
+        BiConsumer<PipeContext, T> action
+    ) {
         if (pipeEntity != null) {
-            PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-            Pipe pipe = block.getPipe();
-            T module = pipe.getModule(moduleClass, pipeEntity);
+            T module = getModule(pipeEntity, moduleClass, stateKey);
 
             if (module != null) {
                 PipeContext ctx = pipeEntity.createContext();
                 action.accept(ctx, module);
             }
         }
+    }
+
+    public static <T extends Module> T getModule(
+        PipeBlockEntity pipeEntity,
+        Class<T> moduleClass,
+        @Nullable String stateKey
+    ) {
+        PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
+        Pipe pipe = block.getPipe();
+
+        if (stateKey == null) {
+            return pipe.getModule(moduleClass, pipeEntity);
+        }
+
+        return findModule(pipe.getModules(pipeEntity), moduleClass, stateKey);
+    }
+
+    static <T extends Module> T findModule(
+        List<Module> modules,
+        Class<T> moduleClass,
+        String stateKey
+    ) {
+        for (Module module : modules) {
+            if (moduleClass.isInstance(module) && stateKey.equals(module.getStateKey())) {
+                return moduleClass.cast(module);
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.SupplierModule;
@@ -20,6 +21,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.BiConsumer;
+
 /**
  * Screen handler for the Supplier GUI.
  * Displays 9 supply slots where players can configure items and target amounts to maintain in the connected inventory.
@@ -35,16 +38,22 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
     private final SupplyInventory supplyInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final String targetModuleStateKey;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
     @Nullable private final ItemStack originalStack;
 
     public SupplierScreenHandler(int syncId, Container playerInventory) {
-        this(syncId, playerInventory, null, new SimpleContainerData(1));
+        this(syncId, playerInventory, null, null, new SimpleContainerData(1));
     }
 
     public SupplierScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
-        this(syncId, playerInventory, pipeEntity, new SimpleContainerData(1));
+        this(syncId, playerInventory, pipeEntity, null, new SimpleContainerData(1));
+    }
+
+    public SupplierScreenHandler(
+            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, String targetModuleStateKey) {
+        this(syncId, playerInventory, pipeEntity, targetModuleStateKey, new SimpleContainerData(1));
     }
 
     public SupplierScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
@@ -52,6 +61,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         this.data = new SimpleContainerData(1);
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
+        this.targetModuleStateKey = null;
         this.context = ContainerLevelAccess.NULL;
         ItemStack stack = player.getItemInHand(hand);
         this.originalStack = stack;
@@ -66,9 +76,15 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         addDataSlots(data);
     }
 
-    private SupplierScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
+    private SupplierScreenHandler(
+            int syncId,
+            Container playerInventory,
+            PipeBlockEntity pipeEntity,
+            @Nullable String targetModuleStateKey,
+            ContainerData data) {
         super(LogisticsPipe.SCREEN.SUPPLIER, syncId);
         this.data = data;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.originalStack = null;
@@ -76,17 +92,21 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
             data.set(0, SupplierModule.SupplyMode.PARTIAL.ordinal());
-            PipeModuleHelper.withModule(this.context, SupplierModule.class, (ctx, module) -> {
+            withSupplierModule((ctx, module) -> {
                 data.set(0, module.getModeOrdinal(ctx));
             });
         } else {
             this.context = ContainerLevelAccess.NULL;
         }
-        this.supplyInventory = new SupplyInventory(pipeEntity);
+        this.supplyInventory = new SupplyInventory(pipeEntity, targetModuleStateKey);
 
         addSupplySlots(supplyInventory);
         addPlayerInventorySlots(playerInventory);
         addDataSlots(data);
+    }
+
+    private void withSupplierModule(BiConsumer<PipeContext, SupplierModule> action) {
+        PipeModuleHelper.withModule(context, SupplierModule.class, targetModuleStateKey, action);
     }
 
     private void addSupplySlots(Container inventory) {
@@ -175,7 +195,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             });
         } else {
             supplyInventory.setItem(slotIndex, ItemStack.EMPTY);
-            PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) ->
+            withSupplierModule((ctx, module) ->
                     module.setSupplyConfig(ctx, slotIndex, "", 0));
         }
     }
@@ -192,7 +212,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                 tag.put(SupplierModule.SUPPLIES, supplies);
             });
         } else {
-            PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) ->
+            withSupplierModule((ctx, module) ->
                     module.setSupplyConfig(ctx, slotIndex, itemId, amount));
         }
     }
@@ -212,7 +232,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> tag.putInt(SupplierModule.MODE, nextMode));
             } else {
                 data.set(0, nextMode);
-                PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
+                withSupplierModule((ctx, module) -> {
                     module.setModeFromOrdinal(ctx, nextMode);
                 });
             }
@@ -240,7 +260,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             super.broadcastChanges();
             return;
         }
-        PipeModuleHelper.withModule(context, SupplierModule.class, (ctx, module) -> {
+        withSupplierModule((ctx, module) -> {
             data.set(0, module.getModeOrdinal(ctx));
         });
         super.broadcastChanges();

--- a/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
@@ -1,10 +1,8 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.storage.NbtCompat;
-import com.logistics.pipe.Pipe;
 import com.logistics.core.lib.pipe.PipeContext;
-import com.logistics.pipe.block.PipeBlock;
+import com.logistics.core.lib.storage.NbtCompat;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.SupplierModule;
 import net.minecraft.core.NonNullList;
@@ -15,6 +13,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -26,9 +25,15 @@ public class SupplyInventory implements Container {
     private final NonNullList<ItemStack> stacks =
             NonNullList.withSize(SupplierModule.MAX_SUPPLY_SLOTS, ItemStack.EMPTY);
     private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     public SupplyInventory(PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public SupplyInventory(PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
 
         if (pipeEntity != null) {
             loadFromModule();
@@ -104,10 +109,7 @@ public class SupplyInventory implements Container {
             return;
         }
 
-        // Get the supplier module
-        PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-        Pipe pipe = block.getPipe();
-        SupplierModule module = pipe.getModule(SupplierModule.class, pipeEntity);
+        SupplierModule module = PipeModuleHelper.getModule(pipeEntity, SupplierModule.class, targetModuleStateKey);
 
         if (module == null) {
             return;

--- a/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
+++ b/src/main/java/com/logistics/pipe/ui/SupplyInventory.java
@@ -117,6 +117,9 @@ public class SupplyInventory implements Container {
 
         // Load configured supplies
         PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
         List<SupplierModule.SupplyConfig> configs = module.getSupplyConfigs(ctx);
 
         int slotIndex = 0;

--- a/src/test/java/com/logistics/pipe/ui/PipeModuleHelperTest.java
+++ b/src/test/java/com/logistics/pipe/ui/PipeModuleHelperTest.java
@@ -1,0 +1,37 @@
+package com.logistics.pipe.ui;
+
+import com.logistics.core.lib.pipe.Module;
+import com.logistics.pipe.modules.PassiveSupplierModule;
+import com.logistics.pipe.modules.SupplierModule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PipeModuleHelper")
+class PipeModuleHelperTest {
+
+    @Test
+    @DisplayName("findModule resolves supplier subclasses by exact state key")
+    void findModule_resolvesSupplierSubclassesByExactStateKey() {
+        PassiveSupplierModule passive = new PassiveSupplierModule(8);
+        SupplierModule active = new SupplierModule();
+        List<Module> modules = List.of(passive, active);
+
+        assertThat(PipeModuleHelper.findModule(modules, SupplierModule.class, active.getStateKey()))
+                .isSameAs(active);
+        assertThat(PipeModuleHelper.findModule(modules, SupplierModule.class, passive.getStateKey()))
+                .isSameAs(passive);
+    }
+
+    @Test
+    @DisplayName("findModule returns null when no module has the requested state key")
+    void findModule_returnsNullForMissingStateKey() {
+        List<Module> modules = List.of(new PassiveSupplierModule(8), new SupplierModule());
+
+        assertThat(PipeModuleHelper.findModule(modules, SupplierModule.class, "missingmodule"))
+                .isNull();
+    }
+}

--- a/src/test/java/com/logistics/pipe/ui/PipeModuleHelperTest.java
+++ b/src/test/java/com/logistics/pipe/ui/PipeModuleHelperTest.java
@@ -1,37 +1,140 @@
 package com.logistics.pipe.ui;
 
-import com.logistics.core.lib.pipe.Module;
-import com.logistics.pipe.modules.PassiveSupplierModule;
+import com.logistics.core.lib.block.capability.PipeConnection;
+import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.core.lib.pipe.IPipeAccess;
+import com.logistics.core.lib.pipe.PipeContext;
+import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.pipe.ChassisPipe;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.modules.SupplierModule;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("PipeModuleHelper")
-class PipeModuleHelperTest {
+class PipeModuleHelperTest extends MinecraftTestEnvironment {
 
     @Test
-    @DisplayName("findModule resolves supplier subclasses by exact state key")
-    void findModule_resolvesSupplierSubclassesByExactStateKey() {
-        PassiveSupplierModule passive = new PassiveSupplierModule(8);
-        SupplierModule active = new SupplierModule();
-        List<Module> modules = List.of(passive, active);
+    @DisplayName("scoped contexts keep duplicate supplier module state separate")
+    void scopedContexts_keepDuplicateSupplierModuleStateSeparate() {
+        SupplierModule first = new SupplierModule();
+        SupplierModule second = new SupplierModule();
+        ItemStack firstStack = new ItemStack(Items.STICK);
+        ItemStack secondStack = new ItemStack(Items.STICK);
+        FakePipeAccess pipe = new FakePipeAccess();
+        PipeContext baseContext = new PipeContext(null, BlockPos.ZERO, null, pipe);
+        String firstStateKey = ChassisPipe.moduleStateKey(firstStack, first);
+        String secondStateKey = ChassisPipe.moduleStateKey(secondStack, second);
 
-        assertThat(PipeModuleHelper.findModule(modules, SupplierModule.class, active.getStateKey()))
-                .isSameAs(active);
-        assertThat(PipeModuleHelper.findModule(modules, SupplierModule.class, passive.getStateKey()))
-                .isSameAs(passive);
+        PipeContext firstContext = baseContext.withModuleStateKey(first, firstStateKey);
+        PipeContext secondContext = baseContext.withModuleStateKey(second, secondStateKey);
+
+        first.setSupplyConfig(firstContext, 0, "minecraft:iron_ingot", 8);
+        second.setSupplyConfig(secondContext, 0, "minecraft:gold_ingot", 16);
+
+        assertThat(first.getSupplyConfigs(firstContext))
+                .containsExactly(new SupplierModule.SupplyConfig("minecraft:iron_ingot", 8));
+        assertThat(second.getSupplyConfigs(secondContext))
+                .containsExactly(new SupplierModule.SupplyConfig("minecraft:gold_ingot", 16));
+        assertThat(first.getSupplyConfigs(baseContext)).isEmpty();
+        assertThat(firstStateKey).isNotEqualTo(secondStateKey);
+        assertThat(ModuleItem.getModuleId(firstStack)).isNotBlank();
     }
 
     @Test
-    @DisplayName("findModule returns null when no module has the requested state key")
-    void findModule_returnsNullForMissingStateKey() {
-        List<Module> modules = List.of(new PassiveSupplierModule(8), new SupplierModule());
+    @DisplayName("scoped context migrates legacy class-key state")
+    void scopedContext_migratesLegacyClassKeyState() {
+        SupplierModule supplier = new SupplierModule();
+        ItemStack stack = new ItemStack(Items.STICK);
+        FakePipeAccess pipe = new FakePipeAccess();
+        PipeContext baseContext = new PipeContext(null, BlockPos.ZERO, null, pipe);
+        supplier.setSupplyConfig(baseContext, 0, "minecraft:diamond", 4);
+        String stateKey = ChassisPipe.moduleStateKey(stack, supplier);
 
-        assertThat(PipeModuleHelper.findModule(modules, SupplierModule.class, "missingmodule"))
-                .isNull();
+        PipeContext scopedContext = baseContext.withModuleStateKey(supplier, stateKey);
+
+        assertThat(supplier.getSupplyConfigs(scopedContext))
+                .containsExactly(new SupplierModule.SupplyConfig("minecraft:diamond", 4));
+        assertThat(pipe.existingModuleState(stateKey)).isNotNull();
+
+        supplier.setSupplyConfig(scopedContext, 0, "", 0);
+
+        assertThat(supplier.getSupplyConfigs(scopedContext)).isEmpty();
+    }
+
+    private static class FakePipeAccess implements IPipeAccess {
+        private final Map<String, CompoundTag> states = new HashMap<>();
+
+        @Override
+        public CompoundTag moduleState(String key) {
+            return states.computeIfAbsent(key, ignored -> new CompoundTag());
+        }
+
+        @Override
+        public CompoundTag existingModuleState(String key) {
+            return states.get(key);
+        }
+
+        @Override
+        public void clearModuleState(String key) {
+            states.remove(key);
+        }
+
+        @Override
+        public EnergyComponent getEnergy() {
+            return null;
+        }
+
+        @Override
+        public void markDirty() {}
+
+        @Override
+        public PipeConnection.Type getCachedConnectionType(Direction direction) {
+            return PipeConnection.Type.NONE;
+        }
+
+        @Override
+        public PipeConnection.Type getConnectionType(Level world, BlockPos pos, Direction direction) {
+            return PipeConnection.Type.NONE;
+        }
+
+        @Override
+        public boolean isNeighborPipe(Level world, BlockPos pos, Direction direction) {
+            return false;
+        }
+
+        @Override
+        public boolean isPowered() {
+            return false;
+        }
+
+        @Override
+        public ILogisticsNetwork getNetwork() {
+            return null;
+        }
+
+        @Override
+        public List<TravelingItem> getTravelingItems() {
+            return List.of();
+        }
+
+        @Override
+        public boolean forceAddItem(TravelingItem item, Direction fromDirection) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes supplier module UI targeting and prevents any duplicate chassis module from sharing state.

## Changes
- Capture the targeted supplier module state key when opening the supplier configuration screen.
- Resolve supplier module UI reads and writes against the specific module that opened the screen.
- Add persistent module item identities so duplicate chassis modules of the same type keep separate state.
- Scope chassis module callbacks, config screens, item drops, and item state sync through the module item's identity.
- Migrate legacy class-keyed module state into the new scoped state when first accessed.
- Extract duplicate slot-loading logic (module ID assignment + state key derivation) into `ChassisPipe.loadSlot`, used by both `getDynamicModuleEntries` and `OpenChassisSlotPacket`.
- Add focused coverage for duplicate module state isolation (SupplierModule and ExtractionModule) and legacy state migration.

## Notes
Previously, supplier screens could resolve modules by class only, so the UI could show or update another supplier module's data. The deeper issue was that chassis modules of the same type shared a class-based state key, so two identical modules could be treated as the same module. Module state is now keyed by a persistent id stored on the module item, so duplicate modules retain independent settings even when moved, removed, or reinserted.

The state isolation fix applies to **all** stateful modules (`ExtractionModule`, `MergerModule`, `ProcessModule`, `CraftingModule`, `ProviderModule`, `SupplierModule`) — any module that can be placed twice in the same chassis was affected.