### PR TITLE
build: add NeoForge support to multi-loader configuration

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  build:
+  check:
     # Skip: draft PRs, release-please PRs
     if: |
       github.event.pull_request.draft == false &&
@@ -41,36 +41,43 @@ jobs:
           name: test-reports-${{ github.run_id }}
           path: common/build/reports/tests/test/
 
+  build:
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        loader: [fabric, neoforge]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
       - name: Compute version
         id: version
         run: |
           MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
-          MC_VERSION_CLEAN="$(echo "$MC_VERSION" | sed 's/-snapshot-[0-9]\+$//')"
           SHA7="$(git rev-parse --short=7 HEAD)"
           PR_NUM="${{ github.event.pull_request.number }}"
-          TARGET_BRANCH="${{ github.base_ref }}"
+          LOADER="${{ matrix.loader }}"
 
           # Example: dev-pr.123+mc26.1.sha.a1b2c3d
           BUILD_VERSION="dev-pr.${PR_NUM}+mc${MC_VERSION}.sha.${SHA7}"
-
-          # Determine Gradle task based on MC version (MC 26.1+ is not obfuscated)
-          if [[ "$MC_VERSION" =~ ^([0-9]+)\. ]]; then
-            MC_MAJOR="${BASH_REMATCH[1]}"
-            if (( MC_MAJOR >= 26 )); then
-              GRADLE_TASK=":fabric:jar"
-            else
-              GRADLE_TASK="remapJar"
-            fi
-          else
-            # Fallback for unexpected version format
-            GRADLE_TASK="remapJar"
-          fi
+          GRADLE_TASK=":${LOADER}:jar"
 
           echo "mod_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
-          echo "minecraft_version_clean=$MC_VERSION_CLEAN" >> "$GITHUB_OUTPUT"
           echo "gradle_task=$GRADLE_TASK" >> "$GITHUB_OUTPUT"
           echo "📦 Version: $BUILD_VERSION"
-          echo "🔨 Gradle task: $GRADLE_TASK (target: $TARGET_BRANCH)"
+          echo "🔨 Gradle task: $GRADLE_TASK"
 
       - name: Build
         run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
@@ -80,5 +87,5 @@ jobs:
       - name: Upload JAR
         uses: actions/upload-artifact@v7
         with:
-          name: logistics-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
-          path: fabric/build/libs/logistics-*.jar
+          name: logistics-${{ matrix.loader }}-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: ${{ matrix.loader }}/build/libs/logistics-*.jar

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -100,7 +100,7 @@ jobs:
           files: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
       - name: Notify Discord beta-testing
-        if: success()
+        if: success() && matrix.loader == 'fabric'
         shell: bash
         env:
           DISCORD_BETA_WEBHOOK_URL: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -12,8 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        loader: [fabric]
+        loader: [fabric, neoforge]
 
     steps:
       - uses: actions/checkout@v6
@@ -52,15 +53,9 @@ jobs:
 
           FULL_VERSION="${PRE_VERSION}+mc${MC_VERSION}.${LOADER}"
 
-          # Gradle task
-          if [[ "$MC_VERSION" =~ ^([0-9]+)\. ]]; then
-            (( ${BASH_REMATCH[1]} >= 26 )) && GRADLE_TASK=":fabric:jar" || GRADLE_TASK="remapJar"
-          else
-            GRADLE_TASK="remapJar"
-          fi
+          GRADLE_TASK=":${LOADER}:jar"
 
-          # CI is fabric-only for now. Keep token explicit.
-          LOADER_SHORT="f"
+          [[ "$LOADER" == "neoforge" ]] && LOADER_SHORT="n" || LOADER_SHORT="f"
 
           MODRINTH_VERSION="${PRE_VERSION}+mc${MC_VERSION}.${LOADER_SHORT}"
           (( ${#MODRINTH_VERSION} > 32 )) && MODRINTH_VERSION="${MODRINTH_VERSION:0:32}"
@@ -83,9 +78,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: logistics-${{ steps.version.outputs.full_version }}
-          path: fabric/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+          path: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
       - name: Publish
+        # NeoForge publishing deferred until multiloader-loader integration is complete
+        if: matrix.loader == 'fabric'
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
@@ -100,7 +97,7 @@ jobs:
           version: ${{ steps.version.outputs.full_version }}
           name: "Logistics v${{ steps.version.outputs.pre_version }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"
 
-          files: fabric/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+          files: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
       - name: Notify Discord beta-testing
         if: success()

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -134,6 +134,12 @@ jobs:
           echo "📦 Build artifacts created:"
           ls -lh ${{ matrix.loader }}/build/libs/
 
+      - name: Upload JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: logistics-${{ matrix.loader }}-${{ steps.version.outputs.full_version }}
+          path: ${{ matrix.loader }}/build/libs/logistics-*.jar
+
       - name: Publish to Modrinth and CurseForge
         # NeoForge publishing deferred until multiloader-loader integration is complete
         if: (github.event_name != 'workflow_dispatch' || inputs.publish) && matrix.loader == 'fabric'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,8 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        loader: [fabric]
+        loader: [fabric, neoforge]
 
     steps:
       - uses: actions/checkout@v6
@@ -77,20 +78,7 @@ jobs:
           # The +mc1.21.11.fabric is SemVer build metadata - platform and loader identifiers
           FULL_VERSION="${VERSION}+mc${MC_VERSION}.${LOADER}"
 
-          # Determine Gradle task based on MC version
-          # MC 26.1+ is not obfuscated (use jar)
-          # MC 1.21.11 and earlier are obfuscated (use remapJar)
-          if [[ "$MC_VERSION" =~ ^([0-9]+)\. ]]; then
-            MC_MAJOR="${BASH_REMATCH[1]}"
-            if (( MC_MAJOR >= 26 )); then
-              GRADLE_TASK=":fabric:jar"
-            else
-              GRADLE_TASK="remapJar"
-            fi
-          else
-            # Fallback for unexpected version format
-            GRADLE_TASK="remapJar"
-          fi
+          GRADLE_TASK=":${LOADER}:jar"
 
           # Detect snapshot/alpha/beta versions for publishing configuration
           if [[ "$MC_VERSION" =~ (snapshot|alpha|beta) ]]; then
@@ -144,12 +132,11 @@ jobs:
       - name: List build artifacts
         run: |
           echo "📦 Build artifacts created:"
-          ls -lh fabric/build/libs/
-          echo ""
-          echo "🔍 Looking for: logistics-${{ steps.version.outputs.full_version }}.jar"
+          ls -lh ${{ matrix.loader }}/build/libs/
 
       - name: Publish to Modrinth and CurseForge
-        if: github.event_name != 'workflow_dispatch' || inputs.publish
+        # NeoForge publishing deferred until multiloader-loader integration is complete
+        if: (github.event_name != 'workflow_dispatch' || inputs.publish) && matrix.loader == 'fabric'
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
@@ -168,6 +155,6 @@ jobs:
           name: "Logistics v${{ steps.version.outputs.version }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"
           version: "${{ steps.version.outputs.full_version }}"
 
-          files: fabric/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+          files: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
           changelog: ${{ github.event.release.body || format('Release {0}', steps.version.outputs.full_version) }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -12,8 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        loader: [fabric]
+        loader: [fabric, neoforge]
 
     steps:
       - uses: actions/checkout@v6
@@ -65,15 +66,9 @@ jobs:
 
           FULL_VERSION="${PRE_ID}+mc${MC_VERSION}.${LOADER}"
 
-          # Gradle task
-          if [[ "$MC_VERSION" =~ ^([0-9]+)\. ]]; then
-            (( ${BASH_REMATCH[1]} >= 26 )) && GRADLE_TASK=":fabric:jar" || GRADLE_TASK="remapJar"
-          else
-            GRADLE_TASK="remapJar"
-          fi
+          GRADLE_TASK=":${LOADER}:jar"
 
-          # CI is fabric-only for now. Keep token explicit.
-          LOADER_SHORT="f"
+          [[ "$LOADER" == "neoforge" ]] && LOADER_SHORT="n" || LOADER_SHORT="f"
 
           MODRINTH_VERSION="${PRE_ID}+mc${MC_VERSION}.${LOADER_SHORT}"
           (( ${#MODRINTH_VERSION} > 32 )) && MODRINTH_VERSION="${MODRINTH_VERSION:0:32}"
@@ -106,9 +101,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: logistics-${{ steps.version.outputs.full_version }}
-          path: fabric/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+          path: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
       - name: Publish
+        # NeoForge publishing deferred until multiloader-loader integration is complete
+        if: matrix.loader == 'fabric'
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
@@ -123,4 +120,4 @@ jobs:
           version: ${{ steps.version.outputs.full_version }}
           name: "Logistics ${{ steps.version.outputs.pre_id }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"
 
-          files: fabric/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+          files: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.diffplug.spotless'
 }
 
-version = System.getenv("MOD_VERSION") ?: project.mod_version
+version = System.getenv("MOD_VERSION") ?: "dev"
 group = project.maven_group
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,9 @@ tasks.register('installGitHooks') {
 }
 
 // Aggregate build: delegates to loader subprojects.
-// TODO(multiloader): add ':neoforge:build' here once neoforge/build.gradle is wired with
-//   net.neoforged.moddev and MDG has support for MC 26.1 calendar versioning.
 tasks.named('build') {
     dependsOn ':fabric:build'
+    dependsOn ':neoforge:build'
     dependsOn ':common:test'
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,13 +1,16 @@
 // Common subproject — shared domain code, compiles against vanilla MC via Loom.
 // No splitEnvironmentSourceSets(): client code lives in fabric/.
 //
-// TODO(multiloader): swap net.fabricmc.fabric-loom here for net.neoforged.moddev once MDG
-//   gains support for MC 26.1 calendar versioning. When that happens:
-//   - Replace the loom {} block with neoForge { neoFormVersion = neoform_version }
+// TODO(multiloader): swap net.fabricmc.fabric-loom here for net.neoforged.moddev.
+//   MDG supports MC 26.1 (confirmed via MultiLoader-Template/tree/26.1). The blocker is
+//   that common/ currently imports Fabric API directly (~25 classes across the codebase).
+//   When ready:
+//   - Replace the loom {} block with neoForge { neoFormVersion = neo_form_version }
 //   - Remove Fabric API / fabric-loader dependencies (common should depend only on vanilla MC)
 //   - Move FabricBlockEntityTypeBuilder usage out of LogisticsMod.java behind an abstraction
 //     (vanilla BlockEntityType has a private constructor in MC 26.1; needs a loader helper)
-//   - Add neoform_version to gradle.properties
+//   - Apply multiloader-loader in neoforge/build.gradle to compile common sources there
+//   See: https://github.com/jaredlll08/MultiLoader-Template/tree/26.1
 plugins {
     id 'multiloader-common'
     id 'net.fabricmc.fabric-loom'

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -7,6 +7,8 @@ plugins {
     id 'net.fabricmc.fabric-loom'
 }
 
+version = System.getenv("MOD_VERSION") ?: "dev-fabric"
+
 base {
     archivesName = rootProject.archives_base_name
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,9 +23,13 @@ fabric_loader_version=0.18.6
 fabric_version=0.145.2+26.1.1
 fabric_energy_version=5.0.0
 
-# Neoforge
-neoforge_loader_version=4
-neoforge_version=21.0
+# NeoForge
+# check versions at https://projects.neoforged.net/neoforged/neoforge
+neoforge_version=26.1.0.5-beta
+neoforge_loader_version_range=[4,)
+minecraft_version_range=[26.1, 26.2)
+neo_form_version=26.1-1
+moddev_version=2.0.141
 
 # Dependencies
 jei_version=29.2.0.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,12 +6,8 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=false
 
 # Mod Properties
-mod_version=dev-local
 maven_group=com.logistics
 archives_base_name=logistics
-
-# Loom
-loom_version=1.16-SNAPSHOT
 
 # Minecraft
 minecraft_version=26.1
@@ -21,6 +17,7 @@ java_version=25
 # check these on https://fabricmc.net/develop
 fabric_loader_version=0.18.6
 fabric_version=0.145.2+26.1.1
+loom_version=1.16-SNAPSHOT
 fabric_energy_version=5.0.0
 
 # NeoForge

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -7,11 +7,11 @@ plugins {
     id 'net.neoforged.moddev'
 }
 
-version = rootProject.version
+version = System.getenv("MOD_VERSION") ?: "dev-neoforge"
 group = rootProject.group
 
 base {
-    archivesName = "${archives_base_name}-neoforge-${minecraft_version}"
+    archivesName = rootProject.archives_base_name
 }
 
 java {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -15,7 +15,7 @@ base {
 }
 
 java {
-    toolchain.languageVersion = JavaLanguageVersion.of(java_version.toInteger())
+    toolchain.languageVersion = JavaLanguageVersion.of(rootProject.java_version.toInteger())
     withSourcesJar()
 }
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,5 +1,63 @@
-// NeoForge loader subproject — stub only, no runnable mod yet.
-// TODO: apply multiloader-loader + net.neoforged.moddev when MDG supports MC 26.1 calendar versioning.
+// NeoForge loader subproject.
+// NOTE(multiloader): This subproject compiles only its own entry-point code for now.
+//   Integrating multiloader-loader (to share common/ sources) requires first removing all
+//   Fabric API references from common/ — see common/build.gradle for the full TODO list.
 plugins {
     id 'java-library'
+    id 'net.neoforged.moddev'
+}
+
+version = rootProject.version
+group = rootProject.group
+
+base {
+    archivesName = "${archives_base_name}-neoforge-${minecraft_version}"
+}
+
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(java_version.toInteger())
+    withSourcesJar()
+}
+
+neoForge {
+    version = neoforge_version
+    runs {
+        client {
+            client()
+            gameDirectory = project.file('runs/client')
+        }
+        server {
+            server()
+            gameDirectory = project.file('runs/server')
+        }
+    }
+    mods {
+        logistics {
+            sourceSet sourceSets.main
+        }
+    }
+}
+
+processResources {
+    var expandProps = [
+        'version'                      : version,
+        'minecraft_version'            : minecraft_version,
+        'minecraft_version_range'      : minecraft_version_range,
+        'neoforge_version'             : neoforge_version,
+        'neoforge_loader_version_range': neoforge_loader_version_range,
+    ]
+    filesMatching('META-INF/neoforge.mods.toml') {
+        expand expandProps
+    }
+    inputs.properties(expandProps)
+}
+
+tasks.withType(JavaCompile).configureEach {
+    it.options.release = rootProject.java_version.toInteger()
+}
+
+jar {
+    from('../LICENSE') {
+        rename { "${it}_logistics" }
+    }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
@@ -1,9 +1,13 @@
 package com.logistics.neoforge;
 
-/**
- * Placeholder for NeoForge bootstrap wiring.
- * Groundwork only: no runtime registration yet.
- */
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
+
+@Mod("logistics")
 public final class LogisticsNeoForge {
-    private LogisticsNeoForge() {}
+
+    public LogisticsNeoForge(IEventBus eventBus) {
+        // NeoForge entry point.
+        // TODO(multiloader): call common domain init here once multiloader-loader is wired.
+    }
 }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[${neoforge_loader_version},)"
+loaderVersion="${neoforge_loader_version_range}"
 license="MIT"
 
 [[mods]]
@@ -21,6 +21,6 @@ side="BOTH"
 [[dependencies.logistics]]
 modId="minecraft"
 type="required"
-versionRange="[${minecraft_version},)"
+versionRange="${minecraft_version_range}"
 ordering="NONE"
 side="BOTH"

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ pluginManagement {
         // Declare version centrally so subproject plugins {} blocks omit the version.
         // Version comes from gradle.properties.
         id 'net.fabricmc.fabric-loom' version "${loom_version}"
+        id 'net.neoforged.moddev' version "${moddev_version}"
         id 'com.diffplug.spotless' version '8.4.0'
     }
 }


### PR DESCRIPTION
## Summary
This update introduces support for the NeoForge loader within the multi-loader configuration. The addition enhances compatibility for users and developers engaging with different mod loaders, particularly Fabric and NeoForge. By integrating NeoForge support, we strive to provide a richer modding experience for users in the Minecraft community.

## Changes
- **Multi-Loader Integration**:
  - Added comprehensive support for NeoForge in workflows and build scripts, allowing for seamless builds across both Fabric and NeoForge platforms.
  - Updated GitHub Actions workflows to handle both loaders, improving CI efficiency and versatility.
  
- **Build Configuration**:
  - Refined Gradle build scripts to ensure proper dependencies and execution paths for NeoForge, laying groundwork for future integration efforts.
  - Implemented structure to dynamically determine Gradle tasks based on the selected loader, simplifying the build process.
  
- **NeoForge Subproject**:
  - Created a dedicated NeoForge subproject with basics for mod initialization.
  - Updated `neoforge.mods.toml` configuration for enhanced metadata management and compatibility settings.
  
- **Documentation and Comments**:
  - Added detailed comments and TODOs within the codebase to outline future tasks and considerations for complete integration of multi-loader capabilities.

## Notes
- This integration marks a significant step toward fully realizing the multi-loader capabilities within the Logistics mod.
- As further enhancements and cleanup occur, users should monitor updates to ensure compatibility with future releases.