### PR TITLE
refactor: wire neoforge subproject and remove fabric-api from common compile classpath

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:fabricmc.net)",
+      "Bash(./gradlew build:*)",
+      "WebSearch",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(jar tf:*)",
+      "Bash(javap:*)",
+      "Bash(jar -tf:*)",
+      "WebFetch(domain:github.com)",
+      "mcp__minecraft-dev__get_minecraft_source",
+      "mcp__minecraft-dev__search_minecraft_code",
+      "mcp__jetbrains__list_directory_tree",
+      "mcp__jetbrains__get_file_text_by_path",
+      "Bash(git checkout:*)",
+      "Bash(git rm:*)",
+      "Bash(./gradlew compileJava:*)",
+      "Bash(./gradlew:*)",
+      "Bash(git add:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(find:*)",
+      "Bash(git:*)",
+      "Bash(xargs -I{} sh -c \"jar tf \"\"{}\"\" 2>/dev/null | grep -i \"\"empty.nbt\"\" | while read line; do echo \"\"{}: $line\"\"; done\")"
+    ]
+  }
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     mappings loom.officialMojangMappings()
 
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
+    // fabric-api remains on the compile classpath in 1.21.1: StirlingEngineBlockEntity and
+    // StirlingEngineScreenHandler use FuelRegistry, which has no vanilla equivalent until 26.1.
+    // Remove once FuelRegistry usage is abstracted behind a platform service.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_version}"
 
     // Team Reborn Energy API (bundled into the Fabric jar via include in fabric/build.gradle)

--- a/common/src/main/java/com/logistics/LogisticsMod.java
+++ b/common/src/main/java/com/logistics/LogisticsMod.java
@@ -3,6 +3,7 @@ package com.logistics;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.block.BlockEntitySupplier;
 import com.logistics.core.lib.block.BlockEntityTypeFactory;
+import com.logistics.core.lib.platform.PlatformService;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -104,23 +105,15 @@ public class LogisticsMod {
     }
 
     protected void registerItemAlias(String name, Item item) {
-        var newItem = BuiltInRegistries.ITEM.getKey(item);
-        if (newItem != null) {
-            BuiltInRegistries.ITEM.addAlias(modId(name).toIdentifier(), newItem);
-        }
+        PlatformService.INSTANCE.registerAlias(BuiltInRegistries.ITEM, modId(name).toIdentifier(), item);
     }
 
     protected void registerBlockAlias(String name, Block block) {
-        var newBlock = BuiltInRegistries.BLOCK.getKey(block);
-        if (newBlock != null) {
-            BuiltInRegistries.BLOCK.addAlias(modId(name).toIdentifier(), newBlock);
-        }
+        PlatformService.INSTANCE.registerAlias(BuiltInRegistries.BLOCK, modId(name).toIdentifier(), block);
     }
 
     protected void registerBlockEntityAlias(String name, BlockEntityType<?> blockEntityType) {
-        var newBlockEntity = BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(blockEntityType);
-        if(newBlockEntity != null) {
-            BuiltInRegistries.BLOCK_ENTITY_TYPE.addAlias(modId(name).toIdentifier(), newBlockEntity);
-        }
+        PlatformService.INSTANCE.registerAlias(
+                BuiltInRegistries.BLOCK_ENTITY_TYPE, modId(name).toIdentifier(), blockEntityType);
     }
 }

--- a/common/src/main/java/com/logistics/LogisticsPipe.java
+++ b/common/src/main/java/com/logistics/LogisticsPipe.java
@@ -2,6 +2,7 @@ package com.logistics;
 
 import com.logistics.api.LogisticsApi;
 import com.logistics.core.bootstrap.DomainBootstrap;
+import com.logistics.core.lib.platform.PlatformService;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.pipe.modules.*;
 import com.logistics.pipe.Pipe;
@@ -467,19 +468,14 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
                 INSTANCE.registerItemAlias("pipe/marking_fluid_" + entry.getKey().getName(), entry.getValue());
             }
 
-            var newMenuId = BuiltInRegistries.MENU.getKey(SCREEN.ITEM_FILTER);
-            if (newMenuId != null) {
-                BuiltInRegistries.MENU.addAlias(
-                        LogisticsMod.modId("item_filter").toIdentifier(),
-                        newMenuId);
-            }
-
-            var newDataId = BuiltInRegistries.DATA_COMPONENT_TYPE.getKey(DATA.WEATHERING_STATE);
-            if (newDataId != null) {
-                BuiltInRegistries.DATA_COMPONENT_TYPE.addAlias(
-                        LogisticsMod.modId("weathering_state").toIdentifier(),
-                        newDataId);
-            }
+            PlatformService.INSTANCE.registerAlias(
+                    BuiltInRegistries.MENU,
+                    LogisticsMod.modId("item_filter").toIdentifier(),
+                    SCREEN.ITEM_FILTER);
+            PlatformService.INSTANCE.registerAlias(
+                    BuiltInRegistries.DATA_COMPONENT_TYPE,
+                    LogisticsMod.modId("weathering_state").toIdentifier(),
+                    DATA.WEATHERING_STATE);
         }
     }
 

--- a/common/src/main/java/com/logistics/core/lib/energy/EnergyCapabilityLookup.java
+++ b/common/src/main/java/com/logistics/core/lib/energy/EnergyCapabilityLookup.java
@@ -1,0 +1,33 @@
+package com.logistics.core.lib.energy;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ServiceLoader;
+
+/**
+ * Loader-provided lookup: find an {@link IEnergyStorage} exposed by a block from a given side.
+ *
+ * <p>Common code calls {@code EnergyCapabilityLookup.INSTANCE.find(level, pos, side)} to
+ * discover energy storage on adjacent blocks. Each loader provides an implementation via
+ * {@code META-INF/services/}:
+ * <ul>
+ *   <li>Fabric: delegates to {@code EnergyStorage.SIDED.find()} (Team Reborn Energy API)
+ *   <li>NeoForge: delegates to NeoForge's {@code Capabilities.EnergyStorage} capability
+ * </ul>
+ */
+public interface EnergyCapabilityLookup {
+
+    /**
+     * Find the {@link IEnergyStorage} exposed by the block at {@code pos} from {@code side},
+     * or {@code null} if no energy storage is exposed.
+     */
+    @Nullable
+    IEnergyStorage find(Level level, BlockPos pos, Direction side);
+
+    EnergyCapabilityLookup INSTANCE = ServiceLoader.load(EnergyCapabilityLookup.class)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No EnergyCapabilityLookup found"));
+}

--- a/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
@@ -1,5 +1,8 @@
 package com.logistics.core.lib.platform;
 
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+
 import java.nio.file.Path;
 import java.util.ServiceLoader;
 
@@ -28,6 +31,15 @@ public interface PlatformService {
     default String getModName(String namespace) {
         return namespace;
     }
+
+    /**
+     * Registers {@code oldId} as a legacy alias for the same registry entry as
+     * {@code currentEntry}, so saves that used the old ID are remapped on load.
+     *
+     * <p>No-op on loaders that don't support registry aliases (e.g. NeoForge stub).
+     * Fabric delegates to {@code Registry.addAlias()} via Fabric API.
+     */
+    default <T> void registerAlias(Registry<T> registry, ResourceLocation oldId, T currentEntry) {}
 
     PlatformService INSTANCE = ServiceLoader.load(PlatformService.class)
             .findFirst()

--- a/common/src/main/java/com/logistics/power/cable/CableBlock.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlock.java
@@ -27,15 +27,15 @@ import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
 import org.jetbrains.annotations.Nullable;
-import team.reborn.energy.api.EnergyStorage;
 
 /**
  * Cable block that connects to engines, machines, and other cables
  * to transfer RF energy across distances.
  *
  * <p>Uses the same visual shape system as pipes (8px core + directional arms)
- * and connects to any block exposing {@link EnergyStorage} via the Team Reborn Energy API.
+ * and connects to any block exposing energy storage via the loader's capability system.
  */
 public class CableBlock extends BaseEntityBlock implements ProbeBehavior.Probeable, SimpleWaterloggedBlock {
     public static final MapCodec<CableBlock> CODEC = simpleCodec(CableBlock::new);
@@ -229,8 +229,8 @@ public class CableBlock extends BaseEntityBlock implements ProbeBehavior.Probeab
         }
 
         // Connect to anything with energy storage (engines, machines, pipes with energy)
-        EnergyStorage storage = EnergyStorage.SIDED.find(level, neighborPos, direction.getOpposite());
-        if (storage != null && (storage.supportsInsertion() || storage.supportsExtraction())) {
+        var storage = EnergyCapabilityLookup.INSTANCE.find(level, neighborPos, direction.getOpposite());
+        if (storage != null && (storage.canInsert() || storage.canExtract())) {
             return ConnectionType.DEVICE;
         }
 

--- a/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
@@ -6,6 +6,7 @@ import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.energy.EnergyCapabilityLookup;
 import com.logistics.core.lib.energy.IEnergyStorage;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.core.lib.power.EnergyDemandProvider;
 import net.minecraft.ChatFormatting;

--- a/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlockEntity.java
@@ -3,13 +3,11 @@ package com.logistics.power.cable;
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.core.lib.power.EnergyDemandProvider;
-import com.logistics.core.lib.block.behavior.ProbeResult;
-import com.logistics.core.lib.compat.NbtCompat;
-import com.logistics.core.lib.energy.IEnergyStorage;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -21,12 +19,11 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import java.util.Locale;
 import org.jetbrains.annotations.Nullable;
-import team.reborn.energy.api.EnergyStorage;
 
 /**
  * Block entity for cables. Cables do not store energy; they expose
  * an insert-only conduit endpoint that forwards accepted energy through the
- * connected cable network during the same transaction.
+ * connected cable network.
  *
  * <p>Any energy that cannot be delivered to a connected consumer is rejected,
  * allowing the source to keep it instead of leaving power buffered in cables.
@@ -190,8 +187,8 @@ public class CableBlockEntity extends BaseBlockEntity
             BlockPos neighborPos = worldPosition.relative(direction);
             if (!level.isLoaded(neighborPos)) continue;
 
-            EnergyStorage storage = EnergyStorage.SIDED.find(level, neighborPos, direction.getOpposite());
-            if (storage == null || !storage.supportsInsertion()) continue;
+            IEnergyStorage storage = EnergyCapabilityLookup.INSTANCE.find(level, neighborPos, direction.getOpposite());
+            if (storage == null || !storage.canInsert()) continue;
 
             if (!hasMachineEntry) {
                 builder.separator();
@@ -208,14 +205,14 @@ public class CableBlockEntity extends BaseBlockEntity
         }
     }
 
-    private long connectedDemand(@Nullable BlockEntity blockEntity, EnergyStorage storage) {
+    private long connectedDemand(@Nullable BlockEntity blockEntity, IEnergyStorage storage) {
         long demand = blockEntity instanceof EnergyDemandProvider provider
                 ? provider.networkDemandPerTick()
                 : storageRoom(storage);
         return Math.min(Math.max(0, demand), getTransferRate());
     }
 
-    private static long storageRoom(EnergyStorage storage) {
+    private static long storageRoom(IEnergyStorage storage) {
         long capacity = storage.getCapacity();
         if (capacity == Long.MAX_VALUE) return Long.MAX_VALUE;
         return Math.max(0, capacity - storage.getAmount());
@@ -225,7 +222,7 @@ public class CableBlockEntity extends BaseBlockEntity
         return rate > 0 ? String.format("%,d RF/t demand", rate) : "idle";
     }
 
-    private final class CableEnergyStorage implements EnergyStorage, IEnergyStorage {
+    private final class CableEnergyStorage implements IEnergyStorage {
         @Nullable
         private final Direction side;
 
@@ -233,46 +230,21 @@ public class CableBlockEntity extends BaseBlockEntity
             this.side = side;
         }
 
-        // ---- TR EnergyStorage (transaction-based, used by Fabric capability lookup) ----
-
         @Override
-        public boolean supportsInsertion() { return true; }
-
-        @Override
-        public long insert(long maxAmount, TransactionContext transaction) {
-            if (maxAmount <= 0 || level == null || level.isClientSide()) {
-                return 0;
-            }
+        public long insert(long maxAmount, boolean simulate) {
+            if (maxAmount <= 0 || level == null || level.isClientSide()) return 0;
             return CableNetworkManager.get(level).insert(
-                    level, worldPosition, side, Math.min(maxAmount, getTransferRate()), transaction);
+                    level, worldPosition, side, Math.min(maxAmount, getTransferRate()), simulate);
         }
 
         @Override
-        public boolean supportsExtraction() { return false; }
-
-        @Override
-        public long extract(long maxAmount, TransactionContext transaction) { return 0; }
+        public long extract(long maxAmount, boolean simulate) { return 0; }
 
         @Override
         public long getAmount() { return 0; }
 
         @Override
         public long getCapacity() { return 0; }
-
-        // ---- IEnergyStorage (simulate-boolean, used by HasEnergyStorage contract) ----
-
-        @Override
-        public long insert(long maxAmount, boolean simulate) {
-            if (maxAmount <= 0 || level == null || level.isClientSide()) return 0;
-            try (Transaction tx = Transaction.openOuter()) {
-                long result = insert(maxAmount, tx);
-                if (!simulate && result > 0) tx.commit();
-                return result;
-            }
-        }
-
-        @Override
-        public long extract(long maxAmount, boolean simulate) { return 0; }
 
         @Override
         public boolean canInsert() { return true; }

--- a/common/src/main/java/com/logistics/power/cable/CableNetwork.java
+++ b/common/src/main/java/com/logistics/power/cable/CableNetwork.java
@@ -1,17 +1,14 @@
 package com.logistics.power.cable;
 
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.core.lib.power.EnergyDemandProvider;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext.Result;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.Nullable;
-import team.reborn.energy.api.EnergyStorage;
-import team.reborn.energy.api.EnergyStorageUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,9 +32,13 @@ import java.util.Set;
  *   <li>Transfers only energy that can be accepted by a target</li>
  * </ol>
  *
+ * <p>Energy transfer uses simulate-boolean semantics: capacity is checked first
+ * ({@code simulate=true}), then energy is committed ({@code simulate=false}).
+ * This is compatible with both Fabric (Team Reborn Energy) and NeoForge Energy.
+ *
  * <p>Push-based sources, such as engines, insert into a cable endpoint directly.
- * That insertion is forwarded to connected targets in the same transaction;
- * any energy that cannot be delivered is rejected rather than stored.
+ * That insertion is forwarded to connected targets; any energy that cannot be
+ * delivered is rejected rather than stored.
  */
 public class CableNetwork {
     private final Set<BlockPos> cablePositions = new HashSet<>();
@@ -102,7 +103,7 @@ public class CableNetwork {
 
     public long insert(
             Level level, BlockPos entryCablePos, @Nullable Direction sourceSide,
-            long maxAmount, TransactionContext transaction) {
+            long maxAmount, boolean simulate) {
         if (maxAmount <= 0 || !contains(entryCablePos)) {
             return 0;
         }
@@ -115,7 +116,7 @@ public class CableNetwork {
         long transferLimit = Math.min(
             maxAmount,
             Math.min(remainingCableTransfer(level, entryCablePos), remainingNetworkTransfer(level)));
-        return insertIntoTargets(level, connections.targets(), transferLimit, transaction, entryCablePos);
+        return insertIntoTargets(level, connections.targets(), transferLimit, simulate, entryCablePos);
     }
 
     private DeviceConnections collectDeviceConnections(Level level, @Nullable DeviceConnectionKey excludedConnection) {
@@ -135,16 +136,16 @@ public class CableNetwork {
                 DeviceConnectionKey key = new DeviceConnectionKey(neighborPos, side);
                 if (key.equals(excludedConnection)) continue;
 
-                EnergyStorage storage = EnergyStorage.SIDED.find(level, neighborPos, side);
+                IEnergyStorage storage = EnergyCapabilityLookup.INSTANCE.find(level, neighborPos, side);
                 if (storage != null) {
                     if (!seenConnections.add(key)) continue;
 
                     BlockEntity blockEntity = level.getBlockEntity(neighborPos);
                     DeviceConnection connection = new DeviceConnection(cablePos, neighborPos, side, storage, blockEntity);
-                    if (storage.supportsInsertion()) {
+                    if (storage.canInsert()) {
                         targets.add(connection);
                     }
-                    if (storage.supportsExtraction() && !isManagedPushSource(blockEntity)) {
+                    if (storage.canExtract() && !isManagedPushSource(blockEntity)) {
                         sources.add(connection);
                     }
                 }
@@ -201,57 +202,51 @@ public class CableNetwork {
         long input = Math.min(maxAmount, availableSourceEnergy(validSources, maxAmount));
         if (input <= 0) return 0;
 
-        try (Transaction transaction = Transaction.openOuter()) {
-            long totalTransferred = 0;
-            long remaining = input;
-            Set<DeviceConnectionKey> blockedTargets = new HashSet<>();
-            Map<DeviceConnectionKey, Long> deliveredThisCall = new HashMap<>();
+        long totalTransferred = 0;
+        long remaining = input;
+        Set<DeviceConnectionKey> blockedTargets = new HashSet<>();
+        Map<DeviceConnectionKey, Long> deliveredThisCall = new HashMap<>();
 
-            while (remaining > 0) {
-                long transferredThisPass = 0;
-                List<EnergyAllocation> allocations = allocateToDemand(
-                        validTargets, remaining, blockedTargets, deliveredThisCall);
-                if (allocations.isEmpty()) break;
+        while (remaining > 0) {
+            long transferredThisPass = 0;
+            List<EnergyAllocation> allocations = allocateToDemand(
+                    validTargets, remaining, blockedTargets, deliveredThisCall);
+            if (allocations.isEmpty()) break;
 
-                for (EnergyAllocation allocation : allocations) {
-                    long requested = Math.min(allocation.amount(), remaining - transferredThisPass);
-                    if (requested <= 0) continue;
+            for (EnergyAllocation allocation : allocations) {
+                long requested = Math.min(allocation.amount(), remaining - transferredThisPass);
+                if (requested <= 0) continue;
 
-                    long moved = moveFromSources(level, validSources, allocation.target(), requested, transaction);
-                    if (moved > 0) {
-                        recordDelivered(deliveredThisCall, allocation.target().key(), moved);
-                        totalTransferred += moved;
-                        transferredThisPass += moved;
-                    }
-                    if (moved < requested) {
-                        blockedTargets.add(allocation.target().key());
-                    }
+                long moved = moveFromSources(level, validSources, allocation.target(), requested);
+                if (moved > 0) {
+                    recordDelivered(deliveredThisCall, allocation.target().key(), moved);
+                    totalTransferred += moved;
+                    transferredThisPass += moved;
                 }
-
-                if (transferredThisPass <= 0) break;
-                remaining -= transferredThisPass;
+                if (moved < requested) {
+                    blockedTargets.add(allocation.target().key());
+                }
             }
 
-            transaction.commit();
-            return totalTransferred;
+            if (transferredThisPass <= 0) break;
+            remaining -= transferredThisPass;
         }
+
+        return totalTransferred;
     }
 
     /**
      * Inserts energy into connected targets, distributing by demand.
+     * Uses simulate-boolean semantics: if {@code simulate=true}, checks capacity without committing.
+     *
+     * <p>When simulating, provisional cable transfers are tracked locally so the while-loop's
+     * repeated passes don't re-use the same cable capacity (which is never recorded in the
+     * real {@code cableTransferredThisTick} during a dry run).
      */
     private long insertIntoTargets(
-            Level level, List<DeviceConnection> targets, long maxAmount, TransactionContext transaction,
+            Level level, List<DeviceConnection> targets, long maxAmount, boolean simulate,
             @Nullable BlockPos entryCablePos) {
         if (targets.isEmpty() || maxAmount <= 0) return 0;
-
-        if (transaction == null) {
-            try (Transaction outer = Transaction.openOuter()) {
-                long inserted = insertIntoTargets(level, targets, maxAmount, outer, entryCablePos);
-                outer.commit();
-                return inserted;
-            }
-        }
 
         List<DeviceConnection> validTargets = filterTargets(targets);
         if (validTargets.isEmpty()) return 0;
@@ -260,6 +255,9 @@ public class CableNetwork {
         long remaining = maxAmount;
         Set<DeviceConnectionKey> blockedTargets = new HashSet<>();
         Map<DeviceConnectionKey, Long> deliveredThisCall = new HashMap<>();
+        // Tracks simulated cable usage within this call so repeated passes don't
+        // re-use the same cable capacity (recordTransfer is skipped during simulate).
+        Map<BlockPos, Long> provisionalTransfers = simulate ? new HashMap<>() : null;
 
         while (remaining > 0) {
             long insertedThisPass = 0;
@@ -270,7 +268,8 @@ public class CableNetwork {
             for (EnergyAllocation allocation : allocations) {
                 CableRoute route = entryCablePos == null
                         ? null
-                        : findBestRoute(level, entryCablePos, allocation.target().cablePos());
+                        : findBestRoute(level, entryCablePos, allocation.target().cablePos(),
+                                provisionalTransfers);
                 long routeLimit = route == null ? 0 : route.remainingTransfer();
                 if (routeLimit <= 0) {
                     blockedTargets.add(allocation.target().key());
@@ -280,9 +279,13 @@ public class CableNetwork {
                 long requested = Math.min(allocation.amount(), Math.min(remaining - insertedThisPass, routeLimit));
                 if (requested <= 0) continue;
 
-                long inserted = allocation.target().storage().insert(requested, transaction);
+                long inserted = allocation.target().storage().insert(requested, simulate);
                 if (inserted > 0) {
-                    recordTransfer(inserted, transaction, route);
+                    if (simulate) {
+                        recordProvisional(provisionalTransfers, inserted, route);
+                    } else {
+                        recordTransfer(inserted, route);
+                    }
                     recordDelivered(deliveredThisCall, allocation.target().key(), inserted);
                     totalInserted += inserted;
                     insertedThisPass += inserted;
@@ -299,10 +302,18 @@ public class CableNetwork {
         return totalInserted;
     }
 
+    private void recordProvisional(@Nullable Map<BlockPos, Long> provisionalTransfers,
+            long amount, @Nullable CableRoute route) {
+        if (provisionalTransfers == null || amount <= 0 || route == null) return;
+        for (BlockPos cablePos : route.positions()) {
+            provisionalTransfers.merge(cablePos, amount, this::saturatedAdd);
+        }
+    }
+
     private List<DeviceConnection> filterSources(List<DeviceConnection> sources) {
         List<DeviceConnection> validSources = new ArrayList<>();
         for (DeviceConnection source : sources) {
-            if (source.storage().supportsExtraction()) {
+            if (source.storage().canExtract()) {
                 validSources.add(source);
             }
         }
@@ -312,7 +323,7 @@ public class CableNetwork {
     private List<DeviceConnection> filterTargets(List<DeviceConnection> targets) {
         List<DeviceConnection> validTargets = new ArrayList<>();
         for (DeviceConnection target : targets) {
-            if (target.storage().supportsInsertion()) {
+            if (target.storage().canInsert()) {
                 validTargets.add(target);
             }
         }
@@ -321,18 +332,15 @@ public class CableNetwork {
 
     private long availableSourceEnergy(List<DeviceConnection> sources, long maxAmount) {
         long total = 0;
-        try (Transaction transaction = Transaction.openOuter()) {
-            for (DeviceConnection source : sources) {
-                if (total >= maxAmount) break;
-                total = saturatedAdd(total, source.storage().extract(maxAmount - total, transaction));
-            }
+        for (DeviceConnection source : sources) {
+            if (total >= maxAmount) break;
+            total = saturatedAdd(total, source.storage().extract(maxAmount - total, true));
         }
         return total;
     }
 
     private long moveFromSources(
-            Level level, List<DeviceConnection> sources, DeviceConnection target, long maxAmount,
-            TransactionContext transaction) {
+            Level level, List<DeviceConnection> sources, DeviceConnection target, long maxAmount) {
         long movedTotal = 0;
         for (DeviceConnection source : sources) {
             if (movedTotal >= maxAmount) break;
@@ -341,15 +349,18 @@ public class CableNetwork {
             CableRoute route = findBestRoute(level, source.cablePos(), target.cablePos());
             if (route == null || route.remainingTransfer() <= 0) continue;
 
-            long moved = EnergyStorageUtil.move(
-                    source.storage(),
-                    target.storage(),
-                    Math.min(maxAmount - movedTotal, route.remainingTransfer()),
-                    transaction);
-            if (moved > 0) {
-                recordTransfer(moved, transaction, route);
+            long toMove = Math.min(maxAmount - movedTotal, route.remainingTransfer());
+            long canExtract = source.storage().extract(toMove, true);
+            if (canExtract <= 0) continue;
+            long canInsert = target.storage().insert(canExtract, true);
+            if (canInsert <= 0) continue;
+            long actualToMove = Math.min(canExtract, canInsert);
+            long extracted = source.storage().extract(actualToMove, false);
+            target.storage().insert(extracted, false);
+            if (extracted > 0) {
+                recordTransfer(extracted, route);
+                movedTotal += extracted;
             }
-            movedTotal += moved;
         }
         return movedTotal;
     }
@@ -489,7 +500,7 @@ public class CableNetwork {
         return Math.max(0, demand);
     }
 
-    private static long storageRoom(EnergyStorage storage) {
+    private static long storageRoom(IEnergyStorage storage) {
         long capacity = storage.getCapacity();
         if (capacity == Long.MAX_VALUE) return Long.MAX_VALUE;
         return Math.max(0, capacity - storage.getAmount());
@@ -508,9 +519,15 @@ public class CableNetwork {
 
     @Nullable
     private CableRoute findBestRoute(Level level, BlockPos start, BlockPos end) {
+        return findBestRoute(level, start, end, null);
+    }
+
+    @Nullable
+    private CableRoute findBestRoute(Level level, BlockPos start, BlockPos end,
+            @Nullable Map<BlockPos, Long> provisionalTransfers) {
         if (!contains(start) || !contains(end)) return null;
 
-        long startCapacity = remainingCableTransfer(level, start);
+        long startCapacity = effectiveRemainingTransfer(level, start, provisionalTransfers);
         if (startCapacity <= 0) return null;
 
         Map<BlockPos, Long> bestCapacity = new HashMap<>();
@@ -532,7 +549,7 @@ public class CableNetwork {
                 BlockPos neighbor = current.relative(direction);
                 if (!cablePositions.contains(neighbor) || !isPositionLoaded(level, neighbor)) continue;
 
-                long neighborCapacity = remainingCableTransfer(level, neighbor);
+                long neighborCapacity = effectiveRemainingTransfer(level, neighbor, provisionalTransfers);
                 if (neighborCapacity <= 0) continue;
 
                 long pathCapacity = Math.min(currentCapacity, neighborCapacity);
@@ -559,7 +576,16 @@ public class CableNetwork {
         return new CableRoute(List.copyOf(path), remainingTransfer);
     }
 
-    private void recordTransfer(long amount, TransactionContext transaction, @Nullable CableRoute route) {
+    private long effectiveRemainingTransfer(Level level, BlockPos cablePos,
+            @Nullable Map<BlockPos, Long> provisionalTransfers) {
+        long remaining = remainingCableTransfer(level, cablePos);
+        if (provisionalTransfers != null) {
+            remaining = Math.max(0, remaining - provisionalTransfers.getOrDefault(cablePos, 0L));
+        }
+        return remaining;
+    }
+
+    private void recordTransfer(long amount, @Nullable CableRoute route) {
         if (amount <= 0) return;
 
         transferredThisTick = saturatedAdd(transferredThisTick, amount);
@@ -567,23 +593,6 @@ public class CableNetwork {
             for (BlockPos cablePos : route.positions()) {
                 cableTransferredThisTick.merge(cablePos, amount, this::saturatedAdd);
             }
-        }
-        if (transaction != null) {
-            transaction.addCloseCallback((context, result) -> {
-                if (result == Result.ABORTED) {
-                    transferredThisTick = Math.max(0, transferredThisTick - amount);
-                    if (route != null) {
-                        for (BlockPos cablePos : route.positions()) {
-                            long remaining = cableTransferredThisTick.getOrDefault(cablePos, 0L) - amount;
-                            if (remaining > 0) {
-                                cableTransferredThisTick.put(cablePos, remaining);
-                            } else {
-                                cableTransferredThisTick.remove(cablePos);
-                            }
-                        }
-                    }
-                }
-            });
         }
     }
 
@@ -594,7 +603,7 @@ public class CableNetwork {
     private record DeviceConnections(List<DeviceConnection> sources, List<DeviceConnection> targets) {}
 
     private record DeviceConnection(
-            BlockPos cablePos, BlockPos pos, Direction side, EnergyStorage storage, @Nullable BlockEntity blockEntity) {
+            BlockPos cablePos, BlockPos pos, Direction side, IEnergyStorage storage, @Nullable BlockEntity blockEntity) {
         private static final Comparator<DeviceConnection> ORDER = Comparator
                 .comparingInt((DeviceConnection connection) -> connection.pos().getX())
                 .thenComparingInt(connection -> connection.pos().getY())

--- a/common/src/main/java/com/logistics/power/cable/CableNetworkManager.java
+++ b/common/src/main/java/com/logistics/power/cable/CableNetworkManager.java
@@ -1,6 +1,5 @@
 package com.logistics.power.cable;
 
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -54,7 +53,7 @@ public class CableNetworkManager {
 
     public long insert(
             Level level, BlockPos cablePos, @Nullable Direction sourceSide,
-            long maxAmount, TransactionContext transaction) {
+            long maxAmount, boolean simulate) {
         if (maxAmount <= 0
                 || !isPositionLoaded(level, cablePos)
                 || !(level.getBlockEntity(cablePos) instanceof CableBlockEntity)) {
@@ -69,14 +68,14 @@ public class CableNetworkManager {
 
         for (CableNetwork network : networks) {
             if (network.contains(cablePos)) {
-                return network.insert(level, cablePos, sourceSide, maxAmount, transaction);
+                return network.insert(level, cablePos, sourceSide, maxAmount, simulate);
             }
         }
 
         CableNetwork network = CableNetwork.buildFrom(level, cablePos);
         networks.add(network);
         allCables.addAll(network.getCablePositions());
-        return network.insert(level, cablePos, sourceSide, maxAmount, transaction);
+        return network.insert(level, cablePos, sourceSide, maxAmount, simulate);
     }
 
     /**

--- a/common/src/main/resources/logistics.accesswidener
+++ b/common/src/main/resources/logistics.accesswidener
@@ -1,1 +1,14 @@
 accessWidener v2 named
+
+# MenuType: private inner supplier interface and constructor — used in LogisticsMod and LogisticsPipe
+# (previously access-widened by Fabric API)
+accessible class net/minecraft/world/inventory/MenuType$MenuSupplier
+accessible method net/minecraft/world/inventory/MenuType <init> (Lnet/minecraft/world/inventory/MenuType$MenuSupplier;Lnet/minecraft/world/flag/FeatureFlagSet;)V
+
+# CreativeModeTab.Output — protected inner interface used by LogisticsCreativeTab
+accessible class net/minecraft/world/item/CreativeModeTab$Output
+
+# CreativeModeTabs built-in tab keys — private fields used in LogisticsCore
+accessible field net/minecraft/world/item/CreativeModeTabs BUILDING_BLOCKS Lnet/minecraft/resources/ResourceKey;
+accessible field net/minecraft/world/item/CreativeModeTabs INGREDIENTS Lnet/minecraft/resources/ResourceKey;
+accessible field net/minecraft/world/item/CreativeModeTabs NATURAL_BLOCKS Lnet/minecraft/resources/ResourceKey;

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
@@ -2,6 +2,8 @@ package com.logistics.fabric;
 
 import com.logistics.core.lib.platform.PlatformService;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
 
 import java.nio.file.Path;
 
@@ -17,5 +19,13 @@ public final class FabricPlatformService implements PlatformService {
                 .getModContainer(namespace)
                 .map(c -> c.getMetadata().getName())
                 .orElse(namespace);
+    }
+
+    @Override
+    public <T> void registerAlias(Registry<T> registry, ResourceLocation oldId, T currentEntry) {
+        ResourceLocation currentId = registry.getKey(currentEntry); // Fabric API extension
+        if (currentId != null) {
+            registry.addAlias(oldId, currentId); // Fabric API extension
+        }
     }
 }

--- a/fabric/src/main/java/com/logistics/fabric/energy/EnergyStorageAccess.java
+++ b/fabric/src/main/java/com/logistics/fabric/energy/EnergyStorageAccess.java
@@ -41,15 +41,23 @@ public final class EnergyStorageAccess {
     }
 
     /**
-     * Adapts a simulate-boolean {@link IEnergyStorage} to Team Reborn's transaction API.
-     * Used for {@code EnergyComponent} instances from the common module.
+     * Adapts a simulate-boolean {@link IEnergyStorage} to Team Reborn's transaction API,
+     * while also implementing {@link IEnergyStorage} directly.
+     *
+     * <p>The TR interface ({@code insert(long, TransactionContext)}) uses close callbacks so
+     * that the actual commit is deferred until the caller's transaction commits. The
+     * {@link IEnergyStorage} interface delegates directly to the underlying storage without
+     * opening any new transactions — safe to call from within TR close callbacks or from
+     * the cable network's simulate-boolean path.
      */
-    private static final class SimulateBooleanAdapter implements EnergyStorage {
+    private static final class SimulateBooleanAdapter implements EnergyStorage, IEnergyStorage {
         private final IEnergyStorage delegate;
 
         SimulateBooleanAdapter(IEnergyStorage delegate) {
             this.delegate = delegate;
         }
+
+        // ── Team Reborn EnergyStorage (transaction-based) ───────────────────────────
 
         @Override
         public long insert(long maxAmount, TransactionContext tx) {
@@ -78,6 +86,29 @@ public final class EnergyStorageAccess {
         }
 
         @Override
+        public boolean supportsInsertion() {
+            return delegate.canInsert();
+        }
+
+        @Override
+        public boolean supportsExtraction() {
+            return delegate.canExtract();
+        }
+
+        // ── IEnergyStorage (simulate-boolean, transaction-free) ──────────────────────
+        // Used by the cable network; safe to call from within TR close callbacks.
+
+        @Override
+        public long insert(long maxAmount, boolean simulate) {
+            return delegate.insert(maxAmount, simulate);
+        }
+
+        @Override
+        public long extract(long maxAmount, boolean simulate) {
+            return delegate.extract(maxAmount, simulate);
+        }
+
+        @Override
         public long getAmount() {
             return delegate.getAmount();
         }
@@ -88,12 +119,12 @@ public final class EnergyStorageAccess {
         }
 
         @Override
-        public boolean supportsInsertion() {
+        public boolean canInsert() {
             return delegate.canInsert();
         }
 
         @Override
-        public boolean supportsExtraction() {
+        public boolean canExtract() {
             return delegate.canExtract();
         }
     }

--- a/fabric/src/main/java/com/logistics/fabric/energy/FabricEnergyCapabilityLookup.java
+++ b/fabric/src/main/java/com/logistics/fabric/energy/FabricEnergyCapabilityLookup.java
@@ -1,0 +1,28 @@
+package com.logistics.fabric.energy;
+
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
+import com.logistics.core.lib.energy.IEnergyStorage;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+import team.reborn.energy.api.EnergyStorage;
+
+/**
+ * Fabric implementation of {@link EnergyCapabilityLookup}.
+ *
+ * <p>Delegates to Team Reborn Energy's {@code EnergyStorage.SIDED} lookup.
+ * If the found storage is already an {@link IEnergyStorage} (e.g. cables, engines),
+ * it is returned directly. Otherwise it is wrapped in {@link TrToIEnergyStorageAdapter}
+ * so that third-party machines are also accessible via the loader-agnostic API.
+ */
+public final class FabricEnergyCapabilityLookup implements EnergyCapabilityLookup {
+
+    @Override
+    public @Nullable IEnergyStorage find(Level level, BlockPos pos, Direction side) {
+        EnergyStorage tr = EnergyStorage.SIDED.find(level, pos, side);
+        if (tr == null) return null;
+        if (tr instanceof IEnergyStorage ies) return ies;
+        return new TrToIEnergyStorageAdapter(tr);
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/energy/FabricEnergyStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/energy/FabricEnergyStorage.java
@@ -2,15 +2,14 @@ package com.logistics.fabric.energy;
 
 import com.logistics.core.lib.energy.IEnergyStorage;
 import team.reborn.energy.api.base.SimpleEnergyStorage;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 
 /**
  * Dual-interface energy storage: implements both {@link IEnergyStorage} (loader-agnostic)
  * and extends Team Reborn's {@link SimpleEnergyStorage} (Fabric-native).
  *
- * <p>Translates {@link IEnergyStorage}'s simulate-boolean API into Team Reborn's
- * transaction system. When {@code simulate=true}, opens a transaction that rolls back
- * on close; when {@code simulate=false}, opens and commits a transaction.
+ * <p>The simulate-boolean {@link IEnergyStorage} methods use direct arithmetic — no TR
+ * transactions are opened. When {@code simulate=true} the state is unchanged; when
+ * {@code simulate=false} the amount is mutated in place.
  *
  * <p>Because this class IS already a Team Reborn {@code EnergyStorage}, the Fabric
  * capability lookup can hand it directly to TRE's {@code SIDED} system — no further
@@ -24,31 +23,24 @@ public class FabricEnergyStorage extends SimpleEnergyStorage implements IEnergyS
 
     @Override
     public long insert(long maxAmount, boolean simulate) {
-        if (simulate) {
-            try (Transaction t = Transaction.openOuter()) {
-                return super.insert(maxAmount, t);
-                // t closes without commit → rollback
-            }
+        // Use direct arithmetic — safe to call from any context, including within a TR
+        // transaction's close callback or from the cable network's simulate-boolean path.
+        // The TR insert(long, TransactionContext) method is still available for callers
+        // that hold a transaction (e.g. the energy push service in LogisticsFabric).
+        long toInsert = Math.min(maxAmount, Math.min(maxInsert, Math.max(0, capacity - amount)));
+        if (!simulate) {
+            amount += toInsert;
         }
-        try (Transaction t = Transaction.openOuter()) {
-            long inserted = super.insert(maxAmount, t);
-            t.commit();
-            return inserted;
-        }
+        return toInsert;
     }
 
     @Override
     public long extract(long maxAmount, boolean simulate) {
-        if (simulate) {
-            try (Transaction t = Transaction.openOuter()) {
-                return super.extract(maxAmount, t);
-            }
+        long toExtract = Math.min(maxAmount, Math.min(maxExtract, amount));
+        if (!simulate) {
+            amount -= toExtract;
         }
-        try (Transaction t = Transaction.openOuter()) {
-            long extracted = super.extract(maxAmount, t);
-            t.commit();
-            return extracted;
-        }
+        return toExtract;
     }
 
     @Override

--- a/fabric/src/main/java/com/logistics/fabric/energy/TrToIEnergyStorageAdapter.java
+++ b/fabric/src/main/java/com/logistics/fabric/energy/TrToIEnergyStorageAdapter.java
@@ -1,0 +1,69 @@
+package com.logistics.fabric.energy;
+
+import com.logistics.core.lib.energy.IEnergyStorage;
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
+import team.reborn.energy.api.EnergyStorage;
+
+/**
+ * Adapts a Team Reborn {@link EnergyStorage} to the loader-agnostic {@link IEnergyStorage}.
+ *
+ * <p>Used by {@link FabricEnergyCapabilityLookup} when the found TR storage is not already
+ * an {@link IEnergyStorage} (e.g. third-party machines or other mods).
+ */
+final class TrToIEnergyStorageAdapter implements IEnergyStorage {
+    private final EnergyStorage delegate;
+
+    TrToIEnergyStorageAdapter(EnergyStorage delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public long insert(long maxAmount, boolean simulate) {
+        if (simulate) {
+            // Approximate simulate using capacity math — avoids opening a transaction,
+            // so this is safe to call from within any transaction context.
+            long available = Math.max(0, delegate.getCapacity() - delegate.getAmount());
+            return Math.min(maxAmount, available);
+        } else {
+            try (Transaction tx = Transaction.openOuter()) {
+                long accepted = delegate.insert(maxAmount, tx);
+                if (accepted > 0) tx.commit();
+                return accepted;
+            }
+        }
+    }
+
+    @Override
+    public long extract(long maxAmount, boolean simulate) {
+        if (simulate) {
+            // Approximate simulate using stored amount — avoids opening a transaction.
+            return Math.min(maxAmount, delegate.getAmount());
+        } else {
+            try (Transaction tx = Transaction.openOuter()) {
+                long extracted = delegate.extract(maxAmount, tx);
+                if (extracted > 0) tx.commit();
+                return extracted;
+            }
+        }
+    }
+
+    @Override
+    public long getAmount() {
+        return delegate.getAmount();
+    }
+
+    @Override
+    public long getCapacity() {
+        return delegate.getCapacity();
+    }
+
+    @Override
+    public boolean canInsert() {
+        return delegate.supportsInsertion();
+    }
+
+    @Override
+    public boolean canExtract() {
+        return delegate.supportsExtraction();
+    }
+}

--- a/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.energy.EnergyCapabilityLookup
+++ b/fabric/src/main/resources/META-INF/services/com.logistics.core.lib.energy.EnergyCapabilityLookup
@@ -1,0 +1,1 @@
+com.logistics.fabric.energy.FabricEnergyCapabilityLookup

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,9 +1,6 @@
 // NeoForge loader subproject.
-// NOTE(multiloader): This subproject compiles only its own entry-point code for now.
-//   Integrating multiloader-loader (to share common/ sources) requires first removing all
-//   Fabric API references from common/ — see common/build.gradle for the full TODO list.
 plugins {
-    id 'java-library'
+    id 'multiloader-loader'
     id 'net.neoforged.moddev'
 }
 

--- a/neoforge/runs/client/config/fml.toml
+++ b/neoforge/runs/client/config/fml.toml
@@ -1,0 +1,32 @@
+#Disables File Watcher. Used to automatically update config if its file has been modified.
+disableConfigWatcher = false
+#Should we control the window. Disabling this disables new GL features and can be bad for mods that rely on them.
+earlyWindowControl = true
+#Max threads for early initialization parallelism,  -1 is based on processor count
+maxThreads = -1
+#Enable NeoForge global version checking
+versionCheck = true
+#Default config path for servers
+defaultConfigPath = "defaultconfigs"
+#Disables Optimized DFU client-side - already disabled on servers
+disableOptimizedDFU = true
+#Early window provider
+earlyWindowProvider = "fmlearlywindow"
+#Early window width
+earlyWindowWidth = 854
+#Early window height
+earlyWindowHeight = 480
+#Early window framebuffer scale
+earlyWindowFBScale = 1
+#Early window starts maximized
+earlyWindowMaximized = false
+#Skip specific GL versions, may help with buggy graphics card drivers
+earlyWindowSkipGLVersions = []
+#Squir?
+earlyWindowSquir = false
+#Define dependency overrides below
+#Dependency overrides can be used to forcibly remove a dependency constraint from a mod or to force a mod to load AFTER another mod
+#Using dependency overrides can cause issues. Use at your own risk.
+#Example dependency override for the mod with the id 'targetMod': dependency constraints (incompatibility clauses or restrictive version ranges) against mod 'dep1' are removed, and the mod will now load after the mod 'dep2'
+#dependencyOverrides.targetMod = ["-dep1", "+dep2"]
+dependencyOverrides = {}

--- a/neoforge/runs/client/crash-reports/crash-2026-05-08_19.40.43-fml.txt
+++ b/neoforge/runs/client/crash-reports/crash-2026-05-08_19.40.43-fml.txt
@@ -1,0 +1,124 @@
+---- Minecraft Crash Report ----
+// I blame Dinnerbone.
+
+Time: 2026-05-08 19:40:43
+Description: Mod loading failures have occurred; consult the issue messages for more details
+
+net.neoforged.neoforge.logging.CrashReportExtender$ModLoadingCrashException: Mod loading has failed
+
+
+A detailed walkthrough of the error, its code path and all known details is as follows:
+---------------------------------------------------------------------------------------
+
+-- Head --
+Thread: Render thread
+Stacktrace:
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModInfo.<init>(ModInfo.java:77) ~[loader-4.0.42.jar%23140!/:4.0] {}
+-- Mod loading issue --
+Details:
+	Mod file: <No mod information provided>
+	Failure message: File /Users/kklaus/Documents/GitHub/logistics-mc-1.21.1/neoforge/build/classes/java/main is not a valid mod file
+	Mod version: <No mod information provided>
+	Mod issues URL: <No issues URL found>
+	Exception message: net.neoforged.neoforgespi.locating.InvalidModFileException: Illegal version number specified dev-neoforge (main)
+Stacktrace:
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModInfo.<init>(ModInfo.java:77) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModFileInfo.lambda$new$2(ModFileInfo.java:91) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?] {}
+	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260) ~[?:?] {}
+	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616) ~[?:?] {}
+	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622) ~[?:?] {}
+	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627) ~[?:?] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModFileInfo.<init>(ModFileInfo.java:92) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModFileParser.modsTomlParser(ModFileParser.java:56) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModFileParser.readModList(ModFileParser.java:37) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModFile.<init>(ModFile.java:77) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModFile.<init>(ModFile.java:66) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.readers.JarModsDotTomlModFileReader.createModFile(JarModsDotTomlModFileReader.java:45) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.readers.JarModsDotTomlModFileReader.read(JarModsDotTomlModFileReader.java:88) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModDiscoverer$DiscoveryPipeline.addJarContent(ModDiscoverer.java:223) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModDiscoverer$DiscoveryPipeline.addPath(ModDiscoverer.java:200) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.locators.UserdevLocator.findCandidates(UserdevLocator.java:34) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.moddiscovery.ModDiscoverer.discoverMods(ModDiscoverer.java:73) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.FMLLoader.beginModScan(FMLLoader.java:131) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/fml_loader@4.0.42/net.neoforged.fml.loading.FMLServiceProvider.beginScanning(FMLServiceProvider.java:84) ~[loader-4.0.42.jar%23140!/:4.0] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.TransformationServiceDecorator.runScan(TransformationServiceDecorator.java:97) ~[modlauncher-11.0.5.jar%23122!/:?] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.TransformationServicesHandler.lambda$runScanningTransformationServices$7(TransformationServicesHandler.java:94) ~[modlauncher-11.0.5.jar%23122!/:?] {}
+	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?] {}
+	at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1787) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575) ~[?:?] {}
+	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260) ~[?:?] {}
+	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616) ~[?:?] {}
+	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622) ~[?:?] {}
+	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627) ~[?:?] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.TransformationServicesHandler.runScanningTransformationServices(TransformationServicesHandler.java:96) ~[modlauncher-11.0.5.jar%23122!/:?] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.TransformationServicesHandler.initializeTransformationServices(TransformationServicesHandler.java:50) ~[modlauncher-11.0.5.jar%23122!/:?] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.run(Launcher.java:84) [modlauncher-11.0.5.jar%23122!/:?] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.main(Launcher.java:74) [modlauncher-11.0.5.jar%23122!/:?] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-11.0.5.jar%23122!/:?] {}
+	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-11.0.5.jar%23122!/:?] {}
+	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:210) [bootstraplauncher-2.0.2.jar:?] {}
+	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:69) [bootstraplauncher-2.0.2.jar:?] {}
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?] {}
+	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?] {}
+	at net.neoforged.devlaunch.Main.main(Main.java:57) [DevLaunch-1.0.2.jar:?] {}
+
+
+-- System Details --
+Details:
+	Minecraft Version: 1.21.1
+	Minecraft Version ID: 1.21.1
+	Operating System: Mac OS X (aarch64) version 26.3.1
+	Java Version: 21.0.10, Homebrew
+	Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Homebrew
+	Memory: 306291352 bytes (292 MiB) / 603979776 bytes (576 MiB) up to 4831838208 bytes (4608 MiB)
+	CPUs: 12
+	Processor Vendor: Apple Inc.
+	Processor Name: Apple M3 Pro
+	Identifier: Apple Inc. Family 0x8765edea Model 0 Stepping 0
+	Microarchitecture: ARM64 SoC: Everest + Sawtooth
+	Frequency (GHz): 4.06
+	Number of physical packages: 1
+	Number of physical CPUs: 12
+	Number of logical CPUs: 12
+	Graphics card #0 name: Apple M3 Pro
+	Graphics card #0 vendor: Apple (0x106b)
+	Graphics card #0 VRAM (MiB): 0.00
+	Graphics card #0 deviceId: unknown
+	Graphics card #0 versionInfo: unknown
+	Memory slot #0 capacity (MiB): 0.00
+	Memory slot #0 clockSpeed (GHz): 0.00
+	Memory slot #0 type: unknown
+	Virtual memory max (MiB): 28672.00
+	Virtual memory used (MiB): 24433.61
+	Swap memory total (MiB): 10240.00
+	Swap memory used (MiB): 8844.56
+	Space in storage for jna.tmpdir (MiB): <path not set>
+	Space in storage for org.lwjgl.system.SharedLibraryExtractPath (MiB): <path not set>
+	Space in storage for io.netty.native.workdir (MiB): <path not set>
+	Space in storage for java.io.tmpdir (MiB): available: 132476.75, total: 948584.19
+	Space in storage for workdir (MiB): available: 132476.75, total: 948584.19
+	JVM Flags: 0 total; 
+	ModLauncher: 11.0.5+main.901c6ea8
+	ModLauncher launch target: forgeclientdev
+	ModLauncher services: 
+		sponge-mixin-0.15.2+mixin.0.8.7.jar mixin PLUGINSERVICE 
+		loader-4.0.42.jar slf4jfixer PLUGINSERVICE 
+		loader-4.0.42.jar runtime_enum_extender PLUGINSERVICE 
+		at-modlauncher-10.0.1.jar accesstransformer PLUGINSERVICE 
+		loader-4.0.42.jar runtimedistcleaner PLUGINSERVICE 
+		modlauncher-11.0.5.jar mixin TRANSFORMATIONSERVICE 
+		modlauncher-11.0.5.jar fml TRANSFORMATIONSERVICE 
+	FML Language Providers: 
+		javafml@4.0
+		lowcodefml@4.0
+		minecraft@4.0
+	Mod List: 
+		neoforge-21.1.228.jar                             |Minecraft                     |minecraft                     |1.21.1              |Manifest: NOSIGNATURE
+		neoforge-21.1.228.jar                             |NeoForge                      |neoforge                      |21.1.228            |Manifest: NOSIGNATURE

--- a/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
@@ -1,16 +1,35 @@
 package com.logistics.neoforge;
 
+import com.logistics.core.bootstrap.LogisticsCommonBootstrap;
+import com.logistics.neoforge.platform.NeoForgeCreativeTabRegistrar;
+import com.logistics.neoforge.platform.NeoForgeResourceReloadRegistrar;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 
 @Mod("logistics")
 public final class LogisticsNeoForge {
 
-    public LogisticsNeoForge(IEventBus eventBus) {
-        // NeoForge entry point.
-        // TODO(multiloader): wire common domain init, energy services, and capability registration
-        //   once multiloader-loader is applied (requires common/ to be fully free of Fabric API).
-        //   See: EnergyPushService / EnergyPresenceChecker in AbstractEngineBlockEntity / AbstractEngineBlock,
-        //        and IEnergyStorage in common/core/lib/energy/ for the contracts to implement here.
+    private static final LogisticsCommonBootstrap COMMON_BOOTSTRAP = new LogisticsCommonBootstrap();
+
+    public LogisticsNeoForge(IEventBus modBus) {
+        COMMON_BOOTSTRAP.initialize();
+
+        // Wire deferred event registrations on the creative tab and reload registrars
+        // (The SPI INSTANCE is the NeoForge impl because it's the only implementation on classpath)
+        var creativeTabRegistrar = com.logistics.core.lib.platform.CreativeTabRegistrar.INSTANCE;
+        if (creativeTabRegistrar instanceof NeoForgeCreativeTabRegistrar nfRegistrar) {
+            nfRegistrar.init(modBus);
+        }
+        var reloadRegistrar = com.logistics.core.lib.platform.ResourceReloadRegistrar.INSTANCE;
+        if (reloadRegistrar instanceof NeoForgeResourceReloadRegistrar nfRegistrar) {
+            nfRegistrar.init(net.neoforged.neoforge.common.NeoForge.EVENT_BUS);
+        }
+
+        modBus.addListener(this::commonSetup);
+    }
+
+    private void commonSetup(FMLCommonSetupEvent event) {
+        // TODO(neoforge): capability registration via RegisterCapabilitiesEvent
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyCapabilityLookup.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyCapabilityLookup.java
@@ -1,0 +1,23 @@
+package com.logistics.neoforge.energy;
+
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
+import com.logistics.core.lib.energy.IEnergyStorage;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * NeoForge stub implementation of {@link EnergyCapabilityLookup}.
+ *
+ * <p>TODO: implement via NeoForge's {@code Capabilities.EnergyStorage} capability lookup,
+ * wrapping the found {@code IEnergyStorage} (NeoForge) in an {@link IEnergyStorage} adapter.
+ */
+public final class NeoForgeEnergyCapabilityLookup implements EnergyCapabilityLookup {
+
+    @Override
+    public @Nullable IEnergyStorage find(Level level, BlockPos pos, Direction side) {
+        // TODO(neoforge): implement via Capabilities.EnergyStorage.getBlockCapability(level, pos, state, blockEntity, side)
+        return null;
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeBlockEntityTypeFactory.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeBlockEntityTypeFactory.java
@@ -6,13 +6,8 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
-import java.util.Set;
-
 /**
  * NeoForge implementation of {@link BlockEntityTypeFactory}.
- *
- * <p>MC 26.1 removed {@code BlockEntityType.Builder}; the type is constructed directly
- * via its constructor (access-widened by NeoForge).
  */
 public final class NeoForgeBlockEntityTypeFactory implements BlockEntityTypeFactory {
 
@@ -22,6 +17,6 @@ public final class NeoForgeBlockEntityTypeFactory implements BlockEntityTypeFact
             throw new IllegalArgumentException(
                     "build() requires at least one block; factory=" + factory.getClass().getName());
         }
-        return new BlockEntityType<>(factory::create, Set.of(blocks));
+        return BlockEntityType.Builder.of(factory::create, blocks).build(null);
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeBlockEntityTypeFactory.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeBlockEntityTypeFactory.java
@@ -1,0 +1,27 @@
+package com.logistics.neoforge.platform;
+
+import com.logistics.core.lib.block.BlockEntitySupplier;
+import com.logistics.core.lib.block.BlockEntityTypeFactory;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+import java.util.Set;
+
+/**
+ * NeoForge implementation of {@link BlockEntityTypeFactory}.
+ *
+ * <p>MC 26.1 removed {@code BlockEntityType.Builder}; the type is constructed directly
+ * via its constructor (access-widened by NeoForge).
+ */
+public final class NeoForgeBlockEntityTypeFactory implements BlockEntityTypeFactory {
+
+    @Override
+    public <T extends BlockEntity> BlockEntityType<T> build(BlockEntitySupplier<T> factory, Block... blocks) {
+        if (blocks == null || blocks.length == 0) {
+            throw new IllegalArgumentException(
+                    "build() requires at least one block; factory=" + factory.getClass().getName());
+        }
+        return new BlockEntityType<>(factory::create, Set.of(blocks));
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeCreativeTabRegistrar.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeCreativeTabRegistrar.java
@@ -1,0 +1,69 @@
+package com.logistics.neoforge.platform;
+
+import com.logistics.core.lib.platform.CreativeTabRegistrar;
+import com.logistics.core.lib.platform.LogisticsCreativeTab;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.level.ItemLike;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * NeoForge implementation of {@link CreativeTabRegistrar}.
+ *
+ * <p>Custom tab registrations are collected at startup and applied when
+ * {@code BuildCreativeModeTabContentsEvent} fires. Register the mod event bus via
+ * {@link #init(IEventBus)} during mod construction.
+ *
+ * <p>TODO: {@link #registerTab} needs NeoForge's CreativeTabRegistry or Registry API —
+ * the vanilla {@code Registry.register(BuiltInRegistries.CREATIVE_MODE_TAB, ...)} path
+ * requires deferred registration on NeoForge.
+ */
+public final class NeoForgeCreativeTabRegistrar implements CreativeTabRegistrar {
+
+    private record TabRegistration(LogisticsCreativeTab tab) {}
+    private record TabModification(ResourceKey<CreativeModeTab> key, Consumer<TabEditor> editor) {}
+
+    private final List<TabRegistration> pendingTabs = new ArrayList<>();
+    private final List<TabModification> pendingModifications = new ArrayList<>();
+
+    public void init(IEventBus modBus) {
+        modBus.addListener(this::onBuildCreativeTab);
+    }
+
+    @Override
+    public void registerTab(LogisticsCreativeTab tab) {
+        // TODO(neoforge): use DeferredRegister for CREATIVE_MODE_TAB on NeoForge
+        pendingTabs.add(new TabRegistration(tab));
+    }
+
+    @Override
+    public void modifyTab(ResourceKey<CreativeModeTab> tab, Consumer<TabEditor> editor) {
+        pendingModifications.add(new TabModification(tab, editor));
+    }
+
+    private void onBuildCreativeTab(BuildCreativeModeTabContentsEvent event) {
+        for (TabModification mod : pendingModifications) {
+            if (!event.getTabKey().equals(mod.key())) continue;
+            mod.editor().accept(new TabEditor() {
+                @Override
+                public void insertAfter(ItemLike anchor, ItemLike item) {
+                    throw new UnsupportedOperationException(
+                            "NeoForge creative tab ordering not yet implemented; "
+                                    + "wire event.insertAfter or equivalent NeoForge API");
+                }
+
+                @Override
+                public void insertBefore(ItemLike anchor, ItemLike item) {
+                    throw new UnsupportedOperationException(
+                            "NeoForge creative tab ordering not yet implemented; "
+                                    + "wire event.insertBefore or equivalent NeoForge API");
+                }
+            });
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
@@ -1,0 +1,25 @@
+package com.logistics.neoforge.platform;
+
+import com.logistics.core.lib.platform.PlatformService;
+import net.neoforged.fml.loading.FMLPaths;
+import net.neoforged.fml.ModList;
+
+import java.nio.file.Path;
+
+/**
+ * NeoForge implementation of {@link PlatformService}.
+ */
+public final class NeoForgePlatformService implements PlatformService {
+
+    @Override
+    public Path configDir() {
+        return FMLPaths.CONFIGDIR.get();
+    }
+
+    @Override
+    public String getModName(String namespace) {
+        return ModList.get().getModContainerById(namespace)
+                .map(c -> c.getModInfo().getDisplayName())
+                .orElse(namespace);
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeResourceReloadRegistrar.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeResourceReloadRegistrar.java
@@ -1,0 +1,39 @@
+package com.logistics.neoforge.platform;
+
+import com.logistics.core.lib.platform.ResourceReloadRegistrar;
+import com.logistics.core.lib.resource.ResourceId;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.event.AddServerReloadListenersEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * NeoForge implementation of {@link ResourceReloadRegistrar}.
+ *
+ * <p>Registrations are collected at startup and applied when
+ * {@code AddServerReloadListenersEvent} fires. Register the game event bus via
+ * {@link #init(IEventBus)} during mod construction.
+ */
+public final class NeoForgeResourceReloadRegistrar implements ResourceReloadRegistrar {
+
+    private record Registration(ResourceId id, PreparableReloadListener listener) {}
+
+    private final List<Registration> pending = new ArrayList<>();
+
+    public void init(IEventBus gameBus) {
+        gameBus.addListener(this::onAddReloadListeners);
+    }
+
+    @Override
+    public void register(ResourceId id, PreparableReloadListener listener) {
+        pending.add(new Registration(id, listener));
+    }
+
+    private void onAddReloadListeners(AddServerReloadListenersEvent event) {
+        for (Registration registration : pending) {
+            event.addListener(registration.id().toIdentifier(), registration.listener());
+        }
+    }
+}

--- a/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.block.BlockEntityTypeFactory
+++ b/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.block.BlockEntityTypeFactory
@@ -1,0 +1,1 @@
+com.logistics.neoforge.platform.NeoForgeBlockEntityTypeFactory

--- a/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.energy.EnergyCapabilityLookup
+++ b/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.energy.EnergyCapabilityLookup
@@ -1,0 +1,1 @@
+com.logistics.neoforge.energy.NeoForgeEnergyCapabilityLookup

--- a/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.platform.CreativeTabRegistrar
+++ b/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.platform.CreativeTabRegistrar
@@ -1,0 +1,1 @@
+com.logistics.neoforge.platform.NeoForgeCreativeTabRegistrar

--- a/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
+++ b/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
@@ -1,0 +1,1 @@
+com.logistics.neoforge.platform.NeoForgePlatformService

--- a/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.platform.ResourceReloadRegistrar
+++ b/neoforge/src/main/resources/META-INF/services/com.logistics.core.lib.platform.ResourceReloadRegistrar
@@ -1,0 +1,1 @@
+com.logistics.neoforge.platform.NeoForgeResourceReloadRegistrar


### PR DESCRIPTION
## Summary

Cherry-picks #360 and #361 from mc/26.1 onto mc/1.21.1.

- Introduces `EnergyCapabilityLookup` SPI and wires NeoForge subproject to compile against common sources
- Removes Fabric API from common's compile classpath; access-widened types now declared explicitly in `logistics.accesswidener`
- Abstracts `Registry.addAlias()` / `Registry.getKey()` (Fabric API extensions) behind `PlatformService.registerAlias()`

## Notes

- `NeoForgeBlockEntityTypeFactory` uses `BlockEntityType.Builder.of(...).build(null)` instead of the direct constructor (1.21.1 still has Builder; 26.1 removed it)
- Access widener uses `v2 named` namespace and omits the GhostSlots entries (those signatures don't exist until 26.1)
- `fabric-api` remains on the **compile** classpath in 1.21.1: `StirlingEngineBlockEntity` and `StirlingEngineScreenHandler` import `FuelRegistry`, which has no vanilla equivalent until 1.21.11 (`level.fuelValues()`). A follow-up PR will abstract this behind a `FuelHelper` SPI.