### PR TITLE
chore: centralize version management in gradle.properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,10 +91,7 @@ Since commits will be cherry-picked across branches, write code that minimizes c
 ./gradlew runServer          # Launch Minecraft server
 ```
 
-**Requirements:**
-- **Java 25** (MC 26.1+ requirement)
-- Minecraft 26.1+
-- Fabric API
+**Requirements:** See `gradle.properties` for current versions (`java_version`, `minecraft_version`, `loader_version`, `fabric_version`).
 
 **Build output:** `build/libs/logistics-{version}.jar`
 - Local: `logistics-dev-local.jar`

--- a/build.gradle
+++ b/build.gradle
@@ -87,14 +87,17 @@ dependencies {
 
 processResources {
 	inputs.property "version", project.version
+	inputs.property "fabric_version", project.fabric_version
+	inputs.property "loader_version", project.loader_version
+	inputs.property "java_version", project.java_version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": inputs.properties.version
+		expand inputs.properties
 	}
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 25
+	it.options.release = project.java_version.toInteger()
 }
 
 // Configure test task

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
 
 processResources {
 	inputs.property "version", project.version
+	inputs.property "minecraft_version", project.minecraft_version
 	inputs.property "fabric_version", project.fabric_version
 	inputs.property "loader_version", project.loader_version
 	inputs.property "java_version", project.java_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,20 +5,25 @@ org.gradle.parallel=true
 # IntelliJ IDEA is not yet fully compatible with configuration cache, see: https://github.com/FabricMC/fabric-loom/issues/1349
 org.gradle.configuration-cache=false
 
-# Fabric Properties
-# check these on https://fabricmc.net/develop
-minecraft_version=26.1
-loader_version=0.18.6
-loom_version=1.16-SNAPSHOT
-
 # Mod Properties
 mod_version=dev-local
 maven_group=com.logistics
 archives_base_name=logistics
 
-# Dependencies
+# Minecraft
+minecraft_version=26.1
+java_version=25
+
+# Fabric
+# check these on https://fabricmc.net/develop
+loader_version=0.18.6
+loom_version=1.16-SNAPSHOT
 fabric_version=0.145.2+26.1.1
 energy_version=5.0.0
+
+# Neoforge
+
+# Dependencies
 jei_version=29.2.0.20
 
 # Test Dependencies

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     "fabric-api": ">=${fabric_version}",
     "fabricloader": ">=${loader_version}",
     "java": ">=${java_version}",
-    "minecraft": ">=26.1"
+    "minecraft": ">=${minecraft_version}"
   },
   "description": "A modern logistics and pipe mod with authentic in-pipe item motion, mod interoperability, and request/autocrafting systems.",
   "entrypoints": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,9 +8,9 @@
     "sources": "https://github.com/indemnity83/logistics"
   },
   "depends": {
-    "fabric-api": ">=0.145.2+26.1.1",
-    "fabricloader": ">=0.18.6",
-    "java": ">=25",
+    "fabric-api": ">=${fabric_version}",
+    "fabricloader": ">=${loader_version}",
+    "java": ">=${java_version}",
     "minecraft": ">=26.1"
   },
   "description": "A modern logistics and pipe mod with authentic in-pipe item motion, mod interoperability, and request/autocrafting systems.",


### PR DESCRIPTION
# Summary
Centralized version management for the project by consolidating all version-related properties into `gradle.properties`. This change aims to reduce duplication across configuration files, enhancing maintainability and clarity.

# Changes
- **Centralized Version Management**:  
  - Moved all version declarations (Minecraft version, loader version, Java version, and fabric version) from `build.gradle` and `fabric.mod.json` into `gradle.properties`.
  - Updated references in `build.gradle` and `fabric.mod.json` to use the properties defined in `gradle.properties`.
  
- **Eliminated Duplication**:  
  - Removed repetitive version specifications in `fabric.mod.json`, ensuring that all dependencies use the centralized properties.

# Notes
- Future updates to versions should only be made in `gradle.properties`, simplifying the release process and reducing potential errors from inconsistent versioning across files.