### PR TITLE
fix: correct lever and dust placement on engine blocks

### DIFF
--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
@@ -13,11 +13,13 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -161,6 +163,24 @@ public abstract class AbstractEngineBlock<E extends AbstractEngineBlockEntity> e
     @Override
     protected BlockState mirror(BlockState state, Mirror mirror) {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
+    }
+
+    /**
+     * Only the base face (opposite of FACING) supports attachments like levers, buttons, and
+     * redstone dust. All SupportType checks go through getBlockSupportShape, so we return a
+     * thin slab on the base face side — giving that face full coverage while leaving all other
+     * faces empty.
+     */
+    @Override
+    public VoxelShape getBlockSupportShape(BlockState state, BlockGetter level, BlockPos pos) {
+        return switch (state.getValue(FACING).getOpposite()) {
+            case UP -> Block.box(0, 15, 0, 16, 16, 16);
+            case DOWN -> Block.box(0, 0, 0, 16, 1, 16);
+            case NORTH -> Block.box(0, 0, 0, 16, 16, 1);
+            case SOUTH -> Block.box(0, 0, 15, 16, 16, 16);
+            case WEST -> Block.box(0, 0, 0, 1, 16, 16);
+            case EAST -> Block.box(15, 0, 0, 16, 16, 16);
+        };
     }
 
     /**

--- a/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
+++ b/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
@@ -41,6 +41,13 @@ public abstract class AbstractEngineBlock<E extends AbstractEngineBlockEntity> e
     public static final EnumProperty<Direction> FACING = BlockStateProperties.FACING;
     public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
 
+    private static final VoxelShape SUPPORT_UP = Block.box(0, 15, 0, 16, 16, 16);
+    private static final VoxelShape SUPPORT_DOWN = Block.box(0, 0, 0, 16, 1, 16);
+    private static final VoxelShape SUPPORT_NORTH = Block.box(0, 0, 0, 16, 16, 1);
+    private static final VoxelShape SUPPORT_SOUTH = Block.box(0, 0, 15, 16, 16, 16);
+    private static final VoxelShape SUPPORT_WEST = Block.box(0, 0, 0, 1, 16, 16);
+    private static final VoxelShape SUPPORT_EAST = Block.box(15, 0, 0, 16, 16, 16);
+
     protected AbstractEngineBlock(Properties settings) {
         super(settings);
         registerDefaultState(defaultBlockState()
@@ -174,12 +181,12 @@ public abstract class AbstractEngineBlock<E extends AbstractEngineBlockEntity> e
     @Override
     public VoxelShape getBlockSupportShape(BlockState state, BlockGetter level, BlockPos pos) {
         return switch (state.getValue(FACING).getOpposite()) {
-            case UP -> Block.box(0, 15, 0, 16, 16, 16);
-            case DOWN -> Block.box(0, 0, 0, 16, 1, 16);
-            case NORTH -> Block.box(0, 0, 0, 16, 16, 1);
-            case SOUTH -> Block.box(0, 0, 15, 16, 16, 16);
-            case WEST -> Block.box(0, 0, 0, 1, 16, 16);
-            case EAST -> Block.box(15, 0, 0, 16, 16, 16);
+            case UP -> SUPPORT_UP;
+            case DOWN -> SUPPORT_DOWN;
+            case NORTH -> SUPPORT_NORTH;
+            case SOUTH -> SUPPORT_SOUTH;
+            case WEST -> SUPPORT_WEST;
+            case EAST -> SUPPORT_EAST;
         };
     }
 


### PR DESCRIPTION
### Summary
This update improves the functionality of engine blocks by fixing issues related to the placement of levers and dust attachments. Ensuring proper attachment points is crucial for enhancing user experience and maintaining consistent operational behavior within the logistics system.

### Changes
- **Fix for Lever and Dust Attachment Placement**: 
  - Adjusted attachment points on engine blocks to only allow connections on the base face, preventing unintended overlap and ensuring that levers and redstone dust can be placed correctly.
  - Enhanced the collision shape of the engine blocks to support this functionality, improving the overall gameplay experience by eliminating placement errors.

### Notes
- No compatibility issues have been identified with this update; existing users will benefit from this fix without additional adjustments.