### PR TITLE
refactor: introduce loader-agnostic IFluidStorage contract

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/block/capability/HasFluidStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/block/capability/HasFluidStorage.java
@@ -1,13 +1,12 @@
 package com.logistics.core.lib.block.capability;
 
 import com.logistics.core.lib.fluids.FluidTankComponent;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import com.logistics.core.lib.fluids.IFluidStorage;
 import net.minecraft.core.Direction;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Marker interface for block entities that expose fluid storage via the Transfer API.
+ * Marker interface for block entities that expose fluid storage.
  * <p>
  * Use {@link FluidTankComponent} to implement this easily.
  */
@@ -19,5 +18,5 @@ public interface HasFluidStorage {
      * @param side The side to access, or null for non-sided access
      * @return The fluid storage, or null if not accessible from this side
      */
-    @Nullable Storage<FluidVariant> fluidStorage(@Nullable Direction side);
+    @Nullable IFluidStorage fluidStorage(@Nullable Direction side);
 }

--- a/common/src/main/java/com/logistics/core/lib/fluids/FluidStorageLookup.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/FluidStorageLookup.java
@@ -1,0 +1,52 @@
+package com.logistics.core.lib.fluids;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Loader-agnostic registry for finding {@link IFluidStorage} instances from the world.
+ *
+ * <p>Loader-specific modules register their implementations once during initialization:
+ * <ul>
+ *   <li>Fabric: registers a {@link Finder} that wraps {@code FluidStorage.SIDED.find()}
+ *   <li>NeoForge: registers a {@link Finder} that wraps the fluid capability
+ * </ul>
+ *
+ * <p>Common code calls {@link #find} without depending on any loader-specific types.
+ */
+public final class FluidStorageLookup {
+
+    /** Finds an {@link IFluidStorage} for a given world position and face. */
+    @FunctionalInterface
+    public interface Finder {
+        @Nullable IFluidStorage find(Level world, BlockPos pos, Direction dir);
+    }
+
+    private static volatile Finder finder;
+
+    private FluidStorageLookup() {}
+
+    /**
+     * Register the platform-specific storage finder. Called once during loader initialization.
+     *
+     * @param f the finder implementation
+     */
+    public static void register(Finder f) {
+        finder = f;
+    }
+
+    /**
+     * Find an {@link IFluidStorage} for the given position and face.
+     *
+     * @param world the level
+     * @param pos   the block position to query
+     * @param dir   the face to access storage from
+     * @return the storage, or {@code null} if none is present
+     */
+    @Nullable
+    public static IFluidStorage find(Level world, BlockPos pos, Direction dir) {
+        return finder != null ? finder.find(world, pos, dir) : null;
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/fluids/FluidTankComponent.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/FluidTankComponent.java
@@ -1,10 +1,8 @@
 package com.logistics.core.lib.fluids;
 
-import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.compat.NbtCompat;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
-import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
+import com.logistics.core.lib.resource.ResourceId;
+import java.util.Collections;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
@@ -13,47 +11,110 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 
 /**
- * Minimal fluid tank component using the Transfer API's {@link SingleVariantStorage}.
- * <p>
- * This is an abstract class because {@link SingleVariantStorage} requires it.
- * Use it like this:
+ * Simple, loader-agnostic fluid tank component implementing {@link IFluidStorage}.
+ *
+ * <p>Stores a single fluid type at a time (single-variant semantics). Uses vanilla Minecraft
+ * types ({@link Fluid}, {@link DataComponentPatch}) for state storage — no loader-specific
+ * dependencies. Loader adapters (e.g. {@code FabricFluidStorage}) bridge this to the platform's
+ * native fluid transfer API.
+ *
+ * <p>Example usage:
  * <pre>{@code
- * private final FluidTankComponent tank =
- *     new FluidTankComponent(4000, this::markDirtyAndSync) {};
+ * private final FluidTankComponent tank = new FluidTankComponent(4000, this::markDirtyAndSync);
  * }</pre>
  */
-public abstract class FluidTankComponent extends SingleVariantStorage<FluidVariant> {
+public class FluidTankComponent implements IFluidStorage {
+
     private final long capacity;
     private final Runnable onChanged;
 
-    protected FluidTankComponent(long capacity, Runnable onChanged) {
+    private Fluid fluid = Fluids.EMPTY;
+    private DataComponentPatch components = DataComponentPatch.EMPTY;
+    private long amount = 0;
+
+    public FluidTankComponent(long capacity, Runnable onChanged) {
         this.capacity = capacity;
         this.onChanged = onChanged;
     }
 
+    // ==================== IFluidStorage ====================
+
     @Override
-    protected FluidVariant getBlankVariant() {
-        return FluidVariant.blank();
+    public long insert(IFluidKey key, long maxAmount, boolean simulate) {
+        if (maxAmount <= 0 || key.isBlank()) return 0;
+
+        boolean isEmpty = fluid == Fluids.EMPTY;
+        boolean matches = !isEmpty && fluid == key.getFluid() && components.equals(key.getComponents());
+
+        if (!isEmpty && !matches) return 0;
+
+        long accepted = Math.min(maxAmount, capacity - amount);
+        if (accepted <= 0) return 0;
+
+        if (!simulate) {
+            if (isEmpty) {
+                fluid = key.getFluid();
+                components = key.getComponents();
+            }
+            amount += accepted;
+            onChanged.run();
+        }
+        return accepted;
     }
 
     @Override
-    protected long getCapacity(FluidVariant variant) {
-        return capacity;
+    public long extract(IFluidKey key, long maxAmount, boolean simulate) {
+        if (maxAmount <= 0 || key.isBlank()) return 0;
+        if (fluid != key.getFluid() || !components.equals(key.getComponents())) return 0;
+
+        long extracted = Math.min(maxAmount, amount);
+        if (extracted <= 0) return 0;
+
+        if (!simulate) {
+            amount -= extracted;
+            if (amount == 0) {
+                fluid = Fluids.EMPTY;
+                components = DataComponentPatch.EMPTY;
+            }
+            onChanged.run();
+        }
+        return extracted;
     }
 
     @Override
-    protected void onFinalCommit() {
-        onChanged.run();
+    public Iterable<IFluidView> contents() {
+        if (fluid == Fluids.EMPTY || amount <= 0) return Collections.emptyList();
+        IFluidKey key = currentKey();
+        long currentAmount = amount;
+        return Collections.singletonList(new IFluidView() {
+            @Override public IFluidKey resource() { return key; }
+            @Override public long amount() { return currentAmount; }
+        });
     }
 
-    public Storage<FluidVariant> storage() {
-        return this;
+    // ==================== Accessors ====================
+
+    /** Returns an {@link IFluidKey} representing the currently stored fluid, or a blank key if empty. */
+    public IFluidKey getFluidKey() {
+        return currentKey();
     }
 
-    @Override
+    /** Returns the current amount of fluid stored, in platform-native units. */
+    public long getAmount() {
+        return amount;
+    }
+
+    /** Returns the maximum capacity, in platform-native units. */
     public long getCapacity() {
         return capacity;
     }
+
+    /** Returns {@code true} if no fluid is stored. */
+    public boolean isEmpty() {
+        return fluid == Fluids.EMPTY || amount <= 0;
+    }
+
+    // ==================== NBT Persistence ====================
 
     public void readNbt(CompoundTag nbt, String key) {
         CompoundTag data = NbtCompat.getCompoundOrEmpty(nbt, key);
@@ -61,7 +122,7 @@ public abstract class FluidTankComponent extends SingleVariantStorage<FluidVaria
 
         String id = NbtCompat.getString(data, "fluid", "");
         ResourceId resourceId = ResourceId.tryParse(id);
-        Fluid fluid = Fluids.EMPTY;
+        fluid = Fluids.EMPTY;
         if (resourceId != null) {
             Fluid registryFluid = BuiltInRegistries.FLUID.getValue(resourceId.toIdentifier());
             if (registryFluid != null) {
@@ -69,19 +130,17 @@ public abstract class FluidTankComponent extends SingleVariantStorage<FluidVaria
             }
         }
         CompoundTag compTag = NbtCompat.getCompoundOrEmpty(data, "components");
-        DataComponentPatch comp = compTag.isEmpty() ? DataComponentPatch.EMPTY :
+        components = compTag.isEmpty() ? DataComponentPatch.EMPTY :
                 DataComponentPatch.CODEC.parse(NbtOps.INSTANCE, compTag).result().orElse(DataComponentPatch.EMPTY);
-
-        variant = FluidVariant.of(fluid, comp);
         amount = NbtCompat.getLong(data, "amount", 0L);
     }
 
     public void writeNbt(CompoundTag nbt, String key) {
         CompoundTag data = new CompoundTag();
-        if (variant.getFluid() != Fluids.EMPTY) {
-            data.putString("fluid", BuiltInRegistries.FLUID.getKey(variant.getFluid()).toString());
-            if (!variant.getComponentsPatch().isEmpty()) {
-                DataComponentPatch.CODEC.encodeStart(NbtOps.INSTANCE, variant.getComponentsPatch())
+        if (fluid != Fluids.EMPTY) {
+            data.putString("fluid", BuiltInRegistries.FLUID.getKey(fluid).toString());
+            if (!components.isEmpty()) {
+                DataComponentPatch.CODEC.encodeStart(NbtOps.INSTANCE, components)
                         .result().ifPresent(tag -> data.put("components", tag));
             }
             data.putLong("amount", amount);
@@ -89,5 +148,21 @@ public abstract class FluidTankComponent extends SingleVariantStorage<FluidVaria
         if (!data.isEmpty()) {
             nbt.put(key, data);
         }
+    }
+
+    // ==================== Internals ====================
+
+    private IFluidKey currentKey() {
+        Fluid f = fluid;
+        DataComponentPatch c = components;
+        return new IFluidKey() {
+            @Override public Fluid getFluid() { return f; }
+            @Override public DataComponentPatch getComponents() { return c; }
+            @Override public boolean equals(Object o) {
+                if (!(o instanceof IFluidKey other)) return false;
+                return f == other.getFluid() && c.equals(other.getComponents());
+            }
+            @Override public int hashCode() { return 31 * f.hashCode() + c.hashCode(); }
+        };
     }
 }

--- a/common/src/main/java/com/logistics/core/lib/fluids/IFluidKey.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/IFluidKey.java
@@ -1,0 +1,43 @@
+package com.logistics.core.lib.fluids;
+
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+
+/**
+ * Loader-agnostic identity token for a fluid type (ignoring amount).
+ *
+ * <p>Implementations must provide correct {@code equals} and {@code hashCode} semantics
+ * so that instances can be used as {@link java.util.Map} keys. Two keys are equal if and
+ * only if they represent the same fluid with the same components.
+ *
+ * <p>This is one of the primary extension points for the fluid-storage abstraction layer.
+ * Loader-specific adapters ({@code FabricFluidKey}, {@code NeoForgeFluidKey}) wrap the
+ * native fluid-identity type and implement this interface.
+ */
+public interface IFluidKey {
+
+    /**
+     * The vanilla fluid type represented by this key.
+     *
+     * @return the fluid; never {@code null}
+     */
+    Fluid getFluid();
+
+    /**
+     * The data components associated with this fluid variant.
+     *
+     * @return the component patch; never {@code null}
+     */
+    DataComponentPatch getComponents();
+
+    /**
+     * Returns {@code true} if this key represents the empty/blank fluid
+     * (i.e. {@link Fluids#EMPTY}).
+     *
+     * @return {@code true} if blank
+     */
+    default boolean isBlank() {
+        return getFluid() == Fluids.EMPTY;
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/fluids/IFluidStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/IFluidStorage.java
@@ -1,0 +1,56 @@
+package com.logistics.core.lib.fluids;
+
+/**
+ * Loader-agnostic fluid storage contract.
+ *
+ * <p>Uses simulate-boolean semantics (not transactions) to remain compatible with both
+ * Fabric (Transfer API) and NeoForge fluid APIs. Loader-specific adapters bridge this
+ * interface to each platform's native API.
+ *
+ * <p>This is the primary extension point for the fluid-storage abstraction layer. Any block
+ * entity that participates in fluid transfer should implement
+ * {@link com.logistics.core.lib.block.capability.HasFluidStorage} and return this type.
+ *
+ * @see com.logistics.core.lib.block.capability.HasFluidStorage
+ * @see FluidStorageLookup
+ */
+public interface IFluidStorage {
+
+    /**
+     * Insert fluid into this storage.
+     *
+     * <p>If {@code maxAmount <= 0}, implementations must return {@code 0} immediately.
+     * The return value is always {@code >= 0} and never exceeds {@code maxAmount}.
+     *
+     * @param fluid     the fluid type to insert
+     * @param maxAmount the maximum amount to insert, in platform-native units
+     * @param simulate  if {@code true}, perform a dry run without modifying state; the returned
+     *                  value is the amount that would be inserted without any state change
+     * @return the amount actually inserted (or that would be inserted if simulating); never negative
+     */
+    long insert(IFluidKey fluid, long maxAmount, boolean simulate);
+
+    /**
+     * Extract fluid from this storage.
+     *
+     * <p>If {@code maxAmount <= 0}, implementations must return {@code 0} immediately.
+     * The return value is always {@code >= 0} and never exceeds {@code maxAmount}.
+     *
+     * @param fluid     the fluid type to extract
+     * @param maxAmount the maximum amount to extract, in platform-native units
+     * @param simulate  if {@code true}, perform a dry run without modifying state; the returned
+     *                  value is the amount that would be extracted without any state change
+     * @return the amount actually extracted (or that would be extracted if simulating); never negative
+     */
+    long extract(IFluidKey fluid, long maxAmount, boolean simulate);
+
+    /**
+     * Iterate over the contents of this storage.
+     *
+     * <p>Each {@link IFluidView} represents a non-empty, non-blank resource.
+     * Implementations must omit empty and blank entries — callers may rely on this.
+     *
+     * @return an iterable over the non-empty views in this storage
+     */
+    Iterable<IFluidView> contents();
+}

--- a/common/src/main/java/com/logistics/core/lib/fluids/IFluidView.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/IFluidView.java
@@ -1,0 +1,20 @@
+package com.logistics.core.lib.fluids;
+
+/**
+ * Read-only view of a fluid resource within an {@link IFluidStorage}.
+ *
+ * <p>Equivalent to Fabric's {@code StorageView<FluidVariant>} in the loader-agnostic API.
+ * Instances are obtained by iterating {@link IFluidStorage#contents()}.
+ *
+ * <p>Contract: {@link #resource()} never returns {@code null} and {@link #amount()} is always
+ * {@code > 0} for any view produced by {@link IFluidStorage#contents()}. Implementations must
+ * not produce zero-amount or blank views; callers may rely on this invariant.
+ */
+public interface IFluidView {
+
+    /** The fluid type stored in this view. Never {@code null} or blank. */
+    IFluidKey resource();
+
+    /** The amount of fluid available in this view, in platform-native units. Always {@code > 0}. */
+    long amount();
+}

--- a/fabric/src/main/java/com/logistics/fabric/capability/FabricCapabilityRegistration.java
+++ b/fabric/src/main/java/com/logistics/fabric/capability/FabricCapabilityRegistration.java
@@ -1,10 +1,13 @@
 package com.logistics.fabric.capability;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.fluids.FluidStorageLookup;
 import com.logistics.core.lib.pipe.PipeConnectionLookup;
 import com.logistics.core.lib.storage.ItemStorageLookup;
+import com.logistics.fabric.fluids.FabricFluidStorage;
 import com.logistics.fabric.storage.FabricItemKey;
 import com.logistics.fabric.storage.FabricItemStorage;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
 import net.minecraft.core.Direction;
 
@@ -23,6 +26,10 @@ public final class FabricCapabilityRegistration {
 
         // Wire the key factory so common code can construct IItemKey from ItemStack
         ItemStorageLookup.registerKeyFactory(FabricItemKey::of);
+
+        // Wire FluidStorageLookup so common code can find IFluidStorage without importing Fabric API
+        FluidStorageLookup.register(
+                (world, pos, dir) -> FabricFluidStorage.wrap(FluidStorage.SIDED.find(world, pos, dir)));
 
         // Quarry: only accepts pipe connections from above
         PipeConnectionRegistry.SIDED.registerForBlockEntity(

--- a/fabric/src/main/java/com/logistics/fabric/capability/FluidStorageAccess.java
+++ b/fabric/src/main/java/com/logistics/fabric/capability/FluidStorageAccess.java
@@ -1,6 +1,7 @@
 package com.logistics.fabric.capability;
 
 import com.logistics.core.lib.block.capability.HasFluidStorage;
+import com.logistics.fabric.fluids.FabricFluidStorage;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 
 /**
@@ -24,7 +25,7 @@ public final class FluidStorageAccess {
     public static void register() {
         FluidStorage.SIDED.registerFallback((world, pos, state, blockEntity, direction) -> {
             if (blockEntity instanceof HasFluidStorage hasStorage) {
-                return hasStorage.fluidStorage(direction);
+                return FabricFluidStorage.asFabric(hasStorage.fluidStorage(direction));
             }
             return null;
         });

--- a/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidKey.java
+++ b/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidKey.java
@@ -8,8 +8,9 @@ import net.minecraft.world.level.material.Fluid;
 /**
  * Fabric adapter: wraps a {@link FluidVariant} as an {@link IFluidKey}.
  *
- * <p>Delegates {@code equals} and {@code hashCode} to {@link FluidVariant} so instances
- * can be used as {@link java.util.Map} keys with correct identity semantics.
+ * <p>Implements {@code equals} and {@code hashCode} using {@link #getFluid()} and
+ * {@link #getComponents()} so cross-type equality with other {@link IFluidKey}
+ * implementations is consistent with hashing.
  */
 public final class FabricFluidKey implements IFluidKey {
 
@@ -61,6 +62,6 @@ public final class FabricFluidKey implements IFluidKey {
 
     @Override
     public int hashCode() {
-        return variant.hashCode();
+        return 31 * getFluid().hashCode() + getComponents().hashCode();
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidKey.java
+++ b/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidKey.java
@@ -1,0 +1,66 @@
+package com.logistics.fabric.fluids;
+
+import com.logistics.core.lib.fluids.IFluidKey;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.world.level.material.Fluid;
+
+/**
+ * Fabric adapter: wraps a {@link FluidVariant} as an {@link IFluidKey}.
+ *
+ * <p>Delegates {@code equals} and {@code hashCode} to {@link FluidVariant} so instances
+ * can be used as {@link java.util.Map} keys with correct identity semantics.
+ */
+public final class FabricFluidKey implements IFluidKey {
+
+    private final FluidVariant variant;
+
+    private FabricFluidKey(FluidVariant variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Create a {@link FabricFluidKey} from a {@link FluidVariant}.
+     *
+     * @param variant the Fabric fluid variant; must not be {@code null}
+     * @return a wrapped fluid key
+     */
+    public static FabricFluidKey of(FluidVariant variant) {
+        return new FabricFluidKey(variant);
+    }
+
+    /** Returns the underlying Fabric {@link FluidVariant}. */
+    public FluidVariant variant() {
+        return variant;
+    }
+
+    @Override
+    public Fluid getFluid() {
+        return variant.getFluid();
+    }
+
+    @Override
+    public DataComponentPatch getComponents() {
+        return variant.getComponentsPatch();
+    }
+
+    @Override
+    public boolean isBlank() {
+        return variant.isBlank();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o instanceof FabricFluidKey other) return variant.equals(other.variant);
+        if (o instanceof IFluidKey other) {
+            return getFluid() == other.getFluid() && getComponents().equals(other.getComponents());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return variant.hashCode();
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidStorage.java
@@ -1,0 +1,237 @@
+package com.logistics.fabric.fluids;
+
+import com.logistics.core.lib.fluids.IFluidKey;
+import com.logistics.core.lib.fluids.IFluidStorage;
+import com.logistics.core.lib.fluids.IFluidView;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Fabric adapter: wraps a Fabric {@link Storage}{@code <FluidVariant>} as an {@link IFluidStorage}.
+ *
+ * <p>Translates {@link IFluidStorage}'s simulate-boolean API into Fabric's transaction system.
+ * When {@code simulate=true}, a transaction is opened and allowed to roll back on close.
+ * When {@code simulate=false}, the transaction is committed.
+ *
+ * <p>Also provides {@link #asFabric(IFluidStorage)} to wrap an {@link IFluidStorage} back into
+ * a Fabric {@code Storage<FluidVariant>}, used by {@code FluidStorageAccess} to expose
+ * {@link com.logistics.core.lib.block.capability.HasFluidStorage} block entities to Fabric's
+ * capability system.
+ */
+public final class FabricFluidStorage implements IFluidStorage {
+
+    private final Storage<FluidVariant> storage;
+
+    private FabricFluidStorage(Storage<FluidVariant> storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * Wrap a Fabric storage as an {@link IFluidStorage}.
+     *
+     * @param storage the Fabric storage to wrap, may be {@code null}
+     * @return a wrapped {@link IFluidStorage}, or {@code null} if input is {@code null}
+     */
+    @Nullable
+    public static IFluidStorage wrap(@Nullable Storage<FluidVariant> storage) {
+        return storage == null ? null : new FabricFluidStorage(storage);
+    }
+
+    /**
+     * Expose an {@link IFluidStorage} to Fabric's capability system as a {@code Storage<FluidVariant>}.
+     *
+     * <p>Used by {@code FluidStorageAccess} to bridge block entities that implement
+     * {@link com.logistics.core.lib.block.capability.HasFluidStorage} to Fabric's fluid
+     * transfer lookup.
+     *
+     * @param storage the loader-agnostic storage to expose, may be {@code null}
+     * @return a Fabric-compatible storage, or {@code null} if input is {@code null}
+     */
+    @Nullable
+    public static Storage<FluidVariant> asFabric(@Nullable IFluidStorage storage) {
+        return storage == null ? null : new StagedStorage(storage);
+    }
+
+    // ==================== IFluidStorage implementation ====================
+
+    @Override
+    public long insert(IFluidKey fluid, long maxAmount, boolean simulate) {
+        FluidVariant variant = toVariant(fluid);
+        if (simulate) {
+            try (Transaction t = Transaction.openOuter()) {
+                return storage.insert(variant, maxAmount, t);
+                // t closes without commit → rollback
+            }
+        }
+        try (Transaction t = Transaction.openOuter()) {
+            long inserted = storage.insert(variant, maxAmount, t);
+            t.commit();
+            return inserted;
+        }
+    }
+
+    @Override
+    public long extract(IFluidKey fluid, long maxAmount, boolean simulate) {
+        FluidVariant variant = toVariant(fluid);
+        if (simulate) {
+            try (Transaction t = Transaction.openOuter()) {
+                return storage.extract(variant, maxAmount, t);
+            }
+        }
+        try (Transaction t = Transaction.openOuter()) {
+            long extracted = storage.extract(variant, maxAmount, t);
+            t.commit();
+            return extracted;
+        }
+    }
+
+    @Override
+    public Iterable<IFluidView> contents() {
+        return () -> new Iterator<>() {
+            private final Iterator<StorageView<FluidVariant>> inner = storage.iterator();
+            private StorageView<FluidVariant> pending = advance();
+
+            private StorageView<FluidVariant> advance() {
+                while (inner.hasNext()) {
+                    StorageView<FluidVariant> v = inner.next();
+                    if (!v.isResourceBlank() && v.getAmount() > 0) return v;
+                }
+                return null;
+            }
+
+            @Override
+            public boolean hasNext() { return pending != null; }
+
+            @Override
+            public IFluidView next() {
+                if (pending == null) throw new java.util.NoSuchElementException();
+                StorageView<FluidVariant> view = pending;
+                pending = advance();
+                IFluidKey key = FabricFluidKey.of(view.getResource());
+                long amt = view.getAmount();
+                return new IFluidView() {
+                    @Override public IFluidKey resource() { return key; }
+                    @Override public long amount() { return amt; }
+                };
+            }
+        };
+    }
+
+    // ==================== asFabric() inner classes ====================
+
+    /**
+     * Fabric {@code Storage<FluidVariant>} backed by an {@link IFluidStorage}.
+     *
+     * <p>Extends {@link SnapshotParticipant} to correctly handle nested transactions.
+     * Positive delta = pending insert; negative delta = pending extract.
+     */
+    private static final class StagedStorage extends SnapshotParticipant<Map<IFluidKey, Long>>
+            implements Storage<FluidVariant> {
+
+        private final IFluidStorage storage;
+        private Map<IFluidKey, Long> pendingDeltas = new HashMap<>();
+
+        StagedStorage(IFluidStorage storage) {
+            this.storage = storage;
+        }
+
+        @Override
+        protected Map<IFluidKey, Long> createSnapshot() {
+            return new HashMap<>(pendingDeltas);
+        }
+
+        @Override
+        protected void readSnapshot(Map<IFluidKey, Long> snapshot) {
+            pendingDeltas = snapshot;
+        }
+
+        @Override
+        protected void onFinalCommit() {
+            for (var e : pendingDeltas.entrySet()) {
+                long delta = e.getValue();
+                if (delta > 0) storage.insert(e.getKey(), delta, false);
+                else if (delta < 0) storage.extract(e.getKey(), -delta, false);
+            }
+            pendingDeltas = new HashMap<>();
+        }
+
+        Map<IFluidKey, Long> deltas(TransactionContext tx) {
+            updateSnapshots(tx);
+            return pendingDeltas;
+        }
+
+        @Override
+        public long insert(FluidVariant resource, long maxAmount, TransactionContext transaction) {
+            IFluidKey key = FabricFluidKey.of(resource);
+            Map<IFluidKey, Long> d = deltas(transaction);
+            long netDelta = d.getOrDefault(key, 0L);
+            long effectiveCapacity = Math.max(0, storage.insert(key, Long.MAX_VALUE, true) - netDelta);
+            long toInsert = Math.min(maxAmount, effectiveCapacity);
+            if (toInsert > 0) d.merge(key, toInsert, Long::sum);
+            return toInsert;
+        }
+
+        @Override
+        public long extract(FluidVariant resource, long maxAmount, TransactionContext transaction) {
+            IFluidKey key = FabricFluidKey.of(resource);
+            Map<IFluidKey, Long> d = deltas(transaction);
+            long netDelta = d.getOrDefault(key, 0L);
+            long effectiveAvailable = Math.max(0, storage.extract(key, Long.MAX_VALUE, true) + netDelta);
+            long toExtract = Math.min(maxAmount, effectiveAvailable);
+            if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
+            return toExtract;
+        }
+
+        @Override
+        public Iterator<StorageView<FluidVariant>> iterator() {
+            return new Iterator<>() {
+                private final Iterator<IFluidView> inner = storage.contents().iterator();
+
+                @Override
+                public boolean hasNext() { return inner.hasNext(); }
+
+                @Override
+                public StorageView<FluidVariant> next() {
+                    IFluidView view = inner.next();
+                    FluidVariant variant = toVariant(view.resource());
+                    long amount = view.amount();
+                    StagedStorage staged = StagedStorage.this;
+                    return new StorageView<>() {
+                        @Override
+                        public long extract(FluidVariant resource, long maxAmount, TransactionContext tx) {
+                            if (!resource.equals(variant)) return 0;
+                            IFluidKey key = FabricFluidKey.of(resource);
+                            Map<IFluidKey, Long> d = staged.deltas(tx);
+                            long netDelta = d.getOrDefault(key, 0L);
+                            long effectiveAvailable = Math.max(0, staged.storage.extract(key, Long.MAX_VALUE, true) + netDelta);
+                            long toExtract = Math.min(Math.min(maxAmount, amount), effectiveAvailable);
+                            if (toExtract > 0) d.merge(key, -toExtract, Long::sum);
+                            return toExtract;
+                        }
+
+                        @Override public boolean isResourceBlank() { return variant.isBlank(); }
+                        @Override public FluidVariant getResource() { return variant; }
+                        @Override public long getAmount() { return amount; }
+                        @Override public long getCapacity() { return amount; }
+                    };
+                }
+            };
+        }
+    }
+
+    // ==================== Helpers ====================
+
+    private static FluidVariant toVariant(IFluidKey key) {
+        if (key instanceof FabricFluidKey fk) return fk.variant();
+        return FluidVariant.of(key.getFluid(), key.getComponents());
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `IFluidStorage`, `IFluidKey`, `IFluidView`, and `FluidStorageLookup` in `common/` — mirroring the patterns established by `IEnergyStorage` (#340) and `IItemStorage` (#349)
- Replaces `FluidTankComponent`'s Fabric `SingleVariantStorage<FluidVariant>` base class with a plain Java implementation; NBT format is unchanged for save-game compatibility
- Updates `HasFluidStorage` to expose `IFluidStorage` instead of Fabric's `Storage<FluidVariant>`
- Adds `FabricFluidKey` and `FabricFluidStorage` adapters in `fabric/` to bridge the new contract to Fabric's Transfer API (both directions)
- Wires `FluidStorageLookup` in `FabricCapabilityRegistration` so common code can query fluid storage without Fabric imports

## Notes

- No block entities currently implement `HasFluidStorage`, so there are no call-site migrations
- `common/` now has zero `net.fabricmc.*` or `team.reborn.*` imports in the fluid storage layer

Closes #324