### PR TITLE
refactor: unify platform access with service implementations

### DIFF
--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -2,7 +2,7 @@ package com.logistics.core;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import net.fabricmc.loader.api.FabricLoader;
+import com.logistics.core.lib.platform.PlatformService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,7 +172,7 @@ public final class LogisticsConfig {
      * Does NOT call refresh listeners — each domain applies config in its own initCommon().
      */
     public static void load() {
-        configPath = FabricLoader.getInstance().getConfigDir().resolve("logistics.json");
+        configPath = PlatformService.INSTANCE.configDir().resolve("logistics.json");
         boolean loaded = false;
         if (Files.exists(configPath)) {
             try (Reader reader = Files.newBufferedReader(configPath)) {

--- a/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
@@ -1,0 +1,27 @@
+package com.logistics.core.lib.platform;
+
+import java.nio.file.Path;
+import java.util.ServiceLoader;
+
+/**
+ * Loader-agnostic access to platform utilities.
+ *
+ * <p>Common code calls {@code PlatformService.INSTANCE} to access platform-specific
+ * paths and services. Each loader provides an implementation via {@code META-INF/services/}.
+ *
+ * <pre>{@code
+ * // common — use the service
+ * Path configFile = PlatformService.INSTANCE.configDir().resolve("logistics.json");
+ *
+ * // fabric implementation
+ * public Path configDir() { return FabricLoader.getInstance().getConfigDir(); }
+ * }</pre>
+ */
+public interface PlatformService {
+    /** Returns the loader's standard config directory (e.g. {@code .minecraft/config/}). */
+    Path configDir();
+
+    PlatformService INSTANCE = ServiceLoader.load(PlatformService.class)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No PlatformService found"));
+}

--- a/common/src/main/java/com/logistics/core/lib/platform/ResourceReloadRegistrar.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/ResourceReloadRegistrar.java
@@ -1,0 +1,34 @@
+package com.logistics.core.lib.platform;
+
+import com.logistics.core.lib.resource.ResourceId;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+
+import java.util.ServiceLoader;
+
+/**
+ * Loader-agnostic registration of server-data reload listeners.
+ *
+ * <p>Common code calls {@code ResourceReloadRegistrar.INSTANCE.register(...)} to attach
+ * a reload listener. Each loader provides an implementation via {@code META-INF/services/}.
+ *
+ * <pre>{@code
+ * // common — register a listener
+ * ResourceReloadRegistrar.INSTANCE.register(
+ *     LogisticsMod.modId("macerator_recipes"),
+ *     new MaceratorReloadListener()
+ * );
+ *
+ * // fabric implementation
+ * public void register(ResourceId id, PreparableReloadListener listener) {
+ *     ResourceLoader.get(PackType.SERVER_DATA).registerReloadListener(id.toIdentifier(), listener);
+ * }
+ * }</pre>
+ */
+public interface ResourceReloadRegistrar {
+    /** Registers a server-data reload listener with the given identifier. */
+    void register(ResourceId id, PreparableReloadListener listener);
+
+    ResourceReloadRegistrar INSTANCE = ServiceLoader.load(ResourceReloadRegistrar.class)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No ResourceReloadRegistrar found"));
+}

--- a/common/src/main/java/com/logistics/core/macerator/MaceratorRecipeManager.java
+++ b/common/src/main/java/com/logistics/core/macerator/MaceratorRecipeManager.java
@@ -6,11 +6,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.resource.ResourceId;
-import net.fabricmc.fabric.api.resource.v1.ResourceLoader;
+import com.logistics.core.lib.platform.ResourceReloadRegistrar;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
-import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.tags.TagKey;
@@ -48,8 +47,8 @@ public class MaceratorRecipeManager {
 
     public static void register() {
         LOGGER.info("Registering macerator recipe reload listener");
-        ResourceLoader.get(PackType.SERVER_DATA).registerReloadListener(
-            LogisticsMod.modId("macerator_recipes").toIdentifier(),
+        ResourceReloadRegistrar.INSTANCE.register(
+            LogisticsMod.modId("macerator_recipes"),
             new PreparableReloadListener() {
                 @Override
                 public CompletableFuture<Void> reload(

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
@@ -1,0 +1,13 @@
+package com.logistics.fabric;
+
+import com.logistics.core.lib.platform.PlatformService;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.nio.file.Path;
+
+public final class FabricPlatformService implements PlatformService {
+    @Override
+    public Path configDir() {
+        return FabricLoader.getInstance().getConfigDir();
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/FabricResourceReloadRegistrar.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricResourceReloadRegistrar.java
@@ -1,0 +1,14 @@
+package com.logistics.fabric;
+
+import com.logistics.core.lib.platform.ResourceReloadRegistrar;
+import com.logistics.core.lib.resource.ResourceId;
+import net.fabricmc.fabric.api.resource.v1.ResourceLoader;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+
+public final class FabricResourceReloadRegistrar implements ResourceReloadRegistrar {
+    @Override
+    public void register(ResourceId id, PreparableReloadListener listener) {
+        ResourceLoader.get(PackType.SERVER_DATA).registerReloadListener(id.toIdentifier(), listener);
+    }
+}


### PR DESCRIPTION
**Summary**  
This update introduces a unified access layer for platform-specific functionalities through the implementation of the `PlatformService` and `ResourceReloadRegistrar`. This change enhances maintainability by centralizing platform access and reinforces the capabilities for resource management across different loaders.

**Changes**  
- **Unification of Platform Access**:  
  - Introduced `PlatformService` interface to standardize access to platform-specific utilities. 
  - Implemented `FabricPlatformService` to provide FabricLoader access for configuration paths.

- **Resource Management Enhancements**:  
  - Added `ResourceReloadRegistrar` interface for the loader-agnostic registration of reload listeners.
  - Integrated `FabricResourceReloadRegistrar` implementation to facilitate resource reloading in a platform-independent way.

- **Code Refactoring**:  
  - Updated various components to utilize the new platform access methods, simplifying configuration loading and resource registration.
  - Migrated relevant resource registration logic from specific implementations into the new uniform structure.

**Notes**  
- This change closes #330 and closes #331 related to inconsistent platform access methods and resource reloading mechanisms.  
- Ensure to update any custom implementations to integrate with the new `PlatformService` and `ResourceReloadRegistrar` patterns for seamless functionality across platforms.