### PR TITLE
fix: correct NeoForge reload listener event for mc/1.21.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,20 @@ If worktrees are detected at these paths, they may be referenced when working on
 - **`mc/26.1`**: Port features to keep up with snapshot releases
 - **`mc/1.21.1`**: Backport features/fixes (many tech mod users still on this version)
 
+### Branch Protection Rules (CRITICAL)
+
+**Never push or commit directly to `mc/*` branches** (`mc/26.1`, `mc/1.21.11`, `mc/1.21.1`). These are protected primary branches. All work — including in auto mode — must go through a feature branch and PR.
+
+**Required workflow for any new work:**
+1. Create a feature branch first: `git checkout -b descriptive-branch-name`
+2. Make commits on the feature branch
+3. Push the feature branch: `git push origin descriptive-branch-name`
+4. Open a PR targeting the appropriate `mc/*` branch
+
+**The only exception** is cherry-picking between `mc/*` branches for porting already-merged commits. Even then, confirm with the user before pushing.
+
+**In auto mode:** Still pause and confirm before any `git push` when the current branch is `mc/*` or when no feature branch has been created yet. A wrong push to a protected branch is very hard to undo cleanly.
+
 ### Cross-Version Workflow
 
 **When fixing bugs:**

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,110 @@
+# Testing Guide
+
+## Test Structure
+
+| Module | Location | Type | Framework |
+|--------|----------|------|-----------|
+| `common` | `common/src/test/java/` | Unit | JUnit 5 + Minecraft bootstrap |
+| `fabric` | `fabric/src/test/java/` | Unit | JUnit 5 (plain) |
+| `neoforge` | `neoforge/src/test/java/` | Unit (stubs) | JUnit 5 (all @Disabled) |
+| `fabric` | `fabric/src/gametest/java/` | Integration | Fabric @GameTest (deprecated) |
+
+### Running tests
+
+```bash
+./gradlew :common:test          # Unit tests for all business logic
+./gradlew :fabric:test          # ServiceLoader smoke tests
+./gradlew :neoforge:test        # Stubs (0 active tests)
+./gradlew :fabric:runGametest   # Integration game tests (deprecated; see below)
+```
+
+---
+
+## What's Covered
+
+`common/src/test/java/` contains JUnit tests for all testable business logic:
+
+- **Pipe modules** — BoostModule, CraftingModule, EnchantmentSinkModule, ExtractionModule, BasicExtractorModule, AdvancedExtractorModule, InsertionModule, ItemFilterModule, MergerModule, ModSinkModule, PassiveSupplierModule, PipeMarkingModule, PolymorphicSinkModule, ProcessModule, QuickSortModule, RequesterModule, SatelliteModule, SinkModule, SupplierModule, TerminusModule, TransportModule, VoidModule, WeatheringModule, BlockConnectionModule (partial), PipeOnlyModule (partial)
+- **Pipe network services** — CraftBatchingService, JobCoordinator, NetworkController, ReconciliationService, RequestPlanner, ReservationManager, SinkResolver
+- **Pipe network graph** — NetworkGraph, NetworkPathfinder
+- **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
+- **Power** — CableTier, PIDController
+- **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic
+- **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem
+
+`fabric/src/test/java/` contains ServiceLoader smoke tests verifying all six `META-INF/services/` registrations are present and the implementation classes can be instantiated.
+
+---
+
+## Cannot Test Without Code Restructuring
+
+The items below cannot be unit tested in their current form. Each entry notes what restructuring would unlock testing.
+
+### Requires a real `Level` / world context
+
+These classes take a `Level` in their constructor or rely on world state during normal operation. Extracting pure logic into a separate class (not a `BlockEntity` subclass) would make it testable.
+
+| Class | Why |
+|-------|-----|
+| All `Block` and `BlockEntity` subclasses (~30+) | `BlockEntity` constructors require `Level`; block interaction is inherently stateful |
+| `MinecraftWorldView` | Wraps a live `ServerLevel`; every method delegates to it |
+| `NetworkCommandExecutor` | Executes commands that mutate world blocks |
+| `NetworkSnapshotBuilder` | Reads live pipe state by iterating world positions |
+| `NetworkRegistry` | Maps `BlockPos → PipeBlockEntity` within a world |
+| `PipeNetwork` / `PipeRuntime` | Full network graph is built from world-resident blocks |
+| `InsertionModule` — inventory routing paths | `getInsertSpace()` calls `ItemStorageLookup.find(level, ...)` which NPEs with null world |
+
+### Requires Minecraft container / menu infrastructure
+
+| Class | Why |
+|-------|-----|
+| All screen handlers (`ChassisScreenHandler`, `RequesterScreenHandler`, `ProviderScreenHandler`, `SupplierScreenHandler`, `SinkScreenHandler`, `ModSinkScreenHandler`, `SatelliteScreenHandler`, `ProcessScreenHandler`, `ItemFilterScreenHandler`, `AdvancedExtractorScreenHandler`, `CraftingScreenHandler`, `StirlingEngineScreenHandler`, `MaceratorScreenHandler`, `KilnScreenHandler`) | Require `AbstractContainerMenu` infrastructure and a live player |
+| All inventory classes (`ChassisInventory`, `RequestInventory`, `FilterInventory`, `SinkInventory`, `SupplyInventory`, `ModSinkInventory`, `ProcessInventory`, `ProviderFilterInventory`, `AdvancedExtractorFilterInventory`, `CraftingRecipeInventory`) | Tightly coupled to screen handlers |
+| `ItemTagUtils` | Queries tag registry at runtime from a live `HolderLookup` |
+
+### Requires Minecraft networking infrastructure
+
+| Class | Why |
+|-------|-----|
+| `RequestItemPacket` | Requires Minecraft's `FriendlyByteBuf` / codec pipeline |
+| `OpenChassisSlotPacket` | Same |
+| `SetSatelliteIdPacket` | Same |
+| `SyncRequesterInventoryPacket` | Same |
+| `PacketValidation` | Tests server-side packet rejection against live world state |
+
+### Requires registered mod blocks (not in vanilla bootstrap)
+
+| Code path | Why |
+|-----------|-----|
+| `BlockConnectionModule.allowsConnection()` — PipeBlock neighbor case | Returns `false` for the blocked pipe type; requires a registered `PipeBlock` instance |
+| `PipeOnlyModule.allowsConnection()` — returning `true` | Only `true` for `PipeBlock` neighbors; no `PipeBlock` available in vanilla bootstrap |
+
+### Requires Fabric / NeoForge loader initialization
+
+| Class | Why |
+|-------|-----|
+| `FabricPlatformService.configDir()` / `getModName()` / `registerAlias()` | Calls `FabricLoader.getInstance()` at method invocation time |
+| `FabricEnergyStorage` / `TrToIEnergyStorageAdapter` | Wrap Team Reborn Energy interfaces; require running TR Energy environment |
+
+---
+
+## Deprecated: Fabric Game Tests
+
+`fabric/src/gametest/` contains **90+ `@GameTest` integration tests** that require a full Minecraft server process (real block placement, game ticks, Fabric transfer API). These are **deprecated** — the long-term goal is to replace them with plain JUnit equivalents as code is restructured to separate pure logic from world dependencies.
+
+They are kept for now to preserve coverage. The primary blocker for conversion is that all tests depend on `GameTestHelper` to place blocks in an actual level and tick the server. Even "simple" placement tests require registered mod blocks and a running level — neither of which is available in a vanilla bootstrap.
+
+### Coverage by file
+
+| File | Tests | Conversion blocker |
+|------|-------|-------------------|
+| `CableGameTest` | 13 | Energy storage + TR transaction API + ticking |
+| `EngineGameTest` | 16 | Fuel burning and energy production require block entity ticking |
+| `PipeFlowGameTest` | 8 | Item travel requires ticking; enchantment serialization needs live data pack |
+| `ModuleGameTest` | 14 | Filter/sink routing requires live `PipeContext` with real block entities |
+| `PipeInfrastructureGameTest` | 5 | Pipe connectivity and cache invalidation require live blocks |
+| `OreGenerationGameTest` | 11 | Ore feature registration and block placement require data-driven registries |
+| `NetworkIntegrationGameTest` | 5 | Provider/requester delivery requires 100-tick game simulation |
+| `QuarryGameTest` | 7 | Energy acceptance and phase tracking require live block entity |
+| `QuarryMiningGameTest` | 3 | Phase machine progression and block mining require full simulation |
+| `KilnGameTest` | 8 | Inventory slot access control requires live block entity |

--- a/common/src/test/java/com/logistics/core/lib/block/BaseBlockEntityPersistenceTest.java
+++ b/common/src/test/java/com/logistics/core/lib/block/BaseBlockEntityPersistenceTest.java
@@ -1,6 +1,5 @@
-package com.logistics.core.lib;
+package com.logistics.core.lib.block;
 
-import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.test.MinecraftTestEnvironment;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;

--- a/common/src/test/java/com/logistics/pipe/modules/BlockConnectionModuleTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/BlockConnectionModuleTest.java
@@ -1,0 +1,31 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Blocks;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link BlockConnectionModule}.
+ *
+ * <p>{@code PipeContext} is {@code @Nullable} and unused in {@code allowsConnection()} —
+ * {@code null} is passed throughout.
+ *
+ * <p>The PipeBlock-neighbor case (returning {@code false} for the blocked pipe type)
+ * cannot be tested without restructuring: it requires registered mod {@code PipeBlock}
+ * instances, which are not available in the vanilla bootstrap. See TESTING.md.
+ */
+@DisplayName("BlockConnectionModule")
+class BlockConnectionModuleTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("non-PipeBlock neighbor always allows connection")
+    void nonPipeBlock_alwaysAllowsConnection() {
+        BlockConnectionModule module = new BlockConnectionModule(() -> null);
+        boolean result = module.allowsConnection(null, Direction.NORTH, Blocks.STONE);
+        assertThat(result).isTrue();
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/modules/InsertionModuleTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/InsertionModuleTest.java
@@ -1,0 +1,82 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.core.lib.block.capability.PipeConnection;
+import com.logistics.core.lib.pipe.PipeContext;
+import com.logistics.core.lib.pipe.RoutePlan;
+import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.test.FakePipeAccess;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link InsertionModule} routing decisions.
+ *
+ * <p>Uses a null world ({@code PipeContext(null, ...)}) which is safe for the tested paths:
+ * {@link PipeContext#isInventoryConnection} and {@link PipeContext#isNeighborPipe} both
+ * delegate to {@link FakePipeAccess} and never dereference the world.
+ *
+ * <p>Inventory routing paths (full/partial space, split) cannot be tested without a real
+ * {@code Level} — {@code ItemStorageLookup.find(level, ...)} NPEs with null world.
+ * See TESTING.md for details.
+ */
+@DisplayName("InsertionModule")
+class InsertionModuleTest extends MinecraftTestEnvironment {
+
+    private InsertionModule module;
+    private FakePipeAccess access;
+    private PipeContext ctx;
+    private TravelingItem item;
+
+    @BeforeEach
+    void setUp() {
+        module = new InsertionModule();
+        access = new FakePipeAccess();
+        ctx = new PipeContext(null, BlockPos.ZERO, null, access);
+        item = new TravelingItem(new ItemStack(Items.DIAMOND, 4), Direction.NORTH, 0.05f);
+    }
+
+    @Test
+    @DisplayName("null options → drop")
+    void nullOptions_drops() {
+        RoutePlan result = module.route(ctx, item, null);
+        assertThat(result.getType()).isEqualTo(RoutePlan.Type.DROP);
+    }
+
+    @Test
+    @DisplayName("empty options → drop")
+    void emptyOptions_drops() {
+        RoutePlan result = module.route(ctx, item, List.of());
+        assertThat(result.getType()).isEqualTo(RoutePlan.Type.DROP);
+    }
+
+    @Test
+    @DisplayName("pipe-only connections → reroute to available pipe directions")
+    void pipeOnly_reroutesToPipes() {
+        access.setConnection(Direction.NORTH, PipeConnection.Type.PIPE);
+        access.setConnection(Direction.SOUTH, PipeConnection.Type.PIPE);
+
+        RoutePlan result = module.route(ctx, item, List.of(Direction.NORTH, Direction.SOUTH));
+
+        assertThat(result.getType()).isEqualTo(RoutePlan.Type.REROUTE);
+        assertThat(result.getDirections()).containsExactlyInAnyOrder(Direction.NORTH, Direction.SOUTH);
+    }
+
+    @Test
+    @DisplayName("no connections in options → drop")
+    void noConnections_drops() {
+        // All connections remain NONE (FakePipeAccess default)
+        RoutePlan result = module.route(ctx, item, List.of(Direction.NORTH, Direction.SOUTH));
+
+        assertThat(result.getType()).isEqualTo(RoutePlan.Type.DROP);
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/modules/PipeOnlyModuleTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/PipeOnlyModuleTest.java
@@ -1,0 +1,31 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Blocks;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PipeOnlyModule}.
+ *
+ * <p>{@code PipeContext} is {@code @Nullable} and unused in {@code allowsConnection()} —
+ * {@code null} is passed throughout.
+ *
+ * <p>The {@code true} return case (PipeBlock neighbor) cannot be tested without restructuring:
+ * it requires a registered mod {@code PipeBlock} instance, which is not available in the
+ * vanilla bootstrap. See TESTING.md.
+ */
+@DisplayName("PipeOnlyModule")
+class PipeOnlyModuleTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("non-PipeBlock neighbor denies connection")
+    void nonPipeBlock_deniesConnection() {
+        PipeOnlyModule module = new PipeOnlyModule();
+        boolean result = module.allowsConnection(null, Direction.NORTH, Blocks.STONE);
+        assertThat(result).isFalse();
+    }
+}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -47,6 +47,10 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_version}"
 
+    testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+    testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"
+
     // Team Reborn Energy API
     modApi include("teamreborn:energy:${rootProject.fabric_energy_version}")
 
@@ -63,6 +67,14 @@ processResources {
     inputs.property "java_version", rootProject.java_version
     filesMatching("fabric.mod.json") {
         expand inputs.properties
+    }
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat = "full"
     }
 }
 

--- a/fabric/src/test/java/com/logistics/fabric/ServiceLoaderSmokeTest.java
+++ b/fabric/src/test/java/com/logistics/fabric/ServiceLoaderSmokeTest.java
@@ -1,0 +1,76 @@
+package com.logistics.fabric;
+
+import com.logistics.core.lib.block.BlockEntityTypeFactory;
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
+import com.logistics.core.lib.platform.CreativeTabRegistrar;
+import com.logistics.core.lib.platform.PlatformService;
+import com.logistics.core.lib.platform.ResourceReloadRegistrar;
+import com.logistics.core.lib.power.FuelHelper;
+import com.logistics.fabric.energy.FabricEnergyCapabilityLookup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ServiceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ServiceLoader smoke tests — verifies that all META-INF/services/ registrations exist and
+ * the implementation classes can be found and instantiated.
+ *
+ * <p>These tests would have caught the incident where a missing services file caused the mod
+ * to fail at startup (ServiceLoader throws) while CI passed (nothing exercised the JVM).
+ *
+ * <p>No Minecraft bootstrap needed — all implementations have implicit no-arg constructors.
+ */
+@DisplayName("ServiceLoader smoke tests (Fabric)")
+class ServiceLoaderSmokeTest {
+
+    @Test
+    @DisplayName("FuelHelper implementation is registered")
+    void fuelHelper_isRegistered() {
+        FuelHelper impl = ServiceLoader.load(FuelHelper.class).findFirst().orElseThrow(
+                () -> new AssertionError("No FuelHelper found in META-INF/services/"));
+        assertThat(impl).isInstanceOf(FabricFuelHelper.class);
+    }
+
+    @Test
+    @DisplayName("PlatformService implementation is registered")
+    void platformService_isRegistered() {
+        PlatformService impl = ServiceLoader.load(PlatformService.class).findFirst().orElseThrow(
+                () -> new AssertionError("No PlatformService found in META-INF/services/"));
+        assertThat(impl).isInstanceOf(FabricPlatformService.class);
+    }
+
+    @Test
+    @DisplayName("BlockEntityTypeFactory implementation is registered")
+    void blockEntityTypeFactory_isRegistered() {
+        BlockEntityTypeFactory impl = ServiceLoader.load(BlockEntityTypeFactory.class).findFirst().orElseThrow(
+                () -> new AssertionError("No BlockEntityTypeFactory found in META-INF/services/"));
+        assertThat(impl).isInstanceOf(FabricBlockEntityBuilder.class);
+    }
+
+    @Test
+    @DisplayName("EnergyCapabilityLookup implementation is registered")
+    void energyCapabilityLookup_isRegistered() {
+        EnergyCapabilityLookup impl = ServiceLoader.load(EnergyCapabilityLookup.class).findFirst().orElseThrow(
+                () -> new AssertionError("No EnergyCapabilityLookup found in META-INF/services/"));
+        assertThat(impl).isInstanceOf(FabricEnergyCapabilityLookup.class);
+    }
+
+    @Test
+    @DisplayName("CreativeTabRegistrar implementation is registered")
+    void creativeTabRegistrar_isRegistered() {
+        CreativeTabRegistrar impl = ServiceLoader.load(CreativeTabRegistrar.class).findFirst().orElseThrow(
+                () -> new AssertionError("No CreativeTabRegistrar found in META-INF/services/"));
+        assertThat(impl).isInstanceOf(FabricCreativeTabRegistrar.class);
+    }
+
+    @Test
+    @DisplayName("ResourceReloadRegistrar implementation is registered")
+    void resourceReloadRegistrar_isRegistered() {
+        ResourceReloadRegistrar impl = ServiceLoader.load(ResourceReloadRegistrar.class).findFirst().orElseThrow(
+                () -> new AssertionError("No ResourceReloadRegistrar found in META-INF/services/"));
+        assertThat(impl).isInstanceOf(FabricResourceReloadRegistrar.class);
+    }
+}

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -35,6 +35,20 @@ neoForge {
     }
 }
 
+dependencies {
+    testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+    testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat = "full"
+    }
+}
+
 processResources {
     var expandProps = [
         'version'                      : version,

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeResourceReloadRegistrar.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeResourceReloadRegistrar.java
@@ -4,7 +4,7 @@ import com.logistics.core.lib.platform.ResourceReloadRegistrar;
 import com.logistics.core.lib.resource.ResourceId;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.event.AddServerReloadListenersEvent;
+import net.neoforged.neoforge.event.AddReloadListenerEvent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +13,7 @@ import java.util.List;
  * NeoForge implementation of {@link ResourceReloadRegistrar}.
  *
  * <p>Registrations are collected at startup and applied when
- * {@code AddServerReloadListenersEvent} fires. Register the game event bus via
+ * {@code AddReloadListenerEvent} fires on the NeoForge event bus. Register via
  * {@link #init(IEventBus)} during mod construction.
  */
 public final class NeoForgeResourceReloadRegistrar implements ResourceReloadRegistrar {
@@ -31,9 +31,9 @@ public final class NeoForgeResourceReloadRegistrar implements ResourceReloadRegi
         pending.add(new Registration(id, listener));
     }
 
-    private void onAddReloadListeners(AddServerReloadListenersEvent event) {
+    private void onAddReloadListeners(AddReloadListenerEvent event) {
         for (Registration registration : pending) {
-            event.addListener(registration.id().toIdentifier(), registration.listener());
+            event.addListener(registration.listener());
         }
     }
 }

--- a/neoforge/src/test/java/com/logistics/neoforge/ServiceLoaderSmokeTest.java
+++ b/neoforge/src/test/java/com/logistics/neoforge/ServiceLoaderSmokeTest.java
@@ -1,0 +1,83 @@
+package com.logistics.neoforge;
+
+import com.logistics.core.lib.block.BlockEntityTypeFactory;
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
+import com.logistics.core.lib.platform.CreativeTabRegistrar;
+import com.logistics.core.lib.platform.PlatformService;
+import com.logistics.core.lib.platform.ResourceReloadRegistrar;
+import com.logistics.core.lib.power.FuelHelper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ServiceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ServiceLoader smoke tests — mirrors {@code fabric/ServiceLoaderSmokeTest}.
+ *
+ * <p>All tests are {@link Disabled} because the NeoForge test environment is not yet
+ * configured to run unit tests (NeoForge MDG test support is not wired up). These stubs
+ * document intent and serve as the target state once the test environment is set up.
+ *
+ * <p>When enabled, each test verifies that the corresponding META-INF/services/ file
+ * exists in the neoforge subproject and the implementation class can be instantiated.
+ */
+@DisplayName("ServiceLoader smoke tests (NeoForge)")
+class ServiceLoaderSmokeTest {
+
+    @Test
+    @Disabled("NeoForge test environment not yet configured")
+    @DisplayName("FuelHelper implementation is registered")
+    void fuelHelper_isRegistered() {
+        FuelHelper impl = ServiceLoader.load(FuelHelper.class).findFirst().orElseThrow(
+                () -> new AssertionError("No FuelHelper found in META-INF/services/"));
+        assertThat(impl).isInstanceOf(NeoForgeFuelHelper.class);
+    }
+
+    @Test
+    @Disabled("NeoForge test environment not yet configured")
+    @DisplayName("PlatformService implementation is registered")
+    void platformService_isRegistered() {
+        PlatformService impl = ServiceLoader.load(PlatformService.class).findFirst().orElseThrow(
+                () -> new AssertionError("No PlatformService found in META-INF/services/"));
+        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+    }
+
+    @Test
+    @Disabled("NeoForge test environment not yet configured")
+    @DisplayName("BlockEntityTypeFactory implementation is registered")
+    void blockEntityTypeFactory_isRegistered() {
+        BlockEntityTypeFactory impl = ServiceLoader.load(BlockEntityTypeFactory.class).findFirst().orElseThrow(
+                () -> new AssertionError("No BlockEntityTypeFactory found in META-INF/services/"));
+        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+    }
+
+    @Test
+    @Disabled("NeoForge test environment not yet configured")
+    @DisplayName("EnergyCapabilityLookup implementation is registered")
+    void energyCapabilityLookup_isRegistered() {
+        EnergyCapabilityLookup impl = ServiceLoader.load(EnergyCapabilityLookup.class).findFirst().orElseThrow(
+                () -> new AssertionError("No EnergyCapabilityLookup found in META-INF/services/"));
+        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+    }
+
+    @Test
+    @Disabled("NeoForge test environment not yet configured")
+    @DisplayName("CreativeTabRegistrar implementation is registered")
+    void creativeTabRegistrar_isRegistered() {
+        CreativeTabRegistrar impl = ServiceLoader.load(CreativeTabRegistrar.class).findFirst().orElseThrow(
+                () -> new AssertionError("No CreativeTabRegistrar found in META-INF/services/"));
+        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+    }
+
+    @Test
+    @Disabled("NeoForge test environment not yet configured")
+    @DisplayName("ResourceReloadRegistrar implementation is registered")
+    void resourceReloadRegistrar_isRegistered() {
+        ResourceReloadRegistrar impl = ServiceLoader.load(ResourceReloadRegistrar.class).findFirst().orElseThrow(
+                () -> new AssertionError("No ResourceReloadRegistrar found in META-INF/services/"));
+        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+    }
+}


### PR DESCRIPTION
## Summary

NeoForge 21.1.x uses `AddReloadListenerEvent` (on the NeoForge event bus), while 21.11.x uses `AddServerReloadListenersEvent`. The 21.1.x version also does not accept a `ResourceLocation` id in its `addListener` call.

The registrar was introduced in #360 using the 21.11.x API, causing a compile failure on this branch.

## Changes

- Replace `AddServerReloadListenersEvent` with `AddReloadListenerEvent`
- Drop the id argument from `event.addListener()` (not supported in NeoForge 21.1.x)

## Notes

This is the mc/1.21.1-specific adaptation — the 21.11.x branch is correct as-is. Also includes the cherry-picked test infrastructure commit (`f6c6a35`).