### PR TITLE
fix: correct power cable compilation errors for mc/26.1

### DIFF
--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -13,13 +13,12 @@ import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.power.EnergyDemandProvider;
 import com.logistics.core.lib.block.behavior.ProbeResult;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext.Result;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -69,54 +68,34 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
             0,
             this::setChanged
     );
-    private final EnergyStorage energyStorage = new EnergyStorage() {
+    private long energyReceivedLastTick = 0;
+    private long energyReceivedThisTick = 0;
+    private final IEnergyStorage trackingStorage = new IEnergyStorage() {
         @Override
-        public boolean supportsExtraction() {
-            return energy.supportsExtraction();
-        }
-
-        @Override
-        public boolean supportsInsertion() {
-            return energy.supportsInsertion();
-        }
-
-        @Override
-        public long insert(long maxAmount, TransactionContext transaction) {
-            long inserted = energy.insert(maxAmount, transaction);
-            if (inserted <= 0) {
-                return 0;
-            }
-
-            if (transaction == null) {
-                energyReceivedThisTick += inserted;
-            } else {
-                transaction.addOuterCloseCallback(result -> {
-                    if (result == Result.COMMITTED) {
-                        energyReceivedThisTick += inserted;
-                    }
-                });
-            }
+        public long insert(long maxAmount, boolean simulate) {
+            long inserted = energy.insert(maxAmount, simulate);
+            if (!simulate && inserted > 0) energyReceivedThisTick += inserted;
             return inserted;
         }
 
         @Override
-        public long extract(long maxAmount, TransactionContext transaction) {
-            return energy.extract(maxAmount, transaction);
+        public long extract(long maxAmount, boolean simulate) {
+            return energy.extract(maxAmount, simulate);
         }
 
         @Override
-        public long getAmount() {
-            return energy.getAmount();
-        }
+        public long getAmount() { return energy.getAmount(); }
 
         @Override
-        public long getCapacity() {
-            return energy.getCapacity();
-        }
+        public long getCapacity() { return energy.getCapacity(); }
+
+        @Override
+        public boolean canInsert() { return energy.canInsert(); }
+
+        @Override
+        public boolean canExtract() { return energy.canExtract(); }
     };
     private long lastSyncedEnergy = 0; // For client sync
-    private long energyReceivedLastTick = 0;
-    private long energyReceivedThisTick = 0;
     private boolean consumedEnergyThisTick = false; // For LED when buffer is low
 
     // Phase state
@@ -165,7 +144,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     @Override
     public IEnergyStorage energyStorage(@Nullable Direction side) {
         // Quarry accepts energy from all sides
-        return energyStorage;
+        return trackingStorage;
     }
 
     public static void tick(Level world, BlockPos pos, BlockState state, LaserQuarryBlockEntity entity) {
@@ -1180,7 +1159,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     @Override
     public long networkDemandPerTick() {
-        long storageRoom = Math.max(0, LogisticsConfig.get().quarry.energyCapacity() - energy.amount);
+        long storageRoom = Math.max(0, LogisticsConfig.get().quarry.energyCapacity() - energy.getAmount());
         long remainingInput = Math.max(0, LogisticsConfig.get().quarry.maxEnergyInput() - energyReceivedThisTick);
         return Math.min(remainingInput, storageRoom);
     }

--- a/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
@@ -66,52 +66,32 @@ public class MaceratorBlockEntity extends BaseBlockEntity
 
     private final ItemInventoryComponent inventory = new ItemInventoryComponent(TOTAL_SLOTS, this::setChanged);
     final EnergyComponent energy = new EnergyComponent(ENERGY_CAPACITY, MAX_ENERGY_INPUT, 0, this::setChanged);
-    private final EnergyStorage energyStorage = new EnergyStorage() {
+    private long energyReceivedThisTick = 0;
+    private final IEnergyStorage trackingStorage = new IEnergyStorage() {
         @Override
-        public boolean supportsInsertion() {
-            return energy.supportsInsertion();
-        }
-
-        @Override
-        public long insert(long maxAmount, TransactionContext transaction) {
-            long inserted = energy.insert(maxAmount, transaction);
-            if (inserted <= 0) {
-                return 0;
-            }
-
-            if (transaction == null) {
-                energyReceivedThisTick += inserted;
-            } else {
-                transaction.addOuterCloseCallback(result -> {
-                    if (result == Result.COMMITTED) {
-                        energyReceivedThisTick += inserted;
-                    }
-                });
-            }
+        public long insert(long maxAmount, boolean simulate) {
+            long inserted = energy.insert(maxAmount, simulate);
+            if (!simulate && inserted > 0) energyReceivedThisTick += inserted;
             return inserted;
         }
 
         @Override
-        public boolean supportsExtraction() {
-            return energy.supportsExtraction();
+        public long extract(long maxAmount, boolean simulate) {
+            return energy.extract(maxAmount, simulate);
         }
 
         @Override
-        public long extract(long maxAmount, TransactionContext transaction) {
-            return energy.extract(maxAmount, transaction);
-        }
+        public long getAmount() { return energy.getAmount(); }
 
         @Override
-        public long getAmount() {
-            return energy.getAmount();
-        }
+        public long getCapacity() { return energy.getCapacity(); }
 
         @Override
-        public long getCapacity() {
-            return energy.getCapacity();
-        }
+        public boolean canInsert() { return energy.canInsert(); }
+
+        @Override
+        public boolean canExtract() { return energy.canExtract(); }
     };
-    private long energyReceivedThisTick = 0;
 
     @Nullable private ResourceId activeRecipeId = null;
     int processProgress = 0;
@@ -270,12 +250,12 @@ public class MaceratorBlockEntity extends BaseBlockEntity
 
     @Override
     public IEnergyStorage energyStorage(@Nullable Direction side) {
-        return energyStorage;
+        return trackingStorage;
     }
 
     @Override
     public long networkDemandPerTick() {
-        long storageRoom = Math.max(0, ENERGY_CAPACITY - energy.amount);
+        long storageRoom = Math.max(0, ENERGY_CAPACITY - energy.getAmount());
         long remainingInput = Math.max(0, MAX_ENERGY_INPUT - energyReceivedThisTick);
         return Math.min(remainingInput, storageRoom);
     }

--- a/common/src/main/java/com/logistics/power/cable/CableBlock.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlock.java
@@ -2,7 +2,7 @@ package com.logistics.power.cable;
 
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.block.behavior.ProbeBehavior;
-import com.logistics.core.lib.support.ProbeResult;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
@@ -1,12 +1,14 @@
 package com.logistics.power.cable;
 
 import com.logistics.LogisticsPower;
-import com.logistics.core.lib.BaseBlockEntity;
+import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.core.lib.power.EnergyDemandProvider;
-import com.logistics.core.lib.support.ProbeResult;
-import com.logistics.core.lib.storage.NbtCompat;
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -50,7 +52,7 @@ public class CableBlockEntity extends BaseBlockEntity
     // ==================== HasEnergyStorage ====================
 
     @Override
-    public EnergyStorage energyStorage(@Nullable Direction side) {
+    public IEnergyStorage energyStorage(@Nullable Direction side) {
         return new CableEnergyStorage(side);
     }
 
@@ -223,13 +225,15 @@ public class CableBlockEntity extends BaseBlockEntity
         return rate > 0 ? String.format("%,d RF/t demand", rate) : "idle";
     }
 
-    private final class CableEnergyStorage implements EnergyStorage {
+    private final class CableEnergyStorage implements EnergyStorage, IEnergyStorage {
         @Nullable
         private final Direction side;
 
         private CableEnergyStorage(@Nullable Direction side) {
             this.side = side;
         }
+
+        // TR EnergyStorage — used by Fabric energy lookup (with transaction support)
 
         @Override
         public boolean supportsInsertion() { return true; }
@@ -254,5 +258,27 @@ public class CableBlockEntity extends BaseBlockEntity
 
         @Override
         public long getCapacity() { return 0; }
+
+        // IEnergyStorage — used by the loader-agnostic HasEnergyStorage contract
+
+        @Override
+        public long insert(long maxAmount, boolean simulate) {
+            if (simulate) return Math.min(maxAmount, getTransferRate());
+            if (level == null || level.isClientSide()) return 0;
+            try (Transaction tx = Transaction.openOuter()) {
+                long result = insert(maxAmount, tx);
+                if (result > 0) tx.commit();
+                return result;
+            }
+        }
+
+        @Override
+        public long extract(long maxAmount, boolean simulate) { return 0; }
+
+        @Override
+        public boolean canInsert() { return true; }
+
+        @Override
+        public boolean canExtract() { return false; }
     }
 }

--- a/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
@@ -263,11 +263,10 @@ public class CableBlockEntity extends BaseBlockEntity
 
         @Override
         public long insert(long maxAmount, boolean simulate) {
-            if (simulate) return Math.min(maxAmount, getTransferRate());
-            if (level == null || level.isClientSide()) return 0;
+            if (maxAmount <= 0 || level == null || level.isClientSide()) return 0;
             try (Transaction tx = Transaction.openOuter()) {
                 long result = insert(maxAmount, tx);
-                if (result > 0) tx.commit();
+                if (!simulate && result > 0) tx.commit();
                 return result;
             }
         }

--- a/fabric/src/client/java/com/logistics/LogisticsPowerClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsPowerClient.java
@@ -10,10 +10,8 @@ import com.logistics.power.screen.StirlingEngineScreen;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.BlockRenderLayerMap;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
-import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 
 import java.util.List;
 
@@ -53,10 +51,9 @@ public final class LogisticsPowerClient implements ClientDomainBootstrap {
         BlockEntityRenderers.register(LogisticsPower.ENTITY.STIRLING_ENGINE_BLOCK_ENTITY, EngineBlockEntityRenderer::new);
         BlockEntityRenderers.register(LogisticsPower.ENTITY.CREATIVE_ENGINE_BLOCK_ENTITY, EngineBlockEntityRenderer::new);
 
-        // Register cable blocks for chunk-baked cutout rendering
-        BlockRenderLayerMap.putBlock(LogisticsPower.BLOCK.COPPER_CABLE, ChunkSectionLayer.CUTOUT);
-        BlockRenderLayerMap.putBlock(LogisticsPower.BLOCK.GOLD_CABLE, ChunkSectionLayer.CUTOUT);
-        BlockRenderLayerMap.putBlock(LogisticsPower.BLOCK.ENDER_CABLE, ChunkSectionLayer.CUTOUT);
+        // Note: In MC 26.1, render layers are set per-quad via QuadEmitter.chunkLayer()
+        // rather than globally via BlockRenderLayerMap. CableModel sets ChunkSectionLayer.CUTOUT
+        // on each emitted quad directly.
 
         // Register screens
         MenuScreens.register(LogisticsPower.SCREEN.STIRLING_ENGINE, StirlingEngineScreen::new);

--- a/fabric/src/client/java/com/logistics/power/render/model/CableModel.java
+++ b/fabric/src/client/java/com/logistics/power/render/model/CableModel.java
@@ -5,18 +5,20 @@ import com.logistics.power.cable.CableBlockEntity;
 import com.logistics.power.cable.CableTier;
 import java.util.List;
 import java.util.function.Predicate;
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
-import net.fabricmc.fabric.api.renderer.v1.model.FabricBlockStateModel;
+import net.fabricmc.fabric.api.client.renderer.v1.mesh.QuadEmitter;
+import net.fabricmc.fabric.api.client.renderer.v1.model.FabricBlockStateModel;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.model.BlockModelPart;
-import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.sprite.Material;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.data.AtlasIds;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 public final class CableModel implements BlockStateModel, FabricBlockStateModel {
@@ -28,12 +30,17 @@ public final class CableModel implements BlockStateModel, FabricBlockStateModel 
     }
 
     @Override
-    public TextureAtlasSprite particleIcon() {
-        return sprite();
+    public Material.Baked particleMaterial() {
+        return new Material.Baked(sprite(), false);
     }
 
     @Override
-    public void collectParts(RandomSource random, List<BlockModelPart> parts) {
+    public int materialFlags() {
+        return 0;
+    }
+
+    @Override
+    public void collectParts(RandomSource random, List<BlockStateModelPart> parts) {
     }
 
     @Override
@@ -294,6 +301,7 @@ public final class CableModel implements BlockStateModel, FabricBlockStateModel 
         emitter.nominalFace(rotatedFace);
         emitter.cullFace(cullable ? rotatedFace : null);
         emitter.color(-1, -1, -1, -1);
+        emitter.chunkLayer(ChunkSectionLayer.CUTOUT);
         emitter.emit();
     }
 
@@ -454,6 +462,7 @@ public final class CableModel implements BlockStateModel, FabricBlockStateModel 
         emitter.nominalFace(face);
         emitter.cullFace(null);
         emitter.color(-1, -1, -1, -1);
+        emitter.chunkLayer(ChunkSectionLayer.CUTOUT);
         emitter.emit();
     }
 

--- a/fabric/src/client/java/com/logistics/power/render/model/CableUnbakedRoot.java
+++ b/fabric/src/client/java/com/logistics/power/render/model/CableUnbakedRoot.java
@@ -1,7 +1,7 @@
 package com.logistics.power.render.model;
 
 import com.logistics.power.cable.CableTier;
-import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.client.resources.model.ResolvableModel;
 import net.minecraft.data.AtlasIds;

--- a/fabric/src/gametest/java/com/logistics/gametest/automation/QuarryGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/automation/QuarryGameTest.java
@@ -79,14 +79,10 @@ public class QuarryGameTest {
             return;
         }
 
-        try (net.fabricmc.fabric.api.transfer.v1.transaction.Transaction transaction =
-                net.fabricmc.fabric.api.transfer.v1.transaction.Transaction.openOuter()) {
-            long inserted = quarry.energyStorage(Direction.NORTH).insert(60, transaction);
-            if (inserted != 60) {
-                context.fail("Expected quarry to accept 60 RF, got " + inserted);
-                return;
-            }
-            transaction.commit();
+        long inserted = quarry.energyStorage(Direction.NORTH).insert(60, false);
+        if (inserted != 60) {
+            context.fail("Expected quarry to accept 60 RF, got " + inserted);
+            return;
         }
 
         context.runAfterDelay(1, () -> {

--- a/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
@@ -4,7 +4,7 @@ import com.logistics.LogisticsCore;
 import com.logistics.LogisticsPower;
 import com.logistics.core.macerator.MaceratorBlockEntity;
 import com.logistics.core.lib.power.AbstractEngineBlock;
-import com.logistics.core.lib.support.ProbeResult;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.logistics.power.cable.CableBlock;
 import com.logistics.power.cable.CableBlockEntity;
 import com.logistics.power.block.entity.CreativeSinkBlockEntity;
@@ -36,11 +36,7 @@ public class CableGameTest {
         }
 
         for (Direction direction : Direction.values()) {
-            EnergyStorage storage = cable.energyStorage(direction);
-            if (storage == null) {
-                context.fail("Copper cable should expose storage from " + direction);
-                return;
-            }
+            EnergyStorage storage = findStorage(context, cablePos, direction);
             if (!storage.supportsInsertion()) {
                 context.fail("Copper cable should support insertion from " + direction);
                 return;
@@ -80,7 +76,7 @@ public class CableGameTest {
         }
 
         Transaction transaction = Transaction.openOuter();
-        long inserted = cable.energyStorage(Direction.WEST).insert(demandBefore, transaction);
+        long inserted = findStorage(context, cablePos, Direction.WEST).insert(demandBefore, transaction);
         if (inserted != demandBefore) {
             transaction.close();
             context.fail("Cable should reserve creative sink demand inside transaction, got: " + inserted);
@@ -123,9 +119,8 @@ public class CableGameTest {
         }
         giveMaceratorWork(machine);
 
-        EnergyStorage cableStorage = sourceCable.energyStorage(Direction.WEST);
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cableStorage.insert(640L, transaction);
+            long inserted = findStorage(context, sourceCablePos, Direction.WEST).insert(640L, transaction);
             if (inserted <= 0) {
                 context.fail("Cable network should pass inserted energy through to the machine");
                 return;
@@ -161,7 +156,7 @@ public class CableGameTest {
         }
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cable.energyStorage(Direction.WEST).insert(30L, transaction);
+            long inserted = findStorage(context, cablePos, Direction.WEST).insert(30L, transaction);
             if (inserted != 30L) {
                 context.fail("Idle machine buffer should accept cable energy, got: " + inserted);
                 return;
@@ -198,7 +193,7 @@ public class CableGameTest {
             return;
         }
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cable.energyStorage(Direction.WEST).insert(demandBefore, transaction);
+            long inserted = findStorage(context, cablePos, Direction.WEST).insert(demandBefore, transaction);
             if (inserted != demandBefore) {
                 context.fail("Cable should reserve creative sink demand inside transaction, got: " + inserted);
                 return;
@@ -234,7 +229,7 @@ public class CableGameTest {
         setSinkDrainRate(largeSink, 10L, context);
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cable.energyStorage(Direction.WEST).insert(9L, transaction);
+            long inserted = findStorage(context, cablePos, Direction.WEST).insert(9L, transaction);
             if (inserted != 9L) {
                 context.fail("Cable should accept all energy demanded by sinks, got: " + inserted);
                 return;
@@ -272,7 +267,7 @@ public class CableGameTest {
         sink.setUnlimitedDrainRate();
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = enderCable.energyStorage(Direction.WEST).insert(60L, transaction);
+            long inserted = findStorage(context, enderCablePos, Direction.WEST).insert(60L, transaction);
             if (inserted != 30L) {
                 context.fail("Ender-to-copper route should be capped at 30 RF/t, got: " + inserted);
                 return;
@@ -281,7 +276,7 @@ public class CableGameTest {
         }
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = enderCable.energyStorage(Direction.WEST).insert(60L, transaction);
+            long inserted = findStorage(context, enderCablePos, Direction.WEST).insert(60L, transaction);
             if (inserted != 0L) {
                 context.fail("Copper bottleneck should be spent for the tick, got extra: " + inserted);
                 return;
@@ -355,7 +350,7 @@ public class CableGameTest {
             }
             giveMaceratorWork(machine);
 
-            EnergyStorage sourceStorage = sourceCable.energyStorage(Direction.WEST);
+            EnergyStorage sourceStorage = findStorage(context, sourceCablePos, Direction.WEST);
             try (Transaction transaction = Transaction.openOuter()) {
                 long inserted = sourceStorage.insert(640L, transaction);
                 if (inserted != 0) {
@@ -467,7 +462,7 @@ public class CableGameTest {
                 giveMaceratorWork(machine);
 
                 try (Transaction transaction = Transaction.openOuter()) {
-                    long inserted = sourceCable.energyStorage(Direction.WEST).insert(640L, transaction);
+                    long inserted = findStorage(context, sourceCablePos, Direction.WEST).insert(640L, transaction);
                     if (inserted <= 0) {
                         context.fail("Restored cable should rejoin network and deliver energy");
                         return;
@@ -483,6 +478,14 @@ public class CableGameTest {
                 context.succeed();
             });
         });
+    }
+
+    private static EnergyStorage findStorage(GameTestHelper ctx, BlockPos relPos, Direction dir) {
+        EnergyStorage storage = EnergyStorage.SIDED.find(ctx.getLevel(), ctx.absolutePos(relPos), dir);
+        if (storage == null) {
+            ctx.fail("No EnergyStorage at " + relPos + " from " + dir);
+        }
+        return storage;
     }
 
     private static void giveMaceratorWork(MaceratorBlockEntity machine) {

--- a/fabric/src/main/java/com/logistics/fabric/FabricNetworkTickHandler.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricNetworkTickHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.fabric;
 
 import com.logistics.pipe.network.NetworkRegistry;
+import com.logistics.power.cable.CableNetworkManager;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
@@ -13,6 +14,7 @@ public final class FabricNetworkTickHandler {
 
     public static void register() {
         ServerTickEvents.END_SERVER_TICK.register(NetworkRegistry::tickNetworks);
+        ServerTickEvents.END_SERVER_TICK.register(CableNetworkManager::tickAll);
         ServerLevelEvents.UNLOAD.register((server, level) -> NetworkRegistry.clearLevel(level));
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/FabricServerLevelEvents.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricServerLevelEvents.java
@@ -1,6 +1,7 @@
 package com.logistics.fabric;
 
 import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
+import com.logistics.power.cable.CableNetworkManager;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
 
 /**
@@ -12,5 +13,6 @@ public final class FabricServerLevelEvents {
 
     public static void register() {
         ServerLevelEvents.UNLOAD.register((server, world) -> LaserQuarryBlockEntity.clearActiveQuarries(world));
+        ServerLevelEvents.UNLOAD.register((server, world) -> CableNetworkManager.clearLevel(world));
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -3,15 +3,12 @@ package com.logistics.fabric;
 import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPower;
 import com.logistics.core.bootstrap.LogisticsCommonBootstrap;
+import com.logistics.core.lib.platform.CreativeTabRegistrar;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.fabric.capability.FabricCapabilityRegistration;
 import com.logistics.fabric.energy.EnergyStorageAccess;
-import com.logistics.power.cable.CableNetworkManager;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
-import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
@@ -45,18 +42,10 @@ public final class LogisticsFabric implements ModInitializer {
             )
         );
 
-        // Cable network lifecycle events
-        ServerTickEvents.END_SERVER_TICK.register(CableNetworkManager::tickAll);
-        ServerWorldEvents.UNLOAD.register((server, level) -> CableNetworkManager.clearLevel(level));
-
-        // Vanilla creative tab entries
-        addVanillaCreativeTabEntries();
-    }
-
-    private static void addVanillaCreativeTabEntries() {
-        ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.INGREDIENTS).register(entries -> {
-            entries.addAfter(Items.SLIME_BALL, LogisticsPower.ITEM.RUBBER_MIX);
-            entries.addAfter(LogisticsPower.ITEM.RUBBER_MIX, LogisticsPower.ITEM.RUBBER_CHUNK);
+        // Vanilla creative tab entries (rubber items beside slime ball in Ingredients)
+        CreativeTabRegistrar.INSTANCE.modifyTab(CreativeModeTabs.INGREDIENTS, editor -> {
+            editor.insertAfter(Items.SLIME_BALL, LogisticsPower.ITEM.RUBBER_MIX);
+            editor.insertAfter(LogisticsPower.ITEM.RUBBER_MIX, LogisticsPower.ITEM.RUBBER_CHUNK);
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes compilation errors introduced when the power cables feature was cherry-picked to mc/26.1. The common code used package paths and API patterns from mc/1.21.11 that don't match the refactored structure on mc/26.1.

## Changes

- **CableBlock**: fix `ProbeResult` import (`core.lib.support` → `core.lib.block.behavior`)
- **CableBlockEntity**: fix `BaseBlockEntity`, `ProbeResult`, `NbtCompat` imports; make `CableEnergyStorage` implement both TR `EnergyStorage` and `IEnergyStorage` so it satisfies `HasEnergyStorage`
- **MaceratorBlockEntity**: replace TR `EnergyStorage` inner class with `IEnergyStorage` tracking wrapper; fix `energy.amount` → `energy.getAmount()`
- **LaserQuarryBlockEntity**: same tracking wrapper pattern; fix `energy.amount` → `energy.getAmount()`
- **LogisticsFabric**: move cable lifecycle registrations to `FabricNetworkTickHandler`/`FabricServerLevelEvents`; replace `ItemGroupEvents` with loader-agnostic `CreativeTabRegistrar`
- **FabricNetworkTickHandler**: add `CableNetworkManager::tickAll`
- **FabricServerLevelEvents**: add `CableNetworkManager.clearLevel`