### PR TITLE
refactor: remove fabric-api from common compile classpath

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,10 +31,9 @@ dependencies {
     minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
 
     testImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
-    // fabric-api still needed: LogisticsMod/LogisticsPipe/LogisticsCore use access-widened types
-    // (MenuType.MenuSupplier, CreativeModeTab.Output, addAlias(), CreativeModeTabs fields).
-    // Remove once those bootstrap files are refactored behind loader-agnostic abstractions.
-    implementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_version}"
+    // fabric-api is NOT on the main compile classpath — only test runtime needs it for the mixin
+    // system (fabric-loader-junit initializes the Fabric environment which applies Fabric API mixins)
+    testImplementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_version}"
 
     // Team Reborn Energy API (bundled into the Fabric jar via include in fabric/build.gradle)
     implementation("teamreborn:energy:${rootProject.fabric_energy_version}")

--- a/common/src/main/java/com/logistics/LogisticsMod.java
+++ b/common/src/main/java/com/logistics/LogisticsMod.java
@@ -3,6 +3,7 @@ package com.logistics;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.block.BlockEntitySupplier;
 import com.logistics.core.lib.block.BlockEntityTypeFactory;
+import com.logistics.core.lib.platform.PlatformService;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -105,23 +106,15 @@ public class LogisticsMod {
     }
 
     protected void registerItemAlias(String name, Item item) {
-        var newItem = BuiltInRegistries.ITEM.getKey(item);
-        if (newItem != null) {
-            BuiltInRegistries.ITEM.addAlias(modId(name).toIdentifier(), newItem);
-        }
+        PlatformService.INSTANCE.registerAlias(BuiltInRegistries.ITEM, modId(name).toIdentifier(), item);
     }
 
     protected void registerBlockAlias(String name, Block block) {
-        var newBlock = BuiltInRegistries.BLOCK.getKey(block);
-        if (newBlock != null) {
-            BuiltInRegistries.BLOCK.addAlias(modId(name).toIdentifier(), newBlock);
-        }
+        PlatformService.INSTANCE.registerAlias(BuiltInRegistries.BLOCK, modId(name).toIdentifier(), block);
     }
 
     protected void registerBlockEntityAlias(String name, BlockEntityType<?> blockEntityType) {
-        var newBlockEntity = BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(blockEntityType);
-        if(newBlockEntity != null) {
-            BuiltInRegistries.BLOCK_ENTITY_TYPE.addAlias(modId(name).toIdentifier(), newBlockEntity);
-        }
+        PlatformService.INSTANCE.registerAlias(
+                BuiltInRegistries.BLOCK_ENTITY_TYPE, modId(name).toIdentifier(), blockEntityType);
     }
 }

--- a/common/src/main/java/com/logistics/LogisticsPipe.java
+++ b/common/src/main/java/com/logistics/LogisticsPipe.java
@@ -2,6 +2,7 @@ package com.logistics;
 
 import com.logistics.api.LogisticsApi;
 import com.logistics.core.bootstrap.DomainBootstrap;
+import com.logistics.core.lib.platform.PlatformService;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.pipe.modules.*;
 import com.logistics.pipe.Pipe;
@@ -467,19 +468,14 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
                 INSTANCE.registerItemAlias("pipe/marking_fluid_" + entry.getKey().getName(), entry.getValue());
             }
 
-            var newMenuId = BuiltInRegistries.MENU.getKey(SCREEN.ITEM_FILTER);
-            if (newMenuId != null) {
-                BuiltInRegistries.MENU.addAlias(
-                        LogisticsMod.modId("item_filter").toIdentifier(),
-                        newMenuId);
-            }
-
-            var newDataId = BuiltInRegistries.DATA_COMPONENT_TYPE.getKey(DATA.WEATHERING_STATE);
-            if (newDataId != null) {
-                BuiltInRegistries.DATA_COMPONENT_TYPE.addAlias(
-                        LogisticsMod.modId("weathering_state").toIdentifier(),
-                        newDataId);
-            }
+            PlatformService.INSTANCE.registerAlias(
+                    BuiltInRegistries.MENU,
+                    LogisticsMod.modId("item_filter").toIdentifier(),
+                    SCREEN.ITEM_FILTER);
+            PlatformService.INSTANCE.registerAlias(
+                    BuiltInRegistries.DATA_COMPONENT_TYPE,
+                    LogisticsMod.modId("weathering_state").toIdentifier(),
+                    DATA.WEATHERING_STATE);
         }
     }
 

--- a/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
@@ -1,5 +1,8 @@
 package com.logistics.core.lib.platform;
 
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+
 import java.nio.file.Path;
 import java.util.ServiceLoader;
 
@@ -28,6 +31,15 @@ public interface PlatformService {
     default String getModName(String namespace) {
         return namespace;
     }
+
+    /**
+     * Registers {@code oldId} as a legacy alias for the same registry entry as
+     * {@code currentEntry}, so saves that used the old ID are remapped on load.
+     *
+     * <p>No-op on loaders that don't support registry aliases (e.g. NeoForge stub).
+     * Fabric delegates to {@code Registry.addAlias()} via Fabric API.
+     */
+    default <T> void registerAlias(Registry<T> registry, Identifier oldId, T currentEntry) {}
 
     PlatformService INSTANCE = ServiceLoader.load(PlatformService.class)
             .findFirst()

--- a/common/src/main/resources/logistics.accesswidener
+++ b/common/src/main/resources/logistics.accesswidener
@@ -3,3 +3,16 @@ accessWidener v2 official
 # Allow RecipeBookComponent subclasses outside the recipebook package to fill ghost slots
 accessible method net/minecraft/client/gui/screens/recipebook/GhostSlots setInput (Lnet/minecraft/world/inventory/Slot;Lnet/minecraft/util/context/ContextMap;Lnet/minecraft/world/item/crafting/display/SlotDisplay;)V
 accessible method net/minecraft/client/gui/screens/recipebook/GhostSlots setResult (Lnet/minecraft/world/inventory/Slot;Lnet/minecraft/util/context/ContextMap;Lnet/minecraft/world/item/crafting/display/SlotDisplay;)V
+
+# MenuType: private inner supplier interface and constructor — used in LogisticsMod and LogisticsPipe
+# (MC 26.1 made these private; previously access-widened by Fabric API)
+accessible class net/minecraft/world/inventory/MenuType$MenuSupplier
+accessible method net/minecraft/world/inventory/MenuType <init> (Lnet/minecraft/world/inventory/MenuType$MenuSupplier;Lnet/minecraft/world/flag/FeatureFlagSet;)V
+
+# CreativeModeTab.Output — protected inner interface used by LogisticsCreativeTab
+accessible class net/minecraft/world/item/CreativeModeTab$Output
+
+# CreativeModeTabs built-in tab keys — private fields used in LogisticsCore
+accessible field net/minecraft/world/item/CreativeModeTabs BUILDING_BLOCKS Lnet/minecraft/resources/ResourceKey;
+accessible field net/minecraft/world/item/CreativeModeTabs INGREDIENTS Lnet/minecraft/resources/ResourceKey;
+accessible field net/minecraft/world/item/CreativeModeTabs NATURAL_BLOCKS Lnet/minecraft/resources/ResourceKey;

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
@@ -2,6 +2,8 @@ package com.logistics.fabric;
 
 import com.logistics.core.lib.platform.PlatformService;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
 
 import java.nio.file.Path;
 
@@ -17,5 +19,13 @@ public final class FabricPlatformService implements PlatformService {
                 .getModContainer(namespace)
                 .map(c -> c.getMetadata().getName())
                 .orElse(namespace);
+    }
+
+    @Override
+    public <T> void registerAlias(Registry<T> registry, Identifier oldId, T currentEntry) {
+        Identifier currentId = registry.getKey(currentEntry); // Fabric API extension
+        if (currentId != null) {
+            registry.addAlias(oldId, currentId); // Fabric API extension
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `common/` no longer depends on `fabric-api` at compile time — main sources compile against vanilla MC only
- Fabric API is kept as `testImplementation` so the fabric-loader-junit test runner can initialize the Fabric mixin environment correctly

## Changes

**Access widener** (`logistics.accesswidener`)
- Added entries for types that Fabric API was previously widening: `MenuType$MenuSupplier`, `MenuType.<init>`, `CreativeModeTab$Output`, `CreativeModeTabs.BUILDING_BLOCKS/INGREDIENTS/NATURAL_BLOCKS`

**`PlatformService`** — new default no-op method:
```java
default <T> void registerAlias(Registry<T> registry, Identifier oldId, T currentEntry) {}
```

**`FabricPlatformService`** — overrides it with Fabric API implementation:
```java
Identifier currentId = registry.getKey(currentEntry); // Fabric API
if (currentId != null) registry.addAlias(oldId, currentId);
```

**`LogisticsMod`** — `registerItemAlias/registerBlockAlias/registerBlockEntityAlias` delegate to `PlatformService.INSTANCE.registerAlias()` instead of calling Fabric API directly

**`LogisticsPipe`** — two additional direct `addAlias` calls in `ALIAS.register()` replaced with `PlatformService.INSTANCE.registerAlias()`

## Verification

- `./gradlew :common:test` — BUILD SUCCESSFUL, all tests pass
- `./gradlew :fabric:build` — BUILD SUCCESSFUL