### PR TITLE
refactor: move quartz crystal registration to core domain

### DIFF
--- a/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/src/main/java/com/logistics/LogisticsAutomation.java
@@ -13,7 +13,6 @@ import com.logistics.automation.marker.MarkerBlockEntity;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
 import net.minecraft.core.Direction;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
@@ -64,7 +63,6 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         public static Block LASER_QUARRY;
         public static Block LASER_QUARRY_FRAME;
         public static Block KILN;
-        public static Block QUARTZ_CRYSTAL;
 
         static void register() {
             MARKER = INSTANCE.registerBlockWithItem("marker",
@@ -76,8 +74,6 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
             KILN = INSTANCE.registerBlockWithItem("kiln",
                 props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
                     .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
-            QUARTZ_CRYSTAL = INSTANCE.registerBlockWithItem("quartz_crystal",
-                props -> new Block(props.strength(0.8f).sound(SoundType.GLASS).noOcclusion()));
         }
     }
 
@@ -111,7 +107,6 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         LogisticsCore.CREATIVE_TAB.addItem(BLOCK.MARKER);
         LogisticsCore.CREATIVE_TAB.addItem(BLOCK.LASER_QUARRY);
         LogisticsCore.CREATIVE_TAB.addItem(BLOCK.KILN);
-        LogisticsCore.CREATIVE_TAB.addItem(BLOCK.QUARTZ_CRYSTAL);
     }
 
     private void registerLegacyAliases() {
@@ -138,5 +133,9 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         registerBlockAlias("core/kiln", BLOCK.KILN);
         registerBlockEntityAlias("core/kiln", ENTITY.KILN_BLOCK_ENTITY);
         registerItemAlias("core/kiln", BLOCK.KILN.asItem());
+
+        // automation domain => core domain (quartz_crystal moved)
+        registerBlockAlias("automation/quartz_crystal", LogisticsCore.BLOCK.QUARTZ_CRYSTAL);
+        registerItemAlias("automation/quartz_crystal", LogisticsCore.BLOCK.QUARTZ_CRYSTAL.asItem());
     }
 }

--- a/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/src/main/java/com/logistics/LogisticsAutomation.java
@@ -13,6 +13,7 @@ import com.logistics.automation.marker.MarkerBlockEntity;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
 import net.minecraft.core.Direction;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 

--- a/src/main/java/com/logistics/LogisticsCore.java
+++ b/src/main/java/com/logistics/LogisticsCore.java
@@ -136,6 +136,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         public static Block APATITE_ORE;
         public static Block APATITE_BLOCK;
         public static Block MACERATOR;
+        public static Block QUARTZ_CRYSTAL;
 
         private BLOCK() {}
 
@@ -162,6 +163,8 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
             MACERATOR = INSTANCE.registerBlockWithItem("macerator",
                 props -> new MaceratorBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
                     .lightLevel(state -> state.getValue(MaceratorBlock.LIT) ? 13 : 0)));
+            QUARTZ_CRYSTAL = INSTANCE.registerBlockWithItem("quartz_crystal",
+                props -> new Block(props.strength(0.8f).sound(SoundType.GLASS).noOcclusion()));
         }
     }
 
@@ -443,6 +446,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
                 ITEM.PROBE
         );
         CREATIVE_TAB.addItem(BLOCK.MACERATOR);
+        CREATIVE_TAB.addItem(BLOCK.QUARTZ_CRYSTAL);
     }
 
     private static void addVanillaCreativeTabEntries() {

--- a/src/main/resources/assets/logistics/lang/en_us.json
+++ b/src/main/resources/assets/logistics/lang/en_us.json
@@ -97,7 +97,6 @@
   "item.logistics.core.ender_dust": "Ender Dust",
   "item.logistics.core.echo_dust": "Echo Dust",
   "item.logistics.core.prismarine_dust": "Prismarine Dust",
-  "block.logistics.automation.quartz_crystal": "Quartz Crystal",
   "block.logistics.core.quartz_crystal": "Quartz Crystal",
   "item.logistics.core.silicon_mix": "Silicon Mix",
   "item.logistics.core.silicon_wafer": "Silicon Wafer",

--- a/src/main/resources/assets/logistics/lang/en_us.json
+++ b/src/main/resources/assets/logistics/lang/en_us.json
@@ -98,6 +98,7 @@
   "item.logistics.core.echo_dust": "Echo Dust",
   "item.logistics.core.prismarine_dust": "Prismarine Dust",
   "block.logistics.automation.quartz_crystal": "Quartz Crystal",
+  "block.logistics.core.quartz_crystal": "Quartz Crystal",
   "item.logistics.core.silicon_mix": "Silicon Mix",
   "item.logistics.core.silicon_wafer": "Silicon Wafer",
   "item.logistics.core.flour": "Flour",

--- a/src/main/resources/data/logistics/loot_table/blocks/core/quartz_crystal.json
+++ b/src/main/resources/data/logistics/loot_table/blocks/core/quartz_crystal.json
@@ -6,7 +6,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "logistics:automation/quartz_crystal"
+          "name": "logistics:core/quartz_crystal"
         }
       ],
       "rolls": 1.0,
@@ -17,5 +17,5 @@
       ]
     }
   ],
-  "random_sequence": "logistics:blocks/automation/quartz_crystal"
+  "random_sequence": "logistics:blocks/core/quartz_crystal"
 }


### PR DESCRIPTION
## Summary
This update transitions the registration of the quartz crystal block from the automation domain to the core domain. This change centralizes the handling of the quartz crystal within the core module, enhancing the overall structure and maintainability of the codebase. 

## Changes
- **Quartz Crystal Registration:**
  - Moved quartz crystal registration from `LogisticsAutomation` to `LogisticsCore`.
  - Updated block identifiers and crafting item aliases accordingly.
  
- **Language File Update:**
  - Updated localization entries for quartz crystal to reflect its new location in the core domain.
  
- **Loot Table Migration:**
  - Renamed the quartz crystal loot table from the automation to the core directory structure.

## Notes
This restructuring improves clarity and ensures that all core-related resources are consistently maintained within the core domain. No significant user-facing features were altered, but the organization of the codebase is enhanced for future development.