### PR TITLE
fix: prevent passive supplier from overfilling inventory items

### DIFF
--- a/src/main/java/com/logistics/pipe/modules/PassiveSupplierModule.java
+++ b/src/main/java/com/logistics/pipe/modules/PassiveSupplierModule.java
@@ -136,10 +136,12 @@ public class PassiveSupplierModule extends SupplierModule implements ItemAccepti
                 ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
         if (storage == null) return 0;
 
-        ItemVariant targetVariant = ItemVariant.of(target);
+        // Config stores item ID only (no component data), so count all variants of the
+        // same item type. This prevents overfilling when enchanted/damaged items arrive
+        // for a stock target configured by item type alone.
         long count = 0;
         for (StorageView<ItemVariant> view : storage) {
-            if (view.getResource().equals(targetVariant)) {
+            if (view.getResource().getItem() == target.getItem()) {
                 count += view.getAmount();
             }
         }


### PR DESCRIPTION
## Summary
This release focuses on a critical bug fix within the Passive Supplier Module to prevent passive suppliers from overfilling the inventory when processing component-bearing items. This ensures a more reliable experience when managing item stock.

## Changes
- **Bug Fix**: 
  - Modified the inventory counting logic in the Passive Supplier Module to avoid overfilling when enchanted or damaged items are processed. 
  - Changed the way item comparisons are made to ensure that only the base item type is counted, regardless of item variants.

## Notes
- No breaking changes or migrations are required for this update. All users should benefit from improved passive supplier behavior without additional modifications.