### PR TITLE
refactor: move creative tab and biome registration to Fabric module

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -95,9 +95,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     private static void addCreativeTabEntries() {
-        LogisticsCore.CREATIVE_TAB.addItem(BLOCK.MARKER);
-        LogisticsCore.CREATIVE_TAB.addItem(BLOCK.LASER_QUARRY);
-        LogisticsCore.CREATIVE_TAB.addItem(BLOCK.KILN);
+        LogisticsCore.LOGISTICS_TAB.add(BLOCK.MARKER, BLOCK.LASER_QUARRY, BLOCK.KILN);
     }
 
     private void registerLegacyAliases() {

--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -11,7 +11,10 @@ import com.logistics.core.macerator.MaceratorRecipeManager;
 import com.logistics.core.macerator.MaceratorRecipeSerializer;
 import com.logistics.core.macerator.MaceratorRecipeWrapper;
 import com.logistics.core.macerator.MaceratorScreenHandler;
+import com.logistics.core.lib.LogisticsCreativeTab;
 import com.logistics.core.lib.resource.ResourceId;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -20,16 +23,17 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.DropExperienceBlock;
 import net.minecraft.world.level.block.SoundType;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
 
 public final class LogisticsCore extends LogisticsMod implements DomainBootstrap {
@@ -345,42 +349,131 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         }
     }
 
-    public static final class CREATIVE_TAB {
-        private CREATIVE_TAB() {}
-        private static final List<Consumer<CreativeModeTab.Output>> ENTRIES = new ArrayList<>();
+    public static final LogisticsCreativeTab LOGISTICS_TAB = LogisticsCreativeTab.create(
+        LogisticsMod.modId("logistics_transport"),
+        Component.literal("Logistics"),
+        () -> new ItemStack(ITEM.IRON_GEAR)
+    );
 
-        public static CreativeModeTab LOGISTICS_TRANSPORT;
+    private static void addCreativeTabEntries() {
+        LOGISTICS_TAB.add(ITEM.WRENCH, ITEM.PROBE);
+        LOGISTICS_TAB.add(BLOCK.MACERATOR);
+        LOGISTICS_TAB.add(BLOCK.QUARTZ_CRYSTAL);
+    }
 
-        public static void populateEntries(CreativeModeTab.Output output) {
-            for (Consumer<CreativeModeTab.Output> entry : ENTRIES) {
-                entry.accept(output);
-            }
-        }
+    /**
+     * Loader-provided adapter for inserting items into vanilla creative tabs.
+     *
+     * <p>Called once during mod initialization with all tab modifications declared in common.
+     * Each {@link #modify} call represents one group of insertions into a specific tab.
+     *
+     * <p>Fabric: each call maps directly to {@code CreativeModeTabEvents.modifyOutputEvent(tab).register(...)}.
+     * NeoForge: collect calls into a map, then dispatch from {@code BuildCreativeModeTabContentsEvent}.
+     */
+    public interface VanillaTabRegistrar {
+        void modify(ResourceKey<CreativeModeTab> tab, Consumer<TabEntries> entries);
 
-        public static void add(Consumer<CreativeModeTab.Output> entryBuilder) {
-            ENTRIES.add(entryBuilder);
-        }
-
-        public static void addItem(ItemLike item) {
-            add(entries -> entries.accept(item));
-        }
-
-        public static void addItems(ItemLike... items) {
-            add(entries -> {
-                for (ItemLike item : items) {
-                    entries.accept(item);
-                }
-            });
+        interface TabEntries {
+            void insertAfter(ItemLike anchor, ItemLike item);
+            void insertBefore(ItemLike anchor, ItemLike item);
         }
     }
 
-    private static void addCreativeTabEntries() {
-        CREATIVE_TAB.addItems(
-                ITEM.WRENCH,
-                ITEM.PROBE
-        );
-        CREATIVE_TAB.addItem(BLOCK.MACERATOR);
-        CREATIVE_TAB.addItem(BLOCK.QUARTZ_CRYSTAL);
+    /**
+     * Declares all vanilla creative tab insertions for the core domain.
+     * Called by the loader-specific setup (e.g. {@code FabricCreativeTabSetup}) via a
+     * loader-specific {@link VanillaTabRegistrar} adapter.
+     */
+    public static void addVanillaCreativeTabEntries(VanillaTabRegistrar registrar) {
+        // Add storage blocks to Building Blocks tab
+        registrar.modify(CreativeModeTabs.BUILDING_BLOCKS, entries -> {
+            entries.insertAfter(Items.COAL_BLOCK, BLOCK.APATITE_BLOCK);
+            entries.insertBefore(Items.IRON_BLOCK, BLOCK.TIN_BLOCK);
+            entries.insertAfter(Items.IRON_BLOCK, BLOCK.BRONZE_BLOCK);
+        });
+
+        // Add materials to Ingredients tab
+        registrar.modify(CreativeModeTabs.INGREDIENTS, entries -> {
+            // Raw materials
+            entries.insertBefore(Items.RAW_IRON, ITEM.RAW_TIN);
+
+            // Ingots
+            entries.insertBefore(Items.IRON_INGOT, ITEM.TIN_INGOT);
+            entries.insertAfter(ITEM.TIN_INGOT, ITEM.BRONZE_INGOT);
+
+            // Nuggets
+            entries.insertBefore(Items.IRON_NUGGET, ITEM.TIN_NUGGET);
+            entries.insertAfter(ITEM.TIN_NUGGET, ITEM.BRONZE_NUGGET);
+
+            // Apatite
+            entries.insertBefore(Items.AMETHYST_SHARD, ITEM.APATITE);
+
+            // Intermediate Crafting Items
+            entries.insertBefore(Items.HEAVY_CORE, ITEM.STURDY_CASING);
+            entries.insertAfter(ITEM.STURDY_CASING, ITEM.MACHINE_CORE);
+            entries.insertAfter(ITEM.MACHINE_CORE, ITEM.WOODEN_GEAR);
+            entries.insertAfter(ITEM.WOODEN_GEAR, ITEM.STONE_GEAR);
+            entries.insertAfter(ITEM.STONE_GEAR, ITEM.COPPER_GEAR);
+            entries.insertAfter(ITEM.COPPER_GEAR, ITEM.TIN_GEAR);
+            entries.insertAfter(ITEM.TIN_GEAR, ITEM.IRON_GEAR);
+            entries.insertAfter(ITEM.IRON_GEAR, ITEM.BRONZE_GEAR);
+            entries.insertAfter(ITEM.BRONZE_GEAR, ITEM.GOLD_GEAR);
+            entries.insertAfter(ITEM.GOLD_GEAR, ITEM.DIAMOND_GEAR);
+            entries.insertAfter(ITEM.DIAMOND_GEAR, ITEM.NETHERITE_GEAR);
+
+            // Valves — after netherite gear
+            Item[] valves = {
+                ITEM.WOODEN_VALVE,
+                ITEM.COPPER_VALVE, ITEM.BRONZE_VALVE,
+                ITEM.IRON_VALVE, ITEM.GOLD_VALVE, ITEM.DIAMOND_VALVE,
+                ITEM.OBSIDIAN_VALVE, ITEM.BLAZING_VALVE, ITEM.EMERALD_VALVE,
+                ITEM.APATITE_VALVE, ITEM.LAPIS_VALVE, ITEM.ENDER_VALVE,
+                ITEM.NETHERITE_VALVE
+            };
+            Item prev = ITEM.NETHERITE_GEAR;
+            for (Item item : valves) {
+                entries.insertAfter(prev, item);
+                prev = item;
+            }
+        });
+
+        // Add dusts, chips, cores to Ingredients tab — after bronze_ingot
+        registrar.modify(CreativeModeTabs.INGREDIENTS, entries -> {
+            Item[] intermediates = {
+                ITEM.APATITE_DUST,
+                ITEM.IRON_DUST, ITEM.COPPER_DUST, ITEM.TIN_DUST, ITEM.BRONZE_DUST,
+                ITEM.GOLD_DUST, ITEM.LAPIS_DUST, ITEM.QUARTZ_DUST, ITEM.COAL_DUST,
+                ITEM.AMETHYST_DUST, ITEM.DIAMOND_DUST, ITEM.EMERALD_DUST,
+                ITEM.NETHERITE_DUST, ITEM.OBSIDIAN_DUST, ITEM.ENDER_DUST,
+                ITEM.ECHO_DUST, ITEM.PRISMARINE_DUST,
+                ITEM.SILICON_MIX, ITEM.SILICON_WAFER, ITEM.FLOUR, ITEM.WOOD_PULP,
+                ITEM.CARBON_CHIP, ITEM.REDSTONE_CHIP, ITEM.AMETHYST_CHIP, ITEM.ECHO_CHIP,
+                ITEM.WOODEN_CORE,
+                ITEM.COPPER_CORE, ITEM.BRONZE_CORE,
+                ITEM.IRON_CORE, ITEM.GOLD_CORE, ITEM.LAPIS_CORE,
+                ITEM.APATITE_CORE, ITEM.DIAMOND_CORE, ITEM.EMERALD_CORE,
+                ITEM.BLAZING_CORE, ITEM.NETHERITE_CORE,
+                ITEM.OBSIDIAN_CORE, ITEM.ENDER_CORE
+            };
+            Item anchor = ITEM.BRONZE_INGOT;
+            for (Item item : intermediates) {
+                entries.insertAfter(anchor, item);
+                anchor = item;
+            }
+        });
+
+        // Add ore blocks to Natural Blocks tab
+        registrar.modify(CreativeModeTabs.NATURAL_BLOCKS, entries -> {
+            // Tin ores
+            entries.insertAfter(Items.DEEPSLATE_COAL_ORE, BLOCK.TIN_ORE);
+            entries.insertAfter(BLOCK.TIN_ORE, BLOCK.DEEPSLATE_TIN_ORE);
+
+            // Apatite ore
+            entries.insertBefore(Items.AMETHYST_BLOCK, BLOCK.APATITE_ORE);
+
+            // Raw tin block
+            entries.insertBefore(Items.RAW_IRON_BLOCK, BLOCK.RAW_TIN_BLOCK);
+        });
     }
 
     private void registerLegacyAliases() {

--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -351,7 +351,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
 
     public static final LogisticsCreativeTab LOGISTICS_TAB = LogisticsCreativeTab.create(
         LogisticsMod.modId("logistics_transport"),
-        Component.literal("Logistics"),
+        Component.translatable("itemGroup.logistics.logistics_transport"),
         () -> new ItemStack(ITEM.IRON_GEAR)
     );
 
@@ -392,7 +392,8 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
             entries.insertAfter(Items.IRON_BLOCK, BLOCK.BRONZE_BLOCK);
         });
 
-        // Add materials to Ingredients tab
+        // Add materials to Ingredients tab — all in one callback so each insertAfter/insertBefore
+        // sees the items placed by earlier calls in the same invocation
         registrar.modify(CreativeModeTabs.INGREDIENTS, entries -> {
             // Raw materials
             entries.insertBefore(Items.RAW_IRON, ITEM.RAW_TIN);
@@ -431,14 +432,12 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
                 ITEM.NETHERITE_VALVE
             };
             Item prev = ITEM.NETHERITE_GEAR;
-            for (Item item : valves) {
-                entries.insertAfter(prev, item);
-                prev = item;
+            for (Item valve : valves) {
+                entries.insertAfter(prev, valve);
+                prev = valve;
             }
-        });
 
-        // Add dusts, chips, cores to Ingredients tab — after bronze_ingot
-        registrar.modify(CreativeModeTabs.INGREDIENTS, entries -> {
+            // Dusts, chips, cores — after bronze_ingot (inserted above)
             Item[] intermediates = {
                 ITEM.APATITE_DUST,
                 ITEM.IRON_DUST, ITEM.COPPER_DUST, ITEM.TIN_DUST, ITEM.BRONZE_DUST,

--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -12,12 +12,6 @@ import com.logistics.core.macerator.MaceratorRecipeSerializer;
 import com.logistics.core.macerator.MaceratorRecipeWrapper;
 import com.logistics.core.macerator.MaceratorScreenHandler;
 import com.logistics.core.lib.resource.ResourceId;
-import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
-import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
-import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
-import net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab;
-import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -26,13 +20,8 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.level.block.Block;
@@ -70,38 +59,10 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         ENTITY.register();
         MENU.register();
         RECIPE.register();
-        CREATIVE_TAB.register();
 
         registerLegacyAliases();
         addCreativeTabEntries();
-        addVanillaCreativeTabEntries();
-        registerWorldgen();
         MaceratorRecipeManager.register();
-    }
-
-    private void registerWorldgen() {
-        // Tin ore worldgen: separate features for stone (rare) and deepslate (abundant)
-        // Stone: ~7% of copper's effective rate (1 vein/chunk vs copper's 16)
-        // Deepslate: ~80% of copper's rate (13 veins/chunk)
-        // Use LogisticsMod.modId() to avoid core/ prefix
-        BiomeModifications.addFeature(
-            BiomeSelectors.foundInOverworld(),
-            GenerationStep.Decoration.UNDERGROUND_ORES,
-            ResourceKey.create(Registries.PLACED_FEATURE, LogisticsMod.modId("tin_ore_stone").toIdentifier())
-        );
-        BiomeModifications.addFeature(
-            BiomeSelectors.foundInOverworld(),
-            GenerationStep.Decoration.UNDERGROUND_ORES,
-            ResourceKey.create(Registries.PLACED_FEATURE, LogisticsMod.modId("tin_ore_deepslate").toIdentifier())
-        );
-
-        // Apatite ore worldgen: large veins (up to 48 blocks) spawning above Y 60
-        // 2 veins per chunk, Y 60-256 (uniform distribution)
-        BiomeModifications.addFeature(
-            BiomeSelectors.foundInOverworld(),
-            GenerationStep.Decoration.UNDERGROUND_ORES,
-            ResourceKey.create(Registries.PLACED_FEATURE, LogisticsMod.modId("apatite_ore_stone").toIdentifier())
-        );
     }
 
     @Override
@@ -390,19 +351,10 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
 
         public static CreativeModeTab LOGISTICS_TRANSPORT;
 
-        static void register() {
-            LOGISTICS_TRANSPORT = Registry.register(
-                    BuiltInRegistries.CREATIVE_MODE_TAB,
-                    LogisticsMod.modId("logistics_transport").toIdentifier(),
-                    FabricCreativeModeTab.builder()
-                            .title(Component.literal("Logistics"))
-                            .icon(() -> new ItemStack(ITEM.IRON_GEAR))
-                            .displayItems((params, entries) -> {
-                                for (Consumer<CreativeModeTab.Output> entry : ENTRIES) {
-                                    entry.accept(entries);
-                                }
-                            })
-                            .build());
+        public static void populateEntries(CreativeModeTab.Output output) {
+            for (Consumer<CreativeModeTab.Output> entry : ENTRIES) {
+                entry.accept(output);
+            }
         }
 
         public static void add(Consumer<CreativeModeTab.Output> entryBuilder) {
@@ -429,98 +381,6 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         );
         CREATIVE_TAB.addItem(BLOCK.MACERATOR);
         CREATIVE_TAB.addItem(BLOCK.QUARTZ_CRYSTAL);
-    }
-
-    private static void addVanillaCreativeTabEntries() {
-        // Add storage blocks to Building Blocks tab
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.BUILDING_BLOCKS).register(entries -> {
-            entries.insertAfter(Items.COAL_BLOCK, BLOCK.APATITE_BLOCK);
-            entries.insertBefore(Items.IRON_BLOCK, BLOCK.TIN_BLOCK);
-            entries.insertAfter(Items.IRON_BLOCK, BLOCK.BRONZE_BLOCK);
-        });
-
-        // Add materials to Ingredients tab
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.INGREDIENTS).register(entries -> {
-            // Raw materials
-            entries.insertBefore(Items.RAW_IRON, ITEM.RAW_TIN);
-
-            // Ingots
-            entries.insertBefore(Items.IRON_INGOT, ITEM.TIN_INGOT);
-            entries.insertAfter(ITEM.TIN_INGOT, ITEM.BRONZE_INGOT);
-
-            // Nuggets
-            entries.insertBefore(Items.IRON_NUGGET, ITEM.TIN_NUGGET);
-            entries.insertAfter(ITEM.TIN_NUGGET, ITEM.BRONZE_NUGGET);
-
-            // Apatite
-            entries.insertBefore(Items.AMETHYST_SHARD, ITEM.APATITE);
-
-            // Intermediate Crafting Items
-            entries.insertBefore(Items.HEAVY_CORE, ITEM.STURDY_CASING);
-            entries.insertAfter(ITEM.STURDY_CASING, ITEM.MACHINE_CORE);
-            entries.insertAfter(ITEM.MACHINE_CORE, ITEM.WOODEN_GEAR);
-            entries.insertAfter(ITEM.WOODEN_GEAR, ITEM.STONE_GEAR);
-            entries.insertAfter(ITEM.STONE_GEAR, ITEM.COPPER_GEAR);
-            entries.insertAfter(ITEM.COPPER_GEAR, ITEM.TIN_GEAR);
-            entries.insertAfter(ITEM.TIN_GEAR, ITEM.IRON_GEAR);
-            entries.insertAfter(ITEM.IRON_GEAR, ITEM.BRONZE_GEAR);
-            entries.insertAfter(ITEM.BRONZE_GEAR, ITEM.GOLD_GEAR);
-            entries.insertAfter(ITEM.GOLD_GEAR, ITEM.DIAMOND_GEAR);
-            entries.insertAfter(ITEM.DIAMOND_GEAR, ITEM.NETHERITE_GEAR);
-
-            // Valves — after netherite gear
-            Item[] valves = {
-                ITEM.WOODEN_VALVE,
-                ITEM.COPPER_VALVE, ITEM.BRONZE_VALVE,
-                ITEM.IRON_VALVE, ITEM.GOLD_VALVE, ITEM.DIAMOND_VALVE,
-                ITEM.OBSIDIAN_VALVE, ITEM.BLAZING_VALVE, ITEM.EMERALD_VALVE,
-                ITEM.APATITE_VALVE, ITEM.LAPIS_VALVE, ITEM.ENDER_VALVE,
-                ITEM.NETHERITE_VALVE
-            };
-            Item prev = ITEM.NETHERITE_GEAR;
-            for (Item item : valves) {
-                entries.insertAfter(prev, item);
-                prev = item;
-            }
-        });
-
-        // Add dusts, chips, cores to Ingredients tab — after bronze_ingot
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.INGREDIENTS).register(entries -> {
-            Item[] intermediates = {
-                ITEM.APATITE_DUST,
-                ITEM.IRON_DUST, ITEM.COPPER_DUST, ITEM.TIN_DUST, ITEM.BRONZE_DUST,
-                ITEM.GOLD_DUST, ITEM.LAPIS_DUST, ITEM.QUARTZ_DUST, ITEM.COAL_DUST,
-                ITEM.AMETHYST_DUST, ITEM.DIAMOND_DUST, ITEM.EMERALD_DUST,
-                ITEM.NETHERITE_DUST, ITEM.OBSIDIAN_DUST, ITEM.ENDER_DUST,
-                ITEM.ECHO_DUST, ITEM.PRISMARINE_DUST,
-                ITEM.SILICON_MIX, ITEM.SILICON_WAFER, ITEM.FLOUR, ITEM.WOOD_PULP,
-                ITEM.CARBON_CHIP, ITEM.REDSTONE_CHIP, ITEM.AMETHYST_CHIP, ITEM.ECHO_CHIP,
-                ITEM.WOODEN_CORE,
-                ITEM.COPPER_CORE, ITEM.BRONZE_CORE,
-                ITEM.IRON_CORE, ITEM.GOLD_CORE, ITEM.LAPIS_CORE,
-                ITEM.APATITE_CORE, ITEM.DIAMOND_CORE, ITEM.EMERALD_CORE,
-                ITEM.BLAZING_CORE, ITEM.NETHERITE_CORE,
-                ITEM.OBSIDIAN_CORE, ITEM.ENDER_CORE
-            };
-            Item anchor = ITEM.BRONZE_INGOT;
-            for (Item item : intermediates) {
-                entries.insertAfter(anchor, item);
-                anchor = item;
-            }
-        });
-
-        // Add ore blocks to Natural Blocks tab
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.NATURAL_BLOCKS).register(entries -> {
-            // Tin ores
-            entries.insertAfter(Items.DEEPSLATE_COAL_ORE, BLOCK.TIN_ORE);
-            entries.insertAfter(BLOCK.TIN_ORE, BLOCK.DEEPSLATE_TIN_ORE);
-
-            // Apatite ore
-            entries.insertBefore(Items.AMETHYST_BLOCK, BLOCK.APATITE_ORE);
-
-            // Raw tin block
-            entries.insertBefore(Items.RAW_IRON_BLOCK, BLOCK.RAW_TIN_BLOCK);
-        });
     }
 
     private void registerLegacyAliases() {

--- a/common/src/main/java/com/logistics/LogisticsPipe.java
+++ b/common/src/main/java/com/logistics/LogisticsPipe.java
@@ -88,14 +88,14 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
 
     private static void addCreativeTabEntries() {
         // Marking fluids
-        LogisticsCore.CREATIVE_TAB.add(entries -> {
+        LogisticsCore.LOGISTICS_TAB.add(entries -> {
             for (DyeColor color : DyeColor.values()) {
                 entries.accept(getMarkingFluidItem(color));
             }
         });
 
         // Copper pipe variants (modular)
-        LogisticsCore.CREATIVE_TAB.add(entries -> {
+        LogisticsCore.LOGISTICS_TAB.add(entries -> {
             if (BLOCK.COPPER_TRANSPORT_PIPE instanceof PipeBlock pipeBlock) {
                 Pipe pipe = pipeBlock.getPipe();
                 if (pipe != null) {
@@ -108,7 +108,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
         });
 
         // Pipes
-        LogisticsCore.CREATIVE_TAB.addItems(
+        LogisticsCore.LOGISTICS_TAB.add(
                 BLOCK.STONE_TRANSPORT_PIPE,
                 BLOCK.ITEM_PASSTHROUGH_PIPE,
                 BLOCK.COPPER_TRANSPORT_PIPE,

--- a/common/src/main/java/com/logistics/LogisticsPower.java
+++ b/common/src/main/java/com/logistics/LogisticsPower.java
@@ -106,7 +106,7 @@ public final class LogisticsPower extends LogisticsMod implements DomainBootstra
     }
 
     private static void addCreativeTabEntries() {
-        LogisticsCore.CREATIVE_TAB.addItems(
+        LogisticsCore.LOGISTICS_TAB.add(
                 BLOCK.REDSTONE_ENGINE,
                 BLOCK.STIRLING_ENGINE,
                 BLOCK.CREATIVE_ENGINE,

--- a/common/src/main/java/com/logistics/core/lib/LogisticsCreativeTab.java
+++ b/common/src/main/java/com/logistics/core/lib/LogisticsCreativeTab.java
@@ -1,0 +1,134 @@
+package com.logistics.core.lib;
+
+import com.logistics.core.lib.resource.ResourceId;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Loader-agnostic creative tab definition.
+ *
+ * <p>Holds the tab's identity (registry ID, display title, icon) and an ordered list of entries.
+ * All content is declared in common code. Loader-specific code (e.g. {@code FabricCreativeTabSetup})
+ * registers the actual MC creative tab and delegates display to {@link #populate}.
+ *
+ * <pre>{@code
+ * // common — define and populate
+ * public static final LogisticsCreativeTab LOGISTICS_TAB = LogisticsCreativeTab.create(
+ *     LogisticsMod.modId("logistics_transport"),
+ *     Component.literal("Logistics"),
+ *     () -> new ItemStack(ITEM.IRON_GEAR)
+ * );
+ * LOGISTICS_TAB.add(ITEM.WRENCH, ITEM.PROBE);
+ *
+ * // fabric adapter — register once
+ * FabricCreativeModeTab.builder()
+ *     .title(LogisticsCore.LOGISTICS_TAB.title())
+ *     .icon(LogisticsCore.LOGISTICS_TAB.icon())
+ *     .displayItems((params, out) -> LogisticsCore.LOGISTICS_TAB.populate(out))
+ *     .build()
+ * }</pre>
+ */
+public final class LogisticsCreativeTab {
+
+    private sealed interface Entry permits Entry.Add, Entry.Custom {
+        record Add(List<ItemLike> items) implements Entry {}
+        record Custom(Consumer<CreativeModeTab.Output> builder) implements Entry {}
+    }
+
+    private final ResourceId id;
+    private final Component title;
+    private final Supplier<ItemStack> icon;
+    private final List<Entry> entries = new ArrayList<>();
+
+    private LogisticsCreativeTab(ResourceId id, Component title, Supplier<ItemStack> icon) {
+        this.id = id;
+        this.title = title;
+        this.icon = icon;
+    }
+
+    public static LogisticsCreativeTab create(ResourceId id, Component title, Supplier<ItemStack> icon) {
+        return new LogisticsCreativeTab(id, title, icon);
+    }
+
+    /** Appends {@code item} to the end of this tab. */
+    public LogisticsCreativeTab add(ItemLike item) {
+        entries.add(new Entry.Add(List.of(item)));
+        return this;
+    }
+
+    /** Appends all {@code items} as a group to the end of this tab. */
+    public LogisticsCreativeTab add(ItemLike... items) {
+        entries.add(new Entry.Add(Arrays.asList(items)));
+        return this;
+    }
+
+    /** Appends a custom entry (e.g. dynamic stacks, variants) to the end of this tab. */
+    public LogisticsCreativeTab add(Consumer<CreativeModeTab.Output> builder) {
+        entries.add(new Entry.Custom(builder));
+        return this;
+    }
+
+    /**
+     * Inserts {@code item} immediately after the last entry containing {@code anchor}.
+     * Falls back to appending if {@code anchor} is not found.
+     */
+    public LogisticsCreativeTab addAfter(ItemLike anchor, ItemLike item) {
+        int idx = lastIndexOf(anchor);
+        entries.add(idx >= 0 ? idx + 1 : entries.size(), new Entry.Add(List.of(item)));
+        return this;
+    }
+
+    /**
+     * Inserts {@code item} immediately before the first entry containing {@code anchor}.
+     * Falls back to appending if {@code anchor} is not found.
+     */
+    public LogisticsCreativeTab addBefore(ItemLike anchor, ItemLike item) {
+        int idx = firstIndexOf(anchor);
+        entries.add(idx >= 0 ? idx : entries.size(), new Entry.Add(List.of(item)));
+        return this;
+    }
+
+    /** Pushes all entries into the tab output. Called by the loader's displayItems callback. */
+    public void populate(CreativeModeTab.Output output) {
+        for (Entry entry : entries) {
+            switch (entry) {
+                case Entry.Add e -> e.items().forEach(output::accept);
+                case Entry.Custom e -> e.builder().accept(output);
+            }
+        }
+    }
+
+    public ResourceId id() { return id; }
+    public Component title() { return title; }
+    public Supplier<ItemStack> icon() { return icon; }
+
+    private int firstIndexOf(ItemLike anchor) {
+        Item target = anchor.asItem();
+        for (int i = 0; i < entries.size(); i++) {
+            if (entryContains(entries.get(i), target)) return i;
+        }
+        return -1;
+    }
+
+    private int lastIndexOf(ItemLike anchor) {
+        Item target = anchor.asItem();
+        for (int i = entries.size() - 1; i >= 0; i--) {
+            if (entryContains(entries.get(i), target)) return i;
+        }
+        return -1;
+    }
+
+    private static boolean entryContains(Entry entry, Item target) {
+        return entry instanceof Entry.Add add &&
+               add.items().stream().anyMatch(il -> il.asItem() == target);
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/LogisticsCreativeTab.java
+++ b/common/src/main/java/com/logistics/core/lib/LogisticsCreativeTab.java
@@ -8,7 +8,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -65,9 +64,11 @@ public final class LogisticsCreativeTab {
         return this;
     }
 
-    /** Appends all {@code items} as a group to the end of this tab. */
+    /** Appends each item individually so each can serve as an anchor for {@link #addAfter}/{@link #addBefore}. */
     public LogisticsCreativeTab add(ItemLike... items) {
-        entries.add(new Entry.Add(Arrays.asList(items)));
+        for (ItemLike item : items) {
+            entries.add(new Entry.Add(List.of(item)));
+        }
         return this;
     }
 

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+  "itemGroup.logistics.logistics_transport": "Logistics",
   "block.logistics.pipe.copper_transport_pipe": "Copper Transport Pipe",
   "block.logistics.pipe.copper_transport_pipe.exposed": "Exposed Copper Transport Pipe",
   "block.logistics.pipe.copper_transport_pipe.weathered": "Weathered Copper Transport Pipe",

--- a/fabric/src/main/java/com/logistics/fabric/FabricBiomeModifications.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricBiomeModifications.java
@@ -1,0 +1,37 @@
+package com.logistics.fabric;
+
+import com.logistics.LogisticsMod;
+import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
+import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.levelgen.GenerationStep;
+
+public final class FabricBiomeModifications {
+    private FabricBiomeModifications() {}
+
+    public static void register() {
+        // Tin ore worldgen: separate features for stone (rare) and deepslate (abundant)
+        // Stone: ~7% of copper's effective rate (1 vein/chunk vs copper's 16)
+        // Deepslate: ~80% of copper's rate (13 veins/chunk)
+        // Use LogisticsMod.modId() to avoid core/ prefix
+        BiomeModifications.addFeature(
+            BiomeSelectors.foundInOverworld(),
+            GenerationStep.Decoration.UNDERGROUND_ORES,
+            ResourceKey.create(Registries.PLACED_FEATURE, LogisticsMod.modId("tin_ore_stone").toIdentifier())
+        );
+        BiomeModifications.addFeature(
+            BiomeSelectors.foundInOverworld(),
+            GenerationStep.Decoration.UNDERGROUND_ORES,
+            ResourceKey.create(Registries.PLACED_FEATURE, LogisticsMod.modId("tin_ore_deepslate").toIdentifier())
+        );
+
+        // Apatite ore worldgen: large veins (up to 48 blocks) spawning above Y 60
+        // 2 veins per chunk, Y 60-256 (uniform distribution)
+        BiomeModifications.addFeature(
+            BiomeSelectors.foundInOverworld(),
+            GenerationStep.Decoration.UNDERGROUND_ORES,
+            ResourceKey.create(Registries.PLACED_FEATURE, LogisticsMod.modId("apatite_ore_stone").toIdentifier())
+        );
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/FabricCreativeTabSetup.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricCreativeTabSetup.java
@@ -1,0 +1,119 @@
+package com.logistics.fabric;
+
+import com.logistics.LogisticsCore;
+import com.logistics.LogisticsMod;
+import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
+import net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public final class FabricCreativeTabSetup {
+    private FabricCreativeTabSetup() {}
+
+    public static void register() {
+        LogisticsCore.CREATIVE_TAB.LOGISTICS_TRANSPORT = Registry.register(
+            BuiltInRegistries.CREATIVE_MODE_TAB,
+            LogisticsMod.modId("logistics_transport").toIdentifier(),
+            FabricCreativeModeTab.builder()
+                .title(Component.literal("Logistics"))
+                .icon(() -> new ItemStack(LogisticsCore.ITEM.IRON_GEAR))
+                .displayItems((params, entries) -> LogisticsCore.CREATIVE_TAB.populateEntries(entries))
+                .build()
+        );
+
+        // Add storage blocks to Building Blocks tab
+        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.BUILDING_BLOCKS).register(entries -> {
+            entries.insertAfter(Items.COAL_BLOCK, LogisticsCore.BLOCK.APATITE_BLOCK);
+            entries.insertBefore(Items.IRON_BLOCK, LogisticsCore.BLOCK.TIN_BLOCK);
+            entries.insertAfter(Items.IRON_BLOCK, LogisticsCore.BLOCK.BRONZE_BLOCK);
+        });
+
+        // Add materials to Ingredients tab
+        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.INGREDIENTS).register(entries -> {
+            // Raw materials
+            entries.insertBefore(Items.RAW_IRON, LogisticsCore.ITEM.RAW_TIN);
+
+            // Ingots
+            entries.insertBefore(Items.IRON_INGOT, LogisticsCore.ITEM.TIN_INGOT);
+            entries.insertAfter(LogisticsCore.ITEM.TIN_INGOT, LogisticsCore.ITEM.BRONZE_INGOT);
+
+            // Nuggets
+            entries.insertBefore(Items.IRON_NUGGET, LogisticsCore.ITEM.TIN_NUGGET);
+            entries.insertAfter(LogisticsCore.ITEM.TIN_NUGGET, LogisticsCore.ITEM.BRONZE_NUGGET);
+
+            // Apatite
+            entries.insertBefore(Items.AMETHYST_SHARD, LogisticsCore.ITEM.APATITE);
+
+            // Intermediate Crafting Items
+            entries.insertBefore(Items.HEAVY_CORE, LogisticsCore.ITEM.STURDY_CASING);
+            entries.insertAfter(LogisticsCore.ITEM.STURDY_CASING, LogisticsCore.ITEM.MACHINE_CORE);
+            entries.insertAfter(LogisticsCore.ITEM.MACHINE_CORE, LogisticsCore.ITEM.WOODEN_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.WOODEN_GEAR, LogisticsCore.ITEM.STONE_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.STONE_GEAR, LogisticsCore.ITEM.COPPER_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.COPPER_GEAR, LogisticsCore.ITEM.TIN_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.TIN_GEAR, LogisticsCore.ITEM.IRON_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.IRON_GEAR, LogisticsCore.ITEM.BRONZE_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.BRONZE_GEAR, LogisticsCore.ITEM.GOLD_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.GOLD_GEAR, LogisticsCore.ITEM.DIAMOND_GEAR);
+            entries.insertAfter(LogisticsCore.ITEM.DIAMOND_GEAR, LogisticsCore.ITEM.NETHERITE_GEAR);
+
+            // Valves — after netherite gear
+            Item[] valves = {
+                LogisticsCore.ITEM.WOODEN_VALVE,
+                LogisticsCore.ITEM.COPPER_VALVE, LogisticsCore.ITEM.BRONZE_VALVE,
+                LogisticsCore.ITEM.IRON_VALVE, LogisticsCore.ITEM.GOLD_VALVE, LogisticsCore.ITEM.DIAMOND_VALVE,
+                LogisticsCore.ITEM.OBSIDIAN_VALVE, LogisticsCore.ITEM.BLAZING_VALVE, LogisticsCore.ITEM.EMERALD_VALVE,
+                LogisticsCore.ITEM.APATITE_VALVE, LogisticsCore.ITEM.LAPIS_VALVE, LogisticsCore.ITEM.ENDER_VALVE,
+                LogisticsCore.ITEM.NETHERITE_VALVE
+            };
+            Item prev = LogisticsCore.ITEM.NETHERITE_GEAR;
+            for (Item item : valves) {
+                entries.insertAfter(prev, item);
+                prev = item;
+            }
+        });
+
+        // Add dusts, chips, cores to Ingredients tab — after bronze_ingot
+        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.INGREDIENTS).register(entries -> {
+            Item[] intermediates = {
+                LogisticsCore.ITEM.APATITE_DUST,
+                LogisticsCore.ITEM.IRON_DUST, LogisticsCore.ITEM.COPPER_DUST, LogisticsCore.ITEM.TIN_DUST, LogisticsCore.ITEM.BRONZE_DUST,
+                LogisticsCore.ITEM.GOLD_DUST, LogisticsCore.ITEM.LAPIS_DUST, LogisticsCore.ITEM.QUARTZ_DUST, LogisticsCore.ITEM.COAL_DUST,
+                LogisticsCore.ITEM.AMETHYST_DUST, LogisticsCore.ITEM.DIAMOND_DUST, LogisticsCore.ITEM.EMERALD_DUST,
+                LogisticsCore.ITEM.NETHERITE_DUST, LogisticsCore.ITEM.OBSIDIAN_DUST, LogisticsCore.ITEM.ENDER_DUST,
+                LogisticsCore.ITEM.ECHO_DUST, LogisticsCore.ITEM.PRISMARINE_DUST,
+                LogisticsCore.ITEM.SILICON_MIX, LogisticsCore.ITEM.SILICON_WAFER, LogisticsCore.ITEM.FLOUR, LogisticsCore.ITEM.WOOD_PULP,
+                LogisticsCore.ITEM.CARBON_CHIP, LogisticsCore.ITEM.REDSTONE_CHIP, LogisticsCore.ITEM.AMETHYST_CHIP, LogisticsCore.ITEM.ECHO_CHIP,
+                LogisticsCore.ITEM.WOODEN_CORE,
+                LogisticsCore.ITEM.COPPER_CORE, LogisticsCore.ITEM.BRONZE_CORE,
+                LogisticsCore.ITEM.IRON_CORE, LogisticsCore.ITEM.GOLD_CORE, LogisticsCore.ITEM.LAPIS_CORE,
+                LogisticsCore.ITEM.APATITE_CORE, LogisticsCore.ITEM.DIAMOND_CORE, LogisticsCore.ITEM.EMERALD_CORE,
+                LogisticsCore.ITEM.BLAZING_CORE, LogisticsCore.ITEM.NETHERITE_CORE,
+                LogisticsCore.ITEM.OBSIDIAN_CORE, LogisticsCore.ITEM.ENDER_CORE
+            };
+            Item anchor = LogisticsCore.ITEM.BRONZE_INGOT;
+            for (Item item : intermediates) {
+                entries.insertAfter(anchor, item);
+                anchor = item;
+            }
+        });
+
+        // Add ore blocks to Natural Blocks tab
+        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.NATURAL_BLOCKS).register(entries -> {
+            // Tin ores
+            entries.insertAfter(Items.DEEPSLATE_COAL_ORE, LogisticsCore.BLOCK.TIN_ORE);
+            entries.insertAfter(LogisticsCore.BLOCK.TIN_ORE, LogisticsCore.BLOCK.DEEPSLATE_TIN_ORE);
+
+            // Apatite ore
+            entries.insertBefore(Items.AMETHYST_BLOCK, LogisticsCore.BLOCK.APATITE_ORE);
+
+            // Raw tin block
+            entries.insertBefore(Items.RAW_IRON_BLOCK, LogisticsCore.BLOCK.RAW_TIN_BLOCK);
+        });
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/FabricCreativeTabSetup.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricCreativeTabSetup.java
@@ -1,119 +1,40 @@
 package com.logistics.fabric;
 
 import com.logistics.LogisticsCore;
-import com.logistics.LogisticsMod;
 import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
 import net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
+import net.minecraft.world.level.ItemLike;
 
 public final class FabricCreativeTabSetup {
     private FabricCreativeTabSetup() {}
 
     public static void register() {
-        LogisticsCore.CREATIVE_TAB.LOGISTICS_TRANSPORT = Registry.register(
+        Registry.register(
             BuiltInRegistries.CREATIVE_MODE_TAB,
-            LogisticsMod.modId("logistics_transport").toIdentifier(),
+            LogisticsCore.LOGISTICS_TAB.id().toIdentifier(),
             FabricCreativeModeTab.builder()
-                .title(Component.literal("Logistics"))
-                .icon(() -> new ItemStack(LogisticsCore.ITEM.IRON_GEAR))
-                .displayItems((params, entries) -> LogisticsCore.CREATIVE_TAB.populateEntries(entries))
+                .title(LogisticsCore.LOGISTICS_TAB.title())
+                .icon(LogisticsCore.LOGISTICS_TAB.icon())
+                .displayItems((params, entries) -> LogisticsCore.LOGISTICS_TAB.populate(entries))
                 .build()
         );
 
-        // Add storage blocks to Building Blocks tab
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.BUILDING_BLOCKS).register(entries -> {
-            entries.insertAfter(Items.COAL_BLOCK, LogisticsCore.BLOCK.APATITE_BLOCK);
-            entries.insertBefore(Items.IRON_BLOCK, LogisticsCore.BLOCK.TIN_BLOCK);
-            entries.insertAfter(Items.IRON_BLOCK, LogisticsCore.BLOCK.BRONZE_BLOCK);
-        });
+        LogisticsCore.addVanillaCreativeTabEntries((tab, modifier) ->
+            CreativeModeTabEvents.modifyOutputEvent(tab).register(fabricEntries ->
+                modifier.accept(new LogisticsCore.VanillaTabRegistrar.TabEntries() {
+                    @Override
+                    public void insertAfter(ItemLike anchor, ItemLike item) {
+                        fabricEntries.insertAfter(anchor, item);
+                    }
 
-        // Add materials to Ingredients tab
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.INGREDIENTS).register(entries -> {
-            // Raw materials
-            entries.insertBefore(Items.RAW_IRON, LogisticsCore.ITEM.RAW_TIN);
-
-            // Ingots
-            entries.insertBefore(Items.IRON_INGOT, LogisticsCore.ITEM.TIN_INGOT);
-            entries.insertAfter(LogisticsCore.ITEM.TIN_INGOT, LogisticsCore.ITEM.BRONZE_INGOT);
-
-            // Nuggets
-            entries.insertBefore(Items.IRON_NUGGET, LogisticsCore.ITEM.TIN_NUGGET);
-            entries.insertAfter(LogisticsCore.ITEM.TIN_NUGGET, LogisticsCore.ITEM.BRONZE_NUGGET);
-
-            // Apatite
-            entries.insertBefore(Items.AMETHYST_SHARD, LogisticsCore.ITEM.APATITE);
-
-            // Intermediate Crafting Items
-            entries.insertBefore(Items.HEAVY_CORE, LogisticsCore.ITEM.STURDY_CASING);
-            entries.insertAfter(LogisticsCore.ITEM.STURDY_CASING, LogisticsCore.ITEM.MACHINE_CORE);
-            entries.insertAfter(LogisticsCore.ITEM.MACHINE_CORE, LogisticsCore.ITEM.WOODEN_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.WOODEN_GEAR, LogisticsCore.ITEM.STONE_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.STONE_GEAR, LogisticsCore.ITEM.COPPER_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.COPPER_GEAR, LogisticsCore.ITEM.TIN_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.TIN_GEAR, LogisticsCore.ITEM.IRON_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.IRON_GEAR, LogisticsCore.ITEM.BRONZE_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.BRONZE_GEAR, LogisticsCore.ITEM.GOLD_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.GOLD_GEAR, LogisticsCore.ITEM.DIAMOND_GEAR);
-            entries.insertAfter(LogisticsCore.ITEM.DIAMOND_GEAR, LogisticsCore.ITEM.NETHERITE_GEAR);
-
-            // Valves — after netherite gear
-            Item[] valves = {
-                LogisticsCore.ITEM.WOODEN_VALVE,
-                LogisticsCore.ITEM.COPPER_VALVE, LogisticsCore.ITEM.BRONZE_VALVE,
-                LogisticsCore.ITEM.IRON_VALVE, LogisticsCore.ITEM.GOLD_VALVE, LogisticsCore.ITEM.DIAMOND_VALVE,
-                LogisticsCore.ITEM.OBSIDIAN_VALVE, LogisticsCore.ITEM.BLAZING_VALVE, LogisticsCore.ITEM.EMERALD_VALVE,
-                LogisticsCore.ITEM.APATITE_VALVE, LogisticsCore.ITEM.LAPIS_VALVE, LogisticsCore.ITEM.ENDER_VALVE,
-                LogisticsCore.ITEM.NETHERITE_VALVE
-            };
-            Item prev = LogisticsCore.ITEM.NETHERITE_GEAR;
-            for (Item item : valves) {
-                entries.insertAfter(prev, item);
-                prev = item;
-            }
-        });
-
-        // Add dusts, chips, cores to Ingredients tab — after bronze_ingot
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.INGREDIENTS).register(entries -> {
-            Item[] intermediates = {
-                LogisticsCore.ITEM.APATITE_DUST,
-                LogisticsCore.ITEM.IRON_DUST, LogisticsCore.ITEM.COPPER_DUST, LogisticsCore.ITEM.TIN_DUST, LogisticsCore.ITEM.BRONZE_DUST,
-                LogisticsCore.ITEM.GOLD_DUST, LogisticsCore.ITEM.LAPIS_DUST, LogisticsCore.ITEM.QUARTZ_DUST, LogisticsCore.ITEM.COAL_DUST,
-                LogisticsCore.ITEM.AMETHYST_DUST, LogisticsCore.ITEM.DIAMOND_DUST, LogisticsCore.ITEM.EMERALD_DUST,
-                LogisticsCore.ITEM.NETHERITE_DUST, LogisticsCore.ITEM.OBSIDIAN_DUST, LogisticsCore.ITEM.ENDER_DUST,
-                LogisticsCore.ITEM.ECHO_DUST, LogisticsCore.ITEM.PRISMARINE_DUST,
-                LogisticsCore.ITEM.SILICON_MIX, LogisticsCore.ITEM.SILICON_WAFER, LogisticsCore.ITEM.FLOUR, LogisticsCore.ITEM.WOOD_PULP,
-                LogisticsCore.ITEM.CARBON_CHIP, LogisticsCore.ITEM.REDSTONE_CHIP, LogisticsCore.ITEM.AMETHYST_CHIP, LogisticsCore.ITEM.ECHO_CHIP,
-                LogisticsCore.ITEM.WOODEN_CORE,
-                LogisticsCore.ITEM.COPPER_CORE, LogisticsCore.ITEM.BRONZE_CORE,
-                LogisticsCore.ITEM.IRON_CORE, LogisticsCore.ITEM.GOLD_CORE, LogisticsCore.ITEM.LAPIS_CORE,
-                LogisticsCore.ITEM.APATITE_CORE, LogisticsCore.ITEM.DIAMOND_CORE, LogisticsCore.ITEM.EMERALD_CORE,
-                LogisticsCore.ITEM.BLAZING_CORE, LogisticsCore.ITEM.NETHERITE_CORE,
-                LogisticsCore.ITEM.OBSIDIAN_CORE, LogisticsCore.ITEM.ENDER_CORE
-            };
-            Item anchor = LogisticsCore.ITEM.BRONZE_INGOT;
-            for (Item item : intermediates) {
-                entries.insertAfter(anchor, item);
-                anchor = item;
-            }
-        });
-
-        // Add ore blocks to Natural Blocks tab
-        CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.NATURAL_BLOCKS).register(entries -> {
-            // Tin ores
-            entries.insertAfter(Items.DEEPSLATE_COAL_ORE, LogisticsCore.BLOCK.TIN_ORE);
-            entries.insertAfter(LogisticsCore.BLOCK.TIN_ORE, LogisticsCore.BLOCK.DEEPSLATE_TIN_ORE);
-
-            // Apatite ore
-            entries.insertBefore(Items.AMETHYST_BLOCK, LogisticsCore.BLOCK.APATITE_ORE);
-
-            // Raw tin block
-            entries.insertBefore(Items.RAW_IRON_BLOCK, LogisticsCore.BLOCK.RAW_TIN_BLOCK);
-        });
+                    @Override
+                    public void insertBefore(ItemLike anchor, ItemLike item) {
+                        fabricEntries.insertBefore(anchor, item);
+                    }
+                })
+            )
+        );
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -22,6 +22,8 @@ public final class LogisticsFabric implements ModInitializer {
         FabricCommandRegistration.register();
         FabricServerLevelEvents.register();
         FabricPacketRegistration.register();
+        FabricCreativeTabSetup.register();
+        FabricBiomeModifications.register();
 
         FabricLoader.getInstance().getModContainer(LogisticsMod.MOD_ID).ifPresent(container ->
             ResourceManagerHelper.registerBuiltinResourcePack(

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCreativeTabSetup.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCreativeTabSetup.java
@@ -1,0 +1,22 @@
+package com.logistics.neoforge;
+
+// TODO(multiloader): Register creative tab content for NeoForge.
+// NeoForge uses BuildCreativeModeTabContentsEvent instead of Fabric's CreativeModeTabEvents.
+//
+// @Mod.EventBusSubscriber(modid = "logistics", bus = Mod.EventBusSubscriber.Bus.MOD)
+// public class NeoForgeCreativeTabSetup {
+//
+//     @SubscribeEvent
+//     public static void buildContents(BuildCreativeModeTabContentsEvent event) {
+//         if (event.getTabKey() == CreativeModeTabs.FUNCTIONAL_BLOCKS) {
+//             // Add all logistics items here, mirroring the Fabric creative tab population
+//             // event.accept(LogisticsCore.ITEM.WRENCH);
+//         }
+//     }
+// }
+//
+// Note: Biome modifications (tin/apatite ore worldgen) use a data-driven JSON approach
+// on NeoForge via BiomeModifier datapacks, rather than the event-based API.
+public final class NeoForgeCreativeTabSetup {
+    private NeoForgeCreativeTabSetup() {}
+}


### PR DESCRIPTION
## Summary
This update relocates the registration of creative tabs and biome features into a dedicated Fabric module. This change is essential for improving compatibility with Fabric's modding ecosystem and streamlining the registration process, allowing for cleaner and more maintainable code.

## Changes
- **Biome Registration**:
  - Moved biome generation logic for tin and apatite ores into a new `FabricBiomeModifications` class.
  - Streamlined the world generation feature registrations using Fabric API.

- **Creative Tab Improvements**:
  - All creative tab registrations are now handled in `FabricCreativeTabSetup`.
  - Enhanced structure for creative tab item listings, providing a more organized approach to managing tab entries.

- **Code Cleanup**:
  - Removed deprecated methods and unnecessary legacy code from the core logistics setup, improving clarity and reducing complexity.
  - Adopted a more modular design, enabling easier updates and modifications in the future.

## Notes
- This change primarily affects mod developers who customize or extend the creative tabs and biome features in the Logistics mod. Compatibility with previous initialization methods is removed, requiring updates to any existing mod dependencies leveraging those features.
- Closes #329