### PR TITLE
fix: prevent component-bearing items from sharing crafter slot

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -890,12 +890,16 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
 
         String itemId = BuiltInRegistries.ITEM.getKey(item.getStack().getItem()).toString();
 
-        // Collect matching recipe slots that are empty or already hold the same item type
+        // Collect matching recipe slots that are empty or already hold the same item.
+        // Use component-aware comparison for the occupancy check so that items with
+        // different data (e.g. two different enchanted books) are never mixed in one slot.
+        // Note: ingredient config stores item ID only, so the recipe-slot match (line above)
+        // is still type-only; only the in-slot occupancy guard is component-aware.
         List<Integer> matchingSlots = new ArrayList<>();
         for (int slot = 0; slot < 9; slot++) {
             if (!itemId.equals(getIngredientItem(ctx, slot))) continue;
             ItemStack inSlot = crafter.getItem(slot);
-            if (!inSlot.isEmpty() && !itemId.equals(BuiltInRegistries.ITEM.getKey(inSlot.getItem()).toString())) continue;
+            if (!inSlot.isEmpty() && !ItemStack.isSameItemSameComponents(inSlot, item.getStack())) continue;
             matchingSlots.add(slot);
         }
         if (matchingSlots.isEmpty()) return 0;


### PR DESCRIPTION
## Summary
This update introduces a critical fix to the crafting module, ensuring that component-bearing items do not overlap in crafter slots. This enhancement improves the reliability of item handling in crafting processes, preventing potential item mix-ups during assembly.

## Changes
- **Crafter Slot Improvements:**
  - Implemented a component-aware comparison for items in crafter slots to prevent different enchanted items or items with unique data from sharing the same slot.
  - Adjusted the recipe slot matching logic to ensure that only empty or correctly typed slots are used, enhancing the crafting experience.

## Notes
No compatibility issues or migrations are necessary for this update. Users should experience a smoother crafting process without additional configuration.