### PR TITLE
refactor: move packet registration out of common module

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsPipe.java
+++ b/common/src/main/java/com/logistics/LogisticsPipe.java
@@ -69,7 +69,6 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
         DATA.register();
         SCREEN.register();
         registerMarkingFluidItems();
-        registerNetworkPackets();
 
         registerLegacyAliases();
         addCreativeTabEntries();
@@ -85,13 +84,6 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
 
     public static void onLevelUnload(ServerLevel level) {
         NetworkRegistry.clearLevel(level);
-    }
-
-    private static void registerNetworkPackets() {
-        com.logistics.pipe.network.packet.RequestItemPacket.register();
-        com.logistics.pipe.network.packet.SyncRequesterInventoryPacket.register();
-        com.logistics.pipe.network.packet.OpenChassisSlotPacket.register();
-        com.logistics.pipe.network.packet.SetSatelliteIdPacket.register();
     }
 
     private static void addCreativeTabEntries() {

--- a/common/src/main/java/com/logistics/pipe/network/packet/OpenChassisSlotPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/OpenChassisSlotPacket.java
@@ -4,8 +4,6 @@ import com.logistics.LogisticsPipe;
 import com.logistics.pipe.ChassisPipe;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.ui.ChassisScreenHandler;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
@@ -34,22 +32,15 @@ public record OpenChassisSlotPacket(int slotIndex) implements CustomPacketPayloa
         return TYPE;
     }
 
-    public static void register() {
-        PayloadTypeRegistry.serverboundPlay().register(TYPE, CODEC);
+    public void handle(ServerPlayer player) {
+        if (!(player.containerMenu instanceof ChassisScreenHandler handler)) return;
 
-        ServerPlayNetworking.registerGlobalReceiver(TYPE, (packet, context) -> {
-            context.server().execute(() -> {
-                ServerPlayer player = context.player();
-                if (!(player.containerMenu instanceof ChassisScreenHandler handler)) return;
+        PipeBlockEntity pe = handler.getPipeEntity();
+        if (pe == null) return;
 
-                PipeBlockEntity pe = handler.getPipeEntity();
-                if (pe == null) return;
-
-                var ctx = pe.createContext();
-                var ops = context.server().registryAccess().createSerializationContext(NbtOps.INSTANCE);
-                ChassisPipe.loadSlot(ctx, packet.slotIndex, ops)
-                        .ifPresent(entry -> entry.module().onWrench(entry.scopedContext(ctx), player));
-            });
-        });
+        var ctx = pe.createContext();
+        var ops = player.level().registryAccess().createSerializationContext(NbtOps.INSTANCE);
+        ChassisPipe.loadSlot(ctx, slotIndex(), ops)
+                .ifPresent(entry -> entry.module().onWrench(entry.scopedContext(ctx), player));
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/packet/PacketValidation.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/PacketValidation.java
@@ -1,7 +1,12 @@
 package com.logistics.pipe.network.packet;
 
+import com.logistics.pipe.block.entity.PipeBlockEntity;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import java.util.function.Consumer;
 
 final class PacketValidation {
     private PacketValidation() {}
@@ -11,11 +16,17 @@ final class PacketValidation {
         return player.distanceToSqr(pos.getCenter()) <= maxDistance * maxDistance;
     }
 
-    static boolean isPlayerOutOfRange(ServerPlayer player, BlockPos pos) {
-        return isPlayerOutOfRange(player, pos, 64);
-    }
-
     static boolean isPlayerOutOfRange(ServerPlayer player, BlockPos pos, double maxDistance) {
         return !isPlayerInRange(player, pos, maxDistance);
+    }
+
+    static void ifPlayerCanReach(ServerPlayer player, BlockPos pos, Consumer<PipeBlockEntity> action) {
+        if (isPlayerOutOfRange(player, pos, 64)) return;
+        if (player.level() instanceof ServerLevel level) {
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof PipeBlockEntity pipeEntity) {
+                action.accept(pipeEntity);
+            }
+        }
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/packet/PacketValidation.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/PacketValidation.java
@@ -1,0 +1,21 @@
+package com.logistics.pipe.network.packet;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+
+final class PacketValidation {
+    private PacketValidation() {}
+
+    static boolean isPlayerInRange(ServerPlayer player, BlockPos pos, double maxDistance) {
+        // distanceToSqr avoids Math.sqrt(); squaring maxDistance gives the same comparison
+        return player.distanceToSqr(pos.getCenter()) <= maxDistance * maxDistance;
+    }
+
+    static boolean isPlayerOutOfRange(ServerPlayer player, BlockPos pos) {
+        return isPlayerOutOfRange(player, pos, 64);
+    }
+
+    static boolean isPlayerOutOfRange(ServerPlayer player, BlockPos pos, double maxDistance) {
+        return !isPlayerInRange(player, pos, maxDistance);
+    }
+}

--- a/common/src/main/java/com/logistics/pipe/network/packet/RequestItemPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/RequestItemPacket.java
@@ -4,14 +4,13 @@ import com.logistics.LogisticsPipe;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.RequesterModule;
 import com.logistics.pipe.ui.PipeModuleHelper;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
@@ -38,30 +37,20 @@ public record RequestItemPacket(BlockPos pipePos, ItemStack stack, int amount)
         return TYPE;
     }
 
-    /**
-     * Register this packet type with Fabric networking.
-     */
-    public static void register() {
-        PayloadTypeRegistry.serverboundPlay().register(TYPE, CODEC);
-
-        ServerPlayNetworking.registerGlobalReceiver(TYPE, (packet, context) -> {
-            context.server().execute(() -> {
-                var player = context.player();
-                BlockPos pos = packet.pipePos();
-                double dx = player.getX() - (pos.getX() + 0.5);
-                double dy = player.getY() - (pos.getY() + 0.5);
-                double dz = player.getZ() - (pos.getZ() + 0.5);
-                if (dx * dx + dy * dy + dz * dz > 64.0 * 64.0) return;
-                if (player.level() instanceof ServerLevel level) {
-                    BlockEntity be = level.getBlockEntity(pos);
-                    if (be instanceof PipeBlockEntity pipeEntity) {
-                        PipeModuleHelper.withModule(
-                                pipeEntity,
-                                RequesterModule.class,
-                                (ctx, module) -> module.requestItem(ctx, packet.stack(), packet.amount()));
-                    }
-                }
-            });
-        });
+    public void handle(ServerPlayer player) {
+        BlockPos pos = pipePos();
+        double dx = player.getX() - (pos.getX() + 0.5);
+        double dy = player.getY() - (pos.getY() + 0.5);
+        double dz = player.getZ() - (pos.getZ() + 0.5);
+        if (dx * dx + dy * dy + dz * dz > 64.0 * 64.0) return;
+        if (player.level() instanceof ServerLevel level) {
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof PipeBlockEntity pipeEntity) {
+                PipeModuleHelper.withModule(
+                        pipeEntity,
+                        RequesterModule.class,
+                        (ctx, module) -> module.requestItem(ctx, stack(), amount()));
+            }
+        }
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/packet/RequestItemPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/RequestItemPacket.java
@@ -9,10 +9,8 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
  * Packet sent from client to server to request an item from the network.
@@ -38,16 +36,11 @@ public record RequestItemPacket(BlockPos pipePos, ItemStack stack, int amount)
     }
 
     public void handle(ServerPlayer player) {
-        BlockPos pos = pipePos();
-        if (PacketValidation.isPlayerOutOfRange(player, pos)) return;
-        if (player.level() instanceof ServerLevel level) {
-            BlockEntity be = level.getBlockEntity(pos);
-            if (be instanceof PipeBlockEntity pipeEntity) {
-                PipeModuleHelper.withModule(
-                        pipeEntity,
-                        RequesterModule.class,
-                        (ctx, module) -> module.requestItem(ctx, stack(), amount()));
-            }
-        }
+        PacketValidation.ifPlayerCanReach(player, pipePos(), this::requestItem);
+    }
+
+    private void requestItem(PipeBlockEntity pipeEntity) {
+        PipeModuleHelper.withModule(pipeEntity, RequesterModule.class,
+                (ctx, module) -> module.requestItem(ctx, stack(), amount()));
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/packet/RequestItemPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/RequestItemPacket.java
@@ -39,10 +39,7 @@ public record RequestItemPacket(BlockPos pipePos, ItemStack stack, int amount)
 
     public void handle(ServerPlayer player) {
         BlockPos pos = pipePos();
-        double dx = player.getX() - (pos.getX() + 0.5);
-        double dy = player.getY() - (pos.getY() + 0.5);
-        double dz = player.getZ() - (pos.getZ() + 0.5);
-        if (dx * dx + dy * dy + dz * dz > 64.0 * 64.0) return;
+        if (PacketValidation.isPlayerOutOfRange(player, pos)) return;
         if (player.level() instanceof ServerLevel level) {
             BlockEntity be = level.getBlockEntity(pos);
             if (be instanceof PipeBlockEntity pipeEntity) {

--- a/common/src/main/java/com/logistics/pipe/network/packet/SetSatelliteIdPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/SetSatelliteIdPacket.java
@@ -37,10 +37,7 @@ public record SetSatelliteIdPacket(BlockPos pipePos, String satelliteId)
 
     public void handle(ServerPlayer player) {
         BlockPos pos = pipePos();
-        double dx = player.getX() - (pos.getX() + 0.5);
-        double dy = player.getY() - (pos.getY() + 0.5);
-        double dz = player.getZ() - (pos.getZ() + 0.5);
-        if (dx * dx + dy * dy + dz * dz > 64.0 * 64.0) return;
+        if (PacketValidation.isPlayerOutOfRange(player, pos)) return;
         if (player.level() instanceof ServerLevel level) {
             BlockEntity be = level.getBlockEntity(pos);
             if (be instanceof PipeBlockEntity pipeEntity) {

--- a/common/src/main/java/com/logistics/pipe/network/packet/SetSatelliteIdPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/SetSatelliteIdPacket.java
@@ -9,9 +9,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
  * Packet sent from client to server to update the satellite ID of a Satellite Logistics Pipe.
@@ -36,16 +34,11 @@ public record SetSatelliteIdPacket(BlockPos pipePos, String satelliteId)
     }
 
     public void handle(ServerPlayer player) {
-        BlockPos pos = pipePos();
-        if (PacketValidation.isPlayerOutOfRange(player, pos)) return;
-        if (player.level() instanceof ServerLevel level) {
-            BlockEntity be = level.getBlockEntity(pos);
-            if (be instanceof PipeBlockEntity pipeEntity) {
-                PipeModuleHelper.withModule(
-                        pipeEntity,
-                        SatelliteModule.class,
-                        (ctx, module) -> module.setSatelliteId(ctx, satelliteId()));
-            }
-        }
+        PacketValidation.ifPlayerCanReach(player, pipePos(), this::setSatelliteId);
+    }
+
+    private void setSatelliteId(PipeBlockEntity pipeEntity) {
+        PipeModuleHelper.withModule(pipeEntity, SatelliteModule.class,
+                (ctx, module) -> module.setSatelliteId(ctx, satelliteId()));
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/packet/SetSatelliteIdPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/SetSatelliteIdPacket.java
@@ -4,14 +4,13 @@ import com.logistics.LogisticsPipe;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.SatelliteModule;
 import com.logistics.pipe.ui.PipeModuleHelper;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
@@ -36,27 +35,20 @@ public record SetSatelliteIdPacket(BlockPos pipePos, String satelliteId)
         return TYPE;
     }
 
-    public static void register() {
-        PayloadTypeRegistry.serverboundPlay().register(TYPE, CODEC);
-
-        ServerPlayNetworking.registerGlobalReceiver(TYPE, (packet, context) -> {
-            context.server().execute(() -> {
-                var player = context.player();
-                BlockPos pos = packet.pipePos();
-                double dx = player.getX() - (pos.getX() + 0.5);
-                double dy = player.getY() - (pos.getY() + 0.5);
-                double dz = player.getZ() - (pos.getZ() + 0.5);
-                if (dx * dx + dy * dy + dz * dz > 64.0 * 64.0) return;
-                if (player.level() instanceof ServerLevel level) {
-                    BlockEntity be = level.getBlockEntity(pos);
-                    if (be instanceof PipeBlockEntity pipeEntity) {
-                        PipeModuleHelper.withModule(
-                                pipeEntity,
-                                SatelliteModule.class,
-                                (ctx, module) -> module.setSatelliteId(ctx, packet.satelliteId()));
-                    }
-                }
-            });
-        });
+    public void handle(ServerPlayer player) {
+        BlockPos pos = pipePos();
+        double dx = player.getX() - (pos.getX() + 0.5);
+        double dy = player.getY() - (pos.getY() + 0.5);
+        double dz = player.getZ() - (pos.getZ() + 0.5);
+        if (dx * dx + dy * dy + dz * dz > 64.0 * 64.0) return;
+        if (player.level() instanceof ServerLevel level) {
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof PipeBlockEntity pipeEntity) {
+                PipeModuleHelper.withModule(
+                        pipeEntity,
+                        SatelliteModule.class,
+                        (ctx, module) -> module.setSatelliteId(ctx, satelliteId()));
+            }
+        }
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/packet/SyncRequesterInventoryPacket.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/SyncRequesterInventoryPacket.java
@@ -1,7 +1,6 @@
 package com.logistics.pipe.network.packet;
 
 import com.logistics.LogisticsPipe;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
@@ -34,11 +33,4 @@ public record SyncRequesterInventoryPacket(BlockPos pipePos, List<ItemStack> ite
         return TYPE;
     }
 
-    /**
-     * Register this packet type (server-to-client).
-     * Client-side receiver is registered in LogisticsPipeClient.
-     */
-    public static void register() {
-        PayloadTypeRegistry.clientboundPlay().register(TYPE, CODEC);
-    }
 }

--- a/fabric/src/main/java/com/logistics/fabric/FabricPacketRegistration.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPacketRegistration.java
@@ -1,0 +1,30 @@
+package com.logistics.fabric;
+
+import com.logistics.pipe.network.packet.OpenChassisSlotPacket;
+import com.logistics.pipe.network.packet.RequestItemPacket;
+import com.logistics.pipe.network.packet.SetSatelliteIdPacket;
+import com.logistics.pipe.network.packet.SyncRequesterInventoryPacket;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+
+public final class FabricPacketRegistration {
+    private FabricPacketRegistration() {}
+
+    public static void register() {
+        // Serverbound packets
+        PayloadTypeRegistry.serverboundPlay().register(RequestItemPacket.TYPE, RequestItemPacket.CODEC);
+        ServerPlayNetworking.registerGlobalReceiver(RequestItemPacket.TYPE,
+                (packet, context) -> context.server().execute(() -> packet.handle(context.player())));
+
+        PayloadTypeRegistry.serverboundPlay().register(SetSatelliteIdPacket.TYPE, SetSatelliteIdPacket.CODEC);
+        ServerPlayNetworking.registerGlobalReceiver(SetSatelliteIdPacket.TYPE,
+                (packet, context) -> context.server().execute(() -> packet.handle(context.player())));
+
+        PayloadTypeRegistry.serverboundPlay().register(OpenChassisSlotPacket.TYPE, OpenChassisSlotPacket.CODEC);
+        ServerPlayNetworking.registerGlobalReceiver(OpenChassisSlotPacket.TYPE,
+                (packet, context) -> context.server().execute(() -> packet.handle(context.player())));
+
+        // Clientbound packets (type registration only; receiver registered in LogisticsPipeClient)
+        PayloadTypeRegistry.clientboundPlay().register(SyncRequesterInventoryPacket.TYPE, SyncRequesterInventoryPacket.CODEC);
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -19,6 +19,7 @@ public final class LogisticsFabric implements ModInitializer {
         FabricNetworkTickHandler.register();
         FabricCommandRegistration.register();
         FabricServerLevelEvents.register();
+        FabricPacketRegistration.register();
 
         FabricLoader.getInstance().getModContainer(LogisticsMod.MOD_ID).ifPresent(container ->
             ResourceManagerHelper.registerBuiltinResourcePack(

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgePacketRegistration.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgePacketRegistration.java
@@ -1,0 +1,40 @@
+package com.logistics.neoforge;
+
+// TODO(multiloader): Register packet payloads for NeoForge networking.
+// NeoForge equivalent of FabricPacketRegistration.
+//
+// @Mod.EventBusSubscriber(modid = "logistics", bus = Mod.EventBusSubscriber.Bus.MOD)
+// public class NeoForgePacketRegistration {
+//
+//     @SubscribeEvent
+//     public static void registerPayloads(RegisterPayloadHandlersEvent event) {
+//         PayloadRegistrar registrar = event.registrar("1");
+//
+//         registrar.playToServer(
+//             RequestItemPacket.TYPE,
+//             RequestItemPacket.CODEC,
+//             (packet, ctx) -> ctx.enqueueWork(() -> packet.handle(ctx.player()))
+//         );
+//
+//         registrar.playToServer(
+//             SetSatelliteIdPacket.TYPE,
+//             SetSatelliteIdPacket.CODEC,
+//             (packet, ctx) -> ctx.enqueueWork(() -> packet.handle(ctx.player()))
+//         );
+//
+//         registrar.playToServer(
+//             OpenChassisSlotPacket.TYPE,
+//             OpenChassisSlotPacket.CODEC,
+//             (packet, ctx) -> ctx.enqueueWork(() -> packet.handle(ctx.player()))
+//         );
+//
+//         registrar.playToClient(
+//             SyncRequesterInventoryPacket.TYPE,
+//             SyncRequesterInventoryPacket.CODEC,
+//             (packet, ctx) -> { /* client receiver registered in LogisticsPipeClient */ }
+//         );
+//     }
+// }
+public final class NeoForgePacketRegistration {
+    private NeoForgePacketRegistration() {}
+}


### PR DESCRIPTION
## Summary
This update refactors the registration of network packets by moving it out of the common module and into dedicated platform-specific registration classes. This change enhances the modularity and maintainability of the code, making it easier to manage packet registration across different environments.

## Changes
### Network Packet Refactoring
- **Packet Registration Separation:** 
  - Removed network packet registration from the common `LogisticsPipe` class.
  - Introduced `FabricPacketRegistration` for Fabric environments to handle serverbound packet registration and handling.
  - Added `NeoForgePacketRegistration` as a placeholder for future NeoForge packet registration capabilities.

### Packet Class Updates
- **Updated Packet Classes:**
  - Modified `RequestItemPacket`, `OpenChassisSlotPacket`, and `SetSatelliteIdPacket` to handle packet logic directly rather than relying on external registration calls.
  - Removed static registration methods from packet classes, streamlining the handling of packet logic.

### Code Cleanup
- **Removed Redundant Code:**
  - Eliminated unnecessary imports and outdated references in packet classes.
  - Streamlined packet handling logic by integrating it directly into the packet classes.

### New Code Structure 
- **Modular Design Improvements:**
  - Established a clearer separation of concerns by organizing packet registration in dedicated classes, improving overall code readability and maintenance.


## Notes
- No compatibility issues are anticipated; however, future implementations for NeoForge will need to follow the established pattern created for Fabric.
- Ensure to test network communication thoroughly after these refactorings to confirm desired behavior remains consistent across different platforms.
- Closes #327 