### PR TITLE
refactor: remove last Fabric API imports from common/

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsPower.java
+++ b/common/src/main/java/com/logistics/LogisticsPower.java
@@ -11,8 +11,7 @@ import com.logistics.power.engine.block.entity.CreativeEngineBlockEntity;
 import com.logistics.power.engine.block.entity.RedstoneEngineBlockEntity;
 import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;
 import com.logistics.power.engine.ui.StirlingEngineScreenHandler;
-import net.fabricmc.fabric.api.menu.v1.ExtendedMenuType;
-import net.minecraft.core.BlockPos;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.inventory.MenuType;
@@ -100,7 +99,7 @@ public final class LogisticsPower extends LogisticsMod implements DomainBootstra
             STIRLING_ENGINE = Registry.register(
                     BuiltInRegistries.MENU,
                     LogisticsPower.resource("stirling_engine").toIdentifier(),
-                    new ExtendedMenuType<>(StirlingEngineScreenHandler::new, BlockPos.STREAM_CODEC));
+                    new MenuType<>(StirlingEngineScreenHandler::new, FeatureFlagSet.of()));
         }
     }
 

--- a/common/src/main/java/com/logistics/core/lib/platform/ServerNetworking.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/ServerNetworking.java
@@ -1,0 +1,46 @@
+package com.logistics.core.lib.platform;
+
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Loader-agnostic server-to-client packet sending (Pattern A — SPI).
+ *
+ * <p>Common code calls {@link #send} to dispatch a packet to a player without depending
+ * on any loader-specific networking API. The loader registers its implementation once
+ * during initialization:
+ * <ul>
+ *   <li>Fabric: delegates to {@code ServerPlayNetworking.send(player, packet)}
+ *   <li>NeoForge: delegates to the equivalent NeoForge API
+ * </ul>
+ */
+public final class ServerNetworking {
+
+    @FunctionalInterface
+    public interface Sender {
+        void send(ServerPlayer player, CustomPacketPayload packet);
+    }
+
+    private static volatile Sender sender;
+
+    private ServerNetworking() {}
+
+    /**
+     * Register the platform-specific sender. Called once during loader initialization.
+     *
+     * @param s the sender implementation
+     */
+    public static void register(Sender s) {
+        sender = s;
+    }
+
+    /**
+     * Send a packet to the given player.
+     *
+     * @param player the target player
+     * @param packet the packet to send
+     */
+    public static void send(ServerPlayer player, CustomPacketPayload packet) {
+        if (sender != null) sender.send(player, packet);
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/platform/ServerNetworking.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/ServerNetworking.java
@@ -31,6 +31,7 @@ public final class ServerNetworking {
      * @param s the sender implementation
      */
     public static void register(Sender s) {
+        if (s == null) throw new NullPointerException("sender must not be null");
         sender = s;
     }
 
@@ -39,8 +40,10 @@ public final class ServerNetworking {
      *
      * @param player the target player
      * @param packet the packet to send
+     * @throws IllegalStateException if no sender has been registered
      */
     public static void send(ServerPlayer player, CustomPacketPayload packet) {
-        if (sender != null) sender.send(player, packet);
+        if (sender == null) throw new IllegalStateException("ServerNetworking sender not registered");
+        sender.send(player, packet);
     }
 }

--- a/common/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
@@ -3,7 +3,7 @@ package com.logistics.pipe.ui;
 import com.logistics.LogisticsPipe;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.network.packet.SyncRequesterInventoryPacket;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import com.logistics.core.lib.platform.ServerNetworking;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerPlayer;
@@ -194,7 +194,7 @@ public class RequesterScreenHandler extends AbstractContainerMenu {
 
             // Send to all players on the server (they'll filter based on open screen)
             for (ServerPlayer player : pipeEntity.getLevel().getServer().getPlayerList().getPlayers()) {
-                ServerPlayNetworking.send(player, packet);
+                ServerNetworking.send(player, packet);
             }
 
             initialSyncSent = true;

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -11,7 +11,6 @@ import com.logistics.power.engine.PIDController;
 import com.logistics.power.engine.block.StirlingEngineBlock;
 import com.logistics.power.engine.ui.StirlingEngineScreenHandler;
 import com.logistics.LogisticsPower;
-import net.fabricmc.fabric.api.menu.v1.ExtendedMenuProvider;
 import com.logistics.core.lib.storage.IItemKey;
 import com.logistics.core.lib.storage.IItemStorage;
 import com.logistics.core.lib.storage.IItemView;
@@ -23,7 +22,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.chat.Component;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.ItemStack;
@@ -58,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
  * When buffer fills up, temperature rises and generation decreases.
  */
 public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
-        implements ExtendedMenuProvider<BlockPos>, ContainerSingleItem.BlockContainerSingleItem, WorldlyContainer, HasItemStorage, MenuBehavior.HasMenu {
+        implements ContainerSingleItem.BlockContainerSingleItem, WorldlyContainer, HasItemStorage, MenuBehavior.HasMenu {
 
     // ==================== Constants ====================
 
@@ -427,26 +425,21 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         return direction != outputDir;
     }
 
-    // ==================== ExtendedScreenHandlerFactory Implementation ====================
-
-    @Override
-    public Component getDisplayName() {
-        return Component.translatable("block.logistics.power.stirling_engine");
-    }
-
-    @Override
-    public BlockPos getScreenOpeningData(ServerPlayer player) {
-        return getBlockPos();
-    }
-
-    @Nullable @Override
-    public AbstractContainerMenu createMenu(int syncId, Inventory playerInventory, Player player) {
-        return new StirlingEngineScreenHandler(syncId, playerInventory, this, propertyDelegate);
-    }
+    // ==================== MenuBehavior.HasMenu Implementation ====================
 
     @Override
     public net.minecraft.world.MenuProvider createMenuProvider() {
-        return this; // StirlingEngineBlockEntity already implements MenuProvider via ExtendedScreenHandlerFactory
+        return new net.minecraft.world.MenuProvider() {
+            @Override
+            public Component getDisplayName() {
+                return Component.translatable("block.logistics.power.stirling_engine");
+            }
+
+            @Nullable @Override
+            public AbstractContainerMenu createMenu(int syncId, Inventory playerInventory, Player player) {
+                return new StirlingEngineScreenHandler(syncId, playerInventory, StirlingEngineBlockEntity.this, propertyDelegate);
+            }
+        };
     }
 
     // ==================== NBT Serialization ====================

--- a/common/src/main/java/com/logistics/power/engine/ui/StirlingEngineScreenHandler.java
+++ b/common/src/main/java/com/logistics/power/engine/ui/StirlingEngineScreenHandler.java
@@ -2,7 +2,6 @@ package com.logistics.power.engine.ui;
 
 import com.logistics.LogisticsPower;
 import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
@@ -30,9 +29,8 @@ public class StirlingEngineScreenHandler extends AbstractContainerMenu {
     private final Container inventory;
     private final ContainerData propertyDelegate;
 
-    // Client constructor (called from ExtendedAbstractContainerMenuType packet)
-    @SuppressWarnings("unused")
-    public StirlingEngineScreenHandler(int syncId, Inventory playerInventory, BlockPos unusedPos) {
+    // Client constructor (called from MenuType on screen open)
+    public StirlingEngineScreenHandler(int syncId, Inventory playerInventory) {
         this(
                 syncId,
                 playerInventory,

--- a/fabric/src/main/java/com/logistics/fabric/FabricPacketRegistration.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPacketRegistration.java
@@ -1,5 +1,6 @@
 package com.logistics.fabric;
 
+import com.logistics.core.lib.platform.ServerNetworking;
 import com.logistics.pipe.network.packet.OpenChassisSlotPacket;
 import com.logistics.pipe.network.packet.RequestItemPacket;
 import com.logistics.pipe.network.packet.SetSatelliteIdPacket;
@@ -11,6 +12,9 @@ public final class FabricPacketRegistration {
     private FabricPacketRegistration() {}
 
     public static void register() {
+        // Wire common ServerNetworking SPI to Fabric's server-play networking
+        ServerNetworking.register(ServerPlayNetworking::send);
+
         // Serverbound packets
         PayloadTypeRegistry.serverboundPlay().register(RequestItemPacket.TYPE, RequestItemPacket.CODEC);
         ServerPlayNetworking.registerGlobalReceiver(RequestItemPacket.TYPE,


### PR DESCRIPTION
## Summary

Eliminates the final three `net.fabricmc.*` imports from `common/` main sources, completing the acceptance criterion from #324: `:common` has zero loader-specific imports.

## Changes

**Power domain — drop unused `ExtendedMenuType` / `ExtendedMenuProvider`:**
- The Stirling Engine screen was using Fabric's `ExtendedMenuType` to send a `BlockPos` to the client on screen open, but the client constructor had it labeled `unusedPos` and ignored it entirely
- Replaced `ExtendedMenuType` with vanilla `MenuType` in `LogisticsPower.SCREEN.register()`
- Removed `ExtendedMenuProvider<BlockPos>` from `StirlingEngineBlockEntity`'s implements clause and dropped `getScreenOpeningData()`
- Simplified `StirlingEngineScreenHandler`'s client constructor to the vanilla `(int syncId, Inventory)` signature

**Pipe domain — abstract `ServerPlayNetworking.send()` via SPI:**
- Introduced `ServerNetworking` in `core.lib.platform` (Pattern A — same shape as `ItemStorageLookup`)
- `FabricPacketRegistration` registers `ServerPlayNetworking::send` as the implementation
- `RequesterScreenHandler.broadcastChanges()` now calls `ServerNetworking.send()` instead of the Fabric API directly

## Notes

- `common/src/main` now has zero `net.fabricmc.*` or `team.reborn.*` imports
- All 69 game tests pass

Closes #324