### PR TITLE
fix: correct power cable compilation errors for mc/1.21.11

### DIFF
--- a/common/src/client/java/com/logistics/core/lib/client/model/ClientModelRegistry.java
+++ b/common/src/client/java/com/logistics/core/lib/client/model/ClientModelRegistry.java
@@ -1,7 +1,7 @@
 package com.logistics.core.lib.client.model;
 
 import com.logistics.core.lib.resource.ResourceId;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.block.model.BlockStateModel;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -14,12 +14,11 @@ import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.block.behavior.ProbeResult;
+import com.logistics.core.lib.power.EnergyDemandProvider;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext.Result;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -69,54 +68,34 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
             0,
             this::setChanged
     );
-    private final EnergyStorage energyStorage = new EnergyStorage() {
+    private long energyReceivedLastTick = 0;
+    private long energyReceivedThisTick = 0;
+    private final IEnergyStorage trackingStorage = new IEnergyStorage() {
         @Override
-        public boolean supportsExtraction() {
-            return energy.supportsExtraction();
-        }
-
-        @Override
-        public boolean supportsInsertion() {
-            return energy.supportsInsertion();
-        }
-
-        @Override
-        public long insert(long maxAmount, TransactionContext transaction) {
-            long inserted = energy.insert(maxAmount, transaction);
-            if (inserted <= 0) {
-                return 0;
-            }
-
-            if (transaction == null) {
-                energyReceivedThisTick += inserted;
-            } else {
-                transaction.addOuterCloseCallback(result -> {
-                    if (result == Result.COMMITTED) {
-                        energyReceivedThisTick += inserted;
-                    }
-                });
-            }
+        public long insert(long maxAmount, boolean simulate) {
+            long inserted = energy.insert(maxAmount, simulate);
+            if (!simulate && inserted > 0) energyReceivedThisTick += inserted;
             return inserted;
         }
 
         @Override
-        public long extract(long maxAmount, TransactionContext transaction) {
-            return energy.extract(maxAmount, transaction);
+        public long extract(long maxAmount, boolean simulate) {
+            return energy.extract(maxAmount, simulate);
         }
 
         @Override
-        public long getAmount() {
-            return energy.getAmount();
-        }
+        public long getAmount() { return energy.getAmount(); }
 
         @Override
-        public long getCapacity() {
-            return energy.getCapacity();
-        }
+        public long getCapacity() { return energy.getCapacity(); }
+
+        @Override
+        public boolean canInsert() { return energy.canInsert(); }
+
+        @Override
+        public boolean canExtract() { return energy.canExtract(); }
     };
     private long lastSyncedEnergy = 0; // For client sync
-    private long energyReceivedLastTick = 0;
-    private long energyReceivedThisTick = 0;
     private boolean consumedEnergyThisTick = false; // For LED when buffer is low
 
     // Phase state
@@ -165,7 +144,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     @Override
     public IEnergyStorage energyStorage(@Nullable Direction side) {
         // Quarry accepts energy from all sides
-        return energyStorage;
+        return trackingStorage;
     }
 
     public static void tick(Level world, BlockPos pos, BlockState state, LaserQuarryBlockEntity entity) {
@@ -1180,7 +1159,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     @Override
     public long networkDemandPerTick() {
-        long storageRoom = Math.max(0, LogisticsConfig.get().quarry.energyCapacity() - energy.amount);
+        long storageRoom = Math.max(0, LogisticsConfig.get().quarry.energyCapacity() - energy.getAmount());
         long remainingInput = Math.max(0, LogisticsConfig.get().quarry.maxEnergyInput() - energyReceivedThisTick);
         return Math.min(remainingInput, storageRoom);
     }

--- a/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
@@ -66,52 +66,32 @@ public class MaceratorBlockEntity extends BaseBlockEntity
 
     private final ItemInventoryComponent inventory = new ItemInventoryComponent(TOTAL_SLOTS, this::setChanged);
     final EnergyComponent energy = new EnergyComponent(ENERGY_CAPACITY, MAX_ENERGY_INPUT, 0, this::setChanged);
-    private final EnergyStorage energyStorage = new EnergyStorage() {
+    private long energyReceivedThisTick = 0;
+    private final IEnergyStorage trackingStorage = new IEnergyStorage() {
         @Override
-        public boolean supportsInsertion() {
-            return energy.supportsInsertion();
-        }
-
-        @Override
-        public long insert(long maxAmount, TransactionContext transaction) {
-            long inserted = energy.insert(maxAmount, transaction);
-            if (inserted <= 0) {
-                return 0;
-            }
-
-            if (transaction == null) {
-                energyReceivedThisTick += inserted;
-            } else {
-                transaction.addOuterCloseCallback(result -> {
-                    if (result == Result.COMMITTED) {
-                        energyReceivedThisTick += inserted;
-                    }
-                });
-            }
+        public long insert(long maxAmount, boolean simulate) {
+            long inserted = energy.insert(maxAmount, simulate);
+            if (!simulate && inserted > 0) energyReceivedThisTick += inserted;
             return inserted;
         }
 
         @Override
-        public boolean supportsExtraction() {
-            return energy.supportsExtraction();
+        public long extract(long maxAmount, boolean simulate) {
+            return energy.extract(maxAmount, simulate);
         }
 
         @Override
-        public long extract(long maxAmount, TransactionContext transaction) {
-            return energy.extract(maxAmount, transaction);
-        }
+        public long getAmount() { return energy.getAmount(); }
 
         @Override
-        public long getAmount() {
-            return energy.getAmount();
-        }
+        public long getCapacity() { return energy.getCapacity(); }
 
         @Override
-        public long getCapacity() {
-            return energy.getCapacity();
-        }
+        public boolean canInsert() { return energy.canInsert(); }
+
+        @Override
+        public boolean canExtract() { return energy.canExtract(); }
     };
-    private long energyReceivedThisTick = 0;
 
     @Nullable private ResourceId activeRecipeId = null;
     int processProgress = 0;
@@ -270,12 +250,12 @@ public class MaceratorBlockEntity extends BaseBlockEntity
 
     @Override
     public IEnergyStorage energyStorage(@Nullable Direction side) {
-        return energyStorage;
+        return trackingStorage;
     }
 
     @Override
     public long networkDemandPerTick() {
-        long storageRoom = Math.max(0, ENERGY_CAPACITY - energy.amount);
+        long storageRoom = Math.max(0, ENERGY_CAPACITY - energy.getAmount());
         long remainingInput = Math.max(0, MAX_ENERGY_INPUT - energyReceivedThisTick);
         return Math.min(remainingInput, storageRoom);
     }

--- a/common/src/main/java/com/logistics/core/macerator/MaceratorRecipeSerializer.java
+++ b/common/src/main/java/com/logistics/core/macerator/MaceratorRecipeSerializer.java
@@ -18,6 +18,8 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
  */
 public class MaceratorRecipeSerializer implements RecipeSerializer<MaceratorRecipeWrapper> {
 
+    public static final MaceratorRecipeSerializer INSTANCE = new MaceratorRecipeSerializer();
+
     private static final MapCodec<MaceratorRecipeWrapper> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
         Ingredient.CODEC.fieldOf("ingredient").forGetter(MaceratorRecipeWrapper::ingredient),
         ItemStack.STRICT_CODEC.fieldOf("result").forGetter(MaceratorRecipeWrapper::result),

--- a/common/src/main/java/com/logistics/power/cable/CableBlock.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlock.java
@@ -2,7 +2,7 @@ package com.logistics.power.cable;
 
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.block.behavior.ProbeBehavior;
-import com.logistics.core.lib.support.ProbeResult;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
@@ -1,12 +1,14 @@
 package com.logistics.power.cable;
 
 import com.logistics.LogisticsPower;
-import com.logistics.core.lib.BaseBlockEntity;
+import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.core.lib.power.EnergyDemandProvider;
-import com.logistics.core.lib.support.ProbeResult;
-import com.logistics.core.lib.storage.NbtCompat;
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -50,7 +52,7 @@ public class CableBlockEntity extends BaseBlockEntity
     // ==================== HasEnergyStorage ====================
 
     @Override
-    public EnergyStorage energyStorage(@Nullable Direction side) {
+    public IEnergyStorage energyStorage(@Nullable Direction side) {
         return new CableEnergyStorage(side);
     }
 
@@ -223,13 +225,15 @@ public class CableBlockEntity extends BaseBlockEntity
         return rate > 0 ? String.format("%,d RF/t demand", rate) : "idle";
     }
 
-    private final class CableEnergyStorage implements EnergyStorage {
+    private final class CableEnergyStorage implements EnergyStorage, IEnergyStorage {
         @Nullable
         private final Direction side;
 
         private CableEnergyStorage(@Nullable Direction side) {
             this.side = side;
         }
+
+        // TR EnergyStorage — used by Fabric energy lookup (with transaction support)
 
         @Override
         public boolean supportsInsertion() { return true; }
@@ -254,5 +258,27 @@ public class CableBlockEntity extends BaseBlockEntity
 
         @Override
         public long getCapacity() { return 0; }
+
+        // IEnergyStorage — used by the loader-agnostic HasEnergyStorage contract
+
+        @Override
+        public long insert(long maxAmount, boolean simulate) {
+            if (simulate) return Math.min(maxAmount, getTransferRate());
+            if (level == null || level.isClientSide()) return 0;
+            try (Transaction tx = Transaction.openOuter()) {
+                long result = insert(maxAmount, tx);
+                if (result > 0) tx.commit();
+                return result;
+            }
+        }
+
+        @Override
+        public long extract(long maxAmount, boolean simulate) { return 0; }
+
+        @Override
+        public boolean canInsert() { return true; }
+
+        @Override
+        public boolean canExtract() { return false; }
     }
 }

--- a/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
@@ -263,11 +263,10 @@ public class CableBlockEntity extends BaseBlockEntity
 
         @Override
         public long insert(long maxAmount, boolean simulate) {
-            if (simulate) return Math.min(maxAmount, getTransferRate());
-            if (level == null || level.isClientSide()) return 0;
+            if (maxAmount <= 0 || level == null || level.isClientSide()) return 0;
             try (Transaction tx = Transaction.openOuter()) {
                 long result = insert(maxAmount, tx);
-                if (result > 0) tx.commit();
+                if (!simulate && result > 0) tx.commit();
                 return result;
             }
         }

--- a/fabric/src/client/java/com/logistics/LogisticsAutomationClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsAutomationClient.java
@@ -12,6 +12,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockRenderLayerMap;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.gui.screens.MenuScreens;
 
 import static com.logistics.LogisticsMod.LOGGER;

--- a/fabric/src/client/java/com/logistics/fabric/FabricModelLoader.java
+++ b/fabric/src/client/java/com/logistics/fabric/FabricModelLoader.java
@@ -3,11 +3,11 @@ package com.logistics.fabric;
 import com.logistics.core.lib.client.model.ClientModelRegistry;
 import com.logistics.core.lib.resource.ResourceId;
 import net.fabricmc.fabric.api.client.model.loading.v1.ExtraModelKey;
-import net.fabricmc.fabric.api.client.model.loading.v1.FabricModelManager;
+import net.fabricmc.fabric.api.client.model.loading.v1.FabricBakedModelManager;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
 import net.fabricmc.fabric.api.client.model.loading.v1.SimpleUnbakedExtraModel;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.block.model.BlockStateModel;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
@@ -56,7 +56,7 @@ public final class FabricModelLoader {
         ClientModelRegistry.registerProvider(key -> {
             ExtraModelKey<BlockStateModel> fk = FABRIC_KEYS.get(key);
             if (fk == null) return null;
-            return ((FabricModelManager) Minecraft.getInstance().getModelManager()).getModel(fk);
+            return ((FabricBakedModelManager) Minecraft.getInstance().getModelManager()).getModel(fk);
         });
 
         initialized = true;

--- a/fabric/src/client/java/com/logistics/pipe/render/PipeBlockEntityRenderer.java
+++ b/fabric/src/client/java/com/logistics/pipe/render/PipeBlockEntityRenderer.java
@@ -14,6 +14,7 @@ import com.logistics.core.lib.pipe.TravelingItem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.model.BlockStateModel;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;

--- a/fabric/src/gametest/java/com/logistics/gametest/automation/QuarryGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/automation/QuarryGameTest.java
@@ -79,14 +79,10 @@ public class QuarryGameTest {
             return;
         }
 
-        try (net.fabricmc.fabric.api.transfer.v1.transaction.Transaction transaction =
-                net.fabricmc.fabric.api.transfer.v1.transaction.Transaction.openOuter()) {
-            long inserted = quarry.energyStorage(Direction.NORTH).insert(60, transaction);
-            if (inserted != 60) {
-                context.fail("Expected quarry to accept 60 RF, got " + inserted);
-                return;
-            }
-            transaction.commit();
+        long inserted = quarry.energyStorage(Direction.NORTH).insert(60, false);
+        if (inserted != 60) {
+            context.fail("Expected quarry to accept 60 RF, got " + inserted);
+            return;
         }
 
         context.runAfterDelay(1, () -> {

--- a/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
@@ -485,7 +485,11 @@ public class CableGameTest {
     }
 
     private static EnergyStorage findStorage(GameTestHelper ctx, BlockPos relPos, Direction dir) {
-        return EnergyStorage.SIDED.find(ctx.getLevel(), ctx.absolutePos(relPos), dir);
+        EnergyStorage storage = EnergyStorage.SIDED.find(ctx.getLevel(), ctx.absolutePos(relPos), dir);
+        if (storage == null) {
+            ctx.fail("No EnergyStorage at " + relPos + " from " + dir);
+        }
+        return storage;
     }
 
     private static void giveMaceratorWork(MaceratorBlockEntity machine) {

--- a/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
@@ -4,7 +4,7 @@ import com.logistics.LogisticsCore;
 import com.logistics.LogisticsPower;
 import com.logistics.core.macerator.MaceratorBlockEntity;
 import com.logistics.core.lib.power.AbstractEngineBlock;
-import com.logistics.core.lib.support.ProbeResult;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.logistics.power.cable.CableBlock;
 import com.logistics.power.cable.CableBlockEntity;
 import com.logistics.power.block.entity.CreativeSinkBlockEntity;
@@ -36,7 +36,7 @@ public class CableGameTest {
         }
 
         for (Direction direction : Direction.values()) {
-            EnergyStorage storage = cable.energyStorage(direction);
+            EnergyStorage storage = findStorage(context, cablePos, direction);
             if (storage == null) {
                 context.fail("Copper cable should expose storage from " + direction);
                 return;
@@ -80,7 +80,7 @@ public class CableGameTest {
         }
 
         Transaction transaction = Transaction.openOuter();
-        long inserted = cable.energyStorage(Direction.WEST).insert(demandBefore, transaction);
+        long inserted = findStorage(context, cablePos, Direction.WEST).insert(demandBefore, transaction);
         if (inserted != demandBefore) {
             transaction.close();
             context.fail("Cable should reserve creative sink demand inside transaction, got: " + inserted);
@@ -123,9 +123,8 @@ public class CableGameTest {
         }
         giveMaceratorWork(machine);
 
-        EnergyStorage cableStorage = sourceCable.energyStorage(Direction.WEST);
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cableStorage.insert(640L, transaction);
+            long inserted = findStorage(context, sourceCablePos, Direction.WEST).insert(640L, transaction);
             if (inserted <= 0) {
                 context.fail("Cable network should pass inserted energy through to the machine");
                 return;
@@ -161,7 +160,7 @@ public class CableGameTest {
         }
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cable.energyStorage(Direction.WEST).insert(30L, transaction);
+            long inserted = findStorage(context, cablePos, Direction.WEST).insert(30L, transaction);
             if (inserted != 30L) {
                 context.fail("Idle machine buffer should accept cable energy, got: " + inserted);
                 return;
@@ -198,7 +197,7 @@ public class CableGameTest {
             return;
         }
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cable.energyStorage(Direction.WEST).insert(demandBefore, transaction);
+            long inserted = findStorage(context, cablePos, Direction.WEST).insert(demandBefore, transaction);
             if (inserted != demandBefore) {
                 context.fail("Cable should reserve creative sink demand inside transaction, got: " + inserted);
                 return;
@@ -234,7 +233,7 @@ public class CableGameTest {
         setSinkDrainRate(largeSink, 10L, context);
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = cable.energyStorage(Direction.WEST).insert(9L, transaction);
+            long inserted = findStorage(context, cablePos, Direction.WEST).insert(9L, transaction);
             if (inserted != 9L) {
                 context.fail("Cable should accept all energy demanded by sinks, got: " + inserted);
                 return;
@@ -272,7 +271,7 @@ public class CableGameTest {
         sink.setUnlimitedDrainRate();
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = enderCable.energyStorage(Direction.WEST).insert(60L, transaction);
+            long inserted = findStorage(context, enderCablePos, Direction.WEST).insert(60L, transaction);
             if (inserted != 30L) {
                 context.fail("Ender-to-copper route should be capped at 30 RF/t, got: " + inserted);
                 return;
@@ -281,7 +280,7 @@ public class CableGameTest {
         }
 
         try (Transaction transaction = Transaction.openOuter()) {
-            long inserted = enderCable.energyStorage(Direction.WEST).insert(60L, transaction);
+            long inserted = findStorage(context, enderCablePos, Direction.WEST).insert(60L, transaction);
             if (inserted != 0L) {
                 context.fail("Copper bottleneck should be spent for the tick, got extra: " + inserted);
                 return;
@@ -355,7 +354,7 @@ public class CableGameTest {
             }
             giveMaceratorWork(machine);
 
-            EnergyStorage sourceStorage = sourceCable.energyStorage(Direction.WEST);
+            EnergyStorage sourceStorage = findStorage(context, sourceCablePos, Direction.WEST);
             try (Transaction transaction = Transaction.openOuter()) {
                 long inserted = sourceStorage.insert(640L, transaction);
                 if (inserted != 0) {
@@ -467,7 +466,7 @@ public class CableGameTest {
                 giveMaceratorWork(machine);
 
                 try (Transaction transaction = Transaction.openOuter()) {
-                    long inserted = sourceCable.energyStorage(Direction.WEST).insert(640L, transaction);
+                    long inserted = findStorage(context, sourceCablePos, Direction.WEST).insert(640L, transaction);
                     if (inserted <= 0) {
                         context.fail("Restored cable should rejoin network and deliver energy");
                         return;
@@ -483,6 +482,10 @@ public class CableGameTest {
                 context.succeed();
             });
         });
+    }
+
+    private static EnergyStorage findStorage(GameTestHelper ctx, BlockPos relPos, Direction dir) {
+        return EnergyStorage.SIDED.find(ctx.getLevel(), ctx.absolutePos(relPos), dir);
     }
 
     private static void giveMaceratorWork(MaceratorBlockEntity machine) {

--- a/fabric/src/main/java/com/logistics/fabric/FabricCreativeTabRegistrar.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricCreativeTabRegistrar.java
@@ -2,8 +2,8 @@ package com.logistics.fabric;
 
 import com.logistics.core.lib.platform.LogisticsCreativeTab;
 import com.logistics.core.lib.platform.CreativeTabRegistrar;
-import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
-import net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab;
+import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
@@ -18,7 +18,7 @@ public final class FabricCreativeTabRegistrar implements CreativeTabRegistrar {
         Registry.register(
             BuiltInRegistries.CREATIVE_MODE_TAB,
             tab.id().toIdentifier(),
-            FabricCreativeModeTab.builder()
+            FabricItemGroup.builder()
                 .title(tab.title())
                 .icon(tab.icon())
                 .displayItems((params, entries) -> tab.populate(entries))
@@ -28,16 +28,16 @@ public final class FabricCreativeTabRegistrar implements CreativeTabRegistrar {
 
     @Override
     public void modifyTab(ResourceKey<CreativeModeTab> tab, Consumer<TabEditor> editor) {
-        CreativeModeTabEvents.modifyOutputEvent(tab).register(fabricEntries ->
+        ItemGroupEvents.modifyEntriesEvent(tab).register(fabricEntries ->
             editor.accept(new TabEditor() {
                 @Override
                 public void insertAfter(ItemLike anchor, ItemLike item) {
-                    fabricEntries.insertAfter(anchor, item);
+                    fabricEntries.addAfter(anchor, item);
                 }
 
                 @Override
                 public void insertBefore(ItemLike anchor, ItemLike item) {
-                    fabricEntries.insertBefore(anchor, item);
+                    fabricEntries.addBefore(anchor, item);
                 }
             })
         );

--- a/fabric/src/main/java/com/logistics/fabric/FabricNetworkTickHandler.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricNetworkTickHandler.java
@@ -1,7 +1,7 @@
 package com.logistics.fabric;
 
 import com.logistics.pipe.network.NetworkRegistry;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 /**
@@ -13,6 +13,6 @@ public final class FabricNetworkTickHandler {
 
     public static void register() {
         ServerTickEvents.END_SERVER_TICK.register(NetworkRegistry::tickNetworks);
-        ServerLevelEvents.UNLOAD.register((server, level) -> NetworkRegistry.clearLevel(level));
+        ServerWorldEvents.UNLOAD.register((server, level) -> NetworkRegistry.clearLevel(level));
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/FabricPacketRegistration.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPacketRegistration.java
@@ -16,19 +16,19 @@ public final class FabricPacketRegistration {
         ServerNetworking.register(ServerPlayNetworking::send);
 
         // Serverbound packets
-        PayloadTypeRegistry.serverboundPlay().register(RequestItemPacket.TYPE, RequestItemPacket.CODEC);
+        PayloadTypeRegistry.playC2S().register(RequestItemPacket.TYPE, RequestItemPacket.CODEC);
         ServerPlayNetworking.registerGlobalReceiver(RequestItemPacket.TYPE,
                 (packet, context) -> context.server().execute(() -> packet.handle(context.player())));
 
-        PayloadTypeRegistry.serverboundPlay().register(SetSatelliteIdPacket.TYPE, SetSatelliteIdPacket.CODEC);
+        PayloadTypeRegistry.playC2S().register(SetSatelliteIdPacket.TYPE, SetSatelliteIdPacket.CODEC);
         ServerPlayNetworking.registerGlobalReceiver(SetSatelliteIdPacket.TYPE,
                 (packet, context) -> context.server().execute(() -> packet.handle(context.player())));
 
-        PayloadTypeRegistry.serverboundPlay().register(OpenChassisSlotPacket.TYPE, OpenChassisSlotPacket.CODEC);
+        PayloadTypeRegistry.playC2S().register(OpenChassisSlotPacket.TYPE, OpenChassisSlotPacket.CODEC);
         ServerPlayNetworking.registerGlobalReceiver(OpenChassisSlotPacket.TYPE,
                 (packet, context) -> context.server().execute(() -> packet.handle(context.player())));
 
         // Clientbound packets (type registration only; receiver registered in LogisticsPipeClient)
-        PayloadTypeRegistry.clientboundPlay().register(SyncRequesterInventoryPacket.TYPE, SyncRequesterInventoryPacket.CODEC);
+        PayloadTypeRegistry.playS2C().register(SyncRequesterInventoryPacket.TYPE, SyncRequesterInventoryPacket.CODEC);
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/FabricResourceReloadRegistrar.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricResourceReloadRegistrar.java
@@ -9,6 +9,6 @@ import net.minecraft.server.packs.resources.PreparableReloadListener;
 public final class FabricResourceReloadRegistrar implements ResourceReloadRegistrar {
     @Override
     public void register(ResourceId id, PreparableReloadListener listener) {
-        ResourceLoader.get(PackType.SERVER_DATA).registerReloadListener(id.toIdentifier(), listener);
+        ResourceLoader.get(PackType.SERVER_DATA).registerReloader(id.toIdentifier(), listener);
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/FabricServerLevelEvents.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricServerLevelEvents.java
@@ -1,7 +1,8 @@
 package com.logistics.fabric;
 
 import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
+import com.logistics.power.cable.CableNetworkManager;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 
 /**
  * Fabric lifecycle event registrations for automation domain.
@@ -11,6 +12,7 @@ public final class FabricServerLevelEvents {
     private FabricServerLevelEvents() {}
 
     public static void register() {
-        ServerLevelEvents.UNLOAD.register((server, world) -> LaserQuarryBlockEntity.clearActiveQuarries(world));
+        ServerWorldEvents.UNLOAD.register((server, world) -> LaserQuarryBlockEntity.clearActiveQuarries(world));
+        ServerWorldEvents.UNLOAD.register((server, world) -> CableNetworkManager.clearLevel(world));
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidKey.java
+++ b/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidKey.java
@@ -42,7 +42,7 @@ public final class FabricFluidKey implements IFluidKey {
 
     @Override
     public DataComponentPatch getComponents() {
-        return variant.getComponentsPatch();
+        return variant.getComponents();
     }
 
     @Override

--- a/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.platform.CreativeTabRegistrar
+++ b/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.platform.CreativeTabRegistrar
@@ -1,0 +1,1 @@
+com.logistics.fabric.FabricCreativeTabRegistrar

--- a/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
+++ b/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
@@ -1,0 +1,1 @@
+com.logistics.fabric.FabricPlatformService

--- a/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.platform.ResourceReloadRegistrar
+++ b/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.platform.ResourceReloadRegistrar
@@ -1,0 +1,1 @@
+com.logistics.fabric.FabricResourceReloadRegistrar


### PR DESCRIPTION
## Summary

Fixes compilation errors introduced when the power cables feature was cherry-picked to mc/1.21.11. The common code used TR transaction-based APIs and Fabric API names that changed between versions.

## Changes

- **CableBlockEntity**: fix `BaseBlockEntity`, `ProbeResult`, `NbtCompat` imports; make `CableEnergyStorage` implement both TR `EnergyStorage` and `IEnergyStorage`
- **MaceratorBlockEntity**: replace TR `EnergyStorage` inner class with `IEnergyStorage` tracking wrapper; fix `energy.amount` → `energy.getAmount()`
- **LaserQuarryBlockEntity**: same tracking wrapper pattern; fix `energy.amount` → `energy.getAmount()`; remove `TransactionContext`/`Result` imports
- **MaceratorRecipeSerializer**: add missing `INSTANCE` field
- **FabricCreativeTabRegistrar**: `creativetab.v1` → `itemgroup.v1`; `insertAfter`/`insertBefore` → `addAfter`/`addBefore`
- **FabricNetworkTickHandler**: `ServerLevelEvents` → `ServerWorldEvents`; add `CableNetworkManager::tickAll`
- **FabricServerLevelEvents**: `ServerLevelEvents` → `ServerWorldEvents`; add `CableNetworkManager.clearLevel`
- **FabricPacketRegistration**: `serverboundPlay()` → `playC2S()`, `clientboundPlay()` → `playS2C()`
- **FabricResourceReloadRegistrar**: `registerReloadListener()` → `registerReloader()`
- **FabricFluidKey**: `getComponentsPatch()` → `getComponents()`