### PR TITLE
refactor: introduce loader-agnostic IItemStorage contract

### DIFF
--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -195,7 +195,7 @@ public class KilnBlockEntity extends BaseBlockEntity
 
     @Override
     public IItemStorage itemStorage(@Nullable Direction side) {
-        return new ContainerItemStorage(this);
+        return new ContainerItemStorage(this, side);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -8,9 +8,8 @@ import com.logistics.core.lib.block.capability.HasItemStorage;
 import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.items.ItemInventoryComponent;
 import com.logistics.core.lib.compat.NbtCompat;
-import net.fabricmc.fabric.api.transfer.v1.item.ContainerStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import com.logistics.core.lib.storage.ContainerItemStorage;
+import com.logistics.core.lib.storage.IItemStorage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -195,8 +194,8 @@ public class KilnBlockEntity extends BaseBlockEntity
     // ==================== Capability Implementations ====================
 
     @Override
-    public Storage<ItemVariant> itemStorage(@Nullable Direction side) {
-        return ContainerStorage.of(this, side);
+    public IItemStorage itemStorage(@Nullable Direction side) {
+        return new ContainerItemStorage(this);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/core/lib/block/BlockEntityUtil.java
+++ b/common/src/main/java/com/logistics/core/lib/block/BlockEntityUtil.java
@@ -1,10 +1,9 @@
 package com.logistics.core.lib.block;
 
 import com.logistics.core.lib.block.capability.HasItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
@@ -22,7 +21,6 @@ public final class BlockEntityUtil {
     /**
      * Get all items from a block entity's storage for dropping when the block is broken.
      * Works with any BlockEntity implementing HasItemStorage.
-     * Uses Transfer API properly with transactions to extract items.
      *
      * <p>This is intended for use in Block.getDrops() to include inventory contents
      * in the dropped items when a block is broken.
@@ -37,31 +35,26 @@ public final class BlockEntityUtil {
             return drops;
         }
 
-        Storage<ItemVariant> storage = hasItems.itemStorage(null);
+        IItemStorage storage = hasItems.itemStorage(null);
         if (storage == null) return drops;
 
-        try (Transaction tx = Transaction.openOuter()) {
-            for (StorageView<ItemVariant> view : storage) {
-                if (view.isResourceBlank()) continue;
+        for (IItemView view : storage.contents()) {
+            IItemKey key = view.resource();
+            long amount = view.amount();
+            if (amount <= 0) continue;
 
-                ItemVariant variant = view.getResource();
-                long amount = view.getAmount();
-                if (amount <= 0) continue;
+            ItemStack template = key.toStack(1);
+            int maxStackSize = template.getMaxStackSize();
 
-                // Split large amounts into multiple stacks respecting max stack size
-                ItemStack sampleStack = variant.toStack(1);
-                int maxStackSize = sampleStack.getMaxStackSize();
-
-                long remaining = view.extract(variant, amount, tx);
-                while (remaining > 0) {
-                    int stackSize = (int) Math.min(remaining, maxStackSize);
-                    drops.add(variant.toStack(stackSize));
-                    remaining -= stackSize;
-                }
-
-                view.extract(variant, amount, tx);
+            // Extract by simulating — drops are the current contents, not a real extraction
+            long remaining = amount;
+            while (remaining > 0) {
+                int stackSize = (int) Math.min(remaining, maxStackSize);
+                drops.add(key.toStack(stackSize));
+                remaining -= stackSize;
             }
-            tx.commit();
+
+            storage.extract(key, amount, false);
         }
 
         return drops;

--- a/common/src/main/java/com/logistics/core/lib/block/BlockEntityUtil.java
+++ b/common/src/main/java/com/logistics/core/lib/block/BlockEntityUtil.java
@@ -46,7 +46,7 @@ public final class BlockEntityUtil {
             ItemStack template = key.toStack(1);
             int maxStackSize = template.getMaxStackSize();
 
-            // Extract by simulating — drops are the current contents, not a real extraction
+            // Build drop stacks from view amount, then do a real extract to remove items from storage
             long remaining = amount;
             while (remaining > 0) {
                 int stackSize = (int) Math.min(remaining, maxStackSize);

--- a/common/src/main/java/com/logistics/core/lib/block/BlockEntityUtil.java
+++ b/common/src/main/java/com/logistics/core/lib/block/BlockEntityUtil.java
@@ -38,7 +38,11 @@ public final class BlockEntityUtil {
         IItemStorage storage = hasItems.itemStorage(null);
         if (storage == null) return drops;
 
-        for (IItemView view : storage.contents()) {
+        // Snapshot contents before extracting to avoid modifying a live iterable during iteration
+        List<IItemView> views = new ArrayList<>();
+        for (IItemView v : storage.contents()) views.add(v);
+
+        for (IItemView view : views) {
             IItemKey key = view.resource();
             long amount = view.amount();
             if (amount <= 0) continue;

--- a/common/src/main/java/com/logistics/core/lib/block/capability/HasItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/block/capability/HasItemStorage.java
@@ -1,23 +1,26 @@
 package com.logistics.core.lib.block.capability;
 
-import com.logistics.core.lib.items.ItemInventoryComponent;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import com.logistics.core.lib.storage.IItemStorage;
 import net.minecraft.core.Direction;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Marker interface for block entities that expose item storage via the Transfer API.
- * <p>
- * Use {@link ItemInventoryComponent} to implement this easily.
+ * Marker interface for block entities that expose item storage.
+ *
+ * <p>Returns the loader-agnostic {@link IItemStorage} contract. Loader-specific adapters
+ * (Fabric, NeoForge) bridge this to their native item-storage lookup APIs.
+ *
+ * <p>Use {@link com.logistics.core.lib.items.ItemInventoryComponent} for simple fixed-size
+ * inventories, or implement directly for custom storage behaviour (e.g. slot filtering).
  */
 public interface HasItemStorage {
+
     /**
      * Get item storage for the specified side.
-     * Return null if the side doesn't support item access.
+     * Return {@code null} if the side doesn't support item access.
      *
-     * @param side The side to access, or null for non-sided access
-     * @return The item storage, or null if not accessible from this side
+     * @param side the side to access, or {@code null} for non-sided access
+     * @return the item storage, or {@code null} if not accessible from this side
      */
-    @Nullable Storage<ItemVariant> itemStorage(@Nullable Direction side);
+    @Nullable IItemStorage itemStorage(@Nullable Direction side);
 }

--- a/common/src/main/java/com/logistics/core/lib/items/ItemInventoryComponent.java
+++ b/common/src/main/java/com/logistics/core/lib/items/ItemInventoryComponent.java
@@ -1,9 +1,6 @@
 package com.logistics.core.lib.items;
 
 import com.logistics.core.lib.compat.NbtCompat;
-import net.fabricmc.fabric.api.transfer.v1.item.ContainerStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
@@ -18,27 +15,21 @@ import net.minecraft.world.item.ItemStack;
 import java.util.Collections;
 
 /**
- * Minimal item inventory component that implements vanilla {@link Container}
- * and exposes a Transfer API {@link Storage} wrapper.
+ * Minimal item inventory component that implements vanilla {@link Container}.
  * <p>
  * Use this for simple fixed-size inventories. For more complex inventory behavior,
  * implement {@link Container} directly.
+ * <p>
+ * Loader-specific storage access is handled by platform capability adapters that wrap
+ * this {@link Container} as needed.
  */
 public final class ItemInventoryComponent implements Container {
     private final NonNullList<ItemStack> stacks;
-    private final Storage<ItemVariant> storage;
     private final Runnable onChanged;
 
     public ItemInventoryComponent(int size, Runnable onChanged) {
         this.stacks = NonNullList.withSize(size, ItemStack.EMPTY);
         this.onChanged = onChanged;
-
-        // Transfer API wrapper over vanilla Inventory
-        this.storage = ContainerStorage.of(this, null);
-    }
-
-    public Storage<ItemVariant> storage() {
-        return storage;
     }
 
     public void readNbt(CompoundTag nbt, String key, HolderLookup.Provider registries) {

--- a/common/src/main/java/com/logistics/core/lib/network/CrafterSnapshot.java
+++ b/common/src/main/java/com/logistics/core/lib/network/CrafterSnapshot.java
@@ -1,6 +1,6 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.List;
@@ -10,11 +10,11 @@ import java.util.List;
  * Contains the output item, the per-batch output count, the recipe ingredients,
  * and the autocrafter's current buffer capacity.
  *
- * <p>Pure value object — no Minecraft world coupling beyond BlockPos/ItemVariant.
+ * <p>Pure value object — no Minecraft world coupling beyond BlockPos/IItemKey.
  */
 public record CrafterSnapshot(
         BlockPos pos,
-        ItemVariant output,
+        IItemKey output,
         long outputCount,
         List<RecipeIngredient> ingredients,
         CrafterBufferState buffer) {

--- a/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
+++ b/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
@@ -58,7 +58,7 @@ public interface ILogisticsNetwork {
      * Increments orderedForRequester immediately.
      * The order persists until cancelled or fulfilled via notifyDelivery.
      *
-     * @param item            item variant to request
+     * @param item            {@link IItemKey} identifying the item to request
      * @param amount          amount needed
      * @param requester       position of the requesting pipe
      * @param fulfillmentMode whether partial dispatch is acceptable
@@ -69,7 +69,7 @@ public interface ILogisticsNetwork {
     /**
      * Place a standing order with default {@link FulfillmentMode#PARTIAL} fulfillment.
      *
-     * @param item      item variant to request
+     * @param item      {@link IItemKey} identifying the item to request
      * @param amount    amount needed
      * @param requester position of the requesting pipe
      * @return UUID of the order (store for cancellation)

--- a/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
+++ b/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
@@ -5,11 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import net.minecraft.world.item.Item;
-
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,10 +31,10 @@ public interface ILogisticsNetwork {
      * Called periodically by provider and crafter modules after scanning their inventories.
      *
      * @param pos      position of the provider pipe
-     * @param items    items currently available (ItemVariant → amount); pass empty map to remove
+     * @param items    items currently available (IItemKey → amount); pass empty map to remove
      * @param priority dispatch priority (1 = real stock, 5 = crafter/on-demand)
      */
-    void registerSupply(BlockPos pos, Map<ItemVariant, Long> items, int priority);
+    void registerSupply(BlockPos pos, Map<IItemKey, Long> items, int priority);
 
     /**
      * Get the total available amount of an item across all providers.
@@ -65,7 +64,7 @@ public interface ILogisticsNetwork {
      * @param fulfillmentMode whether partial dispatch is acceptable
      * @return UUID of the order (store for cancellation)
      */
-    UUID placeOrder(ItemVariant item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode);
+    UUID placeOrder(IItemKey item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode);
 
     /**
      * Place a standing order with default {@link FulfillmentMode#PARTIAL} fulfillment.
@@ -75,7 +74,7 @@ public interface ILogisticsNetwork {
      * @param requester position of the requesting pipe
      * @return UUID of the order (store for cancellation)
      */
-    default UUID placeOrder(ItemVariant item, long amount, BlockPos requester) {
+    default UUID placeOrder(IItemKey item, long amount, BlockPos requester) {
         return placeOrder(item, amount, requester, FulfillmentMode.PARTIAL);
     }
 
@@ -115,7 +114,7 @@ public interface ILogisticsNetwork {
      * @param amount amount needed
      * @return empty list if satisfiable; otherwise the root missing ingredient(s)
      */
-    List<ItemVariant> getMissingIngredients(ItemVariant item, long amount);
+    List<IItemKey> getMissingIngredients(IItemKey item, long amount);
 
     /**
      * Get the total amount of an item currently ordered for a requester but not yet delivered.
@@ -136,7 +135,7 @@ public interface ILogisticsNetwork {
      * @param item      item variant delivered
      * @param amount    amount delivered
      */
-    void notifyDelivery(BlockPos requester, ItemVariant item, long amount);
+    void notifyDelivery(BlockPos requester, IItemKey item, long amount);
 
     // ===== Crafter Snapshot =====
 

--- a/common/src/main/java/com/logistics/core/lib/network/IWorldView.java
+++ b/common/src/main/java/com/logistics/core/lib/network/IWorldView.java
@@ -1,10 +1,11 @@
 package com.logistics.core.lib.network;
 
-import java.util.List;
-import java.util.UUID;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Abstraction for world/pipe queries to enable testing.
@@ -35,12 +36,12 @@ public interface IWorldView {
      *
      * @param provider   position of the provider pipe
      * @param requester  position of the destination requester
-     * @param item       item variant to extract
+     * @param item       item key to extract
      * @param amount     requested amount
      * @param deliveryId UUID to attach to the TravelingItem for delivery accounting
      * @return actual amount dispatched (0 if provider could not fulfill)
      */
-    long dispatch(BlockPos provider, BlockPos requester, ItemVariant item, long amount, UUID deliveryId);
+    long dispatch(BlockPos provider, BlockPos requester, IItemKey item, long amount, UUID deliveryId);
 
     /**
      * Check if this is a client-side world.

--- a/common/src/main/java/com/logistics/core/lib/network/IngredientChecker.java
+++ b/common/src/main/java/com/logistics/core/lib/network/IngredientChecker.java
@@ -1,6 +1,6 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
@@ -19,5 +19,5 @@ public interface IngredientChecker {
      *
      * @return empty list if the ingredient can be satisfied; otherwise the missing items
      */
-    List<ItemVariant> check(ItemStack ingredient, long amount);
+    List<IItemKey> check(ItemStack ingredient, long amount);
 }

--- a/common/src/main/java/com/logistics/core/lib/network/ItemRequest.java
+++ b/common/src/main/java/com/logistics/core/lib/network/ItemRequest.java
@@ -1,15 +1,15 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 /**
  * A request to the logistics network to source and deliver items to a destination.
  * Submitted to the job coordinator to create a network job.
- * Pure value object — no Minecraft world coupling beyond BlockPos/ItemVariant.
+ * Pure value object — no Minecraft world coupling beyond BlockPos/IItemKey.
  */
 public record ItemRequest(
-        ItemVariant item,
+        IItemKey item,
         long amount,
         BlockPos destination,
         FulfillmentMode fulfillmentMode) {
@@ -22,7 +22,7 @@ public record ItemRequest(
     }
 
     /** Convenience factory for the common PARTIAL fulfillment case. */
-    public static ItemRequest partial(ItemVariant item, long amount, BlockPos destination) {
+    public static ItemRequest partial(IItemKey item, long amount, BlockPos destination) {
         return new ItemRequest(item, amount, destination, FulfillmentMode.PARTIAL);
     }
 }

--- a/common/src/main/java/com/logistics/core/lib/network/NetworkCommand.java
+++ b/common/src/main/java/com/logistics/core/lib/network/NetworkCommand.java
@@ -1,6 +1,6 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.Map;
@@ -11,9 +11,9 @@ import java.util.UUID;
  *
  * <p>Sealed hierarchy — exactly three concrete forms:
  * <ul>
- *   <li>{@link ExtractCommand}           — pull items from a provider pipe</li>
+ *   <li>{@link ExtractCommand}             — pull items from a provider pipe</li>
  *   <li>{@link InsertCrafterInputsCommand} — push ingredients into a crafter's input buffer</li>
- *   <li>{@link DeliverCommand}           — route items directly to a destination (future use)</li>
+ *   <li>{@link DeliverCommand}             — route items directly to a destination (future use)</li>
  * </ul>
  *
  * <p>Commands are value objects produced by the network domain layer and consumed by
@@ -25,47 +25,31 @@ public sealed interface NetworkCommand
                 NetworkCommand.InsertCrafterInputsCommand,
                 NetworkCommand.DeliverCommand {
 
-    // ───────────────────────────────────────────────────────────────────────
-
     /**
      * Ask the provider pipe at {@code provider} to extract {@code amount} of {@code item}
      * and begin routing it toward {@code requester}.
-     *
-     * @param deliveryId UUID attached to the resulting {@link com.logistics.pipe.runtime.TravelingItem}
-     *                   for delivery accounting via
-     *                   {@link ILogisticsNetwork#notifyDelivery}
      */
     record ExtractCommand(
             BlockPos provider,
             BlockPos requester,
-            ItemVariant item,
+            IItemKey item,
             long amount,
             UUID deliveryId) implements NetworkCommand {}
 
-    // ───────────────────────────────────────────────────────────────────────
-
     /**
-     * Insert a set of ingredients directly into the input buffer of the crafter at
-     * {@code crafter}.
-     *
-     * <p>Reserved for explicit ingredient routing; not yet used in the main dispatch path
-     * (ingredients currently arrive via normal {@link ExtractCommand} routing).
+     * Insert a set of ingredients directly into the input buffer of the crafter at {@code crafter}.
      */
     record InsertCrafterInputsCommand(
             BlockPos crafter,
-            Map<ItemVariant, Long> ingredients) implements NetworkCommand {}
-
-    // ───────────────────────────────────────────────────────────────────────
+            Map<IItemKey, Long> ingredients) implements NetworkCommand {}
 
     /**
      * Deliver {@code amount} of {@code item} directly to {@code destination}, bypassing the
      * normal {@link com.logistics.pipe.runtime.TravelingItem} routing pipeline.
-     *
-     * <p>Reserved for future use (e.g., instant delivery in creative networks).
      */
     record DeliverCommand(
             BlockPos destination,
-            ItemVariant item,
+            IItemKey item,
             long amount,
             UUID deliveryId) implements NetworkCommand {}
 }

--- a/common/src/main/java/com/logistics/core/lib/network/Order.java
+++ b/common/src/main/java/com/logistics/core/lib/network/Order.java
@@ -1,6 +1,6 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import java.util.UUID;
 
@@ -9,7 +9,7 @@ import java.util.UUID;
  * Persists in the network until explicitly cancelled or fulfilled via notifyDelivery.
  * Replaces ItemRequest + LogisticsOrder.
  */
-public record Order(UUID id, ItemVariant item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode) {
+public record Order(UUID id, IItemKey item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode) {
     public Order {
         if (id == null) throw new NullPointerException("id must not be null");
         if (item == null) throw new NullPointerException("item must not be null");

--- a/common/src/main/java/com/logistics/core/lib/network/PlanningView.java
+++ b/common/src/main/java/com/logistics/core/lib/network/PlanningView.java
@@ -1,6 +1,6 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,7 +17,7 @@ public interface PlanningView {
     /**
      * Immutable snapshot of a single provider's supply for a specific item.
      *
-     * @param provider position of the supplying pipe
+     * @param provider  position of the supplying pipe
      * @param available raw amount available (0 = on-demand crafter, >0 = real stock)
      * @param priority  dispatch priority (lower = preferred; 1 = real stock, 5 = crafter)
      */
@@ -27,7 +27,7 @@ public interface PlanningView {
      * All supply entries for an item, sorted by priority ascending.
      * Returns an empty list if the item has no registered supply.
      */
-    List<SupplyPoint> getSupply(ItemVariant item);
+    List<SupplyPoint> getSupply(IItemKey item);
 
     /**
      * Provider fulfillment-check callback for a dynamic provider (crafter, machine, etc.).

--- a/common/src/main/java/com/logistics/core/lib/network/ProviderCanFulfill.java
+++ b/common/src/main/java/com/logistics/core/lib/network/ProviderCanFulfill.java
@@ -1,6 +1,6 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 
 import java.util.List;
 
@@ -21,5 +21,5 @@ public interface ProviderCanFulfill {
      *                branches of the validation tree
      * @return empty list if the provider can fulfill; otherwise the missing ingredients
      */
-    List<ItemVariant> getMissing(long amount, IngredientChecker checker);
+    List<IItemKey> getMissing(long amount, IngredientChecker checker);
 }

--- a/common/src/main/java/com/logistics/core/lib/network/RecipeIngredient.java
+++ b/common/src/main/java/com/logistics/core/lib/network/RecipeIngredient.java
@@ -1,12 +1,12 @@
 package com.logistics.core.lib.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 
 /**
  * A single ingredient in a crafting recipe: the item required and how many per batch.
  * Pure value object — no Minecraft world coupling.
  */
-public record RecipeIngredient(ItemVariant item, long amountPerBatch) {
+public record RecipeIngredient(IItemKey item, long amountPerBatch) {
     public RecipeIngredient {
         if (item == null) throw new NullPointerException("item must not be null");
         if (amountPerBatch <= 0) throw new IllegalArgumentException("amountPerBatch must be positive, got: " + amountPerBatch);

--- a/common/src/main/java/com/logistics/core/lib/pipe/DispatchableModule.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/DispatchableModule.java
@@ -1,6 +1,6 @@
 package com.logistics.core.lib.pipe;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.UUID;
@@ -19,10 +19,10 @@ public interface DispatchableModule extends Module {
      *
      * @param ctx        the pipe context
      * @param requester  destination position
-     * @param item       item variant to extract
+     * @param item       item key to extract
      * @param amount     requested amount
      * @param deliveryId UUID to attach to the TravelingItem for delivery tracking
      * @return actual amount dispatched (&gt;0), -1 if temporarily busy (deferred), or 0 if unable
      */
-    long onDispatch(PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId);
+    long onDispatch(PipeContext ctx, BlockPos requester, IItemKey item, long amount, UUID deliveryId);
 }

--- a/common/src/main/java/com/logistics/core/lib/pipe/Module.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/Module.java
@@ -1,9 +1,10 @@
 package com.logistics.core.lib.pipe;
 
 import com.logistics.core.lib.resource.ResourceId;
+import com.logistics.core.lib.storage.IItemKey;
 import java.util.List;
 import java.util.UUID;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponentGetter;
@@ -274,7 +275,7 @@ public interface Module {
      *     {@code onDispatch} on modules that implement {@link DispatchableModule}.
      */
     @Deprecated
-    default long onDispatch(PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
+    default long onDispatch(PipeContext ctx, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
         return 0;
     }
 

--- a/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
@@ -1,7 +1,10 @@
 package com.logistics.core.lib.storage;
 
+import net.minecraft.core.Direction;
 import net.minecraft.world.Container;
+import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,7 +13,9 @@ import java.util.List;
  * Wraps a vanilla {@link Container} as an {@link IItemStorage}.
  *
  * <p>Iterates slots linearly for both insertion and extraction.
- * For sided access, pass a wrapper that filters slots by face before constructing this.
+ * When a {@link Direction} is provided and the container implements {@link WorldlyContainer},
+ * slot access is restricted to {@link WorldlyContainer#getSlotsForFace} with the appropriate
+ * directional placement/extraction checks.
  *
  * <p>Useful for block entities that implement {@link Container} and want to expose
  * {@link com.logistics.core.lib.block.capability.HasItemStorage} without depending on
@@ -19,9 +24,15 @@ import java.util.List;
 public final class ContainerItemStorage implements IItemStorage {
 
     private final Container container;
+    @Nullable private final Direction side;
 
     public ContainerItemStorage(Container container) {
+        this(container, null);
+    }
+
+    public ContainerItemStorage(Container container, @Nullable Direction side) {
         this.container = container;
+        this.side = side;
     }
 
     @Override
@@ -29,35 +40,61 @@ public final class ContainerItemStorage implements IItemStorage {
         long remaining = maxAmount;
         ItemStack template = item.toStack(1);
 
-        for (int slot = 0; slot < container.getContainerSize() && remaining > 0; slot++) {
-            if (!container.canPlaceItem(slot, template)) continue;
-            ItemStack current = container.getItem(slot);
-            if (current.isEmpty()) {
-                long toInsert = Math.min(remaining, template.getMaxStackSize());
-                if (!simulate) container.setItem(slot, item.toStack((int) toInsert));
-                remaining -= toInsert;
-            } else if (ItemStack.isSameItemSameComponents(current, template)) {
-                long canFit = current.getMaxStackSize() - current.getCount();
-                long toInsert = Math.min(remaining, canFit);
-                if (toInsert > 0 && !simulate) {
-                    current.grow((int) toInsert);
-                    container.setChanged();
-                }
-                remaining -= toInsert;
+        if (side != null && container instanceof WorldlyContainer wc) {
+            for (int slot : wc.getSlotsForFace(side)) {
+                if (remaining <= 0) break;
+                if (!wc.canPlaceItemThroughFace(slot, template, side)) continue;
+                remaining -= insertIntoSlot(item, template, slot, remaining, simulate);
+            }
+        } else {
+            for (int slot = 0; slot < container.getContainerSize() && remaining > 0; slot++) {
+                if (!container.canPlaceItem(slot, template)) continue;
+                remaining -= insertIntoSlot(item, template, slot, remaining, simulate);
             }
         }
         return maxAmount - remaining;
     }
 
+    private long insertIntoSlot(IItemKey item, ItemStack template, int slot, long remaining, boolean simulate) {
+        ItemStack current = container.getItem(slot);
+        if (current.isEmpty()) {
+            long toInsert = Math.min(remaining, template.getMaxStackSize());
+            if (!simulate) container.setItem(slot, item.toStack((int) toInsert));
+            return toInsert;
+        } else if (ItemStack.isSameItemSameComponents(current, template)) {
+            long canFit = current.getMaxStackSize() - current.getCount();
+            long toInsert = Math.min(remaining, canFit);
+            if (toInsert > 0 && !simulate) {
+                current.grow((int) toInsert);
+                container.setChanged();
+            }
+            return toInsert;
+        }
+        return 0;
+    }
+
     @Override
     public long extract(IItemKey item, long maxAmount, boolean simulate) {
         long remaining = maxAmount;
-        for (int slot = 0; slot < container.getContainerSize() && remaining > 0; slot++) {
-            ItemStack current = container.getItem(slot);
-            if (current.isEmpty() || !item.matches(current)) continue;
-            long toExtract = Math.min(remaining, current.getCount());
-            if (!simulate) container.removeItem(slot, (int) toExtract);
-            remaining -= toExtract;
+
+        if (side != null && container instanceof WorldlyContainer wc) {
+            for (int slot : wc.getSlotsForFace(side)) {
+                if (remaining <= 0) break;
+                ItemStack current = container.getItem(slot);
+                if (current.isEmpty() || !item.matches(current)) continue;
+                if (!wc.canTakeItemThroughFace(slot, current, side)) continue;
+                long toExtract = Math.min(remaining, current.getCount());
+                if (!simulate) container.removeItem(slot, (int) toExtract);
+                remaining -= toExtract;
+            }
+        } else {
+            for (int slot = 0; slot < container.getContainerSize() && remaining > 0; slot++) {
+                ItemStack current = container.getItem(slot);
+                if (current.isEmpty() || !item.matches(current)) continue;
+                long toExtract = Math.min(remaining, current.getCount());
+                if (!simulate) container.removeItem(slot, (int) toExtract);
+                remaining -= toExtract;
+            }
         }
         return maxAmount - remaining;
     }

--- a/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
@@ -59,7 +59,10 @@ public final class ContainerItemStorage implements IItemStorage {
         ItemStack current = container.getItem(slot);
         if (current.isEmpty()) {
             long toInsert = Math.min(remaining, template.getMaxStackSize());
-            if (!simulate) container.setItem(slot, item.toStack((int) toInsert));
+            if (!simulate) {
+                container.setItem(slot, item.toStack((int) toInsert));
+                container.setChanged();
+            }
             return toInsert;
         } else if (ItemStack.isSameItemSameComponents(current, template)) {
             long canFit = current.getMaxStackSize() - current.getCount();

--- a/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
@@ -57,15 +57,17 @@ public final class ContainerItemStorage implements IItemStorage {
 
     private long insertIntoSlot(IItemKey item, ItemStack template, int slot, long remaining, boolean simulate) {
         ItemStack current = container.getItem(slot);
+        long containerLimit = container.getMaxStackSize();
         if (current.isEmpty()) {
-            long toInsert = Math.min(remaining, template.getMaxStackSize());
+            long toInsert = Math.min(remaining, Math.min(template.getMaxStackSize(), containerLimit));
             if (!simulate) {
                 container.setItem(slot, item.toStack((int) toInsert));
                 container.setChanged();
             }
             return toInsert;
         } else if (ItemStack.isSameItemSameComponents(current, template)) {
-            long canFit = current.getMaxStackSize() - current.getCount();
+            long slotLimit = Math.min(current.getMaxStackSize(), containerLimit);
+            long canFit = Math.max(0, slotLimit - current.getCount());
             long toInsert = Math.min(remaining, canFit);
             if (toInsert > 0 && !simulate) {
                 current.grow((int) toInsert);
@@ -105,17 +107,29 @@ public final class ContainerItemStorage implements IItemStorage {
     @Override
     public Iterable<IItemView> contents() {
         List<IItemView> views = new ArrayList<>();
-        for (int slot = 0; slot < container.getContainerSize(); slot++) {
-            ItemStack stack = container.getItem(slot);
-            if (!stack.isEmpty()) {
-                IItemKey key = ItemStorageLookup.of(stack);
-                long amount = stack.getCount();
-                views.add(new IItemView() {
-                    @Override public IItemKey resource() { return key; }
-                    @Override public long amount() { return amount; }
-                });
+        if (side != null && container instanceof WorldlyContainer wc) {
+            for (int slot : wc.getSlotsForFace(side)) {
+                IItemView view = viewForSlot(slot);
+                if (view != null) views.add(view);
+            }
+        } else {
+            for (int slot = 0; slot < container.getContainerSize(); slot++) {
+                IItemView view = viewForSlot(slot);
+                if (view != null) views.add(view);
             }
         }
         return views;
+    }
+
+    @Nullable
+    private IItemView viewForSlot(int slot) {
+        ItemStack stack = container.getItem(slot);
+        if (stack.isEmpty()) return null;
+        IItemKey key = ItemStorageLookup.of(stack);
+        long amount = stack.getCount();
+        return new IItemView() {
+            @Override public IItemKey resource() { return key; }
+            @Override public long amount() { return amount; }
+        };
     }
 }

--- a/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/ContainerItemStorage.java
@@ -1,0 +1,81 @@
+package com.logistics.core.lib.storage;
+
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Wraps a vanilla {@link Container} as an {@link IItemStorage}.
+ *
+ * <p>Iterates slots linearly for both insertion and extraction.
+ * For sided access, pass a wrapper that filters slots by face before constructing this.
+ *
+ * <p>Useful for block entities that implement {@link Container} and want to expose
+ * {@link com.logistics.core.lib.block.capability.HasItemStorage} without depending on
+ * any loader-specific storage API.
+ */
+public final class ContainerItemStorage implements IItemStorage {
+
+    private final Container container;
+
+    public ContainerItemStorage(Container container) {
+        this.container = container;
+    }
+
+    @Override
+    public long insert(IItemKey item, long maxAmount, boolean simulate) {
+        long remaining = maxAmount;
+        ItemStack template = item.toStack(1);
+
+        for (int slot = 0; slot < container.getContainerSize() && remaining > 0; slot++) {
+            if (!container.canPlaceItem(slot, template)) continue;
+            ItemStack current = container.getItem(slot);
+            if (current.isEmpty()) {
+                long toInsert = Math.min(remaining, template.getMaxStackSize());
+                if (!simulate) container.setItem(slot, item.toStack((int) toInsert));
+                remaining -= toInsert;
+            } else if (ItemStack.isSameItemSameComponents(current, template)) {
+                long canFit = current.getMaxStackSize() - current.getCount();
+                long toInsert = Math.min(remaining, canFit);
+                if (toInsert > 0 && !simulate) {
+                    current.grow((int) toInsert);
+                    container.setChanged();
+                }
+                remaining -= toInsert;
+            }
+        }
+        return maxAmount - remaining;
+    }
+
+    @Override
+    public long extract(IItemKey item, long maxAmount, boolean simulate) {
+        long remaining = maxAmount;
+        for (int slot = 0; slot < container.getContainerSize() && remaining > 0; slot++) {
+            ItemStack current = container.getItem(slot);
+            if (current.isEmpty() || !item.matches(current)) continue;
+            long toExtract = Math.min(remaining, current.getCount());
+            if (!simulate) container.removeItem(slot, (int) toExtract);
+            remaining -= toExtract;
+        }
+        return maxAmount - remaining;
+    }
+
+    @Override
+    public Iterable<IItemView> contents() {
+        List<IItemView> views = new ArrayList<>();
+        for (int slot = 0; slot < container.getContainerSize(); slot++) {
+            ItemStack stack = container.getItem(slot);
+            if (!stack.isEmpty()) {
+                IItemKey key = ItemStorageLookup.of(stack);
+                long amount = stack.getCount();
+                views.add(new IItemView() {
+                    @Override public IItemKey resource() { return key; }
+                    @Override public long amount() { return amount; }
+                });
+            }
+        }
+        return views;
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/storage/IItemKey.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/IItemKey.java
@@ -1,0 +1,34 @@
+package com.logistics.core.lib.storage;
+
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Loader-agnostic identity token for an item type (ignoring count).
+ *
+ * <p>Implementations must provide correct {@code equals} and {@code hashCode} semantics
+ * so that instances can be used as {@link java.util.Map} keys. Two keys are equal if and
+ * only if they represent the same item with the same components/data.
+ *
+ * <p>This is one of the primary extension points for the item-storage abstraction layer.
+ * Loader-specific adapters ({@code FabricItemKey}, {@code NeoForgeItemKey}) wrap the
+ * native item-identity type and implement this interface.
+ */
+public interface IItemKey {
+
+    /**
+     * Create an {@link ItemStack} with this item type and the given count.
+     *
+     * @param count the desired stack size
+     * @return a new stack representing this item
+     */
+    ItemStack toStack(int count);
+
+    /**
+     * Returns {@code true} if the given stack represents the same item type as this key
+     * (same item and same components, ignoring count).
+     *
+     * @param stack the stack to test
+     * @return {@code true} if the stack matches this key
+     */
+    boolean matches(ItemStack stack);
+}

--- a/common/src/main/java/com/logistics/core/lib/storage/IItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/IItemStorage.java
@@ -39,8 +39,8 @@ public interface IItemStorage {
     /**
      * Iterate over the contents of this storage.
      *
-     * <p>Each {@link IItemView} represents a resource group or slot. Empty slots may
-     * or may not be included, depending on the implementation.
+     * <p>Each {@link IItemView} represents a non-empty resource group or slot.
+     * Implementations must omit empty slots — callers may rely on this.
      *
      * @return an iterable over the non-empty views in this storage
      */

--- a/common/src/main/java/com/logistics/core/lib/storage/IItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/IItemStorage.java
@@ -19,20 +19,28 @@ public interface IItemStorage {
     /**
      * Insert items into this storage.
      *
+     * <p>If {@code maxAmount <= 0}, implementations must return {@code 0} immediately.
+     * The return value is always {@code >= 0} and never exceeds {@code maxAmount}.
+     *
      * @param item      the item type to insert
      * @param maxAmount the maximum number of items to insert
-     * @param simulate  if {@code true}, perform a dry run without modifying state
-     * @return the amount actually inserted (or that would be inserted if simulating)
+     * @param simulate  if {@code true}, perform a dry run without modifying state; the returned
+     *                  value is the amount that would be inserted without any state change
+     * @return the amount actually inserted (or that would be inserted if simulating); never negative
      */
     long insert(IItemKey item, long maxAmount, boolean simulate);
 
     /**
      * Extract items from this storage.
      *
+     * <p>If {@code maxAmount <= 0}, implementations must return {@code 0} immediately.
+     * The return value is always {@code >= 0} and never exceeds {@code maxAmount}.
+     *
      * @param item      the item type to extract
      * @param maxAmount the maximum number of items to extract
-     * @param simulate  if {@code true}, perform a dry run without modifying state
-     * @return the amount actually extracted (or that would be extracted if simulating)
+     * @param simulate  if {@code true}, perform a dry run without modifying state; the returned
+     *                  value is the amount that would be extracted without any state change
+     * @return the amount actually extracted (or that would be extracted if simulating); never negative
      */
     long extract(IItemKey item, long maxAmount, boolean simulate);
 

--- a/common/src/main/java/com/logistics/core/lib/storage/IItemStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/IItemStorage.java
@@ -1,0 +1,48 @@
+package com.logistics.core.lib.storage;
+
+/**
+ * Loader-agnostic item storage contract.
+ *
+ * <p>Uses simulate-boolean semantics (not transactions) to remain compatible with both
+ * Fabric (Transfer API) and NeoForge (IItemHandler) item APIs. Loader-specific adapters
+ * bridge this interface to each platform's native API.
+ *
+ * <p>This is the primary extension point for the item-storage abstraction layer. Any block
+ * entity that participates in the item network should implement
+ * {@link com.logistics.core.lib.block.capability.HasItemStorage} and return this type.
+ *
+ * @see com.logistics.core.lib.block.capability.HasItemStorage
+ * @see ItemStorageLookup
+ */
+public interface IItemStorage {
+
+    /**
+     * Insert items into this storage.
+     *
+     * @param item      the item type to insert
+     * @param maxAmount the maximum number of items to insert
+     * @param simulate  if {@code true}, perform a dry run without modifying state
+     * @return the amount actually inserted (or that would be inserted if simulating)
+     */
+    long insert(IItemKey item, long maxAmount, boolean simulate);
+
+    /**
+     * Extract items from this storage.
+     *
+     * @param item      the item type to extract
+     * @param maxAmount the maximum number of items to extract
+     * @param simulate  if {@code true}, perform a dry run without modifying state
+     * @return the amount actually extracted (or that would be extracted if simulating)
+     */
+    long extract(IItemKey item, long maxAmount, boolean simulate);
+
+    /**
+     * Iterate over the contents of this storage.
+     *
+     * <p>Each {@link IItemView} represents a resource group or slot. Empty slots may
+     * or may not be included, depending on the implementation.
+     *
+     * @return an iterable over the non-empty views in this storage
+     */
+    Iterable<IItemView> contents();
+}

--- a/common/src/main/java/com/logistics/core/lib/storage/IItemView.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/IItemView.java
@@ -5,12 +5,16 @@ package com.logistics.core.lib.storage;
  *
  * <p>Equivalent to Fabric's {@code StorageView<ItemVariant>} in the loader-agnostic API.
  * Instances are obtained by iterating {@link IItemStorage#contents()}.
+ *
+ * <p>Contract: {@link #resource()} never returns {@code null} and {@link #amount()} is always
+ * {@code > 0} for any view produced by {@link IItemStorage#contents()}. Implementations must
+ * not produce zero-amount views; callers may rely on this invariant.
  */
 public interface IItemView {
 
-    /** The item type stored in this slot or resource group. */
+    /** The item type stored in this slot or resource group. Never {@code null}. */
     IItemKey resource();
 
-    /** The number of items available in this view. */
+    /** The number of items available in this view. Always {@code > 0}. */
     long amount();
 }

--- a/common/src/main/java/com/logistics/core/lib/storage/IItemView.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/IItemView.java
@@ -1,0 +1,16 @@
+package com.logistics.core.lib.storage;
+
+/**
+ * Read-only view of a slot or resource within an {@link IItemStorage}.
+ *
+ * <p>Equivalent to Fabric's {@code StorageView<ItemVariant>} in the loader-agnostic API.
+ * Instances are obtained by iterating {@link IItemStorage#contents()}.
+ */
+public interface IItemView {
+
+    /** The item type stored in this slot or resource group. */
+    IItemKey resource();
+
+    /** The number of items available in this view. */
+    long amount();
+}

--- a/common/src/main/java/com/logistics/core/lib/storage/ItemStorageLookup.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/ItemStorageLookup.java
@@ -33,8 +33,8 @@ public final class ItemStorageLookup {
         IItemKey of(ItemStack stack);
     }
 
-    private static Finder finder;
-    private static KeyFactory keyFactory;
+    private static volatile Finder finder;
+    private static volatile KeyFactory keyFactory;
 
     private ItemStorageLookup() {}
 

--- a/common/src/main/java/com/logistics/core/lib/storage/ItemStorageLookup.java
+++ b/common/src/main/java/com/logistics/core/lib/storage/ItemStorageLookup.java
@@ -1,0 +1,85 @@
+package com.logistics.core.lib.storage;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Loader-agnostic registry for finding {@link IItemStorage} instances from the world
+ * and constructing {@link IItemKey} instances from vanilla {@link ItemStack}s.
+ *
+ * <p>Loader-specific modules register their implementations once during initialization:
+ * <ul>
+ *   <li>Fabric: registers a {@link Finder} that wraps {@code ItemStorage.SIDED.find()}
+ *   <li>NeoForge: registers a {@link Finder} that wraps the {@code IItemHandler} capability
+ * </ul>
+ *
+ * <p>Common code (pipe modules, pipe runtime) calls {@link #find} and {@link #of} without
+ * depending on any loader-specific types.
+ */
+public final class ItemStorageLookup {
+
+    /** Finds an {@link IItemStorage} for a given world position and face. */
+    @FunctionalInterface
+    public interface Finder {
+        @Nullable IItemStorage find(Level world, BlockPos pos, Direction dir);
+    }
+
+    /** Constructs an {@link IItemKey} from a vanilla {@link ItemStack}. */
+    @FunctionalInterface
+    public interface KeyFactory {
+        IItemKey of(ItemStack stack);
+    }
+
+    private static Finder finder;
+    private static KeyFactory keyFactory;
+
+    private ItemStorageLookup() {}
+
+    /**
+     * Register the platform-specific storage finder. Called once during loader initialization.
+     *
+     * @param f the finder implementation
+     */
+    public static void register(Finder f) {
+        finder = f;
+    }
+
+    /**
+     * Register the platform-specific key factory. Called once during loader initialization.
+     *
+     * @param f the factory implementation
+     */
+    public static void registerKeyFactory(KeyFactory f) {
+        keyFactory = f;
+    }
+
+    /**
+     * Find an {@link IItemStorage} for the given position and face.
+     *
+     * @param world the level
+     * @param pos   the block position to query
+     * @param dir   the face to access storage from
+     * @return the storage, or {@code null} if none is present
+     */
+    @Nullable
+    public static IItemStorage find(Level world, BlockPos pos, Direction dir) {
+        return finder != null ? finder.find(world, pos, dir) : null;
+    }
+
+    /**
+     * Create an {@link IItemKey} representing the item type of the given stack.
+     *
+     * @param stack the stack to identify (count is ignored)
+     * @return an {@link IItemKey} for the stack's item type and components
+     * @throws IllegalStateException if no key factory has been registered
+     */
+    public static IItemKey of(ItemStack stack) {
+        if (keyFactory == null) {
+            throw new IllegalStateException("ItemStorageLookup key factory not registered");
+        }
+        return keyFactory.of(stack);
+    }
+}

--- a/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
@@ -217,7 +217,7 @@ public class MaceratorBlockEntity extends BaseBlockEntity
 
     @Override
     public IItemStorage itemStorage(@Nullable Direction side) {
-        return new ContainerItemStorage(this);
+        return new ContainerItemStorage(this, side);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
@@ -9,9 +9,8 @@ import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.items.ItemInventoryComponent;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.compat.NbtCompat;
-import net.fabricmc.fabric.api.transfer.v1.item.ContainerStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import com.logistics.core.lib.storage.ContainerItemStorage;
+import com.logistics.core.lib.storage.IItemStorage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -217,8 +216,8 @@ public class MaceratorBlockEntity extends BaseBlockEntity
     // ==================== Capability Implementations ====================
 
     @Override
-    public Storage<ItemVariant> itemStorage(@Nullable Direction side) {
-        return ContainerStorage.of(this, side);
+    public IItemStorage itemStorage(@Nullable Direction side) {
+        return new ContainerItemStorage(this);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/ChassisPipe.java
+++ b/common/src/main/java/com/logistics/pipe/ChassisPipe.java
@@ -15,7 +15,7 @@ import com.logistics.core.lib.pipe.TransferHandlerModule;
 import com.logistics.core.lib.pipe.TravelingItem;
 import net.minecraft.util.RandomSource;
 import com.logistics.pipe.ui.ChassisScreenHandler;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.NbtOps;
@@ -197,7 +197,7 @@ public class ChassisPipe extends Pipe {
     }
 
     @Override
-    public long dispatch(PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
+    public long dispatch(PipeContext ctx, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
         if (ctx.world().isClientSide()) return 0;
         for (DynamicModule entry : getDynamicModuleEntries(ctx)) {
             Module module = entry.module();

--- a/common/src/main/java/com/logistics/pipe/Pipe.java
+++ b/common/src/main/java/com/logistics/pipe/Pipe.java
@@ -20,7 +20,7 @@ import com.logistics.core.lib.pipe.TravelingItem;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.block.Block;
@@ -501,7 +501,7 @@ public class Pipe {
      * @return actual amount dispatched (&gt;0), -1 if the provider is temporarily busy (deferred),
      *         or 0 if no module could fulfill
      */
-    public long dispatch(PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
+    public long dispatch(PipeContext ctx, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
         if (ctx.world().isClientSide()) return 0;
         for (Module module : getModules(ctx)) {
             if (module instanceof DispatchableModule dispatchable) {

--- a/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -14,7 +14,7 @@ import com.logistics.LogisticsPipe;
 import com.logistics.core.lib.pipe.TravelingItem;
 import com.logistics.pipe.item.ModuleItem;
 import com.mojang.serialization.MapCodec;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -480,14 +480,14 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
     }
 
     /**
-     * Check for ItemStorage.SIDED on the neighboring block (legacy inventory support).
+     * Check for item storage on the neighboring block (legacy inventory support).
      * Returns INVENTORY if found, null otherwise.
      */
     @Nullable private PipeConnection.Type checkItemStorage(
             Level world, BlockPos pos, BlockPos neighborPos, Direction direction, Block neighborBlock) {
-        var storage = ItemStorage.SIDED.find(world, neighborPos, direction.getOpposite());
+        var storage = ItemStorageLookup.find(world, neighborPos, direction.getOpposite());
 
-        if (storage != null && storage.iterator().hasNext()) {
+        if (storage != null && storage.contents().iterator().hasNext()) {
             PipeConnection.Type candidate = PipeConnection.Type.INVENTORY;
             if (pipe != null) {
                 PipeBlockEntity pipeEntity =

--- a/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -487,7 +487,7 @@ public class PipeBlock extends BaseEntityBlock implements ProbeBehavior.Probeabl
             Level world, BlockPos pos, BlockPos neighborPos, Direction direction, Block neighborBlock) {
         var storage = ItemStorageLookup.find(world, neighborPos, direction.getOpposite());
 
-        if (storage != null && storage.contents().iterator().hasNext()) {
+        if (storage != null) {
             PipeConnection.Type candidate = PipeConnection.Type.INVENTORY;
             if (pipe != null) {
                 PipeBlockEntity pipeEntity =

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -22,8 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import com.logistics.core.lib.storage.IItemStorage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -89,7 +88,7 @@ public class PipeBlockEntity extends BaseBlockEntity
 
     @Override
     @Nullable
-    public Storage<ItemVariant> itemStorage(@Nullable Direction side) {
+    public IItemStorage itemStorage(@Nullable Direction side) {
         return getItemStorage(side);
     }
 
@@ -444,7 +443,7 @@ public class PipeBlockEntity extends BaseBlockEntity
         this.lastConnectionsMask = lastConnectionsMask;
     }
 
-    @Nullable public Storage<ItemVariant> getItemStorage(@Nullable Direction side) {
+    @Nullable public PipeItemStorage getItemStorage(@Nullable Direction side) {
         if (side == null || level == null) {
             return null;
         }

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeItemStorage.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeItemStorage.java
@@ -54,7 +54,7 @@ public class PipeItemStorage implements IItemStorage {
         if (accepted <= 0) return 0;
 
         if (!simulate) {
-            ItemStack stack = item.toStack((int) accepted);
+            ItemStack stack = item.toStack((int) Math.min(accepted, Integer.MAX_VALUE));
             pipe.acceptInsertedStack(stack, fromDirection, NO_SPEED);
         }
 

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeItemStorage.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeItemStorage.java
@@ -1,18 +1,33 @@
 package com.logistics.pipe.block.entity;
 
 import com.logistics.core.lib.pipe.TravelingItem;
-import java.util.Collections;
-import java.util.Iterator;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext.Result;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 
-public class PipeItemStorage implements Storage<ItemVariant> {
-    /** Sentinel passed to the speed-overload of acceptInsertedStack to indicate no speed override. */
+import java.util.Collections;
+
+/**
+ * Exposes a {@link PipeBlockEntity} as an {@link IItemStorage} for incoming item insertion.
+ *
+ * <p>Pipes do not expose extractable contents ({@link #extract} and {@link #contents} return
+ * empty/zero). Only {@link #insert} is meaningful — it routes items into the pipe's traveling
+ * item system.
+ *
+ * <p>Two insert entry points exist:
+ * <ul>
+ *   <li>{@link #insert(IItemKey, long, boolean)} — used by loader capability adapters when
+ *       external inventories push items into the pipe.</li>
+ *   <li>{@link #insertTravelingItem(TravelingItem)} — used by {@code PipeRuntime} for
+ *       pipe-to-pipe item hand-off, preserving {@link TravelingItem} metadata such as speed
+ *       and delivery tracking.</li>
+ * </ul>
+ */
+public class PipeItemStorage implements IItemStorage {
+
+    /** Sentinel: no speed override for externally-inserted items. */
     private static final Float NO_SPEED = null;
 
     private final PipeBlockEntity pipe;
@@ -23,59 +38,58 @@ public class PipeItemStorage implements Storage<ItemVariant> {
         this.fromDirection = fromDirection;
     }
 
+    /**
+     * Insert items from an external source into this pipe.
+     *
+     * <p>When {@code simulate=true}, queries whether the pipe would accept the items without
+     * modifying any state. When {@code simulate=false}, commits the insertion and schedules
+     * a new {@link TravelingItem} into the pipe.
+     */
     @Override
-    public long insert(ItemVariant resource, long maxAmount, TransactionContext transaction) {
-        if (resource.isBlank() || maxAmount <= 0) {
-            return 0;
-        }
+    public long insert(IItemKey item, long maxAmount, boolean simulate) {
+        if (maxAmount <= 0) return 0;
 
-        ItemStack previewStack = resource.toStack(1);
+        ItemStack previewStack = item.toStack(1);
         long accepted = pipe.getInsertableAmount(maxAmount, fromDirection, previewStack);
-        if (accepted <= 0) {
-            return 0;
-        }
+        if (accepted <= 0) return 0;
 
-        transaction.addCloseCallback((context, result) -> {
-            if (result == Result.COMMITTED) {
-                ItemStack stack = resource.toStack((int) accepted);
-                pipe.acceptInsertedStack(stack, fromDirection, NO_SPEED);
-            }
-        });
+        if (!simulate) {
+            ItemStack stack = item.toStack((int) accepted);
+            pipe.acceptInsertedStack(stack, fromDirection, NO_SPEED);
+        }
 
         return accepted;
     }
 
-    public long insert(TravelingItem item, TransactionContext transaction) {
-        if (item.getStack().isEmpty()) {
-            return 0;
-        }
+    /**
+     * Insert a {@link TravelingItem} from an adjacent pipe, preserving its transit metadata.
+     *
+     * <p>This path is used exclusively by {@code PipeRuntime} for pipe-to-pipe hand-off.
+     * It propagates speed, delivery ID, and destination from the source traveling item so the
+     * next pipe segment continues the journey correctly.
+     *
+     * @return the number of items accepted
+     */
+    public long insertTravelingItem(TravelingItem item) {
+        if (item.getStack().isEmpty()) return 0;
 
         long accepted = pipe.getInsertableAmount(item.getStack().getCount(), fromDirection, item.getStack());
-        if (accepted <= 0) {
-            return 0;
-        }
+        if (accepted <= 0) return 0;
 
         ItemStack stack = item.getStack().copy();
         stack.setCount((int) accepted);
-
-        // Capture item reference so the close-callback can propagate transient state
-        // (inTransitOrder, remainingTtl) to the new TravelingItem in the next pipe.
-        transaction.addCloseCallback((context, result) -> {
-            if (result == Result.COMMITTED) {
-                pipe.acceptInsertedStack(stack, fromDirection, item);
-            }
-        });
+        pipe.acceptInsertedStack(stack, fromDirection, item);
 
         return accepted;
     }
 
     @Override
-    public long extract(ItemVariant resource, long maxAmount, TransactionContext transaction) {
-        return 0;
+    public long extract(IItemKey item, long maxAmount, boolean simulate) {
+        return 0; // Pipes do not expose extractable contents
     }
 
     @Override
-    public Iterator<StorageView<ItemVariant>> iterator() {
-        return Collections.emptyIterator();
+    public Iterable<IItemView> contents() {
+        return Collections.emptyList(); // Pipes have no storage views
     }
 }

--- a/common/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
@@ -9,14 +9,13 @@ import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.serialization.DirectionSerializer;
 import com.logistics.core.lib.filter.FilterSlots;
 import com.logistics.core.lib.pipe.PipeContext;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.core.lib.pipe.TravelingItem;
 import com.logistics.pipe.ui.AdvancedExtractorScreenHandler;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -164,28 +163,25 @@ public class AdvancedExtractorModule implements Module, TickingModule {
         if (PipeBlockEntity.VIRTUAL_CAPACITY - occupied < itemsPerPull) return;
 
         BlockPos targetPos = ctx.pos().relative(dir);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, dir.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, dir.getOpposite());
         if (storage == null) return;
 
-        try (Transaction tx = Transaction.openOuter()) {
-            for (StorageView<ItemVariant> view : storage) {
-                ItemVariant variant = view.getResource();
-                if (variant.isBlank()) continue;
-                if (isFilteredOut(ctx, variant.toStack())) {
-                    NetDbg.out("[AdvancedExtractor @ {}] Filtered out {} (mode={})", ctx.pos(), variant.getItem(), isFilterInverted(ctx) ? "exclude" : "include");
-                    continue;
-                }
+        for (IItemView view : storage.contents()) {
+            IItemKey key = view.resource();
+            if (view.amount() <= 0) continue;
+            if (isFilteredOut(ctx, key.toStack(1))) {
+                NetDbg.out("[AdvancedExtractor @ {}] Filtered out {} (mode={})", ctx.pos(), key.toStack(1).getItem(), isFilterInverted(ctx) ? "exclude" : "include");
+                continue;
+            }
 
-                long extracted = view.extract(variant, itemsPerPull, tx);
-                if (extracted > 0) {
-                    NetDbg.out("[AdvancedExtractor @ {}] Extracted {}x{} via {}", ctx.pos(), extracted, variant.getItem(), dir);
-                    ItemStack stack = variant.toStack((int) extracted);
-                    TravelingItem item = new TravelingItem(
-                            stack, dir.getOpposite(), LogisticsConfig.get().pipe.minSpeed);
-                    ctx.blockEntity().forceAddItem(item, dir);
-                    tx.commit();
-                    return;
-                }
+            long extracted = storage.extract(key, itemsPerPull, false);
+            if (extracted > 0) {
+                NetDbg.out("[AdvancedExtractor @ {}] Extracted {}x{} via {}", ctx.pos(), extracted, key.toStack(1).getItem(), dir);
+                ItemStack stack = key.toStack((int) extracted);
+                TravelingItem item = new TravelingItem(
+                        stack, dir.getOpposite(), LogisticsConfig.get().pipe.minSpeed);
+                ctx.blockEntity().forceAddItem(item, dir);
+                return;
             }
         }
     }

--- a/common/src/main/java/com/logistics/pipe/modules/BasicExtractorModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/BasicExtractorModule.java
@@ -88,12 +88,13 @@ public class BasicExtractorModule implements Module, TickingModule {
             return;
         }
 
+        int allowed = Math.min(itemsPerPull, remaining);
         boolean anyExtracted = false;
         for (IItemView view : storage.contents()) {
-            if (remaining <= 0) break;
+            if (allowed <= 0 || remaining <= 0) break;
             IItemKey key = view.resource();
 
-            int toExtract = Math.min(itemsPerPull, remaining);
+            int toExtract = Math.min(allowed, remaining);
             long extracted = storage.extract(key, toExtract, false);
             if (extracted > 0) {
                 ItemStack stack = key.toStack((int) extracted);
@@ -101,6 +102,7 @@ public class BasicExtractorModule implements Module, TickingModule {
                 TravelingItem item = new TravelingItem(stack, dir.getOpposite(), LogisticsConfig.get().pipe.minSpeed);
                 ctx.blockEntity().forceAddItem(item, dir);
                 remaining -= (int) extracted;
+                allowed -= (int) extracted;
                 anyExtracted = true;
             }
         }

--- a/common/src/main/java/com/logistics/pipe/modules/BasicExtractorModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/BasicExtractorModule.java
@@ -8,13 +8,12 @@ import com.logistics.core.lib.pipe.TickingModule;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.serialization.DirectionSerializer;
 import com.logistics.core.lib.pipe.PipeContext;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.core.lib.pipe.TravelingItem;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
@@ -83,31 +82,27 @@ public class BasicExtractorModule implements Module, TickingModule {
         if (remaining <= 0) return;
 
         BlockPos targetPos = ctx.pos().relative(dir);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, dir.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, dir.getOpposite());
         if (storage == null) {
             NetDbg.out("[BasicExtractor @ {}] No storage on {}, skipping", ctx.pos(), dir);
             return;
         }
 
         boolean anyExtracted = false;
-        try (Transaction tx = Transaction.openOuter()) {
-            for (StorageView<ItemVariant> view : storage) {
-                if (remaining <= 0) break;
-                ItemVariant variant = view.getResource();
-                if (variant.isBlank()) continue;
+        for (IItemView view : storage.contents()) {
+            if (remaining <= 0) break;
+            IItemKey key = view.resource();
 
-                int toExtract = Math.min(itemsPerPull, remaining);
-                long extracted = view.extract(variant, toExtract, tx);
-                if (extracted > 0) {
-                    ItemStack stack = variant.toStack((int) extracted);
-                    NetDbg.out("[BasicExtractor @ {}] Extracted {}x{} via {}", ctx.pos(), extracted, variant.getItem(), dir);
-                    TravelingItem item = new TravelingItem(stack, dir.getOpposite(), LogisticsConfig.get().pipe.minSpeed);
-                    ctx.blockEntity().forceAddItem(item, dir);
-                    remaining -= (int) extracted;
-                    anyExtracted = true;
-                }
+            int toExtract = Math.min(itemsPerPull, remaining);
+            long extracted = storage.extract(key, toExtract, false);
+            if (extracted > 0) {
+                ItemStack stack = key.toStack((int) extracted);
+                NetDbg.out("[BasicExtractor @ {}] Extracted {}x{} via {}", ctx.pos(), extracted, stack.getItem(), dir);
+                TravelingItem item = new TravelingItem(stack, dir.getOpposite(), LogisticsConfig.get().pipe.minSpeed);
+                ctx.blockEntity().forceAddItem(item, dir);
+                remaining -= (int) extracted;
+                anyExtracted = true;
             }
-            if (anyExtracted) tx.commit();
         }
     }
 

--- a/common/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -21,7 +21,8 @@ import com.logistics.pipe.network.NetworkRegistry;
 import com.logistics.core.lib.pipe.RoutePlan;
 import com.logistics.core.lib.pipe.TravelingItem;
 import com.logistics.pipe.ui.CraftingScreenHandler;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -442,7 +443,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
      */
     @Override
     public long onDispatch(
-            PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
+            PipeContext ctx, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
         String resultId = getResultItem(ctx);
         if (resultId.isEmpty()) {
             NetDbg.out("[Crafter @ {}] Dispatch rejected: no result configured", ctx.pos());
@@ -584,7 +585,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
         CompoundTag ingredientOrderIds = new CompoundTag();
         for (Map.Entry<String, Long> entry : neededByItem.entrySet()) {
             UUID ingredientOrderId = network.placeOrder(
-                    ItemVariant.of(resolvedIngredients.get(entry.getKey())), entry.getValue(), ctx.pos());
+                    ItemStorageLookup.of(resolvedIngredients.get(entry.getKey())), entry.getValue(), ctx.pos());
             ingredientOrderIds.putString(entry.getKey(), ingredientOrderId.toString());
         }
 
@@ -688,12 +689,12 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
             if (ingredientId.isEmpty()) continue;
             ItemStack ingredientStack = resolveItem(ingredientId);
             if (ingredientStack.isEmpty()) continue;
-            ingredients.add(new RecipeIngredient(ItemVariant.of(ingredientStack), getIngredientCount(ctx, slot)));
+            ingredients.add(new RecipeIngredient(ItemStorageLookup.of(ingredientStack), getIngredientCount(ctx, slot)));
         }
         if (ingredients.isEmpty()) return null;
 
         CrafterBufferState buffer = computeBufferState(ctx, autocrafterDir);
-        return new CrafterSnapshot(ctx.pos(), ItemVariant.of(resultStack), resultCount, ingredients, buffer);
+        return new CrafterSnapshot(ctx.pos(), ItemStorageLookup.of(resultStack), resultCount, ingredients, buffer);
     }
 
     private void updateCrafterSupply(PipeContext ctx) {
@@ -727,8 +728,8 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
         }
 
         // Advertise 0 — signals "craftable on demand" (no stock, but can fulfill any order)
-        Map<ItemVariant, Long> craftable = new HashMap<>();
-        craftable.put(ItemVariant.of(resultStack), 0L);
+        Map<IItemKey, Long> craftable = new HashMap<>();
+        craftable.put(ItemStorageLookup.of(resultStack), 0L);
         network.registerSupply(ctx.pos(), craftable, CRAFTER_PRIORITY);
 
         // Register buffer snapshot so RequestPlanner can cap batch sizes
@@ -743,7 +744,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
             int resultCount = getResultCount(ctx);
             if (resultCount <= 0) return List.of();
             long batchCount = (amount + resultCount - 1L) / resultCount;
-            List<ItemVariant> missing = new ArrayList<>();
+            List<IItemKey> missing = new ArrayList<>();
             for (int slot = 0; slot < 9; slot++) {
                 String id = getIngredientItem(ctx, slot);
                 if (id.isEmpty()) continue;
@@ -867,7 +868,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
         if (item.getDeliveryId() != null) {
             ILogisticsNetwork network = ctx.network();
             if (network != null) {
-                network.notifyDelivery(ctx.pos(), ItemVariant.of(item.getStack()), placed);
+                network.notifyDelivery(ctx.pos(), ItemStorageLookup.of(item.getStack()), placed);
             }
         }
 

--- a/common/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ExtractionModule.java
@@ -7,14 +7,13 @@ import com.logistics.core.lib.pipe.TickingModule;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.pipe.PipeContext;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.core.lib.pipe.TravelingItem;
 import java.util.List;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -156,17 +155,17 @@ public class ExtractionModule implements Module, TickingModule {
         }
 
         BlockPos targetPos = ctx.pos().relative(direction);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
 
         if (storage == null) {
             return 0;
         }
 
         // Find first non-empty slot and check stack size
-        for (StorageView<ItemVariant> view : storage) {
-            ItemVariant variant = view.getResource();
-            if (!variant.isBlank()) {
-                return Math.min(64, variant.getItem().getDefaultMaxStackSize());
+        for (IItemView view : storage.contents()) {
+            IItemKey key = view.resource();
+            if (view.amount() > 0) {
+                return Math.min(64, key.toStack(1).getItem().getDefaultMaxStackSize());
             }
         }
         return 0;
@@ -195,27 +194,24 @@ public class ExtractionModule implements Module, TickingModule {
         }
 
         BlockPos targetPos = ctx.pos().relative(direction);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
 
         if (storage == null) {
             return false;
         }
 
-        try (Transaction transaction = Transaction.openOuter()) {
-            for (StorageView<ItemVariant> view : storage) {
-                ItemVariant variant = view.getResource();
-                if (variant.isBlank()) {
-                    continue;
-                }
+        for (IItemView view : storage.contents()) {
+            IItemKey key = view.resource();
+            if (view.amount() <= 0) {
+                continue;
+            }
 
-                long extracted = view.extract(variant, maxItems, transaction);
-                if (extracted > 0) {
-                    ItemStack stack = variant.toStack((int) extracted);
-                    TravelingItem item = new TravelingItem(stack, direction.getOpposite(), LogisticsConfig.get().pipe.minSpeed);
-                    ctx.blockEntity().forceAddItem(item, direction);
-                    transaction.commit();
-                    return true;
-                }
+            long extracted = storage.extract(key, maxItems, false);
+            if (extracted > 0) {
+                ItemStack stack = key.toStack((int) extracted);
+                TravelingItem item = new TravelingItem(stack, direction.getOpposite(), LogisticsConfig.get().pipe.minSpeed);
+                ctx.blockEntity().forceAddItem(item, direction);
+                return true;
             }
         }
 

--- a/common/src/main/java/com/logistics/pipe/modules/InsertionModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/InsertionModule.java
@@ -7,13 +7,12 @@ import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.core.lib.pipe.RoutePlan;
 import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -74,31 +73,29 @@ public class InsertionModule implements Module, RoutingModule {
 
     private long getInsertSpace(PipeContext ctx, TravelingItem item, Direction direction) {
         BlockPos targetPos = ctx.pos().relative(direction);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
         if (storage == null) {
             return 0;
         }
 
-        ItemVariant variant = ItemVariant.of(item.getStack());
+        IItemKey key = ItemStorageLookup.of(item.getStack());
         long amount = item.getStack().getCount();
-        if (variant.isBlank() || amount <= 0) {
+        if (amount <= 0) {
             return 0;
         }
 
-        long reserved = getRoutedAmount(ctx, direction, variant);
+        long reserved = getRoutedAmount(ctx, direction, key);
         if (reserved < 0) {
             reserved = 0;
         }
 
-        try (Transaction transaction = Transaction.openOuter()) {
-            long requested = amount + reserved;
-            long accepted = storage.insert(variant, requested, transaction);
-            long available = accepted - reserved;
-            return Math.max(0, available);
-        }
+        long requested = amount + reserved;
+        long accepted = storage.insert(key, requested, true);
+        long available = accepted - reserved;
+        return Math.max(0, available);
     }
 
-    private long getRoutedAmount(PipeContext ctx, Direction direction, ItemVariant variant) {
+    private long getRoutedAmount(PipeContext ctx, Direction direction, IItemKey key) {
         long total = 0;
         for (TravelingItem other : ctx.blockEntity().getTravelingItems()) {
             if (!other.isRouted()) {
@@ -109,8 +106,8 @@ public class InsertionModule implements Module, RoutingModule {
                 continue;
             }
 
-            ItemVariant otherVariant = ItemVariant.of(other.getStack());
-            if (!variant.equals(otherVariant)) {
+            IItemKey otherKey = ItemStorageLookup.of(other.getStack());
+            if (!key.equals(otherKey)) {
                 continue;
             }
 

--- a/common/src/main/java/com/logistics/pipe/modules/PassiveSupplierModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/PassiveSupplierModule.java
@@ -7,10 +7,9 @@ import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.pipe.RoutePlan;
 import com.logistics.core.lib.pipe.TravelingItem;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -132,17 +131,17 @@ public class PassiveSupplierModule extends SupplierModule implements ItemAccepti
 
     private long scanInventory(PipeContext ctx, Direction direction, ItemStack target) {
         BlockPos targetPos = ctx.pos().relative(direction);
-        Storage<ItemVariant> storage =
-                ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+        IItemStorage storage =
+                ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
         if (storage == null) return 0;
 
         // Config stores item ID only (no component data), so count all variants of the
         // same item type. This prevents overfilling when enchanted/damaged items arrive
         // for a stock target configured by item type alone.
         long count = 0;
-        for (StorageView<ItemVariant> view : storage) {
-            if (view.getResource().getItem() == target.getItem()) {
-                count += view.getAmount();
+        for (IItemView view : storage.contents()) {
+            if (view.resource().toStack(1).getItem() == target.getItem()) {
+                count += view.amount();
             }
         }
         return count;

--- a/common/src/main/java/com/logistics/pipe/modules/PolymorphicSinkModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/PolymorphicSinkModule.java
@@ -9,12 +9,12 @@ import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.serialization.DirectionSerializer;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.pipe.RoutePlan;
 import com.logistics.core.lib.pipe.TravelingItem;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
@@ -105,14 +105,13 @@ public class PolymorphicSinkModule implements Module, RoutingModule, ItemAccepti
         }
 
         BlockPos targetPos = ctx.pos().relative(sinkDir);
-        var storage = ItemStorage.SIDED.find(ctx.world(), targetPos, sinkDir.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, sinkDir.getOpposite());
         if (storage == null) {
             return false;
         }
 
-        for (StorageView<ItemVariant> view : storage) {
-            if (!view.getResource().isBlank() && view.getAmount() > 0
-                    && view.getResource().toStack().getItem() == stack.getItem()) {
+        for (IItemView view : storage.contents()) {
+            if (view.amount() > 0 && view.resource().toStack(1).getItem() == stack.getItem()) {
                 return true;
             }
         }

--- a/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
@@ -15,11 +15,10 @@ import com.logistics.core.lib.network.ProviderCanFulfill;
 import com.logistics.core.lib.pipe.RoutePlan;
 import com.logistics.core.lib.pipe.TravelingItem;
 import com.logistics.pipe.ui.ProcessScreenHandler;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -268,7 +267,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
     }
 
     @Override
-    public long onDispatch(PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
+    public long onDispatch(PipeContext ctx, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
         // Find which output matches the requested item
         int matchedOutput = -1;
         for (int i = 0; i < MAX_OUTPUTS; i++) {
@@ -316,7 +315,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
             ItemStack inputStack = resolveItem(inputItem);
             if (inputStack.isEmpty()) continue;
 
-            ItemVariant inputVariant = ItemVariant.of(inputStack);
+            IItemKey inputKey = ItemStorageLookup.of(inputStack);
             long needed = executions * inputCount;
 
             // Resolve destination: per-input dest first, then global, then self
@@ -334,7 +333,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
                 }
             }
 
-            UUID orderId = network.placeOrder(inputVariant, needed, orderDest);
+            UUID orderId = network.placeOrder(inputKey, needed, orderDest);
             orderIds.add(StringTag.valueOf(orderId.toString()));
         }
 
@@ -396,13 +395,13 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
         // Advertise 0 — signals "produceable on demand" (like CraftingModule)
         // The network will validate ingredients via buildProviderCheck before dispatching.
         // Supply is always advertised even while jobs are queued, so additional orders can arrive.
-        Map<ItemVariant, Long> supply = new HashMap<>();
+        Map<IItemKey, Long> supply = new HashMap<>();
         for (int i = 0; i < MAX_OUTPUTS; i++) {
             String outId = getOutputItem(ctx, i);
             if (outId.isEmpty()) continue;
             ItemStack outStack = resolveItem(outId);
             if (!outStack.isEmpty()) {
-                supply.put(ItemVariant.of(outStack), 0L);
+                supply.put(ItemStorageLookup.of(outStack), 0L);
             }
         }
 
@@ -433,7 +432,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
                 int inputCount = getInputCount(ctx, i);
                 ItemStack inputStack = resolveItem(inputId);
                 if (inputStack.isEmpty()) continue;
-                List<ItemVariant> missing = checker.check(inputStack, executions * inputCount);
+                List<IItemKey> missing = checker.check(inputStack, executions * inputCount);
                 if (!missing.isEmpty()) return missing;
             }
             return List.of();
@@ -504,8 +503,8 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
             long requestedRemaining = Math.max(0, requested - totalSentToRequester);
             long toRequester = Math.min(stillNeeded, requestedRemaining);
 
-            ItemVariant variant = ItemVariant.of(outStack);
-            long extractedNow = extractAndRoute(ctx, variant, stillNeeded, requester, toRequester);
+            IItemKey key = ItemStorageLookup.of(outStack);
+            long extractedNow = extractAndRoute(ctx, key, stillNeeded, requester, toRequester);
 
             if (extractedNow > 0) {
                 long sentNow = Math.min(extractedNow, toRequester);
@@ -530,51 +529,48 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
         }
     }
 
-    private long extractAndRoute(PipeContext ctx, ItemVariant variant, long needed, BlockPos requester, long toRequester) {
+    private long extractAndRoute(PipeContext ctx, IItemKey key, long needed, BlockPos requester, long toRequester) {
         long extracted = 0;
         for (Direction dir : ctx.getInventoryConnections()) {
             BlockPos neighborPos = ctx.pos().relative(dir);
-            Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), neighborPos, dir.getOpposite());
+            IItemStorage storage = ItemStorageLookup.find(ctx.world(), neighborPos, dir.getOpposite());
             if (storage == null) continue;
 
-            try (Transaction tx = Transaction.openOuter()) {
-                long toExtract = needed - extracted;
-                long got = 0;
-                for (StorageView<ItemVariant> view : storage.nonEmptyViews()) {
-                    if (!view.getResource().equals(variant)) continue;
-                    long canGet = Math.min(view.getAmount(), toExtract - got);
-                    if (canGet <= 0) continue;
-                    got += storage.extract(variant, canGet, tx);
-                    if (got >= toExtract) break;
+            long toExtract = needed - extracted;
+            long got = 0;
+            for (IItemView view : storage.contents()) {
+                if (!view.resource().equals(key)) continue;
+                long canGet = Math.min(view.amount(), toExtract - got);
+                if (canGet <= 0) continue;
+                got += storage.extract(key, canGet, false);
+                if (got >= toExtract) break;
+            }
+            if (got > 0) {
+                extracted += got;
+                long forRequester = Math.min(got, toRequester);
+                toRequester -= forRequester;
+                long forSink = got - forRequester;
+                long rem = forRequester;
+                while (rem > 0) {
+                    int chunk = (int) Math.min(rem, Integer.MAX_VALUE);
+                    TravelingItem t = new TravelingItem(
+                            key.toStack(chunk), dir.getOpposite(),
+                            LogisticsConfig.get().pipe.injectSpeed, requester);
+                    t.setDeliveryId(getFirstEntryDeliveryId(ctx));
+                    ctx.blockEntity().forceAddItem(t, dir);
+                    rem -= chunk;
                 }
-                if (got > 0) {
-                    tx.commit();
-                    extracted += got;
-                    long forRequester = Math.min(got, toRequester);
-                    toRequester -= forRequester;
-                    long forSink = got - forRequester;
-                    long rem = forRequester;
-                    while (rem > 0) {
-                        int chunk = (int) Math.min(rem, Integer.MAX_VALUE);
-                        TravelingItem t = new TravelingItem(
-                                variant.toStack(chunk), dir.getOpposite(),
-                                LogisticsConfig.get().pipe.injectSpeed, requester);
-                        t.setDeliveryId(getFirstEntryDeliveryId(ctx));
-                        ctx.blockEntity().forceAddItem(t, dir);
-                        rem -= chunk;
-                    }
-                    rem = forSink;
-                    while (rem > 0) {
-                        // Route excess to a sink (null destination = find default route)
-                        int chunk = (int) Math.min(rem, Integer.MAX_VALUE);
-                        TravelingItem t = new TravelingItem(
-                                variant.toStack(chunk), dir.getOpposite(),
-                                LogisticsConfig.get().pipe.injectSpeed, null);
-                        ctx.blockEntity().forceAddItem(t, dir);
-                        rem -= chunk;
-                    }
-                    if (extracted >= needed) break;
+                rem = forSink;
+                while (rem > 0) {
+                    // Route excess to a sink (null destination = find default route)
+                    int chunk = (int) Math.min(rem, Integer.MAX_VALUE);
+                    TravelingItem t = new TravelingItem(
+                            key.toStack(chunk), dir.getOpposite(),
+                            LogisticsConfig.get().pipe.injectSpeed, null);
+                    ctx.blockEntity().forceAddItem(t, dir);
+                    rem -= chunk;
                 }
+                if (extracted >= needed) break;
             }
         }
         return extracted;

--- a/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
@@ -35,6 +35,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -305,7 +306,8 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
         int satId = getInputSatelliteId(ctx);
         String globalDest = satId > 0 ? String.valueOf(satId) : "";
 
-        // Place orders for each input
+        // Place orders for each input; track created order IDs for rollback on failure
+        List<UUID> createdOrderIds = new ArrayList<>();
         ListTag orderIds = new ListTag();
         for (int i = 0; i < MAX_INPUTS; i++) {
             String inputItem = getInputItem(ctx, i);
@@ -327,6 +329,8 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
             } else {
                 orderDest = network.findSatellite(effectiveDest);
                 if (orderDest == null) {
+                    // Cancel any orders already placed this iteration before aborting
+                    createdOrderIds.forEach(network::cancelOrder);
                     NetDbg.out("[Process @ {}] Dispatch rejected: satellite '{}' not found for input {}", ctx.pos(), effectiveDest, i);
                     LogisticsPipe.LOGGER.warn("[Process @ {}] Satellite '{}' not found for input {}; aborting dispatch", ctx.pos(), effectiveDest, i);
                     return 0;
@@ -334,6 +338,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
             }
 
             UUID orderId = network.placeOrder(inputKey, needed, orderDest);
+            createdOrderIds.add(orderId);
             orderIds.add(StringTag.valueOf(orderId.toString()));
         }
 

--- a/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -9,17 +9,16 @@ import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.pipe.TickingModule;
 import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.filter.FilterSlots;
 import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.filter.FilterSlots;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.network.NetworkRegistry;
 import com.logistics.core.lib.pipe.TravelingItem;
 import com.logistics.pipe.ui.ProviderScreenHandler;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -207,21 +206,21 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
      * when the network places a large order.
      */
     @Override
-    public long onDispatch(PipeContext ctx, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
-        if (isFilteredOut(ctx, item.toStack())) return 0;
+    public long onDispatch(PipeContext ctx, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
+        if (isFilteredOut(ctx, item.toStack(1))) return 0;
         if (ctx.getInventoryConnections().isEmpty()) return 0;
 
         enqueueDispatch(ctx, item, amount, requester, deliveryId);
         NetDbg.out("[Provider @ {}] Queued dispatch: {}x {} → {} (delivery {})",
-                ctx.pos(), amount, item.toStack().getItem(), requester,
+                ctx.pos(), amount, item.toStack(1).getItem(), requester,
                 deliveryId == null ? "none" : deliveryId.toString().substring(0, 8));
         return amount; // Promise: extraction happens from queue at rate-limited pace
     }
 
-    private void enqueueDispatch(PipeContext ctx, ItemVariant item, long amount,
+    private void enqueueDispatch(PipeContext ctx, IItemKey item, long amount,
             BlockPos requester, @Nullable UUID deliveryId) {
         ProviderDispatchQueue queue = loadQueue(ctx);
-        String itemId = BuiltInRegistries.ITEM.getKey(item.getItem()).toString();
+        String itemId = BuiltInRegistries.ITEM.getKey(item.toStack(1).getItem()).toString();
         RegistryOps<Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
         CompoundTag itemTag = ItemStack.CODEC.encodeStart(ops, item.toStack(1))
                 .result()
@@ -253,14 +252,14 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
         if (rid == null) { queue.removeHead(); saveQueue(ctx, queue); return; }
         var holder = BuiltInRegistries.ITEM.get(rid.toIdentifier());
         if (holder.isEmpty()) { queue.removeHead(); saveQueue(ctx, queue); return; }
-        ItemVariant item;
+        IItemKey item;
         if (head.itemTag() != null) {
             RegistryOps<Tag> ops = ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE);
             ItemStack stack = ItemStack.CODEC.parse(ops, head.itemTag()).result()
                     .orElse(new ItemStack(holder.get().value()));
-            item = ItemVariant.of(stack);
+            item = ItemStorageLookup.of(stack);
         } else {
-            item = ItemVariant.of(new ItemStack(holder.get().value()));
+            item = ItemStorageLookup.of(new ItemStack(holder.get().value()));
         }
 
         ProviderMode mode = getMode(ctx);
@@ -277,18 +276,15 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
 
             for (Direction direction : ctx.getInventoryConnections()) {
                 BlockPos targetPos = ctx.pos().relative(direction);
-                Storage<ItemVariant> storage =
-                        ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+                IItemStorage storage =
+                        ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
                 if (storage == null) continue;
 
-                try (Transaction transaction = Transaction.openOuter()) {
-                    long got = extractItems(storage, item, toExtract, transaction, mode);
-                    if (got > 0) {
-                        transaction.commit();
-                        extracted = got;
-                        extractDir = direction;
-                        break;
-                    }
+                long got = extractItems(storage, item, toExtract, mode);
+                if (got > 0) {
+                    extracted = got;
+                    extractDir = direction;
+                    break;
                 }
             }
 
@@ -302,7 +298,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
                 itemsLeft -= extracted;
                 stacksLeft -= 1;
                 NetDbg.out("[Provider @ {}] Queue drain: {}x {} → {} ({} remaining)",
-                        ctx.pos(), extracted, item.toStack().getItem(), head.requester(),
+                        ctx.pos(), extracted, item.toStack(1).getItem(), head.requester(),
                         head.remaining() - extracted);
             } else {
                 // Inventory empty or inaccessible — drop the entry so the queue doesn't block
@@ -315,7 +311,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
                     network.notifyDelivery(head.requester(), item, head.remaining());
                 }
                 NetDbg.out("[Provider @ {}] Queue drain failed (empty?): {}x {} — dropping entry",
-                        ctx.pos(), head.remaining(), item.toStack().getItem());
+                        ctx.pos(), head.remaining(), item.toStack(1).getItem());
                 queue.removeHead();
                 break;
             }
@@ -422,7 +418,7 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
 
         ProviderMode mode = getMode(ctx);
         Map<ItemStack, Long> availableItems = aggregateInventoryItems(ctx, inventoryFaces, mode);
-        network.registerSupply(ctx.pos(), toVariantMap(availableItems), SUPPLY_PRIORITY);
+        network.registerSupply(ctx.pos(), toKeyMap(availableItems), SUPPLY_PRIORITY);
 
         if (!availableItems.isEmpty() && NetDbg.isEnabled()) {
             long totalItems = availableItems.values().stream().mapToLong(Long::longValue).sum();
@@ -432,82 +428,79 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
     }
 
     private Map<ItemStack, Long> aggregateInventoryItems(PipeContext ctx, List<Direction> inventoryFaces, ProviderMode mode) {
-        Map<ItemVariant, ItemStack> variantToStack = new HashMap<>();
-        Map<ItemVariant, Long> variantAmounts = new HashMap<>();
+        Map<IItemKey, ItemStack> keyToStack = new HashMap<>();
+        Map<IItemKey, Long> keyAmounts = new HashMap<>();
 
         for (Direction direction : inventoryFaces) {
-            scanInventoryAtDirection(ctx, direction, mode, variantToStack, variantAmounts);
+            scanInventoryAtDirection(ctx, direction, mode, keyToStack, keyAmounts);
         }
 
         // Subtract items already committed to queued dispatch entries so the supply table
         // does not double-count items that are reserved but not yet physically extracted.
         Map<String, Long> reservations = loadQueue(ctx).getReservations();
         if (!reservations.isEmpty()) {
-            for (Map.Entry<ItemVariant, Long> entry : new ArrayList<>(variantAmounts.entrySet())) {
-                String id = BuiltInRegistries.ITEM.getKey(entry.getKey().getItem()).toString();
+            for (Map.Entry<IItemKey, Long> entry : new ArrayList<>(keyAmounts.entrySet())) {
+                String id = BuiltInRegistries.ITEM.getKey(entry.getKey().toStack(1).getItem()).toString();
                 long adjusted = ProviderDispatchQueue.subtractReservation(entry.getValue(), reservations, id);
                 if (adjusted == 0) {
-                    variantAmounts.remove(entry.getKey());
-                    variantToStack.remove(entry.getKey());
+                    keyAmounts.remove(entry.getKey());
+                    keyToStack.remove(entry.getKey());
                 } else {
-                    variantAmounts.put(entry.getKey(), adjusted);
+                    keyAmounts.put(entry.getKey(), adjusted);
                 }
             }
         }
 
         Map<ItemStack, Long> result = new HashMap<>();
-        for (Map.Entry<ItemVariant, Long> entry : variantAmounts.entrySet()) {
-            result.put(variantToStack.get(entry.getKey()), entry.getValue());
+        for (Map.Entry<IItemKey, Long> entry : keyAmounts.entrySet()) {
+            result.put(keyToStack.get(entry.getKey()), entry.getValue());
         }
         return result;
     }
 
     private void scanInventoryAtDirection(
             PipeContext ctx, Direction direction, ProviderMode mode,
-            Map<ItemVariant, ItemStack> variantToStack, Map<ItemVariant, Long> variantAmounts) {
+            Map<IItemKey, ItemStack> keyToStack, Map<IItemKey, Long> keyAmounts) {
 
         BlockPos targetPos = ctx.pos().relative(direction);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
         if (storage == null) return;
 
-        List<StorageView<ItemVariant>> views = new ArrayList<>();
-        for (StorageView<ItemVariant> view : storage) {
+        List<IItemView> views = new ArrayList<>();
+        for (IItemView view : storage.contents()) {
             views.add(view);
         }
 
         int startIndex = mode.getCropStart();
         int endIndex = Math.max(0, views.size() - mode.getCropEnd());
-        Map<ItemVariant, Boolean> firstSlotSeen = new HashMap<>();
+        Map<IItemKey, Boolean> firstSlotSeen = new HashMap<>();
 
         for (int i = startIndex; i < endIndex; i++) {
-            StorageView<ItemVariant> view = views.get(i);
-            ItemVariant variant = view.getResource();
-            if (variant.isBlank()) continue;
-
-            long rawAmount = view.getAmount();
+            IItemView view = views.get(i);
+            IItemKey key = view.resource();
+            long rawAmount = view.amount();
             if (rawAmount <= 0) continue;
 
-            ItemStack stack = variant.toStack();
+            ItemStack stack = key.toStack(1);
             if (isFilteredOut(ctx, stack)) continue;
 
-            boolean isFirstSlot = !firstSlotSeen.containsKey(variant);
-            firstSlotSeen.put(variant, true);
+            boolean isFirstSlot = !firstSlotSeen.containsKey(key);
+            firstSlotSeen.put(key, true);
 
             long adjustedAmount = calculateAvailableAmount(mode, rawAmount, isFirstSlot);
             if (adjustedAmount <= 0) continue;
 
-            variantToStack.putIfAbsent(variant, stack);
-            variantAmounts.merge(variant, adjustedAmount, Long::sum);
+            keyToStack.putIfAbsent(key, stack);
+            keyAmounts.merge(key, adjustedAmount, Long::sum);
         }
     }
 
     // ==================== Item Extraction ====================
 
-    private long extractItems(Storage<ItemVariant> storage, ItemVariant variant, long requested,
-            Transaction transaction, ProviderMode mode) {
-        List<StorageView<ItemVariant>> views = new ArrayList<>();
-        for (StorageView<ItemVariant> view : storage.nonEmptyViews()) {
-            views.add(view);
+    private long extractItems(IItemStorage storage, IItemKey key, long requested, ProviderMode mode) {
+        List<IItemView> views = new ArrayList<>();
+        for (IItemView view : storage.contents()) {
+            if (view.amount() > 0) views.add(view);
         }
 
         int startIndex = mode.getCropStart();
@@ -518,16 +511,16 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
         boolean isFirstSlotOfType = true;
 
         for (int i = startIndex; i < endIndex && remaining > 0; i++) {
-            StorageView<ItemVariant> view = views.get(i);
-            if (!view.getResource().equals(variant)) continue;
+            IItemView view = views.get(i);
+            if (!view.resource().equals(key)) continue;
 
-            long available = view.getAmount();
+            long available = view.amount();
             long adjustedAmount = calculateAvailableAmount(mode, available, isFirstSlotOfType);
             isFirstSlotOfType = false;
             if (adjustedAmount <= 0) continue;
 
             long canExtract = Math.min(adjustedAmount, remaining);
-            long extracted = view.extract(variant, canExtract, transaction);
+            long extracted = storage.extract(key, canExtract, false);
             totalExtracted += extracted;
             remaining -= extracted;
         }
@@ -537,11 +530,11 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
 
     // ==================== Helpers ====================
 
-    /** Convert ItemStack→Long map to ItemVariant→Long map for network supply. */
-    private static Map<ItemVariant, Long> toVariantMap(Map<ItemStack, Long> items) {
-        Map<ItemVariant, Long> result = new HashMap<>(items.size());
+    /** Convert ItemStack→Long map to IItemKey→Long map for network supply. */
+    private static Map<IItemKey, Long> toKeyMap(Map<ItemStack, Long> items) {
+        Map<IItemKey, Long> result = new HashMap<>(items.size());
         for (Map.Entry<ItemStack, Long> entry : items.entrySet()) {
-            result.merge(ItemVariant.of(entry.getKey()), entry.getValue(), Long::sum);
+            result.merge(ItemStorageLookup.of(entry.getKey()), entry.getValue(), Long::sum);
         }
         return result;
     }

--- a/common/src/main/java/com/logistics/pipe/modules/QuickSortModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/QuickSortModule.java
@@ -107,7 +107,8 @@ public class QuickSortModule implements Module, TickingModule {
         // Query network for a filtered destination (no default-route sinks)
         IItemView candidateView = slots.get(candidate);
         IItemKey key = candidateView.resource();
-        int stackSize = (int) Math.min(candidateView.amount(), key.toStack(1).getItem().getDefaultMaxStackSize());
+        ItemStack template = key.toStack(1);
+        int stackSize = (int) Math.min(candidateView.amount(), template.getItem().getDefaultMaxStackSize());
         ItemStack queryStack = key.toStack(stackSize);
 
         ILogisticsNetwork network = ctx.network();
@@ -115,7 +116,7 @@ public class QuickSortModule implements Module, TickingModule {
 
         BlockPos destination = network.findFilteredSinkFor(queryStack);
         if (destination == null) {
-            NetDbg.out("[QuickSort @ {}] No network destination for {} in slot {}", ctx.pos(), key.toStack(1).getItem(), candidate);
+            NetDbg.out("[QuickSort @ {}] No network destination for {} in slot {}", ctx.pos(), template.getItem(), candidate);
             // No destination — stall if full circle, otherwise just wait for next cycle
             if (candidate == lastSuccess) {
                 if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (no network destination for {})", ctx.pos(), key.toStack(1).getItem());

--- a/common/src/main/java/com/logistics/pipe/modules/QuickSortModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/QuickSortModule.java
@@ -8,11 +8,10 @@ import com.logistics.core.lib.pipe.TickingModule;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.pipe.TravelingItem;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
@@ -57,13 +56,13 @@ public class QuickSortModule implements Module, TickingModule {
         if (inventoryDir == null) return;
 
         BlockPos targetPos = ctx.pos().relative(inventoryDir);
-        Storage<ItemVariant> storage =
-                ItemStorage.SIDED.find(ctx.world(), targetPos, inventoryDir.getOpposite());
+        IItemStorage storage =
+                ItemStorageLookup.find(ctx.world(), targetPos, inventoryDir.getOpposite());
         if (storage == null) return;
 
         // Build indexed slot list for stable position tracking
-        List<StorageView<ItemVariant>> slots = new ArrayList<>();
-        for (StorageView<ItemVariant> view : storage) {
+        List<IItemView> slots = new ArrayList<>();
+        for (IItemView view : storage.contents()) {
             slots.add(view);
         }
         int size = slots.size();
@@ -84,8 +83,8 @@ public class QuickSortModule implements Module, TickingModule {
         int candidate = -1;
         for (int i = 1; i <= size; i++) {
             int idx = (lastScanned + i) % size;
-            StorageView<ItemVariant> view = slots.get(idx);
-            if (!view.getResource().isBlank() && view.getAmount() > 0) {
+            IItemView view = slots.get(idx);
+            if (view.amount() > 0) {
                 candidate = idx;
                 break;
             }
@@ -106,20 +105,20 @@ public class QuickSortModule implements Module, TickingModule {
         ctx.saveInt(this, LAST_SLOT_SCANNED, candidate);
 
         // Query network for a filtered destination (no default-route sinks)
-        StorageView<ItemVariant> candidateView = slots.get(candidate);
-        ItemVariant variant = candidateView.getResource();
-        int stackSize = (int) Math.min(candidateView.getAmount(), variant.getItem().getDefaultMaxStackSize());
-        ItemStack queryStack = variant.toStack(stackSize);
+        IItemView candidateView = slots.get(candidate);
+        IItemKey key = candidateView.resource();
+        int stackSize = (int) Math.min(candidateView.amount(), key.toStack(1).getItem().getDefaultMaxStackSize());
+        ItemStack queryStack = key.toStack(stackSize);
 
         ILogisticsNetwork network = ctx.network();
         if (network == null) return;
 
         BlockPos destination = network.findFilteredSinkFor(queryStack);
         if (destination == null) {
-            NetDbg.out("[QuickSort @ {}] No network destination for {} in slot {}", ctx.pos(), variant.getItem(), candidate);
+            NetDbg.out("[QuickSort @ {}] No network destination for {} in slot {}", ctx.pos(), key.toStack(1).getItem(), candidate);
             // No destination — stall if full circle, otherwise just wait for next cycle
             if (candidate == lastSuccess) {
-                if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (no network destination for {})", ctx.pos(), variant.getItem());
+                if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (no network destination for {})", ctx.pos(), key.toStack(1).getItem());
                 ctx.saveInt(this, STALLED, 1);
             }
             return;
@@ -132,27 +131,24 @@ public class QuickSortModule implements Module, TickingModule {
         if (PipeBlockEntity.VIRTUAL_CAPACITY - occupied < stackSize) return;
 
         // Extract and inject into the pipe with destination pre-set
-        try (Transaction tx = Transaction.openOuter()) {
-            long extracted = candidateView.extract(variant, stackSize, tx);
-            if (extracted > 0) {
-                ItemStack extractedStack = variant.toStack((int) extracted);
-                NetDbg.out("[QuickSort @ {}] Extracted {}x{} from slot {}", ctx.pos(), extracted, variant.getItem(), candidate);
-                TravelingItem travelingItem = new TravelingItem(
-                        extractedStack, inventoryDir.getOpposite(),
-                        LogisticsConfig.get().pipe.minSpeed, destination);
-                ctx.blockEntity().forceAddItem(travelingItem, inventoryDir);
-                tx.commit();
-                // Success: clear stall, record last successful slot
-                if (ctx.getInt(this, STALLED, 0) == 1) NetDbg.out("[QuickSort @ {}] Exiting stall", ctx.pos());
-                ctx.saveInt(this, STALLED, 0);
-                ctx.saveInt(this, LAST_SUCCESS_SLOT, candidate);
-            } else {
-                // Slot appeared non-empty but extraction failed (temporarily locked) —
-                // advance past it and back off to the stall delay
-                ctx.saveInt(this, LAST_SLOT_SCANNED, (candidate + 1) % size);
-                if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (extraction locked for {} in slot {})", ctx.pos(), variant.getItem(), candidate);
-                ctx.saveInt(this, STALLED, 1);
-            }
+        long extracted = storage.extract(key, stackSize, false);
+        if (extracted > 0) {
+            ItemStack extractedStack = key.toStack((int) extracted);
+            NetDbg.out("[QuickSort @ {}] Extracted {}x{} from slot {}", ctx.pos(), extracted, key.toStack(1).getItem(), candidate);
+            TravelingItem travelingItem = new TravelingItem(
+                    extractedStack, inventoryDir.getOpposite(),
+                    LogisticsConfig.get().pipe.minSpeed, destination);
+            ctx.blockEntity().forceAddItem(travelingItem, inventoryDir);
+            // Success: clear stall, record last successful slot
+            if (ctx.getInt(this, STALLED, 0) == 1) NetDbg.out("[QuickSort @ {}] Exiting stall", ctx.pos());
+            ctx.saveInt(this, STALLED, 0);
+            ctx.saveInt(this, LAST_SUCCESS_SLOT, candidate);
+        } else {
+            // Slot appeared non-empty but extraction failed (temporarily locked) —
+            // advance past it and back off to the stall delay
+            ctx.saveInt(this, LAST_SLOT_SCANNED, (candidate + 1) % size);
+            if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (extraction locked for {} in slot {})", ctx.pos(), key.toStack(1).getItem(), candidate);
+            ctx.saveInt(this, STALLED, 1);
         }
     }
 

--- a/common/src/main/java/com/logistics/pipe/modules/QuickSortModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/QuickSortModule.java
@@ -17,7 +17,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,8 +31,6 @@ import java.util.List;
  */
 public class QuickSortModule implements Module, TickingModule {
     private static final String TICKS_SINCE_ACTION = "ticks_since_action";
-    private static final String LAST_SLOT_SCANNED = "last_slot_scanned";
-    private static final String LAST_SUCCESS_SLOT = "last_success_slot";
     private static final String STALLED = "stalled";
 
     private static final int NORMAL_DELAY = 6;
@@ -60,97 +57,54 @@ public class QuickSortModule implements Module, TickingModule {
                 ItemStorageLookup.find(ctx.world(), targetPos, inventoryDir.getOpposite());
         if (storage == null) return;
 
-        // Build indexed slot list for stable position tracking
-        List<IItemView> slots = new ArrayList<>();
-        for (IItemView view : storage.contents()) {
-            slots.add(view);
-        }
-        int size = slots.size();
-        if (size == 0) {
-            if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (inventory has no slots)", ctx.pos());
-            ctx.saveInt(this, STALLED, 1);
-            return;
-        }
-
-        // Bounds-check position counters against current inventory size
-        int lastScanned = ctx.getInt(this, LAST_SLOT_SCANNED, 0);
-        int lastSuccess = ctx.getInt(this, LAST_SUCCESS_SLOT, 0);
-        if (lastScanned >= size) lastScanned = 0;
-        if (lastSuccess >= size) lastSuccess = 0;
-
-        // Advance forward from lastScanned, skipping empty slots.
-        // Stall if we wrap all the way back to lastSuccess without finding a non-empty slot.
-        int candidate = -1;
-        for (int i = 1; i <= size; i++) {
-            int idx = (lastScanned + i) % size;
-            IItemView view = slots.get(idx);
-            if (view.amount() > 0) {
-                candidate = idx;
-                break;
-            }
-            if (idx == lastSuccess) {
-                // Scanned back to last-success position with nothing found — stall
-                if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (all slots empty)", ctx.pos());
-                ctx.saveInt(this, STALLED, 1);
-                return;
-            }
-        }
-        if (candidate == -1) {
-            if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (all slots empty)", ctx.pos());
-            ctx.saveInt(this, STALLED, 1);
-            return;
-        }
-
-        // Commit the new scan position
-        ctx.saveInt(this, LAST_SLOT_SCANNED, candidate);
-
-        // Query network for a filtered destination (no default-route sinks)
-        IItemView candidateView = slots.get(candidate);
-        IItemKey key = candidateView.resource();
-        ItemStack template = key.toStack(1);
-        int stackSize = (int) Math.min(candidateView.amount(), template.getItem().getDefaultMaxStackSize());
-        ItemStack queryStack = key.toStack(stackSize);
-
         ILogisticsNetwork network = ctx.network();
         if (network == null) return;
 
-        BlockPos destination = network.findFilteredSinkFor(queryStack);
-        if (destination == null) {
-            NetDbg.out("[QuickSort @ {}] No network destination for {} in slot {}", ctx.pos(), template.getItem(), candidate);
-            // No destination — stall if full circle, otherwise just wait for next cycle
-            if (candidate == lastSuccess) {
-                if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (no network destination for {})", ctx.pos(), key.toStack(1).getItem());
-                ctx.saveInt(this, STALLED, 1);
+        // Iterate contents() fresh each tick — slot indices from contents() are ephemeral
+        // (the list only contains non-empty views and changes as items are extracted), so
+        // we resolve the candidate by key each tick rather than persisting slot numbers.
+        boolean anyNonEmpty = false;
+        for (IItemView view : storage.contents()) {
+            anyNonEmpty = true;
+            IItemKey key = view.resource();
+            ItemStack template = key.toStack(1);
+            int stackSize = (int) Math.min(view.amount(), template.getItem().getDefaultMaxStackSize());
+            ItemStack queryStack = key.toStack(stackSize);
+
+            BlockPos destination = network.findFilteredSinkFor(queryStack);
+            if (destination == null) {
+                NetDbg.out("[QuickSort @ {}] No network destination for {}", ctx.pos(), template.getItem());
+                continue;
             }
-            return;
+
+            // Check pipe has room for the extracted items
+            int occupied = ctx.blockEntity().getTravelingItems().stream()
+                    .mapToInt(ti -> ti.getStack().getCount())
+                    .sum();
+            if (PipeBlockEntity.VIRTUAL_CAPACITY - occupied < stackSize) continue;
+
+            // Extract and inject into the pipe with destination pre-set
+            long extracted = storage.extract(key, stackSize, false);
+            if (extracted > 0) {
+                ItemStack extractedStack = key.toStack((int) extracted);
+                NetDbg.out("[QuickSort @ {}] Extracted {}x{}", ctx.pos(), extracted, template.getItem());
+                TravelingItem travelingItem = new TravelingItem(
+                        extractedStack, inventoryDir.getOpposite(),
+                        LogisticsConfig.get().pipe.minSpeed, destination);
+                ctx.blockEntity().forceAddItem(travelingItem, inventoryDir);
+                if (ctx.getInt(this, STALLED, 0) == 1) NetDbg.out("[QuickSort @ {}] Exiting stall", ctx.pos());
+                ctx.saveInt(this, STALLED, 0);
+                return;
+            }
         }
 
-        // Check pipe has room for the extracted items
-        int occupied = ctx.blockEntity().getTravelingItems().stream()
-                .mapToInt(ti -> ti.getStack().getCount())
-                .sum();
-        if (PipeBlockEntity.VIRTUAL_CAPACITY - occupied < stackSize) return;
-
-        // Extract and inject into the pipe with destination pre-set
-        long extracted = storage.extract(key, stackSize, false);
-        if (extracted > 0) {
-            ItemStack extractedStack = key.toStack((int) extracted);
-            NetDbg.out("[QuickSort @ {}] Extracted {}x{} from slot {}", ctx.pos(), extracted, key.toStack(1).getItem(), candidate);
-            TravelingItem travelingItem = new TravelingItem(
-                    extractedStack, inventoryDir.getOpposite(),
-                    LogisticsConfig.get().pipe.minSpeed, destination);
-            ctx.blockEntity().forceAddItem(travelingItem, inventoryDir);
-            // Success: clear stall, record last successful slot
-            if (ctx.getInt(this, STALLED, 0) == 1) NetDbg.out("[QuickSort @ {}] Exiting stall", ctx.pos());
-            ctx.saveInt(this, STALLED, 0);
-            ctx.saveInt(this, LAST_SUCCESS_SLOT, candidate);
+        // Nothing routable found this cycle — stall
+        if (!anyNonEmpty) {
+            if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (inventory empty)", ctx.pos());
         } else {
-            // Slot appeared non-empty but extraction failed (temporarily locked) —
-            // advance past it and back off to the stall delay
-            ctx.saveInt(this, LAST_SLOT_SCANNED, (candidate + 1) % size);
-            if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (extraction locked for {} in slot {})", ctx.pos(), key.toStack(1).getItem(), candidate);
-            ctx.saveInt(this, STALLED, 1);
+            if (ctx.getInt(this, STALLED, 0) == 0) NetDbg.out("[QuickSort @ {}] Entering stall (no routable items)", ctx.pos());
         }
+        ctx.saveInt(this, STALLED, 1);
     }
 
     @Nullable

--- a/common/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -7,12 +7,13 @@ import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.pipe.TickingModule;
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.core.lib.serialization.DirectionSerializer;
 import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.serialization.DirectionSerializer;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.network.NetworkRegistry;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import com.logistics.pipe.ui.RequesterScreenHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -152,7 +153,7 @@ public class RequesterModule implements Module, TickingModule {
             long clamped = Math.min(needed, MAX_REQUEST_AMOUNT);
             if (clamped > 0) {
                 NetDbg.out("[Requester @ {}] Placed order for {}x{}", ctx.pos(), clamped, item);
-                network.placeOrder(ItemVariant.of(stack), clamped, ctx.pos());
+                network.placeOrder(ItemStorageLookup.of(stack), clamped, ctx.pos());
 
                 // TODO(Phase 11): Consume energy
                 // ctx.setEnergy(ctx.getEnergy() - RF_PER_REQUEST_CYCLE);
@@ -269,7 +270,7 @@ public class RequesterModule implements Module, TickingModule {
             return;
         }
 
-        ItemVariant variant = ItemVariant.of(stack);
+        IItemKey key = ItemStorageLookup.of(stack);
 
         // Pre-validate: fail immediately only if there is no supply path at all for this item
         // (no provider and no crafter). For craftable items we allow queuing even when
@@ -296,10 +297,10 @@ public class RequesterModule implements Module, TickingModule {
         // the full requested amount. getMissingIngredients accounts for existing stock and
         // asks the crafter only for the remainder, so this mirrors the dispatch logic exactly.
         if (available == Long.MAX_VALUE) {
-            List<ItemVariant> missing = network.getMissingIngredients(variant, amount);
+            List<IItemKey> missing = network.getMissingIngredients(key, amount);
             if (!missing.isEmpty()) {
                 String missingNames = missing.stream()
-                        .map(v -> v.toStack().getHoverName().getString())
+                        .map(k -> k.toStack(1).getHoverName().getString())
                         .collect(Collectors.joining(", "));
                 sendAlert(ctx, Component.literal(
                         "[Logistics] Cannot fill order for " + itemName
@@ -308,7 +309,7 @@ public class RequesterModule implements Module, TickingModule {
             }
         }
 
-        network.placeOrder(variant, amount, ctx.pos(), FulfillmentMode.FULL);
+        network.placeOrder(key, amount, ctx.pos(), FulfillmentMode.FULL);
     }
 
     private void sendAlert(PipeContext ctx, Component msg) {

--- a/common/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -12,15 +12,15 @@ import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.pipe.network.SupplierModeConfig;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.core.lib.pipe.RoutePlan;
 import com.logistics.core.lib.pipe.TravelingItem;
 import com.logistics.pipe.ui.SupplierScreenHandler;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -234,7 +234,7 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
             }
 
             if (shouldRequest) {
-                network.placeOrder(ItemVariant.of(stack), toRequest, ctx.pos(), modeConfig.fulfillmentMode());
+                network.placeOrder(ItemStorageLookup.of(stack), toRequest, ctx.pos(), modeConfig.fulfillmentMode());
             }
         }
     }
@@ -245,30 +245,26 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
     private Map<ItemStack, Long> scanInventory(PipeContext ctx, Direction direction) {
         Map<ItemStack, Long> stock = new HashMap<>();
         BlockPos targetPos = ctx.pos().relative(direction);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
 
         if (storage == null) {
             return stock;
         }
 
-        for (StorageView<ItemVariant> view : storage) {
-            ItemVariant variant = view.getResource();
-            if (variant.isBlank()) {
-                continue;
-            }
-
-            long amount = view.getAmount();
+        for (IItemView view : storage.contents()) {
+            IItemKey key = view.resource();
+            long amount = view.amount();
             if (amount <= 0) {
                 continue;
             }
 
-            ItemStack stack = variant.toStack();
+            ItemStack stack = key.toStack(1);
 
             // Find existing matching stack in map to properly aggregate
             ItemStack existingKey = null;
-            for (ItemStack key : stock.keySet()) {
-                if (ItemStack.isSameItemSameComponents(key, stack)) {
-                    existingKey = key;
+            for (ItemStack k : stock.keySet()) {
+                if (ItemStack.isSameItemSameComponents(k, stack)) {
+                    existingKey = k;
                     break;
                 }
             }
@@ -288,27 +284,27 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
      */
     private long getAvailableSpace(PipeContext ctx, Direction direction, ItemStack targetStack) {
         BlockPos targetPos = ctx.pos().relative(direction);
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(ctx.world(), targetPos, direction.getOpposite());
+        IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
 
         if (storage == null) {
             return 0;
         }
 
-        ItemVariant targetVariant = ItemVariant.of(targetStack);
+        IItemKey targetKey = ItemStorageLookup.of(targetStack);
         long availableSpace = 0;
 
-        for (StorageView<ItemVariant> view : storage) {
-            long capacity = view.getCapacity();
-            ItemVariant variant = view.getResource();
-            long currentAmount = view.getAmount();
+        for (IItemView view : storage.contents()) {
+            IItemKey key = view.resource();
+            long currentAmount = view.amount();
 
-            if (variant.isBlank()) {
+            if (currentAmount == 0) {
                 // Empty slot - can hold full stack
                 availableSpace += targetStack.getMaxStackSize();
-            } else if (variant.equals(targetVariant)) {
-                // Slot has same item - can hold more up to capacity
-                long spaceInSlot = capacity - currentAmount;
-                availableSpace += spaceInSlot;
+            } else if (key.equals(targetKey)) {
+                // Slot has same item - simulate insert to find space
+                long canInsert = storage.insert(targetKey, targetStack.getMaxStackSize(), true);
+                availableSpace += canInsert;
+                break; // avoid double-counting; let insert simulation handle overall space
             }
             // Different item - can't use this slot
         }

--- a/common/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -291,25 +291,7 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
         }
 
         IItemKey targetKey = ItemStorageLookup.of(targetStack);
-        long availableSpace = 0;
-
-        for (IItemView view : storage.contents()) {
-            IItemKey key = view.resource();
-            long currentAmount = view.amount();
-
-            if (currentAmount == 0) {
-                // Empty slot - can hold full stack
-                availableSpace += targetStack.getMaxStackSize();
-            } else if (key.equals(targetKey)) {
-                // Slot has same item - simulate insert to find space
-                long canInsert = storage.insert(targetKey, targetStack.getMaxStackSize(), true);
-                availableSpace += canInsert;
-                break; // avoid double-counting; let insert simulation handle overall space
-            }
-            // Different item - can't use this slot
-        }
-
-        return availableSpace;
+        return storage.insert(targetKey, Long.MAX_VALUE, true);
     }
 
     /**

--- a/common/src/main/java/com/logistics/pipe/network/ItemReservation.java
+++ b/common/src/main/java/com/logistics/pipe/network/ItemReservation.java
@@ -1,6 +1,6 @@
 package com.logistics.pipe.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.UUID;
@@ -12,35 +12,17 @@ import java.util.UUID;
  * <p>Mutable (state field changes over the reservation lifecycle). Not a record.
  */
 public final class ItemReservation {
-    /** Unique identity of this reservation. */
     public final ReservationId id;
-
-    /** The order this reservation was created for. */
     public final UUID orderId;
-
-    /** Provider pipe holding the stock. */
     public final BlockPos provider;
-
-    /** Requester pipe that placed the order. */
     public final BlockPos requester;
-
-    /** Item being reserved. */
-    public final ItemVariant item;
-
-    /** Amount reserved. */
+    public final IItemKey item;
     public final long amount;
-
-    /**
-     * Whether this is a hard reservation (committed, cannot be bumped) vs.
-     * soft (lower-priority, can be displaced by a higher-priority order in a future phase).
-     */
     public final boolean hard;
-
-    /** Current lifecycle state. Mutated by {@link ReservationManager}. */
     AllocationState state;
 
     ItemReservation(ReservationId id, UUID orderId, BlockPos provider, BlockPos requester,
-                    ItemVariant item, long amount, boolean hard, AllocationState initialState) {
+                    IItemKey item, long amount, boolean hard, AllocationState initialState) {
         this.id = id;
         this.orderId = orderId;
         this.provider = provider;
@@ -58,7 +40,7 @@ public final class ItemReservation {
     @Override
     public String toString() {
         return id + " order=" + orderId.toString().substring(0, 8)
-                + " " + amount + "x " + item.toStack().getItem()
+                + " " + amount + "x " + item.toStack(1).getItem()
                 + " from=" + provider + " to=" + requester
                 + " [" + state + (hard ? ",hard" : ",soft") + "]";
     }

--- a/common/src/main/java/com/logistics/pipe/network/JobCoordinator.java
+++ b/common/src/main/java/com/logistics/pipe/network/JobCoordinator.java
@@ -2,7 +2,7 @@ package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.ItemRequest;
 import com.logistics.core.lib.network.PlanningView;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.ArrayList;
@@ -88,7 +88,7 @@ public class JobCoordinator implements NetworkController.OrderFailureListener {
         job.transitionTo(JobState.ACTIVE);
         NetDbg.out("[Jobs] Submitted job {} for {}x {} | plan: {} extract/craft nodes",
                 jobId.toString().substring(0, 8), request.amount(),
-                request.item().toStack().getItem(), plan.roots().size());
+                request.item().toStack(1).getItem(), plan.roots().size());
         return job;
     }
 
@@ -123,7 +123,7 @@ public class JobCoordinator implements NetworkController.OrderFailureListener {
 
             long lost = result.amountLost();
             NetDbg.out("[Jobs] Reconciliation: job {} lost {}x {}",
-                    job.id().toString().substring(0, 8), lost, job.item().toStack().getItem());
+                    job.id().toString().substring(0, 8), lost, job.item().toStack(1).getItem());
 
             // Attempt to replan from alternative supply
             Optional<FulfillmentPlan> replan = service.replan(job, lost, view);
@@ -155,14 +155,14 @@ public class JobCoordinator implements NetworkController.OrderFailureListener {
      * Called when items physically arrive at a destination.
      * Updates the matching active job's {@code deliveredAmount}.
      */
-    public void onDelivery(BlockPos requester, ItemVariant item, long amount) {
+    public void onDelivery(BlockPos requester, IItemKey item, long amount) {
         for (NetworkJob job : jobs.values()) {
             if (job.state().isTerminal()) continue;
             if (job.destination().equals(requester) && job.item().equals(item)) {
                 job.recordDelivery(amount);
                 NetDbg.out("[Jobs] Delivery {} | {}x {} | outstanding={}",
                         job.id().toString().substring(0, 8), amount,
-                        item.toStack().getItem(), job.outstanding());
+                        item.toStack(1).getItem(), job.outstanding());
                 return;
             }
         }
@@ -173,8 +173,8 @@ public class JobCoordinator implements NetworkController.OrderFailureListener {
      * Implements {@link NetworkController.OrderFailureListener}.
      */
     @Override
-    public void onOrderFailed(UUID orderId, BlockPos requester, ItemVariant item,
-                              long amount, List<ItemVariant> missing) {
+    public void onOrderFailed(UUID orderId, BlockPos requester, IItemKey item,
+                              long amount, List<IItemKey> missing) {
         UUID jobId = orderToJob.remove(orderId);
         if (jobId == null) return;
         jobToOrder.remove(jobId);
@@ -183,7 +183,7 @@ public class JobCoordinator implements NetworkController.OrderFailureListener {
         job.transitionTo(JobState.FAILED);
         NetDbg.out("[Jobs] Job {} FAILED | {}x {} | missing: {}",
                 job.id().toString().substring(0, 8), amount,
-                item.toStack().getItem(), missing);
+                item.toStack(1).getItem(), missing);
     }
 
     // ===== Queries =====

--- a/common/src/main/java/com/logistics/pipe/network/MinecraftWorldView.java
+++ b/common/src/main/java/com/logistics/pipe/network/MinecraftWorldView.java
@@ -10,7 +10,7 @@ import com.logistics.core.lib.pipe.Module;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
@@ -81,7 +81,7 @@ public class MinecraftWorldView implements IWorldView {
     }
 
     @Override
-    public long dispatch(BlockPos provider, BlockPos requester, ItemVariant item, long amount, UUID deliveryId) {
+    public long dispatch(BlockPos provider, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
         if (!(level.getBlockEntity(provider) instanceof PipeBlockEntity pipeEntity)) return 0;
         BlockState state = level.getBlockState(provider);
         if (!(state.getBlock() instanceof PipeBlock pipeBlock)) return 0;

--- a/common/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/common/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -2,7 +2,8 @@ package com.logistics.pipe.network;
 
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.network.*;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -50,7 +51,7 @@ public class NetworkController implements PlanningView {
      * Command returned by {@link #nextDispatchable()} describing what the network wants dispatched.
      */
     public record DispatchCommand(
-            UUID orderId, BlockPos provider, BlockPos requester, ItemVariant item, long amount) {}
+            UUID orderId, BlockPos provider, BlockPos requester, IItemKey item, long amount) {}
 
     /**
      * Listener notified when an order is cancelled because its ingredient chain cannot be
@@ -58,18 +59,18 @@ public class NetworkController implements PlanningView {
      */
     @FunctionalInterface
     public interface OrderFailureListener {
-        void onOrderFailed(UUID orderId, BlockPos requester, ItemVariant item,
-                           long amount, List<ItemVariant> missing);
+        void onOrderFailed(UUID orderId, BlockPos requester, IItemKey item,
+                           long amount, List<IItemKey> missing);
     }
 
     // Per-item supply entries, sorted by priority ascending (1 = real stock first, 5 = crafter fallback)
-    private final Map<ItemVariant, List<SupplyEntry>> supplyTable = new HashMap<>();
+    private final Map<IItemKey, List<SupplyEntry>> supplyTable = new HashMap<>();
 
     // Standing orders in insertion order (FIFO)
     private final Map<UUID, Order> orderQueue = new LinkedHashMap<>();
 
     // How many items each requester has outstanding (ordered but not yet delivered)
-    private final Map<BlockPos, Map<ItemVariant, Long>> orderedForRequester = new HashMap<>();
+    private final Map<BlockPos, Map<IItemKey, Long>> orderedForRequester = new HashMap<>();
 
     // Fulfillment-check callbacks for dynamic providers (crafters, machines, etc.)
     private final Map<BlockPos, ProviderCanFulfill> providerChecks = new HashMap<>();
@@ -108,10 +109,10 @@ public class NetworkController implements PlanningView {
      * Replaces all previous supply entries for this position with the new inventory snapshot.
      *
      * @param pos      provider position
-     * @param items    current available items (ItemVariant → amount)
+     * @param items    current available items (IItemKey → amount)
      * @param priority dispatch priority (lower = preferred; 1 = real stock, 5 = crafter)
      */
-    public void registerSupply(BlockPos pos, Map<ItemVariant, Long> items, int priority) {
+    public void registerSupply(BlockPos pos, Map<IItemKey, Long> items, int priority) {
         // Remove all existing entries for this position
         for (List<SupplyEntry> entries : supplyTable.values()) {
             entries.removeIf(e -> e.pos.equals(pos));
@@ -119,7 +120,7 @@ public class NetworkController implements PlanningView {
         supplyTable.entrySet().removeIf(e -> e.getValue().isEmpty());
 
         // Add fresh entries, maintaining sorted order by priority
-        for (Map.Entry<ItemVariant, Long> entry : items.entrySet()) {
+        for (Map.Entry<IItemKey, Long> entry : items.entrySet()) {
             if (entry.getValue() < 0) continue;
             List<SupplyEntry> list = supplyTable.computeIfAbsent(entry.getKey(), k -> new ArrayList<>());
             list.add(new SupplyEntry(pos, entry.getValue(), priority));
@@ -144,7 +145,7 @@ public class NetworkController implements PlanningView {
      *
      * @return UUID of the new order (store for later cancellation)
      */
-    public UUID placeOrder(ItemVariant item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode) {
+    public UUID placeOrder(IItemKey item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode) {
         if (amount <= 0) throw new IllegalArgumentException("Order amount must be positive, got: " + amount);
         UUID id = UUID.randomUUID();
         orderQueue.put(id, new Order(id, item, amount, requester, fulfillmentMode));
@@ -152,12 +153,12 @@ public class NetworkController implements PlanningView {
                 .computeIfAbsent(requester, k -> new HashMap<>())
                 .merge(item, amount, Long::sum);
         NetDbg.out("Order placed: {} | {}x {} → {} (requester)",
-                id.toString().substring(0, 8), amount, item.toStack().getItem(), requester);
+                id.toString().substring(0, 8), amount, item.toStack(1).getItem(), requester);
         return id;
     }
 
     /** Place a standing order with default {@link FulfillmentMode#PARTIAL} fulfillment. */
-    public UUID placeOrder(ItemVariant item, long amount, BlockPos requester) {
+    public UUID placeOrder(IItemKey item, long amount, BlockPos requester) {
         return placeOrder(item, amount, requester, FulfillmentMode.PARTIAL);
     }
 
@@ -244,7 +245,7 @@ public class NetworkController implements PlanningView {
 
         if (supply.available == 0) {
             // On-demand supply (crafter): validate ingredient chain before dispatching
-            List<ItemVariant> missing = getMissingIngredients(order.item(), order.amount());
+            List<IItemKey> missing = getMissingIngredients(order.item(), order.amount());
             if (!missing.isEmpty()) {
                 cancelAndNotify(orderIt, order, missing);
                 return null;
@@ -285,7 +286,7 @@ public class NetworkController implements PlanningView {
         if (order.fulfillmentMode() == FulfillmentMode.FULL
                 && getAvailableAmount(order.item()) < order.amount()) return null;
         if (crafterExists) {
-            List<ItemVariant> missing = getMissingIngredients(order.item(), order.amount());
+            List<IItemKey> missing = getMissingIngredients(order.item(), order.amount());
             if (!missing.isEmpty()) {
                 cancelAndNotify(orderIt, order, missing);
                 return null;
@@ -339,9 +340,9 @@ public class NetworkController implements PlanningView {
      * Record physical delivery of items to a requester. Decrements orderedForRequester.
      * Called by PipeRuntime when a TravelingItem enters an inventory.
      */
-    public void notifyDelivery(BlockPos requester, ItemVariant item, long amount) {
+    public void notifyDelivery(BlockPos requester, IItemKey item, long amount) {
         if (amount <= 0) return;
-        NetDbg.out("Delivery notified: {} received {}x {}", requester, amount, item.toStack().getItem());
+        NetDbg.out("Delivery notified: {} received {}x {}", requester, amount, item.toStack(1).getItem());
         decrementOrdered(requester, item, amount);
         reservationManager.markDelivered(requester, item);
     }
@@ -353,9 +354,9 @@ public class NetworkController implements PlanningView {
      * (from real stock + dynamic providers, recursively). Otherwise returns the terminal missing
      * ingredient(s). Creates a fresh shared-reservation context for the whole validation tree.
      */
-    public List<ItemVariant> getMissingIngredients(ItemVariant item, long amount) {
-        Map<ItemVariant, Long> claimed = new HashMap<>();
-        Set<ItemVariant> visited = new HashSet<>();
+    public List<IItemKey> getMissingIngredients(IItemKey item, long amount) {
+        Map<IItemKey, Long> claimed = new HashMap<>();
+        Set<IItemKey> visited = new HashSet<>();
         return collectMissing(item, amount, claimed, visited);
     }
 
@@ -369,9 +370,9 @@ public class NetworkController implements PlanningView {
      * <p>{@code visited} is a DFS path guard against ingredient cycles. Items are removed on
      * exit from the {@code finally} block so they can appear in separate branches.
      */
-    private List<ItemVariant> collectMissing(
-            ItemVariant item, long amount,
-            Map<ItemVariant, Long> claimed, Set<ItemVariant> visited) {
+    private List<IItemKey> collectMissing(
+            IItemKey item, long amount,
+            Map<IItemKey, Long> claimed, Set<IItemKey> visited) {
         if (!visited.add(item)) return List.of(); // cycle guard: optimistically assume satisfiable
 
         try {
@@ -413,8 +414,8 @@ public class NetworkController implements PlanningView {
                         return List.of(item);
                     }
                     IngredientChecker checker = (ing, amt) ->
-                            collectMissing(ItemVariant.of(ing), amt, claimed, visited);
-                    List<ItemVariant> missing = check.getMissing(remaining, checker);
+                            collectMissing(ItemStorageLookup.of(ing), amt, claimed, visited);
+                    List<IItemKey> missing = check.getMissing(remaining, checker);
                     if (missing.isEmpty()) return List.of();
                     return missing; // return first failure; only one provider is tried
                 }
@@ -451,7 +452,7 @@ public class NetworkController implements PlanningView {
      * Entries are in priority order (same as the internal supply table).
      */
     @Override
-    public List<PlanningView.SupplyPoint> getSupply(ItemVariant item) {
+    public List<PlanningView.SupplyPoint> getSupply(IItemKey item) {
         List<SupplyEntry> entries = supplyTable.get(item);
         if (entries == null || entries.isEmpty()) return List.of();
         List<PlanningView.SupplyPoint> result = new ArrayList<>(entries.size());
@@ -487,8 +488,8 @@ public class NetworkController implements PlanningView {
      * Get how many items are currently ordered (in-flight or pending) for a requester.
      * Used by suppliers/requesters to avoid placing duplicate orders.
      */
-    public long getOrderedAmountFor(BlockPos requester, ItemVariant item) {
-        Map<ItemVariant, Long> map = orderedForRequester.get(requester);
+    public long getOrderedAmountFor(BlockPos requester, IItemKey item) {
+        Map<IItemKey, Long> map = orderedForRequester.get(requester);
         return map == null ? 0L : map.getOrDefault(item, 0L);
     }
 
@@ -497,7 +498,7 @@ public class NetworkController implements PlanningView {
      * Returns Long.MAX_VALUE if any crafter entry (available == 0) can produce it on demand,
      * since the item can always be crafted. Otherwise returns the sum of real-stock amounts.
      */
-    public long getAvailableAmount(ItemVariant item) {
+    public long getAvailableAmount(IItemKey item) {
         List<SupplyEntry> entries = supplyTable.get(item);
         if (entries == null || entries.isEmpty()) return 0L;
         long total = 0;
@@ -513,7 +514,7 @@ public class NetworkController implements PlanningView {
      */
     public Map<ItemStack, Long> getAllAvailableItems() {
         Map<ItemStack, Long> result = new HashMap<>();
-        for (Map.Entry<ItemVariant, List<SupplyEntry>> entry : supplyTable.entrySet()) {
+        for (Map.Entry<IItemKey, List<SupplyEntry>> entry : supplyTable.entrySet()) {
             long total = 0;
             for (SupplyEntry e : entry.getValue()) {
                 total += e.available; // 0 for crafters; positive for real stock
@@ -530,7 +531,7 @@ public class NetworkController implements PlanningView {
      */
     public void merge(NetworkController other) {
         // Merge supply tables (re-sort by priority after combining)
-        for (Map.Entry<ItemVariant, List<SupplyEntry>> entry : other.supplyTable.entrySet()) {
+        for (Map.Entry<IItemKey, List<SupplyEntry>> entry : other.supplyTable.entrySet()) {
             List<SupplyEntry> myList = supplyTable.computeIfAbsent(entry.getKey(), k -> new ArrayList<>());
             for (SupplyEntry e : entry.getValue()) {
                 myList.add(e.copy());
@@ -544,8 +545,8 @@ public class NetworkController implements PlanningView {
         }
 
         // Merge orderedForRequester
-        for (Map.Entry<BlockPos, Map<ItemVariant, Long>> entry : other.orderedForRequester.entrySet()) {
-            Map<ItemVariant, Long> myMap =
+        for (Map.Entry<BlockPos, Map<IItemKey, Long>> entry : other.orderedForRequester.entrySet()) {
+            Map<IItemKey, Long> myMap =
                     orderedForRequester.computeIfAbsent(entry.getKey(), k -> new HashMap<>());
             entry.getValue().forEach((variant, amount) -> myMap.merge(variant, amount, Long::sum));
         }
@@ -563,20 +564,20 @@ public class NetworkController implements PlanningView {
     // ===== Helpers =====
 
     private void cancelAndNotify(
-            Iterator<Map.Entry<UUID, Order>> orderIt, Order order, List<ItemVariant> missing) {
+            Iterator<Map.Entry<UUID, Order>> orderIt, Order order, List<IItemKey> missing) {
         orderIt.remove();
         decrementOrdered(order.requester(), order.item(), order.amount());
         NetDbg.out("Order failed (missing ingredients): {} | {}x {} → {} | missing: {}",
                 order.id().toString().substring(0, 8), order.amount(),
-                order.item().toStack().getItem(), order.requester(), missing);
+                order.item().toStack(1).getItem(), order.requester(), missing);
         if (failureListener != null) {
             failureListener.onOrderFailed(
                     order.id(), order.requester(), order.item(), order.amount(), missing);
         }
     }
 
-    private void decrementOrdered(BlockPos requester, ItemVariant item, long amount) {
-        Map<ItemVariant, Long> map = orderedForRequester.get(requester);
+    private void decrementOrdered(BlockPos requester, IItemKey item, long amount) {
+        Map<IItemKey, Long> map = orderedForRequester.get(requester);
         if (map != null) {
             long remaining = map.merge(item, -amount, Long::sum);
             if (remaining <= 0) map.remove(item);

--- a/common/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/common/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -241,7 +241,13 @@ public class NetworkController implements PlanningView {
     @Nullable
     private DispatchCommand tryDispatch(
             Iterator<Map.Entry<UUID, Order>> orderIt, Order order, List<SupplyEntry> entries) {
-        SupplyEntry supply = entries.getFirst();
+        // Skip deferred providers (buffer full this tick) to find the first dispatchable source
+        int supplyIdx = 0;
+        while (supplyIdx < entries.size() && deferredProviders.contains(entries.get(supplyIdx).pos)) {
+            supplyIdx++;
+        }
+        if (supplyIdx >= entries.size()) return null;
+        SupplyEntry supply = entries.get(supplyIdx);
 
         if (supply.available == 0) {
             // On-demand supply (crafter): validate ingredient chain before dispatching
@@ -267,7 +273,7 @@ public class NetworkController implements PlanningView {
             reservationManager.reserve(order.id(), supply.pos, order.requester(),
                     order.item(), order.amount(), true);
             if (effective - order.amount() == 0) {
-                entries.removeFirst();
+                entries.remove(supplyIdx);
                 if (entries.isEmpty()) supplyTable.remove(order.item());
             }
             return new DispatchCommand(
@@ -296,7 +302,7 @@ public class NetworkController implements PlanningView {
         // Pre-check passed (or no crafter covers this item): dispatch partial stock now
         reservationManager.reserve(order.id(), supply.pos, order.requester(),
                 order.item(), effective, true);
-        entries.removeFirst();
+        entries.remove(supplyIdx);
         if (entries.isEmpty()) supplyTable.remove(order.item());
         return new DispatchCommand(
                 order.id(), supply.pos, order.requester(), order.item(), effective);

--- a/common/src/main/java/com/logistics/pipe/network/NetworkJob.java
+++ b/common/src/main/java/com/logistics/pipe/network/NetworkJob.java
@@ -1,8 +1,7 @@
 package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.FulfillmentMode;
-import com.logistics.core.lib.network.ItemRequest;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.ArrayList;
@@ -16,22 +15,16 @@ import java.util.UUID;
  * <p>Tracks amounts at three resolution levels:
  * <ul>
  *   <li>{@link #requestedAmount()} — what the requester asked for</li>
- *   <li>{@link #plannedAmount()}   — what the network committed to source (≤ requested for PARTIAL jobs)</li>
+ *   <li>{@link #plannedAmount()}   — what the network committed to source</li>
  *   <li>{@link #deliveredAmount()} — what has physically arrived at the destination</li>
  * </ul>
  *
- * <p>{@link #outstanding()} = plannedAmount − deliveredAmount − invalidatedAmount.
- * When outstanding reaches 0 the job transitions to {@link JobState#COMPLETE}.
- *
- * <p>Mutable state; mutated only by {@link JobCoordinator}. Created via
- * {@link JobCoordinator#submit(ItemRequest)}.
- *
- * <p>Zero Minecraft API coupling beyond BlockPos/ItemVariant.
+ * <p>Mutable state; mutated only by {@link JobCoordinator}.
  */
 public final class NetworkJob {
 
     private final UUID id;
-    private final ItemVariant item;
+    private final IItemKey item;
     private final long requestedAmount;
     private long plannedAmount;
     private long deliveredAmount;
@@ -41,7 +34,7 @@ public final class NetworkJob {
     private final List<WorkOrder> workOrders = new ArrayList<>();
     private JobState state;
 
-    NetworkJob(UUID id, ItemVariant item, long requestedAmount, long plannedAmount,
+    NetworkJob(UUID id, IItemKey item, long requestedAmount, long plannedAmount,
                FulfillmentMode fulfillmentMode, BlockPos destination) {
         this.id = id;
         this.item = item;
@@ -52,77 +45,51 @@ public final class NetworkJob {
         this.state = JobState.PLANNED;
     }
 
-    // ===== Identity =====
-
     public UUID id() { return id; }
-    public ItemVariant item() { return item; }
+    public IItemKey item() { return item; }
     public FulfillmentMode fulfillmentMode() { return fulfillmentMode; }
     public BlockPos destination() { return destination; }
-
-    // ===== Amount tracking =====
-
     public long requestedAmount() { return requestedAmount; }
     public long plannedAmount() { return plannedAmount; }
     public long deliveredAmount() { return deliveredAmount; }
     public long invalidatedAmount() { return invalidatedAmount; }
 
-    /**
-     * Amount still expected to arrive: planned − delivered − invalidated.
-     * Zero when the job is complete or fully failed.
-     */
     public long outstanding() {
         return Math.max(0L, plannedAmount - deliveredAmount - invalidatedAmount);
     }
 
-    // ===== State =====
-
     public JobState state() { return state; }
-
-    // ===== Work orders =====
 
     public List<WorkOrder> workOrders() {
         return Collections.unmodifiableList(workOrders);
     }
 
-    // ===== Package-private mutation (JobCoordinator only) =====
-
-    void addWorkOrder(WorkOrder order) {
-        workOrders.add(order);
-    }
-
-    void setPlannedAmount(long amount) {
-        this.plannedAmount = amount;
-    }
+    void addWorkOrder(WorkOrder order) { workOrders.add(order); }
+    void setPlannedAmount(long amount) { this.plannedAmount = amount; }
 
     void transitionTo(JobState newState) {
-        if (state.isTerminal()) return; // no transitions out of terminal states
+        if (state.isTerminal()) return;
         this.state = newState;
     }
 
     void recordDelivery(long amount) {
         if (amount <= 0) return;
         deliveredAmount += amount;
-        if (outstanding() <= 0) {
-            state = JobState.COMPLETE;
-        } else {
-            state = JobState.DELIVERING;
-        }
+        if (outstanding() <= 0) state = JobState.COMPLETE;
+        else state = JobState.DELIVERING;
     }
 
     void recordInvalidation(long amount) {
         if (amount <= 0) return;
         invalidatedAmount += amount;
-        if (outstanding() <= 0 && deliveredAmount == 0) {
-            state = JobState.FAILED;
-        } else if (outstanding() <= 0) {
-            state = JobState.COMPLETE; // partially delivered is good enough for PARTIAL jobs
-        }
+        if (outstanding() <= 0 && deliveredAmount == 0) state = JobState.FAILED;
+        else if (outstanding() <= 0) state = JobState.COMPLETE;
     }
 
     @Override
     public String toString() {
         return "NetworkJob[" + id.toString().substring(0, 8)
-                + " " + item.toStack().getItem()
+                + " " + item.toStack(1).getItem()
                 + " req=" + requestedAmount + " plan=" + plannedAmount
                 + " del=" + deliveredAmount + " inv=" + invalidatedAmount
                 + " " + state + "]";

--- a/common/src/main/java/com/logistics/pipe/network/NetworkSnapshotBuilder.java
+++ b/common/src/main/java/com/logistics/pipe/network/NetworkSnapshotBuilder.java
@@ -1,7 +1,7 @@
 package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.*;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.HashMap;
@@ -10,10 +10,6 @@ import java.util.Map;
 
 /**
  * Accumulates snapshot data registered by modules and builds a {@link NetworkSnapshot}.
- *
- * <p>Modules call the {@code register*} methods (analogous to
- * {@link ILogisticsNetwork#registerSupply}) to contribute their current state.
- * Once all modules have reported, {@link #build()} produces an immutable snapshot.
  *
  * <p>A new builder should be created each snapshot cycle; builders are not thread-safe
  * and are not reused across ticks.
@@ -24,49 +20,25 @@ public class NetworkSnapshotBuilder {
     private final Map<BlockPos, SupplierSnapshot> suppliers = new HashMap<>();
     private final Map<BlockPos, CrafterSnapshot> crafters = new HashMap<>();
 
-    /**
-     * Register or replace the provider snapshot for a position.
-     *
-     * @param pos      provider pipe position
-     * @param stock    current available items
-     * @param priority dispatch priority (1 = real stock, 5 = crafter/on-demand)
-     */
-    public void registerProvider(BlockPos pos, Map<ItemVariant, Long> stock, int priority) {
+    public void registerProvider(BlockPos pos, Map<IItemKey, Long> stock, int priority) {
         providers.put(pos, new ProviderSnapshot(pos, stock, priority));
     }
 
-    /**
-     * Register or replace the supplier snapshot for a position.
-     *
-     * @param pos   supplier pipe position
-     * @param slots current state of each configured supply slot
-     */
     public void registerSupplier(BlockPos pos, List<SupplySlotState> slots) {
         suppliers.put(pos, new SupplierSnapshot(pos, slots));
     }
 
-    /**
-     * Register or replace the crafter snapshot for a position.
-     *
-     * @param pos         crafting pipe position
-     * @param output      item the crafter produces
-     * @param outputCount items produced per batch
-     * @param ingredients recipe ingredients
-     * @param buffer      current autocrafter buffer capacity
-     */
-    public void registerCrafter(BlockPos pos, ItemVariant output, long outputCount,
+    public void registerCrafter(BlockPos pos, IItemKey output, long outputCount,
                                 List<RecipeIngredient> ingredients, CrafterBufferState buffer) {
         crafters.put(pos, new CrafterSnapshot(pos, output, outputCount, ingredients, buffer));
     }
 
-    /** Remove all snapshot entries for a position (e.g. when a pipe is removed). */
     public void unregister(BlockPos pos) {
         providers.remove(pos);
         suppliers.remove(pos);
         crafters.remove(pos);
     }
 
-    /** Build an immutable {@link NetworkSnapshot} from the current registered state. */
     public NetworkSnapshot build() {
         return new NetworkSnapshot(providers, suppliers, crafters);
     }

--- a/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -2,7 +2,8 @@ package com.logistics.pipe.network;
 
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.network.*;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
@@ -127,13 +128,13 @@ public class PipeNetwork implements ILogisticsNetwork {
     }
 
     @Override
-    public void registerSupply(BlockPos pos, Map<ItemVariant, Long> items, int priority) {
+    public void registerSupply(BlockPos pos, Map<IItemKey, Long> items, int priority) {
         controller.registerSupply(pos, items, priority);
     }
 
     @Override
     public long getAvailableAmount(ItemStack stack) {
-        return controller.getAvailableAmount(ItemVariant.of(stack));
+        return controller.getAvailableAmount(ItemStorageLookup.of(stack));
     }
 
     @Override
@@ -142,7 +143,7 @@ public class PipeNetwork implements ILogisticsNetwork {
     }
 
     @Override
-    public UUID placeOrder(ItemVariant item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode) {
+    public UUID placeOrder(IItemKey item, long amount, BlockPos requester, FulfillmentMode fulfillmentMode) {
         return controller.placeOrder(item, amount, requester, fulfillmentMode);
     }
 
@@ -172,17 +173,17 @@ public class PipeNetwork implements ILogisticsNetwork {
     }
 
     @Override
-    public List<ItemVariant> getMissingIngredients(ItemVariant item, long amount) {
+    public List<IItemKey> getMissingIngredients(IItemKey item, long amount) {
         return controller.getMissingIngredients(item, amount);
     }
 
     @Override
     public long getOrderedAmountFor(BlockPos requester, ItemStack stack) {
-        return controller.getOrderedAmountFor(requester, ItemVariant.of(stack));
+        return controller.getOrderedAmountFor(requester, ItemStorageLookup.of(stack));
     }
 
     @Override
-    public void notifyDelivery(BlockPos requester, ItemVariant item, long amount) {
+    public void notifyDelivery(BlockPos requester, IItemKey item, long amount) {
         controller.notifyDelivery(requester, item, amount);
         jobCoordinator.onDelivery(requester, item, amount);
     }
@@ -200,7 +201,7 @@ public class PipeNetwork implements ILogisticsNetwork {
         while ((cmd = controller.nextDispatchable()) != null) {
             NetDbg.out("[Network {}] Dispatch: {} | provider={} → requester={} | {}x {}",
                     getNetworkIdShort(id), cmd.orderId().toString().substring(0, 8),
-                    cmd.provider(), cmd.requester(), cmd.amount(), cmd.item().toStack().getItem());
+                    cmd.provider(), cmd.requester(), cmd.amount(), cmd.item().toStack(1).getItem());
             try {
                 CommandResult result = executor.execute(new NetworkCommand.ExtractCommand(
                         cmd.provider(), cmd.requester(), cmd.item(), cmd.amount(), cmd.orderId()));

--- a/common/src/main/java/com/logistics/pipe/network/PlanNode.java
+++ b/common/src/main/java/com/logistics/pipe/network/PlanNode.java
@@ -1,6 +1,6 @@
 package com.logistics.pipe.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.List;
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * A node in a {@link FulfillmentPlan} tree describing how to source an item.
  *
- * <p>Sealed hierarchy — exactly two concrete forms:
+ * <p>Sealed hierarchy:
  * <ul>
  *   <li>{@link ExtractNode} — pull items from a real-stock provider</li>
  *   <li>{@link CraftNode}   — trigger a crafter to produce items</li>
@@ -16,27 +16,14 @@ import java.util.List;
  */
 public sealed interface PlanNode permits PlanNode.ExtractNode, PlanNode.CraftNode {
 
-    // ───────────────────────────────────────────────────────────────────────
-
-    /**
-     * Pull {@code amount} of {@code item} from a real-stock provider.
-     */
     record ExtractNode(
             BlockPos provider,
-            ItemVariant item,
+            IItemKey item,
             long amount) implements PlanNode {}
 
-    // ───────────────────────────────────────────────────────────────────────
-
-    /**
-     * Trigger a crafter to produce {@code batches} worth of {@code output}.
-     *
-     * <p>{@code ingredientDeps} lists sub-plans for ingredients that must be sourced first.
-     * Empty in Phase 6 (ingredient recursion is added in a later phase).
-     */
     record CraftNode(
             BlockPos crafter,
-            ItemVariant output,
+            IItemKey output,
             long batches,
             List<PlanNode> ingredientDeps) implements PlanNode {}
 }

--- a/common/src/main/java/com/logistics/pipe/network/PlanningContext.java
+++ b/common/src/main/java/com/logistics/pipe/network/PlanningContext.java
@@ -1,7 +1,7 @@
 package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.PlanningView;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,8 +22,8 @@ import java.util.Set;
  */
 final class PlanningContext {
 
-    final Map<ItemVariant, Long> claimed = new HashMap<>();
-    final Set<ItemVariant> visited = new HashSet<>();
+    final Map<IItemKey, Long> claimed = new HashMap<>();
+    final Set<IItemKey> visited = new HashSet<>();
 
     static PlanningContext fresh() {
         return new PlanningContext();
@@ -34,7 +34,7 @@ final class PlanningContext {
      * claimed in this planning run.
      * Crafter entries ({@code available == 0}) are excluded from the stock sum.
      */
-    long effectiveRealStock(ItemVariant item, List<PlanningView.SupplyPoint> supply) {
+    long effectiveRealStock(IItemKey item, List<PlanningView.SupplyPoint> supply) {
         long raw = 0;
         for (PlanningView.SupplyPoint sp : supply) {
             if (sp.available() > 0) raw += sp.available();

--- a/common/src/main/java/com/logistics/pipe/network/ProviderSnapshot.java
+++ b/common/src/main/java/com/logistics/pipe/network/ProviderSnapshot.java
@@ -1,6 +1,6 @@
 package com.logistics.pipe.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.Map;
@@ -9,14 +9,13 @@ import java.util.Map;
  * Immutable snapshot of what a provider pipe has available at the moment of capture.
  * Pure value object — no Minecraft world coupling.
  */
-public record ProviderSnapshot(BlockPos pos, Map<ItemVariant, Long> stock, int priority) {
+public record ProviderSnapshot(BlockPos pos, Map<IItemKey, Long> stock, int priority) {
     public ProviderSnapshot {
         if (pos == null) throw new NullPointerException("pos must not be null");
-        stock = Map.copyOf(stock); // defensive immutable copy
+        stock = Map.copyOf(stock);
     }
 
-    /** Total available amount of a specific item in this snapshot. */
-    public long available(ItemVariant item) {
+    public long available(IItemKey item) {
         return stock.getOrDefault(item, 0L);
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/RequestPlanner.java
+++ b/common/src/main/java/com/logistics/pipe/network/RequestPlanner.java
@@ -3,7 +3,7 @@ package com.logistics.pipe.network;
 import com.logistics.core.lib.network.CrafterSnapshot;
 import com.logistics.core.lib.network.FulfillmentMode;
 import com.logistics.core.lib.network.PlanningView;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,7 +39,7 @@ public class RequestPlanner {
      * @return a plan describing how to source the item;
      *         {@link FulfillmentPlan#empty()} if FULL mode and cannot fully satisfy
      */
-    public FulfillmentPlan plan(ItemVariant item, long amount, FulfillmentMode mode, PlanningView view) {
+    public FulfillmentPlan plan(IItemKey item, long amount, FulfillmentMode mode, PlanningView view) {
         PlanningContext ctx = PlanningContext.fresh();
         List<PlanNode> roots = new ArrayList<>();
         long planned = planItem(item, amount, view, ctx, roots);
@@ -55,7 +55,7 @@ public class RequestPlanner {
      * @return amount planned (may be less than needed if supply is insufficient)
      */
     private long planItem(
-            ItemVariant item, long needed,
+            IItemKey item, long needed,
             PlanningView view, PlanningContext ctx, List<PlanNode> out) {
         if (!ctx.visited.add(item)) return 0; // cycle guard
         try {

--- a/common/src/main/java/com/logistics/pipe/network/ReservationManager.java
+++ b/common/src/main/java/com/logistics/pipe/network/ReservationManager.java
@@ -1,6 +1,6 @@
 package com.logistics.pipe.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public class ReservationManager {
      * @return a new {@link ReservationId} for this reservation
      */
     public ReservationId reserve(UUID orderId, BlockPos provider, BlockPos requester,
-                                 ItemVariant item, long amount, boolean hard) {
+                                 IItemKey item, long amount, boolean hard) {
         ReservationId id = ReservationId.random();
         byId.put(id, new ItemReservation(id, orderId, provider, requester, item, amount, hard,
                 AllocationState.RESERVED));
@@ -110,7 +110,7 @@ public class ReservationManager {
      * {@code (requester, item)} as {@link AllocationState#DELIVERED} and release it.
      * Called when a {@code TravelingItem} physically arrives at its destination.
      */
-    public void markDelivered(BlockPos requester, ItemVariant item) {
+    public void markDelivered(BlockPos requester, IItemKey item) {
         for (var it = byId.entrySet().iterator(); it.hasNext(); ) {
             ItemReservation res = it.next().getValue();
             if (res.requester.equals(requester) && res.item.equals(item)
@@ -132,7 +132,7 @@ public class ReservationManager {
      * @param raw      raw registered supply amount (from {@code SupplyEntry.available})
      * @return max(0, raw − sum of active reservations)
      */
-    public long effectiveAvailable(BlockPos provider, ItemVariant item, long raw) {
+    public long effectiveAvailable(BlockPos provider, IItemKey item, long raw) {
         long reserved = 0;
         for (ItemReservation res : byId.values()) {
             if (res.provider.equals(provider) && res.item.equals(item) && res.state.isActive()) {

--- a/common/src/main/java/com/logistics/pipe/network/WorkOrder.java
+++ b/common/src/main/java/com/logistics/pipe/network/WorkOrder.java
@@ -1,38 +1,23 @@
 package com.logistics.pipe.network;
 
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A single unit of work within a {@link NetworkJob}.
- * Sealed hierarchy — exactly three concrete forms are possible:
- * <ul>
- *   <li>{@link ExtractWorkOrder} — pull items from a provider</li>
- *   <li>{@link CraftWorkOrder}   — trigger an autocrafter to produce items</li>
- *   <li>{@link DeliverWorkOrder} — route items to the requester</li>
- * </ul>
- * Pure value objects. Use {@link #withLevel(CommitmentLevel)} to produce an updated copy.
+ * Sealed hierarchy — exactly three concrete forms.
  */
 public sealed interface WorkOrder
         permits WorkOrder.ExtractWorkOrder, WorkOrder.CraftWorkOrder, WorkOrder.DeliverWorkOrder {
 
     CommitmentLevel level();
-
-    /** Return a copy of this work order with the given {@link CommitmentLevel}. */
     WorkOrder withLevel(CommitmentLevel newLevel);
 
-    // ───────────────────────────────────────────────────────────────────────
-
-    /**
-     * Pull {@code amount} of {@code item} from a specific provider.
-     *
-     * @param reservation the reservation backing this extraction, or {@code null} if not yet allocated
-     */
     record ExtractWorkOrder(
             @Nullable ReservationId reservation,
             BlockPos provider,
-            ItemVariant item,
+            IItemKey item,
             long amount,
             CommitmentLevel level) implements WorkOrder {
 
@@ -42,14 +27,9 @@ public sealed interface WorkOrder
         }
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-
-    /**
-     * Submit {@code batches} crafting jobs to an autocrafter.
-     */
     record CraftWorkOrder(
             BlockPos crafter,
-            ItemVariant output,
+            IItemKey output,
             long batches,
             CommitmentLevel level) implements WorkOrder {
 
@@ -59,14 +39,9 @@ public sealed interface WorkOrder
         }
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-
-    /**
-     * Deliver {@code amount} of {@code item} to {@code destination}.
-     */
     record DeliverWorkOrder(
             BlockPos destination,
-            ItemVariant item,
+            IItemKey item,
             long amount,
             CommitmentLevel level) implements WorkOrder {
 

--- a/common/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/common/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -388,10 +388,10 @@ public final class PipeRuntime {
             if (pipeStorage != null) {
                 long inserted = pipeStorage.insertTravelingItem(item);
                 if (inserted <= 0) {
-                    notifyDropAndDrop(world, pos, item, inserted);
+                    notifyDropAndDrop(world, pos, item);
                 }
             } else {
-                notifyDropAndDrop(world, pos, item, 0);
+                notifyDropAndDrop(world, pos, item);
             }
             return;
         }
@@ -435,10 +435,10 @@ public final class PipeRuntime {
         }
 
         // Item could not enter any storage — drop it.
-        notifyDropAndDrop(world, pos, item, item.getStack().getCount());
+        notifyDropAndDrop(world, pos, item);
     }
 
-    private static void notifyDropAndDrop(Level world, BlockPos pos, TravelingItem item, long inserted) {
+    private static void notifyDropAndDrop(Level world, BlockPos pos, TravelingItem item) {
         if (item.getDeliveryId() != null && item.getDestination() != null) {
             PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
             if (network != null) {

--- a/common/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/common/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -9,15 +9,13 @@ import com.logistics.pipe.Pipe;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.logistics.pipe.block.entity.PipeItemStorage;
 import com.logistics.pipe.network.NetworkRegistry;
 import com.logistics.pipe.network.PipeNetwork;
 import java.util.ArrayList;
 import java.util.List;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
@@ -265,7 +263,7 @@ public final class PipeRuntime {
                 if (network != null) {
                     network.notifyDelivery(
                             item.getDestination(),
-                            ItemVariant.of(item.getStack()),
+                            ItemStorageLookup.of(item.getStack()),
                             item.getStack().getCount());
                 }
             }
@@ -383,60 +381,70 @@ public final class PipeRuntime {
         Direction direction = item.getDirection();
         BlockPos targetPos = pos.relative(direction);
 
-        Storage<ItemVariant> storage = ItemStorage.SIDED.find(world, targetPos, direction.getOpposite());
+        // Pipe-to-pipe: bypass the capability system entirely and hand off directly.
+        // This preserves TravelingItem metadata (speed, delivery ID, destination).
+        if (world.getBlockEntity(targetPos) instanceof PipeBlockEntity targetPipe) {
+            PipeItemStorage pipeStorage = targetPipe.getItemStorage(direction.getOpposite());
+            if (pipeStorage != null) {
+                long inserted = pipeStorage.insertTravelingItem(item);
+                if (inserted <= 0) {
+                    notifyDropAndDrop(world, pos, item, inserted);
+                }
+            } else {
+                notifyDropAndDrop(world, pos, item, 0);
+            }
+            return;
+        }
+
+        // Non-pipe target: use the loader-agnostic storage lookup.
+        IItemStorage storage = ItemStorageLookup.find(world, targetPos, direction.getOpposite());
 
         if (storage != null) {
-            // For non-pipe storages, give modules a chance to handle the insertion themselves
-            // (e.g., slot-specific insertion into an autocrafter).
-            if (!(storage instanceof PipeItemStorage) && ctx.hasPipe()) {
+            // Give modules a chance to handle insertion (e.g., slot-specific insertion into an autocrafter).
+            if (ctx.hasPipe()) {
                 TravelingItem remaining = ctx.pipe().handleTransfer(ctx.pipeContext(), item, direction);
                 if (remaining == null) return; // module fully handled it
-                item = remaining; // use possibly-modified item for default insertion
+                item = remaining;
             }
 
-            try (Transaction transaction = Transaction.openOuter()) {
-                long inserted;
-                if (storage instanceof PipeItemStorage pipeStorage) {
-                    inserted = pipeStorage.insert(item, transaction);
-                } else {
-                    ItemVariant variant = ItemVariant.of(item.getStack());
-                    inserted = storage.insert(variant, item.getStack().getCount(), transaction);
-                }
+            long inserted = storage.insert(ItemStorageLookup.of(item.getStack()), item.getStack().getCount(), false);
 
-                if (inserted > 0) {
-                    transaction.commit();
-                    // Notify delivery when item fully enters a real inventory (not another pipe).
-                    // Skip on partial insertion — orderedForRequester accounting is best-effort.
-                    if (!(storage instanceof PipeItemStorage) && item.getDeliveryId() != null
-                            && item.getDestination() != null && inserted == item.getStack().getCount()) {
-                        PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
-                        if (network != null) {
-                            network.notifyDelivery(
-                                    item.getDestination(),
-                                    ItemVariant.of(item.getStack()),
-                                    inserted);
-                        } else {
-                            NetDbg.out("[PipeRuntime] notifyDelivery skipped at {}: no network found for {} ({})",
-                                    pos, item.getStack().getItem(), item.getDeliveryId());
-                        }
+            if (inserted > 0) {
+                // Notify delivery when item fully enters a real inventory.
+                // Skip on partial insertion — orderedForRequester accounting is best-effort.
+                if (item.getDeliveryId() != null
+                        && item.getDestination() != null
+                        && inserted == item.getStack().getCount()) {
+                    PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
+                    if (network != null) {
+                        network.notifyDelivery(
+                                item.getDestination(),
+                                ItemStorageLookup.of(item.getStack()),
+                                inserted);
+                    } else {
+                        NetDbg.out("[PipeRuntime] notifyDelivery skipped at {}: no network found for {} ({})",
+                                pos, item.getStack().getItem(), item.getDeliveryId());
                     }
-                    if (inserted < item.getStack().getCount()) {
-                        item.getStack().shrink((int) inserted);
-                        PipeBlockEntity.dropItem(world, pos, item);
-                    }
-                    return;
                 }
+                if (inserted < item.getStack().getCount()) {
+                    item.getStack().shrink((int) inserted);
+                    PipeBlockEntity.dropItem(world, pos, item);
+                }
+                return;
             }
         }
 
-        // Item could not enter any storage — drop it. If it had delivery tracking,
-        // notify the network so orderedForRequester doesn't stay permanently elevated.
+        // Item could not enter any storage — drop it.
+        notifyDropAndDrop(world, pos, item, item.getStack().getCount());
+    }
+
+    private static void notifyDropAndDrop(Level world, BlockPos pos, TravelingItem item, long inserted) {
         if (item.getDeliveryId() != null && item.getDestination() != null) {
             PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
             if (network != null) {
                 network.notifyDelivery(
                         item.getDestination(),
-                        ItemVariant.of(item.getStack()),
+                        ItemStorageLookup.of(item.getStack()),
                         item.getStack().getCount());
             }
         }

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -12,11 +12,10 @@ import com.logistics.power.engine.block.StirlingEngineBlock;
 import com.logistics.power.engine.ui.StirlingEngineScreenHandler;
 import com.logistics.LogisticsPower;
 import net.fabricmc.fabric.api.menu.v1.ExtendedMenuProvider;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
-import java.util.Iterator;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -137,33 +136,56 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     // ==================== HasItemStorage ====================
 
     @Override
-    public Storage<ItemVariant> itemStorage(@Nullable Direction side) {
+    public IItemStorage itemStorage(@Nullable Direction side) {
         // Don't expose inventory on the output face (facing direction)
         if (side != null && isOutputDirection(side)) {
             return null;
         }
 
-        Storage<ItemVariant> baseStorage = inventory.storage();
-
-        // Wrap storage to validate fuel items (matches GUI validation behavior)
-        return new Storage<ItemVariant>() {
+        // Wrap the single fuel slot with fuel-validation logic
+        return new IItemStorage() {
             @Override
-            public long insert(ItemVariant resource, long maxAmount, TransactionContext transaction) {
+            public long insert(IItemKey item, long maxAmount, boolean simulate) {
                 // Reject non-fuel items (same validation as isValid() for GUI)
-                if (level == null || !level.fuelValues().isFuel(resource.toStack())) {
+                if (level == null || !level.fuelValues().isFuel(item.toStack(1))) {
                     return 0;
                 }
-                return baseStorage.insert(resource, maxAmount, transaction);
+                ItemStack current = inventory.getItem(0);
+                ItemStack incoming = item.toStack((int) maxAmount);
+                if (current.isEmpty()) {
+                    if (!simulate) inventory.setItem(0, incoming);
+                    return maxAmount;
+                } else if (ItemStack.isSameItemSameComponents(current, incoming)) {
+                    long canFit = current.getMaxStackSize() - current.getCount();
+                    long toInsert = Math.min(maxAmount, canFit);
+                    if (toInsert > 0 && !simulate) {
+                        current.grow((int) toInsert);
+                        inventory.setChanged();
+                    }
+                    return toInsert;
+                }
+                return 0;
             }
 
             @Override
-            public long extract(ItemVariant resource, long maxAmount, TransactionContext transaction) {
-                return baseStorage.extract(resource, maxAmount, transaction);
+            public long extract(IItemKey item, long maxAmount, boolean simulate) {
+                ItemStack current = inventory.getItem(0);
+                if (current.isEmpty() || !item.matches(current)) return 0;
+                long toExtract = Math.min(maxAmount, current.getCount());
+                if (!simulate) inventory.removeItem(0, (int) toExtract);
+                return toExtract;
             }
 
             @Override
-            public Iterator<StorageView<ItemVariant>> iterator() {
-                return baseStorage.iterator();
+            public Iterable<IItemView> contents() {
+                ItemStack stack = inventory.getItem(0);
+                if (stack.isEmpty()) return java.util.Collections.emptyList();
+                IItemKey key = ItemStorageLookup.of(stack);
+                IItemView view = new IItemView() {
+                    @Override public IItemKey resource() { return key; }
+                    @Override public long amount() { return stack.getCount(); }
+                };
+                return java.util.Collections.singletonList(view);
             }
         };
     }

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -151,11 +151,12 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
                     return 0;
                 }
                 ItemStack current = inventory.getItem(0);
-                ItemStack incoming = item.toStack((int) maxAmount);
+                ItemStack template = item.toStack(1);
+                long clampedAmount = Math.min(maxAmount, template.getMaxStackSize());
                 if (current.isEmpty()) {
-                    if (!simulate) inventory.setItem(0, incoming);
-                    return maxAmount;
-                } else if (ItemStack.isSameItemSameComponents(current, incoming)) {
+                    if (!simulate) inventory.setItem(0, item.toStack((int) clampedAmount));
+                    return clampedAmount;
+                } else if (ItemStack.isSameItemSameComponents(current, template)) {
                     long canFit = current.getMaxStackSize() - current.getCount();
                     long toInsert = Math.min(maxAmount, canFit);
                     if (toInsert > 0 && !simulate) {

--- a/common/src/test/java/com/logistics/pipe/network/JobCoordinatorTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/JobCoordinatorTest.java
@@ -2,8 +2,9 @@ package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.FulfillmentMode;
 import com.logistics.core.lib.network.ItemRequest;
+import com.logistics.core.lib.storage.IItemKey;
 import com.logistics.test.MinecraftTestEnvironment;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.test.TestItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
@@ -34,19 +35,19 @@ class JobCoordinatorTest extends MinecraftTestEnvironment {
         controller.setOrderFailureListener(coordinator);
     }
 
-    private ItemVariant diamond() {
-        return ItemVariant.of(new ItemStack(Items.DIAMOND));
+    private IItemKey diamond() {
+        return new TestItemKey(Items.DIAMOND);
     }
 
-    private ItemVariant emerald() {
-        return ItemVariant.of(new ItemStack(Items.EMERALD));
+    private IItemKey emerald() {
+        return new TestItemKey(Items.EMERALD);
     }
 
-    private ItemRequest partialRequest(ItemVariant item, long amount, BlockPos dest) {
+    private ItemRequest partialRequest(IItemKey item, long amount, BlockPos dest) {
         return new ItemRequest(item, amount, dest, FulfillmentMode.PARTIAL);
     }
 
-    private ItemRequest fullRequest(ItemVariant item, long amount, BlockPos dest) {
+    private ItemRequest fullRequest(IItemKey item, long amount, BlockPos dest) {
         return new ItemRequest(item, amount, dest, FulfillmentMode.FULL);
     }
 

--- a/common/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
@@ -1,8 +1,9 @@
 package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.FulfillmentMode;
+import com.logistics.core.lib.storage.IItemKey;
 import com.logistics.test.MinecraftTestEnvironment;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.test.TestItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
@@ -39,28 +40,28 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
         controller = new NetworkController();
     }
 
-    private ItemVariant diamond() {
-        return ItemVariant.of(new ItemStack(Items.DIAMOND));
+    private IItemKey diamond() {
+        return new TestItemKey(Items.DIAMOND);
     }
 
-    private ItemVariant emerald() {
-        return ItemVariant.of(new ItemStack(Items.EMERALD));
+    private IItemKey emerald() {
+        return new TestItemKey(Items.EMERALD);
     }
 
-    private ItemVariant oakLog() {
-        return ItemVariant.of(new ItemStack(Items.OAK_LOG));
+    private IItemKey oakLog() {
+        return new TestItemKey(Items.OAK_LOG);
     }
 
-    private ItemVariant oakPlanks() {
-        return ItemVariant.of(new ItemStack(Items.OAK_PLANKS));
+    private IItemKey oakPlanks() {
+        return new TestItemKey(Items.OAK_PLANKS);
     }
 
-    private ItemVariant stick() {
-        return ItemVariant.of(new ItemStack(Items.STICK));
+    private IItemKey stick() {
+        return new TestItemKey(Items.STICK);
     }
 
-    private ItemVariant ironIngot() {
-        return ItemVariant.of(new ItemStack(Items.IRON_INGOT));
+    private IItemKey ironIngot() {
+        return new TestItemKey(Items.IRON_INGOT);
     }
 
     // ===== Supply Registration =====
@@ -389,10 +390,10 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
     void testSharedClaimed_siblingBranchesSeeSameStock() {
         // Chain: G crafter needs 1 A + 1 B; A crafter needs 1 X; B crafter needs 1 X; only 1 X in stock
         // Validation of G should fail because X cannot satisfy both A and B
-        ItemVariant x = ironIngot();
-        ItemVariant a = oakPlanks();
-        ItemVariant b = stick();
-        ItemVariant g = diamond();
+        IItemKey x = ironIngot();
+        IItemKey a = oakPlanks();
+        IItemKey b = stick();
+        IItemKey g = diamond();
 
         controller.registerSupply(PROVIDER1, Map.of(x, 1L), 1);
         controller.registerSupply(CRAFTER_POS, Map.of(a, 0L), 5);
@@ -407,7 +408,7 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
                 checker.check(x.toStack(1), amount));
         // G crafter: 1 A + 1 B → 1 G
         controller.registerProviderCheck(CRAFTER_POS3, (amount, checker) -> {
-            List<ItemVariant> missing = new ArrayList<>();
+            List<IItemKey> missing = new ArrayList<>();
             missing.addAll(checker.check(a.toStack(1), amount)); // uses 1 X
             missing.addAll(checker.check(b.toStack(1), amount)); // needs another X — none left
             return missing;
@@ -473,7 +474,7 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
         controller.registerProviderCheck(CRAFTER_POS, (amount, checker) ->
                 checker.check(new ItemStack(Items.OAK_LOG), amount));
 
-        List<ItemVariant> capturedMissing = new ArrayList<>();
+        List<IItemKey> capturedMissing = new ArrayList<>();
         controller.setOrderFailureListener((orderId, req, item, amt, missing) ->
                 capturedMissing.addAll(missing));
 
@@ -481,7 +482,7 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
         controller.nextDispatchable();
 
         assertFalse(capturedMissing.isEmpty(), "Missing list should be reported");
-        assertTrue(capturedMissing.stream().anyMatch(v -> v.getItem() == Items.OAK_LOG),
+        assertTrue(capturedMissing.stream().anyMatch(v -> v.matches(new ItemStack(Items.OAK_LOG))),
                 "Missing item should be the root ingredient (oak log), got: " + capturedMissing);
     }
 }

--- a/common/src/test/java/com/logistics/pipe/network/ReconciliationServiceTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/ReconciliationServiceTest.java
@@ -1,11 +1,11 @@
 package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.FulfillmentMode;
+import com.logistics.core.lib.storage.IItemKey;
 import com.logistics.test.MinecraftTestEnvironment;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.test.TestItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.ItemStack;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,11 +33,11 @@ class ReconciliationServiceTest extends MinecraftTestEnvironment {
         controller = new NetworkController();
     }
 
-    private ItemVariant diamond() {
-        return ItemVariant.of(new ItemStack(Items.DIAMOND));
+    private IItemKey diamond() {
+        return new TestItemKey(Items.DIAMOND);
     }
 
-    private NetworkJob activeJob(ItemVariant item, long amount, FulfillmentMode mode) {
+    private NetworkJob activeJob(IItemKey item, long amount, FulfillmentMode mode) {
         NetworkJob job = new NetworkJob(UUID.randomUUID(), item, amount, amount, mode, DESTINATION);
         job.transitionTo(JobState.ACTIVE);
         return job;

--- a/common/src/test/java/com/logistics/pipe/network/RequestPlannerTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/RequestPlannerTest.java
@@ -4,11 +4,11 @@ import com.logistics.core.lib.network.CrafterBufferState;
 import com.logistics.core.lib.network.CrafterSnapshot;
 import com.logistics.core.lib.network.FulfillmentMode;
 import com.logistics.core.lib.network.PlanningView;
+import com.logistics.core.lib.storage.IItemKey;
 import com.logistics.test.MinecraftTestEnvironment;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.test.TestItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.ItemStack;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,20 +39,20 @@ class RequestPlannerTest extends MinecraftTestEnvironment {
         controller = new NetworkController();
     }
 
-    private ItemVariant diamond() {
-        return ItemVariant.of(new ItemStack(Items.DIAMOND));
+    private IItemKey diamond() {
+        return new TestItemKey(Items.DIAMOND);
     }
 
-    private ItemVariant emerald() {
-        return ItemVariant.of(new ItemStack(Items.EMERALD));
+    private IItemKey emerald() {
+        return new TestItemKey(Items.EMERALD);
     }
 
-    private ItemVariant oakPlanks() {
-        return ItemVariant.of(new ItemStack(Items.OAK_PLANKS));
+    private IItemKey oakPlanks() {
+        return new TestItemKey(Items.OAK_PLANKS);
     }
 
-    private ItemVariant oakLog() {
-        return ItemVariant.of(new ItemStack(Items.OAK_LOG));
+    private IItemKey oakLog() {
+        return new TestItemKey(Items.OAK_LOG);
     }
 
     // ===== Stock-first planning =====

--- a/common/src/test/java/com/logistics/pipe/network/ReservationManagerTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/ReservationManagerTest.java
@@ -1,10 +1,10 @@
 package com.logistics.pipe.network;
 
+import com.logistics.core.lib.storage.IItemKey;
 import com.logistics.test.MinecraftTestEnvironment;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import com.logistics.test.TestItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.ItemStack;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,12 +30,12 @@ class ReservationManagerTest extends MinecraftTestEnvironment {
         manager = new ReservationManager();
     }
 
-    private ItemVariant diamond() {
-        return ItemVariant.of(new ItemStack(Items.DIAMOND));
+    private IItemKey diamond() {
+        return new TestItemKey(Items.DIAMOND);
     }
 
-    private ItemVariant emerald() {
-        return ItemVariant.of(new ItemStack(Items.EMERALD));
+    private IItemKey emerald() {
+        return new TestItemKey(Items.EMERALD);
     }
 
     // ===== Reserve + effectiveAvailable =====

--- a/common/src/test/java/com/logistics/pipe/network/SinkResolverTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/SinkResolverTest.java
@@ -2,8 +2,8 @@ package com.logistics.pipe.network;
 
 import com.logistics.core.lib.network.IWorldView;
 import com.logistics.core.lib.network.NetworkGraph;
+import com.logistics.core.lib.storage.IItemKey;
 import com.logistics.test.MinecraftTestEnvironment;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
@@ -35,7 +35,7 @@ class SinkResolverTest extends MinecraftTestEnvironment {
         @Override public boolean isPipe(BlockPos pos) { return false; }
         @Override public List<BlockPos> getConnectedNeighbors(BlockPos pos) { return List.of(); }
         @Override public boolean matchesSinkFilter(BlockPos pos, ItemStack stack) { return accepting.contains(pos); }
-        @Override public long dispatch(BlockPos p, BlockPos r, ItemVariant i, long a, UUID d) { return 0; }
+        @Override public long dispatch(BlockPos p, BlockPos r, IItemKey i, long a, UUID d) { return 0; }
         @Override public boolean isClientSide() { return false; }
         @Override public void broadcastAlert(BlockPos pos, Component message) {}
     };

--- a/common/src/test/java/com/logistics/test/MinecraftTestEnvironment.java
+++ b/common/src/test/java/com/logistics/test/MinecraftTestEnvironment.java
@@ -1,5 +1,6 @@
 package com.logistics.test;
 
+import com.logistics.core.lib.storage.ItemStorageLookup;
 import com.mojang.serialization.Lifecycle;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.Holder;
@@ -91,6 +92,10 @@ public abstract class MinecraftTestEnvironment {
                 BuiltInRegistries.DATA_COMPONENT_INITIALIZERS
                         .build(tagSafeRegistries)
                         .forEach(DataComponentInitializers.PendingComponents::apply);
+
+                // Register the test-environment key factory so ItemStorageLookup.of() works
+                // without a loader-specific implementation (Fabric/NeoForge).
+                ItemStorageLookup.registerKeyFactory(TestItemKey::of);
 
                 bootstrapped = true;
             } catch (Exception e) {

--- a/common/src/test/java/com/logistics/test/TestItemKey.java
+++ b/common/src/test/java/com/logistics/test/TestItemKey.java
@@ -1,0 +1,54 @@
+package com.logistics.test;
+
+import com.logistics.core.lib.storage.IItemKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Objects;
+
+/**
+ * Loader-agnostic {@link IItemKey} implementation for unit tests.
+ *
+ * <p>Identifies items by {@link Item} identity only (no NBT/components).
+ * Register the factory via {@code ItemStorageLookup.registerKeyFactory(TestItemKey::of)}
+ * in test setup.
+ */
+public final class TestItemKey implements IItemKey {
+
+    private final Item item;
+
+    public TestItemKey(Item item) {
+        this.item = item;
+    }
+
+    public static TestItemKey of(ItemStack stack) {
+        return new TestItemKey(stack.getItem());
+    }
+
+    @Override
+    public ItemStack toStack(int count) {
+        return new ItemStack(item, count);
+    }
+
+    @Override
+    public boolean matches(ItemStack stack) {
+        return stack.is(item);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TestItemKey other)) return false;
+        return Objects.equals(item, other.item);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(item);
+    }
+
+    @Override
+    public String toString() {
+        return "TestItemKey[" + item + "]";
+    }
+}

--- a/fabric/src/gametest/java/com/logistics/gametest/automation/KilnGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/automation/KilnGameTest.java
@@ -3,9 +3,8 @@ package com.logistics.gametest.automation;
 import com.logistics.LogisticsAutomation;
 import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.kiln.KilnBlockEntity;
+import com.logistics.core.lib.storage.IItemStorage;
 import net.fabricmc.fabric.api.gametest.v1.GameTest;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTestHelper;
@@ -208,7 +207,7 @@ public class KilnGameTest {
         }
 
         for (Direction direction : Direction.values()) {
-            Storage<ItemVariant> storage = kiln.itemStorage(direction);
+            IItemStorage storage = kiln.itemStorage(direction);
             if (storage == null) {
                 context.fail("Kiln should provide item storage from " + direction);
                 return;

--- a/fabric/src/gametest/java/com/logistics/gametest/power/EngineGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/EngineGameTest.java
@@ -6,10 +6,9 @@ import com.logistics.power.engine.block.entity.CreativeEngineBlockEntity;
 import com.logistics.power.engine.block.entity.RedstoneEngineBlockEntity;
 import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;
 import com.logistics.core.lib.power.AbstractEngineBlock;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.fabric.storage.FabricItemKey;
 import net.fabricmc.fabric.api.gametest.v1.GameTest;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTestHelper;
@@ -112,7 +111,7 @@ public class EngineGameTest {
         }
 
         // Try to access inventory from the front (NORTH) - should be null
-        Storage<ItemVariant> frontStorage = engine.itemStorage(Direction.NORTH);
+        IItemStorage frontStorage = engine.itemStorage(Direction.NORTH);
         if (frontStorage != null) {
             context.fail("Stirling engine inventory should NOT be accessible from front face (NORTH)");
         }
@@ -138,18 +137,18 @@ public class EngineGameTest {
         }
 
         // Try to access inventory from the back (SOUTH) - should work
-        Storage<ItemVariant> backStorage = engine.itemStorage(Direction.SOUTH);
+        IItemStorage backStorage = engine.itemStorage(Direction.SOUTH);
         if (backStorage == null) {
             context.fail("Stirling engine inventory should be accessible from back face (SOUTH)");
         }
 
         // Try to access from other sides
-        Storage<ItemVariant> topStorage = engine.itemStorage(Direction.UP);
+        IItemStorage topStorage = engine.itemStorage(Direction.UP);
         if (topStorage == null) {
             context.fail("Stirling engine inventory should be accessible from top face");
         }
 
-        Storage<ItemVariant> sideStorage = engine.itemStorage(Direction.EAST);
+        IItemStorage sideStorage = engine.itemStorage(Direction.EAST);
         if (sideStorage == null) {
             context.fail("Stirling engine inventory should be accessible from side faces");
         }
@@ -175,17 +174,14 @@ public class EngineGameTest {
         }
 
         // Insert coal from the back (valid fuel)
-        Storage<ItemVariant> backStorage = engine.itemStorage(Direction.SOUTH);
+        IItemStorage backStorage = engine.itemStorage(Direction.SOUTH);
         if (backStorage == null) {
             context.fail("Back storage should be accessible");
         }
 
-        try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = backStorage.insert(ItemVariant.of(Items.COAL), 1, transaction);
-            if (inserted != 1) {
-                context.fail("Should be able to insert 1 coal, inserted: " + inserted);
-            }
-            transaction.commit();
+        long inserted = backStorage.insert(FabricItemKey.of(new ItemStack(Items.COAL)), 1, false);
+        if (inserted != 1) {
+            context.fail("Should be able to insert 1 coal, inserted: " + inserted);
         }
 
         // Verify coal was added to inventory
@@ -215,17 +211,14 @@ public class EngineGameTest {
         }
 
         // Try to insert dirt (not fuel) from the back
-        Storage<ItemVariant> backStorage = engine.itemStorage(Direction.SOUTH);
+        IItemStorage backStorage = engine.itemStorage(Direction.SOUTH);
         if (backStorage == null) {
             context.fail("Back storage should be accessible");
         }
 
-        try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = backStorage.insert(ItemVariant.of(Items.DIRT), 1, transaction);
-            if (inserted != 0) {
-                context.fail("Should NOT be able to insert dirt (non-fuel), inserted: " + inserted);
-            }
-            transaction.commit();
+        long inserted = backStorage.insert(FabricItemKey.of(new ItemStack(Items.DIRT)), 1, false);
+        if (inserted != 0) {
+            context.fail("Should NOT be able to insert dirt (non-fuel), inserted: " + inserted);
         }
 
         // Verify inventory is still empty

--- a/fabric/src/main/java/com/logistics/fabric/capability/FabricCapabilityRegistration.java
+++ b/fabric/src/main/java/com/logistics/fabric/capability/FabricCapabilityRegistration.java
@@ -2,6 +2,10 @@ package com.logistics.fabric.capability;
 
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.lib.pipe.PipeConnectionLookup;
+import com.logistics.core.lib.storage.ItemStorageLookup;
+import com.logistics.fabric.storage.FabricItemKey;
+import com.logistics.fabric.storage.FabricItemStorage;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
 import net.minecraft.core.Direction;
 
 public final class FabricCapabilityRegistration {
@@ -12,6 +16,13 @@ public final class FabricCapabilityRegistration {
         FluidStorageAccess.register();
         // EnergyStorageAccess is registered separately by LogisticsFabric.registerEnergyServices()
         PipeConnectionAccess.register();
+
+        // Wire ItemStorageLookup so common pipe modules can find IItemStorage without importing Fabric API
+        ItemStorageLookup.register(
+                (world, pos, dir) -> FabricItemStorage.wrap(ItemStorage.SIDED.find(world, pos, dir)));
+
+        // Wire the key factory so common code can construct IItemKey from ItemStack
+        ItemStorageLookup.registerKeyFactory(FabricItemKey::of);
 
         // Quarry: only accepts pipe connections from above
         PipeConnectionRegistry.SIDED.registerForBlockEntity(

--- a/fabric/src/main/java/com/logistics/fabric/capability/ItemStorageAccess.java
+++ b/fabric/src/main/java/com/logistics/fabric/capability/ItemStorageAccess.java
@@ -1,10 +1,11 @@
 package com.logistics.fabric.capability;
 
 import com.logistics.core.lib.block.capability.HasItemStorage;
+import com.logistics.fabric.storage.FabricItemStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
 
 /**
- * Bridges internal {@link HasItemStorage} interface to Fabric's ItemStorage lookup API.
+ * Bridges the loader-agnostic {@link HasItemStorage} interface to Fabric's ItemStorage lookup API.
  * <p>
  * Any block entity implementing HasItemStorage will automatically work with:
  * <ul>
@@ -25,7 +26,7 @@ public final class ItemStorageAccess {
     public static void register() {
         ItemStorage.SIDED.registerFallback((world, pos, state, blockEntity, direction) -> {
             if (blockEntity instanceof HasItemStorage hasStorage) {
-                return hasStorage.itemStorage(direction);
+                return FabricItemStorage.asFabric(hasStorage.itemStorage(direction));
             }
             return null;
         });

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemKey.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemKey.java
@@ -1,0 +1,57 @@
+package com.logistics.fabric.storage;
+
+import com.logistics.core.lib.storage.IItemKey;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Fabric adapter: wraps {@link ItemVariant} as an {@link IItemKey}.
+ *
+ * <p>Equality and hash-code delegate to {@link ItemVariant}, so instances can be used as
+ * {@link java.util.Map} keys with the same semantics as native Fabric code.
+ */
+public final class FabricItemKey implements IItemKey {
+
+    private final ItemVariant variant;
+
+    public FabricItemKey(ItemVariant variant) {
+        this.variant = variant;
+    }
+
+    /** Convenience factory: create a {@code FabricItemKey} from a vanilla stack. */
+    public static FabricItemKey of(ItemStack stack) {
+        return new FabricItemKey(ItemVariant.of(stack));
+    }
+
+    /** Returns the underlying {@link ItemVariant}. */
+    public ItemVariant variant() {
+        return variant;
+    }
+
+    @Override
+    public ItemStack toStack(int count) {
+        return variant.toStack(count);
+    }
+
+    @Override
+    public boolean matches(ItemStack stack) {
+        return ItemVariant.of(stack).equals(variant);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FabricItemKey other)) return false;
+        return variant.equals(other.variant);
+    }
+
+    @Override
+    public int hashCode() {
+        return variant.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "FabricItemKey{" + variant + "}";
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemKey.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemKey.java
@@ -15,6 +15,7 @@ public final class FabricItemKey implements IItemKey {
     private final ItemVariant variant;
 
     public FabricItemKey(ItemVariant variant) {
+        if (variant == null) throw new NullPointerException("variant must not be null");
         this.variant = variant;
     }
 

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
@@ -8,10 +8,10 @@ import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -126,36 +126,50 @@ public final class FabricItemStorage implements IItemStorage {
     /**
      * Fabric {@code Storage<ItemVariant>} backed by an {@link IItemStorage}.
      *
-     * <p>Maintains a per-{@link TransactionContext} staged delta map so that multiple
-     * operations within the same transaction see each other's pending mutations.
-     * Positive delta = pending insert; negative delta = pending extract.
-     * On commit the accumulated deltas are applied to the real storage; on rollback they are discarded.
+     * <p>Extends {@link SnapshotParticipant} to correctly handle nested transactions:
+     * {@code pendingDeltas} is snapshotted at each nesting depth, nested commits merge
+     * into the parent (not into live storage), and {@link #onFinalCommit()} flushes to
+     * the real storage only when the outermost transaction commits.
+     *
+     * <p>Positive delta = pending insert; negative delta = pending extract.
      */
-    private static final class StagedStorage implements Storage<ItemVariant> {
+    private static final class StagedStorage extends SnapshotParticipant<Map<IItemKey, Long>>
+            implements Storage<ItemVariant> {
 
         private final IItemStorage storage;
-        private final Map<TransactionContext, Map<IItemKey, Long>> staged = new IdentityHashMap<>();
+        private Map<IItemKey, Long> pendingDeltas = new HashMap<>();
 
         StagedStorage(IItemStorage storage) {
             this.storage = storage;
         }
 
-        /** Returns the staged delta map for {@code transaction}, registering the commit/rollback callback on first access. */
-        Map<IItemKey, Long> deltas(TransactionContext transaction) {
-            return staged.computeIfAbsent(transaction, t -> {
-                Map<IItemKey, Long> d = new HashMap<>();
-                t.addCloseCallback((closedTx, result) -> {
-                    Map<IItemKey, Long> committed = staged.remove(closedTx);
-                    if (result.wasCommitted() && committed != null) {
-                        for (var e : committed.entrySet()) {
-                            long delta = e.getValue();
-                            if (delta > 0) storage.insert(e.getKey(), delta, false);
-                            else if (delta < 0) storage.extract(e.getKey(), -delta, false);
-                        }
-                    }
-                });
-                return d;
-            });
+        @Override
+        protected Map<IItemKey, Long> createSnapshot() {
+            return new HashMap<>(pendingDeltas);
+        }
+
+        @Override
+        protected void readSnapshot(Map<IItemKey, Long> snapshot) {
+            pendingDeltas = snapshot;
+        }
+
+        @Override
+        protected void onFinalCommit() {
+            for (var e : pendingDeltas.entrySet()) {
+                long delta = e.getValue();
+                if (delta > 0) storage.insert(e.getKey(), delta, false);
+                else if (delta < 0) storage.extract(e.getKey(), -delta, false);
+            }
+            pendingDeltas = new HashMap<>();
+        }
+
+        /**
+         * Registers this participant with {@code tx} (if not already registered at this nesting depth)
+         * and returns the current pending-delta map for mutation.
+         */
+        Map<IItemKey, Long> deltas(TransactionContext tx) {
+            updateSnapshots(tx);
+            return pendingDeltas;
         }
 
         @Override
@@ -163,7 +177,7 @@ public final class FabricItemStorage implements IItemStorage {
             IItemKey key = new FabricItemKey(resource);
             Map<IItemKey, Long> d = deltas(transaction);
             long netDelta = d.getOrDefault(key, 0L);
-            long effectiveCapacity = Math.max(0, storage.insert(key, Integer.MAX_VALUE, true) - netDelta);
+            long effectiveCapacity = Math.max(0, storage.insert(key, Long.MAX_VALUE, true) - netDelta);
             long toInsert = Math.min(maxAmount, effectiveCapacity);
             if (toInsert > 0) d.merge(key, toInsert, Long::sum);
             return toInsert;
@@ -174,7 +188,7 @@ public final class FabricItemStorage implements IItemStorage {
             IItemKey key = new FabricItemKey(resource);
             Map<IItemKey, Long> d = deltas(transaction);
             long netDelta = d.getOrDefault(key, 0L);
-            long effectiveAvailable = Math.max(0, storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
+            long effectiveAvailable = Math.max(0, storage.extract(key, Long.MAX_VALUE, true) + netDelta);
             long toExtract = Math.min(maxAmount, effectiveAvailable);
             if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
             return toExtract;
@@ -223,7 +237,7 @@ public final class FabricItemStorage implements IItemStorage {
             IItemKey key = new FabricItemKey(resource);
             Map<IItemKey, Long> d = staged.deltas(tx);
             long netDelta = d.getOrDefault(key, 0L);
-            long effectiveAvailable = Math.max(0, staged.storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
+            long effectiveAvailable = Math.max(0, staged.storage.extract(key, Long.MAX_VALUE, true) + netDelta);
             long toExtract = Math.min(Math.min(maxAmount, getAmount()), effectiveAvailable);
             if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
             return toExtract;

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
@@ -97,7 +97,13 @@ public final class FabricItemStorage implements IItemStorage {
                             public long extract(ItemVariant resource, long maxAmount,
                                     net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext tx) {
                                 IItemKey key = new FabricItemKey(resource);
-                                return storage.extract(key, maxAmount, false);
+                                long simulated = storage.extract(key, maxAmount, true);
+                                if (simulated > 0) {
+                                    tx.addCloseCallback((t, result) -> {
+                                        if (result.wasCommitted()) storage.extract(key, simulated, false);
+                                    });
+                                }
+                                return simulated;
                             }
 
                             @Override
@@ -128,7 +134,7 @@ public final class FabricItemStorage implements IItemStorage {
 
     @Override
     public long insert(IItemKey item, long maxAmount, boolean simulate) {
-        ItemVariant variant = ((FabricItemKey) item).variant();
+        ItemVariant variant = item instanceof FabricItemKey fk ? fk.variant() : ItemVariant.of(item.toStack(1));
         if (simulate) {
             try (Transaction t = Transaction.openOuter()) {
                 return storage.insert(variant, maxAmount, t);
@@ -144,7 +150,7 @@ public final class FabricItemStorage implements IItemStorage {
 
     @Override
     public long extract(IItemKey item, long maxAmount, boolean simulate) {
-        ItemVariant variant = ((FabricItemKey) item).variant();
+        ItemVariant variant = item instanceof FabricItemKey fk ? fk.variant() : ItemVariant.of(item.toStack(1));
         if (simulate) {
             try (Transaction t = Transaction.openOuter()) {
                 return storage.extract(variant, maxAmount, t);
@@ -159,15 +165,28 @@ public final class FabricItemStorage implements IItemStorage {
 
     @Override
     public Iterable<IItemView> contents() {
-        return () -> {
-            Iterator<StorageView<ItemVariant>> inner = storage.iterator();
-            return new Iterator<>() {
-                @Override
-                public boolean hasNext() { return inner.hasNext(); }
+        return () -> new Iterator<>() {
+            private final Iterator<StorageView<ItemVariant>> inner = storage.iterator();
+            private StorageView<ItemVariant> pending = advance();
 
-                @Override
-                public IItemView next() { return new FabricItemView(inner.next()); }
-            };
+            private StorageView<ItemVariant> advance() {
+                while (inner.hasNext()) {
+                    StorageView<ItemVariant> v = inner.next();
+                    if (v.getAmount() > 0) return v;
+                }
+                return null;
+            }
+
+            @Override
+            public boolean hasNext() { return pending != null; }
+
+            @Override
+            public IItemView next() {
+                if (pending == null) throw new java.util.NoSuchElementException();
+                IItemView view = new FabricItemView(pending);
+                pending = advance();
+                return view;
+            }
         };
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
@@ -7,6 +7,7 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -57,106 +58,7 @@ public final class FabricItemStorage implements IItemStorage {
      */
     @Nullable
     public static Storage<ItemVariant> asFabric(@Nullable IItemStorage storage) {
-        if (storage == null) return null;
-        // Staged delta map: tracks pending mutations within a TransactionContext so that
-        // multiple operations in the same transaction see each other's effects before commit.
-        // Key = TransactionContext (identity), Value = per-key net delta (positive = pending insert,
-        // negative = pending extract). A single addCloseCallback per transaction applies or discards
-        // all deltas when the transaction closes.
-        Map<net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext, Map<IItemKey, Long>> staged =
-                new IdentityHashMap<>();
-
-        return new Storage<ItemVariant>() {
-
-            private Map<IItemKey, Long> deltas(
-                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
-                return staged.computeIfAbsent(transaction, t -> {
-                    Map<IItemKey, Long> d = new HashMap<>();
-                    t.addCloseCallback((closedTx, result) -> {
-                        Map<IItemKey, Long> committed = staged.remove(closedTx);
-                        if (result.wasCommitted() && committed != null) {
-                            for (var e : committed.entrySet()) {
-                                long delta = e.getValue();
-                                if (delta > 0) storage.insert(e.getKey(), delta, false);
-                                else if (delta < 0) storage.extract(e.getKey(), -delta, false);
-                            }
-                        }
-                    });
-                    return d;
-                });
-            }
-
-            @Override
-            public long insert(ItemVariant resource, long maxAmount,
-                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
-                IItemKey key = new FabricItemKey(resource);
-                Map<IItemKey, Long> d = deltas(transaction);
-                long netDelta = d.getOrDefault(key, 0L);
-                long effectiveCapacity = Math.max(0, storage.insert(key, Integer.MAX_VALUE, true) - netDelta);
-                long toInsert = Math.min(maxAmount, effectiveCapacity);
-                if (toInsert > 0) d.merge(key, toInsert, Long::sum);
-                return toInsert;
-            }
-
-            @Override
-            public long extract(ItemVariant resource, long maxAmount,
-                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
-                IItemKey key = new FabricItemKey(resource);
-                Map<IItemKey, Long> d = deltas(transaction);
-                long netDelta = d.getOrDefault(key, 0L);
-                long effectiveAvailable = Math.max(0, storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
-                long toExtract = Math.min(maxAmount, effectiveAvailable);
-                if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
-                return toExtract;
-            }
-
-            @Override
-            public Iterator<StorageView<ItemVariant>> iterator() {
-                Iterator<IItemView> inner = storage.contents().iterator();
-                return new Iterator<>() {
-                    @Override
-                    public boolean hasNext() { return inner.hasNext(); }
-
-                    @Override
-                    public StorageView<ItemVariant> next() {
-                        IItemView view = inner.next();
-                        return new StorageView<>() {
-                            @Override
-                            public long extract(ItemVariant resource, long maxAmount,
-                                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext tx) {
-                                if (!resource.equals(getResource())) return 0;
-                                IItemKey key = new FabricItemKey(resource);
-                                Map<IItemKey, Long> d = deltas(tx);
-                                long netDelta = d.getOrDefault(key, 0L);
-                                long effectiveAvailable = Math.max(
-                                        0, storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
-                                long toExtract = Math.min(Math.min(maxAmount, getAmount()), effectiveAvailable);
-                                if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
-                                return toExtract;
-                            }
-
-                            @Override
-                            public boolean isResourceBlank() {
-                                return view.resource().toStack(1).isEmpty();
-                            }
-
-                            @Override
-                            public ItemVariant getResource() {
-                                IItemKey key = view.resource();
-                                if (key instanceof FabricItemKey fk) return fk.variant();
-                                return ItemVariant.of(key.toStack(1));
-                            }
-
-                            @Override
-                            public long getAmount() { return view.amount(); }
-
-                            @Override
-                            public long getCapacity() { return view.amount(); }
-                        };
-                    }
-                };
-            }
-        };
+        return storage == null ? null : new StagedStorage(storage);
     }
 
     // ==================== IItemStorage implementation ====================
@@ -217,5 +119,132 @@ public final class FabricItemStorage implements IItemStorage {
                 return view;
             }
         };
+    }
+
+    // ==================== asFabric() inner classes ====================
+
+    /**
+     * Fabric {@code Storage<ItemVariant>} backed by an {@link IItemStorage}.
+     *
+     * <p>Maintains a per-{@link TransactionContext} staged delta map so that multiple
+     * operations within the same transaction see each other's pending mutations.
+     * Positive delta = pending insert; negative delta = pending extract.
+     * On commit the accumulated deltas are applied to the real storage; on rollback they are discarded.
+     */
+    private static final class StagedStorage implements Storage<ItemVariant> {
+
+        private final IItemStorage storage;
+        private final Map<TransactionContext, Map<IItemKey, Long>> staged = new IdentityHashMap<>();
+
+        StagedStorage(IItemStorage storage) {
+            this.storage = storage;
+        }
+
+        /** Returns the staged delta map for {@code transaction}, registering the commit/rollback callback on first access. */
+        Map<IItemKey, Long> deltas(TransactionContext transaction) {
+            return staged.computeIfAbsent(transaction, t -> {
+                Map<IItemKey, Long> d = new HashMap<>();
+                t.addCloseCallback((closedTx, result) -> {
+                    Map<IItemKey, Long> committed = staged.remove(closedTx);
+                    if (result.wasCommitted() && committed != null) {
+                        for (var e : committed.entrySet()) {
+                            long delta = e.getValue();
+                            if (delta > 0) storage.insert(e.getKey(), delta, false);
+                            else if (delta < 0) storage.extract(e.getKey(), -delta, false);
+                        }
+                    }
+                });
+                return d;
+            });
+        }
+
+        @Override
+        public long insert(ItemVariant resource, long maxAmount, TransactionContext transaction) {
+            IItemKey key = new FabricItemKey(resource);
+            Map<IItemKey, Long> d = deltas(transaction);
+            long netDelta = d.getOrDefault(key, 0L);
+            long effectiveCapacity = Math.max(0, storage.insert(key, Integer.MAX_VALUE, true) - netDelta);
+            long toInsert = Math.min(maxAmount, effectiveCapacity);
+            if (toInsert > 0) d.merge(key, toInsert, Long::sum);
+            return toInsert;
+        }
+
+        @Override
+        public long extract(ItemVariant resource, long maxAmount, TransactionContext transaction) {
+            IItemKey key = new FabricItemKey(resource);
+            Map<IItemKey, Long> d = deltas(transaction);
+            long netDelta = d.getOrDefault(key, 0L);
+            long effectiveAvailable = Math.max(0, storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
+            long toExtract = Math.min(maxAmount, effectiveAvailable);
+            if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
+            return toExtract;
+        }
+
+        @Override
+        public Iterator<StorageView<ItemVariant>> iterator() {
+            return new StagedStorageIterator(storage.contents().iterator(), this);
+        }
+    }
+
+    /** Iterates {@link IItemView}s from an {@link IItemStorage}, wrapping each as a {@link StagedStorageView}. */
+    private static final class StagedStorageIterator implements Iterator<StorageView<ItemVariant>> {
+
+        private final Iterator<IItemView> inner;
+        private final StagedStorage staged;
+
+        StagedStorageIterator(Iterator<IItemView> inner, StagedStorage staged) {
+            this.inner = inner;
+            this.staged = staged;
+        }
+
+        @Override
+        public boolean hasNext() { return inner.hasNext(); }
+
+        @Override
+        public StorageView<ItemVariant> next() {
+            return new StagedStorageView(inner.next(), staged);
+        }
+    }
+
+    /** Fabric {@link StorageView} backed by an {@link IItemView}, with transaction-staged extract. */
+    private static final class StagedStorageView implements StorageView<ItemVariant> {
+
+        private final IItemView view;
+        private final StagedStorage staged;
+
+        StagedStorageView(IItemView view, StagedStorage staged) {
+            this.view = view;
+            this.staged = staged;
+        }
+
+        @Override
+        public long extract(ItemVariant resource, long maxAmount, TransactionContext tx) {
+            if (!resource.equals(getResource())) return 0;
+            IItemKey key = new FabricItemKey(resource);
+            Map<IItemKey, Long> d = staged.deltas(tx);
+            long netDelta = d.getOrDefault(key, 0L);
+            long effectiveAvailable = Math.max(0, staged.storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
+            long toExtract = Math.min(Math.min(maxAmount, getAmount()), effectiveAvailable);
+            if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
+            return toExtract;
+        }
+
+        @Override
+        public boolean isResourceBlank() {
+            return view.resource().toStack(1).isEmpty();
+        }
+
+        @Override
+        public ItemVariant getResource() {
+            IItemKey key = view.resource();
+            if (key instanceof FabricItemKey fk) return fk.variant();
+            return ItemVariant.of(key.toStack(1));
+        }
+
+        @Override
+        public long getAmount() { return view.amount(); }
+
+        @Override
+        public long getCapacity() { return view.amount(); }
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
@@ -96,8 +96,10 @@ public final class FabricItemStorage implements IItemStorage {
                             @Override
                             public long extract(ItemVariant resource, long maxAmount,
                                     net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext tx) {
+                                if (!resource.equals(getResource())) return 0;
                                 IItemKey key = new FabricItemKey(resource);
-                                long simulated = storage.extract(key, maxAmount, true);
+                                long bounded = Math.min(maxAmount, getAmount());
+                                long simulated = storage.extract(key, bounded, true);
                                 if (simulated > 0) {
                                     tx.addCloseCallback((t, result) -> {
                                         if (result.wasCommitted()) storage.extract(key, simulated, false);

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
@@ -9,7 +9,10 @@ import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Fabric adapter: wraps a Fabric {@link Storage}{@code <ItemVariant>} as an {@link IItemStorage}.
@@ -55,31 +58,56 @@ public final class FabricItemStorage implements IItemStorage {
     @Nullable
     public static Storage<ItemVariant> asFabric(@Nullable IItemStorage storage) {
         if (storage == null) return null;
+        // Staged delta map: tracks pending mutations within a TransactionContext so that
+        // multiple operations in the same transaction see each other's effects before commit.
+        // Key = TransactionContext (identity), Value = per-key net delta (positive = pending insert,
+        // negative = pending extract). A single addCloseCallback per transaction applies or discards
+        // all deltas when the transaction closes.
+        Map<net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext, Map<IItemKey, Long>> staged =
+                new IdentityHashMap<>();
+
         return new Storage<ItemVariant>() {
+
+            private Map<IItemKey, Long> deltas(
+                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
+                return staged.computeIfAbsent(transaction, t -> {
+                    Map<IItemKey, Long> d = new HashMap<>();
+                    t.addCloseCallback((closedTx, result) -> {
+                        Map<IItemKey, Long> committed = staged.remove(closedTx);
+                        if (result.wasCommitted() && committed != null) {
+                            for (var e : committed.entrySet()) {
+                                long delta = e.getValue();
+                                if (delta > 0) storage.insert(e.getKey(), delta, false);
+                                else if (delta < 0) storage.extract(e.getKey(), -delta, false);
+                            }
+                        }
+                    });
+                    return d;
+                });
+            }
+
             @Override
             public long insert(ItemVariant resource, long maxAmount,
                     net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
                 IItemKey key = new FabricItemKey(resource);
-                long simulated = storage.insert(key, maxAmount, true);
-                if (simulated > 0) {
-                    transaction.addCloseCallback((tx, result) -> {
-                        if (result.wasCommitted()) storage.insert(key, simulated, false);
-                    });
-                }
-                return simulated;
+                Map<IItemKey, Long> d = deltas(transaction);
+                long netDelta = d.getOrDefault(key, 0L);
+                long effectiveCapacity = Math.max(0, storage.insert(key, Integer.MAX_VALUE, true) - netDelta);
+                long toInsert = Math.min(maxAmount, effectiveCapacity);
+                if (toInsert > 0) d.merge(key, toInsert, Long::sum);
+                return toInsert;
             }
 
             @Override
             public long extract(ItemVariant resource, long maxAmount,
                     net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
                 IItemKey key = new FabricItemKey(resource);
-                long simulated = storage.extract(key, maxAmount, true);
-                if (simulated > 0) {
-                    transaction.addCloseCallback((tx, result) -> {
-                        if (result.wasCommitted()) storage.extract(key, simulated, false);
-                    });
-                }
-                return simulated;
+                Map<IItemKey, Long> d = deltas(transaction);
+                long netDelta = d.getOrDefault(key, 0L);
+                long effectiveAvailable = Math.max(0, storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
+                long toExtract = Math.min(maxAmount, effectiveAvailable);
+                if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
+                return toExtract;
             }
 
             @Override
@@ -98,14 +126,13 @@ public final class FabricItemStorage implements IItemStorage {
                                     net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext tx) {
                                 if (!resource.equals(getResource())) return 0;
                                 IItemKey key = new FabricItemKey(resource);
-                                long bounded = Math.min(maxAmount, getAmount());
-                                long simulated = storage.extract(key, bounded, true);
-                                if (simulated > 0) {
-                                    tx.addCloseCallback((t, result) -> {
-                                        if (result.wasCommitted()) storage.extract(key, simulated, false);
-                                    });
-                                }
-                                return simulated;
+                                Map<IItemKey, Long> d = deltas(tx);
+                                long netDelta = d.getOrDefault(key, 0L);
+                                long effectiveAvailable = Math.max(
+                                        0, storage.extract(key, Integer.MAX_VALUE, true) + netDelta);
+                                long toExtract = Math.min(Math.min(maxAmount, getAmount()), effectiveAvailable);
+                                if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
+                                return toExtract;
                             }
 
                             @Override

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
@@ -1,0 +1,160 @@
+package com.logistics.fabric.storage;
+
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+
+/**
+ * Fabric adapter: wraps a Fabric {@link Storage}{@code <ItemVariant>} as an {@link IItemStorage}.
+ *
+ * <p>Translates {@link IItemStorage}'s simulate-boolean API into Fabric's transaction system.
+ * When {@code simulate=true}, a transaction is opened and allowed to roll back on close.
+ * When {@code simulate=false}, the transaction is committed.
+ *
+ * <p>Also provides {@link #asFabric(IItemStorage)} to wrap an {@link IItemStorage} back into
+ * a Fabric {@code Storage<ItemVariant>}, used by {@code ItemStorageAccess} to expose
+ * {@link com.logistics.core.lib.block.capability.HasItemStorage} block entities to Fabric's
+ * capability system.
+ */
+public final class FabricItemStorage implements IItemStorage {
+
+    private final Storage<ItemVariant> storage;
+
+    private FabricItemStorage(Storage<ItemVariant> storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * Wrap a Fabric storage as an {@link IItemStorage}.
+     *
+     * @param storage the Fabric storage to wrap, may be {@code null}
+     * @return a wrapped {@link IItemStorage}, or {@code null} if input is {@code null}
+     */
+    @Nullable
+    public static IItemStorage wrap(@Nullable Storage<ItemVariant> storage) {
+        return storage == null ? null : new FabricItemStorage(storage);
+    }
+
+    /**
+     * Expose an {@link IItemStorage} to Fabric's capability system as a {@code Storage<ItemVariant>}.
+     *
+     * <p>Used by {@code ItemStorageAccess} to bridge block entities that implement
+     * {@link com.logistics.core.lib.block.capability.HasItemStorage} to Fabric's item
+     * transfer lookup.
+     *
+     * @param storage the loader-agnostic storage to expose, may be {@code null}
+     * @return a Fabric-compatible storage, or {@code null} if input is {@code null}
+     */
+    @Nullable
+    public static Storage<ItemVariant> asFabric(@Nullable IItemStorage storage) {
+        if (storage == null) return null;
+        return new Storage<ItemVariant>() {
+            @Override
+            public long insert(ItemVariant resource, long maxAmount,
+                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
+                // Delegate as non-simulate; the outer transaction handles atomicity
+                IItemKey key = new FabricItemKey(resource);
+                return storage.insert(key, maxAmount, false);
+            }
+
+            @Override
+            public long extract(ItemVariant resource, long maxAmount,
+                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
+                IItemKey key = new FabricItemKey(resource);
+                return storage.extract(key, maxAmount, false);
+            }
+
+            @Override
+            public Iterator<StorageView<ItemVariant>> iterator() {
+                Iterator<IItemView> inner = storage.contents().iterator();
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() { return inner.hasNext(); }
+
+                    @Override
+                    public StorageView<ItemVariant> next() {
+                        IItemView view = inner.next();
+                        return new StorageView<>() {
+                            @Override
+                            public long extract(ItemVariant resource, long maxAmount,
+                                    net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext tx) {
+                                IItemKey key = new FabricItemKey(resource);
+                                return storage.extract(key, maxAmount, false);
+                            }
+
+                            @Override
+                            public boolean isResourceBlank() {
+                                return view.resource().toStack(1).isEmpty();
+                            }
+
+                            @Override
+                            public ItemVariant getResource() {
+                                return ((FabricItemKey) view.resource()).variant();
+                            }
+
+                            @Override
+                            public long getAmount() { return view.amount(); }
+
+                            @Override
+                            public long getCapacity() { return view.amount(); }
+                        };
+                    }
+                };
+            }
+        };
+    }
+
+    // ==================== IItemStorage implementation ====================
+
+    @Override
+    public long insert(IItemKey item, long maxAmount, boolean simulate) {
+        ItemVariant variant = ((FabricItemKey) item).variant();
+        if (simulate) {
+            try (Transaction t = Transaction.openOuter()) {
+                return storage.insert(variant, maxAmount, t);
+                // t closes without commit → rollback
+            }
+        }
+        try (Transaction t = Transaction.openOuter()) {
+            long inserted = storage.insert(variant, maxAmount, t);
+            t.commit();
+            return inserted;
+        }
+    }
+
+    @Override
+    public long extract(IItemKey item, long maxAmount, boolean simulate) {
+        ItemVariant variant = ((FabricItemKey) item).variant();
+        if (simulate) {
+            try (Transaction t = Transaction.openOuter()) {
+                return storage.extract(variant, maxAmount, t);
+            }
+        }
+        try (Transaction t = Transaction.openOuter()) {
+            long extracted = storage.extract(variant, maxAmount, t);
+            t.commit();
+            return extracted;
+        }
+    }
+
+    @Override
+    public Iterable<IItemView> contents() {
+        return () -> {
+            Iterator<StorageView<ItemVariant>> inner = storage.iterator();
+            return new Iterator<>() {
+                @Override
+                public boolean hasNext() { return inner.hasNext(); }
+
+                @Override
+                public IItemView next() { return new FabricItemView(inner.next()); }
+            };
+        };
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemStorage.java
@@ -59,16 +59,27 @@ public final class FabricItemStorage implements IItemStorage {
             @Override
             public long insert(ItemVariant resource, long maxAmount,
                     net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
-                // Delegate as non-simulate; the outer transaction handles atomicity
                 IItemKey key = new FabricItemKey(resource);
-                return storage.insert(key, maxAmount, false);
+                long simulated = storage.insert(key, maxAmount, true);
+                if (simulated > 0) {
+                    transaction.addCloseCallback((tx, result) -> {
+                        if (result.wasCommitted()) storage.insert(key, simulated, false);
+                    });
+                }
+                return simulated;
             }
 
             @Override
             public long extract(ItemVariant resource, long maxAmount,
                     net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext transaction) {
                 IItemKey key = new FabricItemKey(resource);
-                return storage.extract(key, maxAmount, false);
+                long simulated = storage.extract(key, maxAmount, true);
+                if (simulated > 0) {
+                    transaction.addCloseCallback((tx, result) -> {
+                        if (result.wasCommitted()) storage.extract(key, simulated, false);
+                    });
+                }
+                return simulated;
             }
 
             @Override
@@ -96,7 +107,9 @@ public final class FabricItemStorage implements IItemStorage {
 
                             @Override
                             public ItemVariant getResource() {
-                                return ((FabricItemKey) view.resource()).variant();
+                                IItemKey key = view.resource();
+                                if (key instanceof FabricItemKey fk) return fk.variant();
+                                return ItemVariant.of(key.toStack(1));
                             }
 
                             @Override

--- a/fabric/src/main/java/com/logistics/fabric/storage/FabricItemView.java
+++ b/fabric/src/main/java/com/logistics/fabric/storage/FabricItemView.java
@@ -1,0 +1,28 @@
+package com.logistics.fabric.storage;
+
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemView;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+
+/**
+ * Fabric adapter: wraps {@link StorageView}{@code <ItemVariant>} as an {@link IItemView}.
+ */
+public final class FabricItemView implements IItemView {
+
+    private final StorageView<ItemVariant> view;
+
+    public FabricItemView(StorageView<ItemVariant> view) {
+        this.view = view;
+    }
+
+    @Override
+    public IItemKey resource() {
+        return new FabricItemKey(view.getResource());
+    }
+
+    @Override
+    public long amount() {
+        return view.getAmount();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #333

Removes all `net.fabricmc.fabric.api.transfer.*` imports from `common/` (item storage only; fluid storage is out of scope) and replaces them with four loader-agnostic interfaces. This is the prerequisite for eventually compiling `common/` under NeoForge's toolchain without Fabric API on the classpath.

## Changes

**New interfaces in `core.lib.storage`:**
- `IItemKey` — loader-agnostic item identity (replaces `ItemVariant`)
- `IItemView` — read-only snapshot of a slot (replaces `StorageView<ItemVariant>`)
- `IItemStorage` — insert/extract/contents with simulate-boolean semantics (replaces `Storage<ItemVariant>` + `Transaction`)
- `ItemStorageLookup` — static registry for finding `IItemStorage` from the world and constructing `IItemKey` from `ItemStack`
- `ContainerItemStorage` — wraps vanilla `Container` as `IItemStorage` (used by Kiln, Macerator)

**Fabric adapters in `fabric/storage`:**
- `FabricItemKey` — wraps `ItemVariant`
- `FabricItemView` — wraps `StorageView<ItemVariant>`
- `FabricItemStorage` — bidirectional adapter: `wrap()` (Fabric→IItemStorage) and `asFabric()` (IItemStorage→Fabric Storage)

**Updated throughout `common/`:**
- `HasItemStorage.itemStorage()` return type: `Storage<ItemVariant>` → `IItemStorage`
- All network value objects (`Order`, `ItemRequest`, `RecipeIngredient`, etc.) and domain types (`ProviderModule`, `PipeRuntime`, etc.) use `IItemKey` instead of `ItemVariant`
- `PipeRuntime.transferItem()` uses an `instanceof PipeBlockEntity` check for pipe-to-pipe routing to avoid circular wrapping, then falls back to `ItemStorageLookup.find()` for external inventories
- Unit tests updated to use `TestItemKey` (a minimal `IItemKey` backed by `Item` identity)

## Notes

- The simulate-boolean pattern matches the existing `IEnergyStorage` / `FabricEnergyStorage` design — no `ITransaction` interface is needed
- NeoForge adapter stubs were removed; they will be added when the NeoForge subproject gains a compile dependency on `common/` (tracked separately)
- Fluid storage (`HasFluidStorage`, `FluidTankComponent`) is intentionally unchanged — out of scope for this PR