### PR TITLE
feat: add NeoForge platform SPI services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 build/
 out/
 classes/
+/common/bin/
+/fabric/bin/
+/neoforge/bin/
+/neoforge/runs/
 
 # Eclipse
 *.launch

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.neoforged.moddev'
 }
 
-version = System.getenv("MOD_VERSION") ?: "dev-neoforge"
+version = System.getenv("MOD_VERSION") ?: "0.0.0-dev.neoforge"
 group = rootProject.group
 
 base {
@@ -31,6 +31,15 @@ neoForge {
     mods {
         logistics {
             sourceSet sourceSets.main
+        }
+    }
+}
+
+tasks.named('compileJava', JavaCompile) {
+    dependsOn configurations.commonClientJava
+    source configurations.commonClientJava.files.collect {
+        fileTree(it) {
+            exclude '**/jei/**'
         }
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyCapabilityLookup.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyCapabilityLookup.java
@@ -2,22 +2,19 @@ package com.logistics.neoforge.energy;
 
 import com.logistics.core.lib.energy.EnergyCapabilityLookup;
 import com.logistics.core.lib.energy.IEnergyStorage;
+import net.neoforged.neoforge.capabilities.Capabilities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * NeoForge stub implementation of {@link EnergyCapabilityLookup}.
- *
- * <p>TODO: implement via NeoForge's {@code Capabilities.EnergyStorage} capability lookup,
- * wrapping the found {@code IEnergyStorage} (NeoForge) in an {@link IEnergyStorage} adapter.
+ * NeoForge implementation of {@link EnergyCapabilityLookup}.
  */
 public final class NeoForgeEnergyCapabilityLookup implements EnergyCapabilityLookup {
 
     @Override
     public @Nullable IEnergyStorage find(Level level, BlockPos pos, Direction side) {
-        // TODO(neoforge): implement via Capabilities.EnergyStorage.getBlockCapability(level, pos, state, blockEntity, side)
-        return null;
+        return NeoForgeEnergyStorage.wrap(level.getCapability(Capabilities.Energy.BLOCK, pos, side));
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyStorage.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyStorage.java
@@ -1,0 +1,155 @@
+package com.logistics.neoforge.energy;
+
+import com.logistics.core.lib.energy.IEnergyStorage;
+import net.neoforged.neoforge.transfer.energy.EnergyHandler;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
+import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
+import org.jetbrains.annotations.Nullable;
+
+public final class NeoForgeEnergyStorage implements IEnergyStorage {
+    private final EnergyHandler handler;
+
+    private NeoForgeEnergyStorage(EnergyHandler handler) {
+        this.handler = handler;
+    }
+
+    @Nullable
+    public static IEnergyStorage wrap(@Nullable EnergyHandler handler) {
+        return handler == null ? null : new NeoForgeEnergyStorage(handler);
+    }
+
+    @Nullable
+    public static EnergyHandler asNeoForge(@Nullable IEnergyStorage storage) {
+        return storage == null ? null : new CommonEnergyHandler(storage);
+    }
+
+    @Override
+    public long insert(long maxAmount, boolean simulate) {
+        try (Transaction tx = openTransaction()) {
+            int inserted = handler.insert(clampToInt(maxAmount), tx);
+            if (!simulate) {
+                tx.commit();
+            }
+            return inserted;
+        }
+    }
+
+    @Override
+    public long extract(long maxAmount, boolean simulate) {
+        try (Transaction tx = openTransaction()) {
+            int extracted = handler.extract(clampToInt(maxAmount), tx);
+            if (!simulate) {
+                tx.commit();
+            }
+            return extracted;
+        }
+    }
+
+    @Override
+    public long getAmount() {
+        return handler.getAmountAsLong();
+    }
+
+    @Override
+    public long getCapacity() {
+        return handler.getCapacityAsLong();
+    }
+
+    @Override
+    public boolean canInsert() {
+        if (handler instanceof CommonEnergyHandler common) {
+            return common.canInsert();
+        }
+        try (Transaction tx = openTransaction()) {
+            return handler.insert(1, tx) > 0;
+        }
+    }
+
+    @Override
+    public boolean canExtract() {
+        if (handler instanceof CommonEnergyHandler common) {
+            return common.canExtract();
+        }
+        try (Transaction tx = openTransaction()) {
+            return handler.extract(1, tx) > 0;
+        }
+    }
+
+    private static Transaction openTransaction() {
+        TransactionContext current = Transaction.getCurrentOpenedTransaction();
+        return current == null ? Transaction.openRoot() : Transaction.open(current);
+    }
+
+    private static int clampToInt(long amount) {
+        return (int) Math.max(0, Math.min(amount, Integer.MAX_VALUE));
+    }
+
+    private static final class CommonEnergyHandler extends SnapshotJournal<Long> implements EnergyHandler {
+        private final IEnergyStorage storage;
+        private long pendingDelta;
+
+        private CommonEnergyHandler(IEnergyStorage storage) {
+            this.storage = storage;
+        }
+
+        @Override
+        public long getAmountAsLong() {
+            return Math.max(0, storage.getAmount() + pendingDelta);
+        }
+
+        @Override
+        public long getCapacityAsLong() {
+            return storage.getCapacity();
+        }
+
+        private boolean canInsert() {
+            return storage.canInsert();
+        }
+
+        private boolean canExtract() {
+            return storage.canExtract();
+        }
+
+        @Override
+        public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            updateSnapshots(transaction);
+            long inserted = Math.min(amount, storage.insert(amount, true));
+            if (inserted > 0) {
+                pendingDelta += inserted;
+            }
+            return clampToInt(inserted);
+        }
+
+        @Override
+        public int extract(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
+            updateSnapshots(transaction);
+            long extracted = Math.min(getAmountAsLong(), storage.extract(amount, true));
+            if (extracted > 0) {
+                pendingDelta -= extracted;
+            }
+            return clampToInt(extracted);
+        }
+
+        @Override
+        protected Long createSnapshot() {
+            return pendingDelta;
+        }
+
+        @Override
+        protected void revertToSnapshot(Long snapshot) {
+            pendingDelta = snapshot;
+        }
+
+        @Override
+        protected void onRootCommit(Long originalState) {
+            long delta = pendingDelta - originalState;
+            if (delta > 0) {
+                storage.insert(delta, false);
+            } else if (delta < 0) {
+                storage.extract(-delta, false);
+            }
+            pendingDelta = 0;
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidKey.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidKey.java
@@ -1,0 +1,60 @@
+package com.logistics.neoforge.fluids;
+
+import com.logistics.core.lib.fluids.IFluidKey;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.world.level.material.Fluid;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+
+public final class NeoForgeFluidKey implements IFluidKey {
+    private final FluidResource resource;
+
+    public NeoForgeFluidKey(FluidResource resource) {
+        if (resource == null) {
+            throw new NullPointerException("resource must not be null");
+        }
+        this.resource = resource;
+    }
+
+    public static NeoForgeFluidKey of(FluidStack stack) {
+        return new NeoForgeFluidKey(FluidResource.of(stack));
+    }
+
+    public static NeoForgeFluidKey of(FluidResource resource) {
+        return new NeoForgeFluidKey(resource);
+    }
+
+    public FluidResource resource() {
+        return resource;
+    }
+
+    @Override
+    public Fluid getFluid() {
+        return resource.getFluid();
+    }
+
+    @Override
+    public DataComponentPatch getComponents() {
+        return resource.getComponentsPatch();
+    }
+
+    @Override
+    public boolean isBlank() {
+        return resource.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o instanceof NeoForgeFluidKey other) return resource.equals(other.resource);
+        if (o instanceof IFluidKey other) {
+            return getFluid() == other.getFluid() && getComponents().equals(other.getComponents());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * getFluid().hashCode() + getComponents().hashCode();
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidStorage.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidStorage.java
@@ -1,0 +1,207 @@
+package com.logistics.neoforge.fluids;
+
+import com.logistics.core.lib.fluids.IFluidKey;
+import com.logistics.core.lib.fluids.IFluidStorage;
+import com.logistics.core.lib.fluids.IFluidView;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.neoforged.neoforge.transfer.ResourceHandler;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
+import org.jetbrains.annotations.Nullable;
+
+public final class NeoForgeFluidStorage implements IFluidStorage {
+    private final ResourceHandler<FluidResource> handler;
+
+    private NeoForgeFluidStorage(ResourceHandler<FluidResource> handler) {
+        this.handler = handler;
+    }
+
+    @Nullable
+    public static IFluidStorage wrap(@Nullable ResourceHandler<FluidResource> handler) {
+        return handler == null ? null : new NeoForgeFluidStorage(handler);
+    }
+
+    @Nullable
+    public static ResourceHandler<FluidResource> asNeoForge(@Nullable IFluidStorage storage) {
+        return storage == null ? null : new CommonFluidHandler(storage);
+    }
+
+    @Override
+    public long insert(IFluidKey fluid, long maxAmount, boolean simulate) {
+        FluidResource resource = toResource(fluid);
+        if (resource.isEmpty() || maxAmount <= 0) {
+            return 0;
+        }
+        try (Transaction tx = Transaction.openRoot()) {
+            int inserted = handler.insert(resource, clampToInt(maxAmount), tx);
+            if (!simulate) {
+                tx.commit();
+            }
+            return inserted;
+        }
+    }
+
+    @Override
+    public long extract(IFluidKey fluid, long maxAmount, boolean simulate) {
+        FluidResource resource = toResource(fluid);
+        if (resource.isEmpty() || maxAmount <= 0) {
+            return 0;
+        }
+        try (Transaction tx = Transaction.openRoot()) {
+            int extracted = handler.extract(resource, clampToInt(maxAmount), tx);
+            if (!simulate) {
+                tx.commit();
+            }
+            return extracted;
+        }
+    }
+
+    @Override
+    public Iterable<IFluidView> contents() {
+        List<IFluidView> views = new ArrayList<>();
+        for (int i = 0; i < handler.size(); i++) {
+            FluidResource resource = handler.getResource(i);
+            long amount = handler.getAmountAsLong(i);
+            if (resource.isEmpty() || amount <= 0) {
+                continue;
+            }
+            IFluidKey key = NeoForgeFluidKey.of(resource);
+            views.add(new IFluidView() {
+                @Override public IFluidKey resource() { return key; }
+                @Override public long amount() { return amount; }
+            });
+        }
+        return views;
+    }
+
+    private static FluidResource toResource(IFluidKey key) {
+        return key instanceof NeoForgeFluidKey nfKey
+                ? nfKey.resource()
+                : FluidResource.of(key.getFluid(), key.getComponents());
+    }
+
+    private static int clampToInt(long amount) {
+        return (int) Math.max(0, Math.min(amount, Integer.MAX_VALUE));
+    }
+
+    private static final class CommonFluidHandler extends SnapshotJournal<Map<IFluidKey, Long>>
+            implements ResourceHandler<FluidResource> {
+        private final IFluidStorage storage;
+        private Map<IFluidKey, Long> pendingDeltas = new HashMap<>();
+
+        private CommonFluidHandler(IFluidStorage storage) {
+            this.storage = storage;
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
+        public FluidResource getResource(int index) {
+            checkIndex(index);
+            for (IFluidView view : storage.contents()) {
+                if (view.amount() > 0) {
+                    return toResource(view.resource());
+                }
+            }
+            return FluidResource.EMPTY;
+        }
+
+        @Override
+        public long getAmountAsLong(int index) {
+            checkIndex(index);
+            for (IFluidView view : storage.contents()) {
+                if (view.amount() > 0) {
+                    return view.amount();
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public long getCapacityAsLong(int index, FluidResource resource) {
+            checkIndex(index);
+            if (resource.isEmpty()) {
+                return 0;
+            }
+            return storage.insert(NeoForgeFluidKey.of(resource), Integer.MAX_VALUE, true);
+        }
+
+        @Override
+        public boolean isValid(int index, FluidResource resource) {
+            checkIndex(index);
+            return !resource.isEmpty() && getCapacityAsLong(index, resource) > 0;
+        }
+
+        @Override
+        public int insert(int index, FluidResource resource, int amount, TransactionContext transaction) {
+            checkIndex(index);
+            if (resource.isEmpty() || amount <= 0) {
+                return 0;
+            }
+            updateSnapshots(transaction);
+            IFluidKey key = NeoForgeFluidKey.of(resource);
+            long pending = pendingDeltas.getOrDefault(key, 0L);
+            long available = Math.max(0, storage.insert(key, Integer.MAX_VALUE, true) - pending);
+            long inserted = Math.min(amount, available);
+            if (inserted > 0) {
+                pendingDeltas.merge(key, inserted, Long::sum);
+            }
+            return clampToInt(inserted);
+        }
+
+        @Override
+        public int extract(int index, FluidResource resource, int amount, TransactionContext transaction) {
+            checkIndex(index);
+            if (resource.isEmpty() || amount <= 0) {
+                return 0;
+            }
+            updateSnapshots(transaction);
+            IFluidKey key = NeoForgeFluidKey.of(resource);
+            long pending = pendingDeltas.getOrDefault(key, 0L);
+            long available = Math.max(0, storage.extract(key, Integer.MAX_VALUE, true) + pending);
+            long extracted = Math.min(amount, available);
+            if (extracted > 0) {
+                pendingDeltas.merge(key, -extracted, Long::sum);
+            }
+            return clampToInt(extracted);
+        }
+
+        @Override
+        protected Map<IFluidKey, Long> createSnapshot() {
+            return new HashMap<>(pendingDeltas);
+        }
+
+        @Override
+        protected void revertToSnapshot(Map<IFluidKey, Long> snapshot) {
+            pendingDeltas = snapshot;
+        }
+
+        @Override
+        protected void onRootCommit(Map<IFluidKey, Long> originalState) {
+            for (var entry : pendingDeltas.entrySet()) {
+                long original = originalState.getOrDefault(entry.getKey(), 0L);
+                long delta = entry.getValue() - original;
+                if (delta > 0) {
+                    storage.insert(entry.getKey(), delta, false);
+                } else if (delta < 0) {
+                    storage.extract(entry.getKey(), -delta, false);
+                }
+            }
+            pendingDeltas = new HashMap<>();
+        }
+
+        private static void checkIndex(int index) {
+            if (index != 0) {
+                throw new IndexOutOfBoundsException(index);
+            }
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeCreativeTabRegistrar.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeCreativeTabRegistrar.java
@@ -2,33 +2,21 @@ package com.logistics.neoforge.platform;
 
 import com.logistics.core.lib.platform.CreativeTabRegistrar;
 import com.logistics.core.lib.platform.LogisticsCreativeTab;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
-/**
- * NeoForge implementation of {@link CreativeTabRegistrar}.
- *
- * <p>Custom tab registrations are collected at startup and applied when
- * {@code BuildCreativeModeTabContentsEvent} fires. Register the mod event bus via
- * {@link #init(IEventBus)} during mod construction.
- *
- * <p>TODO: {@link #registerTab} needs NeoForge's CreativeTabRegistry or Registry API —
- * the vanilla {@code Registry.register(BuiltInRegistries.CREATIVE_MODE_TAB, ...)} path
- * requires deferred registration on NeoForge.
- */
 public final class NeoForgeCreativeTabRegistrar implements CreativeTabRegistrar {
-
-    private record TabRegistration(LogisticsCreativeTab tab) {}
     private record TabModification(ResourceKey<CreativeModeTab> key, Consumer<TabEditor> editor) {}
 
-    private final List<TabRegistration> pendingTabs = new ArrayList<>();
     private final List<TabModification> pendingModifications = new ArrayList<>();
 
     public void init(IEventBus modBus) {
@@ -37,8 +25,14 @@ public final class NeoForgeCreativeTabRegistrar implements CreativeTabRegistrar 
 
     @Override
     public void registerTab(LogisticsCreativeTab tab) {
-        // TODO(neoforge): use DeferredRegister for CREATIVE_MODE_TAB on NeoForge
-        pendingTabs.add(new TabRegistration(tab));
+        Registry.register(
+                BuiltInRegistries.CREATIVE_MODE_TAB,
+                tab.id().toIdentifier(),
+                CreativeModeTab.builder()
+                        .title(tab.title())
+                        .icon(tab.icon())
+                        .displayItems((params, output) -> tab.populate(output))
+                        .build());
     }
 
     @Override
@@ -52,16 +46,22 @@ public final class NeoForgeCreativeTabRegistrar implements CreativeTabRegistrar 
             mod.editor().accept(new TabEditor() {
                 @Override
                 public void insertAfter(ItemLike anchor, ItemLike item) {
-                    throw new UnsupportedOperationException(
-                            "NeoForge creative tab ordering not yet implemented; "
-                                    + "wire event.insertAfter or equivalent NeoForge API");
+                    ItemStack newEntry = new ItemStack(item);
+                    try {
+                        event.insertAfter(new ItemStack(anchor), newEntry, CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
+                    } catch (IllegalArgumentException ignored) {
+                        event.accept(newEntry);
+                    }
                 }
 
                 @Override
                 public void insertBefore(ItemLike anchor, ItemLike item) {
-                    throw new UnsupportedOperationException(
-                            "NeoForge creative tab ordering not yet implemented; "
-                                    + "wire event.insertBefore or equivalent NeoForge API");
+                    ItemStack newEntry = new ItemStack(item);
+                    try {
+                        event.insertBefore(new ItemStack(anchor), newEntry, CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
+                    } catch (IllegalArgumentException ignored) {
+                        event.accept(newEntry);
+                    }
                 }
             });
         }

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
@@ -1,8 +1,10 @@
 package com.logistics.neoforge.platform;
 
 import com.logistics.core.lib.platform.PlatformService;
-import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
 import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLPaths;
 
 import java.nio.file.Path;
 
@@ -21,5 +23,13 @@ public final class NeoForgePlatformService implements PlatformService {
         return ModList.get().getModContainerById(namespace)
                 .map(c -> c.getModInfo().getDisplayName())
                 .orElse(namespace);
+    }
+
+    @Override
+    public <T> void registerAlias(Registry<T> registry, Identifier oldId, T currentEntry) {
+        Identifier currentId = registry.getKey(currentEntry);
+        if (currentId != null) {
+            NeoForgeRegistryAliasHelper.addAlias(registry, oldId, currentId);
+        }
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeRegistryAliasHelper.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeRegistryAliasHelper.java
@@ -1,0 +1,14 @@
+package com.logistics.neoforge.platform;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+import net.neoforged.neoforge.registries.IRegistryExtension;
+
+final class NeoForgeRegistryAliasHelper {
+    private NeoForgeRegistryAliasHelper() {}
+
+    @SuppressWarnings("unchecked")
+    static <T> void addAlias(Registry<T> registry, Identifier from, Identifier to) {
+        ((IRegistryExtension<T>) registry).addAlias(from, to);
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/storage/NeoForgeItemKey.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/storage/NeoForgeItemKey.java
@@ -1,0 +1,44 @@
+package com.logistics.neoforge.storage;
+
+import com.logistics.core.lib.storage.IItemKey;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.transfer.item.ItemResource;
+
+public final class NeoForgeItemKey implements IItemKey {
+    private final ItemResource resource;
+
+    public NeoForgeItemKey(ItemResource resource) {
+        if (resource == null) {
+            throw new NullPointerException("resource must not be null");
+        }
+        this.resource = resource;
+    }
+
+    public static NeoForgeItemKey of(ItemStack stack) {
+        return new NeoForgeItemKey(ItemResource.of(stack));
+    }
+
+    public ItemResource resource() {
+        return resource;
+    }
+
+    @Override
+    public ItemStack toStack(int count) {
+        return resource.toStack(count);
+    }
+
+    @Override
+    public boolean matches(ItemStack stack) {
+        return resource.matches(stack);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || (o instanceof NeoForgeItemKey other && resource.equals(other.resource));
+    }
+
+    @Override
+    public int hashCode() {
+        return resource.hashCode();
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/storage/NeoForgeItemStorage.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/storage/NeoForgeItemStorage.java
@@ -1,0 +1,220 @@
+package com.logistics.neoforge.storage;
+
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.core.lib.storage.IItemStorage;
+import com.logistics.core.lib.storage.IItemView;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.neoforged.neoforge.transfer.ResourceHandler;
+import net.neoforged.neoforge.transfer.item.ItemResource;
+import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
+import org.jetbrains.annotations.Nullable;
+
+public final class NeoForgeItemStorage implements IItemStorage {
+    private final ResourceHandler<ItemResource> handler;
+
+    private NeoForgeItemStorage(ResourceHandler<ItemResource> handler) {
+        this.handler = handler;
+    }
+
+    @Nullable
+    public static IItemStorage wrap(@Nullable ResourceHandler<ItemResource> handler) {
+        return handler == null ? null : new NeoForgeItemStorage(handler);
+    }
+
+    @Nullable
+    public static ResourceHandler<ItemResource> asNeoForge(@Nullable IItemStorage storage) {
+        return storage == null ? null : new CommonItemHandler(storage);
+    }
+
+    @Override
+    public long insert(IItemKey item, long maxAmount, boolean simulate) {
+        ItemResource resource = toResource(item);
+        if (resource.isEmpty() || maxAmount <= 0) {
+            return 0;
+        }
+        try (Transaction tx = Transaction.openRoot()) {
+            int inserted = handler.insert(resource, clampToInt(maxAmount), tx);
+            if (!simulate) {
+                tx.commit();
+            }
+            return inserted;
+        }
+    }
+
+    @Override
+    public long extract(IItemKey item, long maxAmount, boolean simulate) {
+        ItemResource resource = toResource(item);
+        if (resource.isEmpty() || maxAmount <= 0) {
+            return 0;
+        }
+        try (Transaction tx = Transaction.openRoot()) {
+            int extracted = handler.extract(resource, clampToInt(maxAmount), tx);
+            if (!simulate) {
+                tx.commit();
+            }
+            return extracted;
+        }
+    }
+
+    @Override
+    public Iterable<IItemView> contents() {
+        List<IItemView> views = new ArrayList<>();
+        for (int i = 0; i < handler.size(); i++) {
+            ItemResource resource = handler.getResource(i);
+            long amount = handler.getAmountAsLong(i);
+            if (resource.isEmpty() || amount <= 0) {
+                continue;
+            }
+            IItemKey key = new NeoForgeItemKey(resource);
+            views.add(new IItemView() {
+                @Override public IItemKey resource() { return key; }
+                @Override public long amount() { return amount; }
+            });
+        }
+        return views;
+    }
+
+    private static ItemResource toResource(IItemKey key) {
+        return key instanceof NeoForgeItemKey nfKey ? nfKey.resource() : ItemResource.of(key.toStack(1));
+    }
+
+    private static int clampToInt(long amount) {
+        return (int) Math.max(0, Math.min(amount, Integer.MAX_VALUE));
+    }
+
+    /**
+     * Adapts a common {@link IItemStorage} to NeoForge's slot-based {@link ResourceHandler}.
+     *
+     * <p>Reports {@link #size()}{@code == 1} regardless of how many distinct item types the
+     * underlying storage holds. {@link #getResource(int)} returns the first non-empty item
+     * (and {@link #getAmountAsLong(int)} its amount). This is an intentional "unified slot"
+     * view — the common abstraction has no fixed slot count, so we expose it as a single
+     * virtual slot. Insert and extract operations route through {@link #insert} and
+     * {@link #extract} which use the {@link IItemKey} content map and behave correctly
+     * for storages with multiple item types.
+     *
+     * <p>External code that enumerates slots will only observe the first item type.
+     * For correct multi-item interaction, callers should use the key-based insert/extract
+     * methods rather than slot iteration.
+     */
+    private static final class CommonItemHandler extends SnapshotJournal<Map<IItemKey, Long>>
+            implements ResourceHandler<ItemResource> {
+        private final IItemStorage storage;
+        private Map<IItemKey, Long> pendingDeltas = new HashMap<>();
+
+        private CommonItemHandler(IItemStorage storage) {
+            this.storage = storage;
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
+        public ItemResource getResource(int index) {
+            checkIndex(index);
+            for (IItemView view : storage.contents()) {
+                if (view.amount() > 0) {
+                    return toResource(view.resource());
+                }
+            }
+            return ItemResource.EMPTY;
+        }
+
+        @Override
+        public long getAmountAsLong(int index) {
+            checkIndex(index);
+            for (IItemView view : storage.contents()) {
+                if (view.amount() > 0) {
+                    return view.amount();
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public long getCapacityAsLong(int index, ItemResource resource) {
+            checkIndex(index);
+            if (resource.isEmpty()) {
+                return 0;
+            }
+            return storage.insert(new NeoForgeItemKey(resource), Integer.MAX_VALUE, true);
+        }
+
+        @Override
+        public boolean isValid(int index, ItemResource resource) {
+            checkIndex(index);
+            return !resource.isEmpty() && getCapacityAsLong(index, resource) > 0;
+        }
+
+        @Override
+        public int insert(int index, ItemResource resource, int amount, TransactionContext transaction) {
+            checkIndex(index);
+            if (resource.isEmpty() || amount <= 0) {
+                return 0;
+            }
+            updateSnapshots(transaction);
+            IItemKey key = new NeoForgeItemKey(resource);
+            long pending = pendingDeltas.getOrDefault(key, 0L);
+            long available = Math.max(0, storage.insert(key, Integer.MAX_VALUE, true) - pending);
+            long inserted = Math.min(amount, available);
+            if (inserted > 0) {
+                pendingDeltas.merge(key, inserted, Long::sum);
+            }
+            return clampToInt(inserted);
+        }
+
+        @Override
+        public int extract(int index, ItemResource resource, int amount, TransactionContext transaction) {
+            checkIndex(index);
+            if (resource.isEmpty() || amount <= 0) {
+                return 0;
+            }
+            updateSnapshots(transaction);
+            IItemKey key = new NeoForgeItemKey(resource);
+            long pending = pendingDeltas.getOrDefault(key, 0L);
+            long available = Math.max(0, storage.extract(key, Integer.MAX_VALUE, true) + pending);
+            long extracted = Math.min(amount, available);
+            if (extracted > 0) {
+                pendingDeltas.merge(key, -extracted, Long::sum);
+            }
+            return clampToInt(extracted);
+        }
+
+        @Override
+        protected Map<IItemKey, Long> createSnapshot() {
+            return new HashMap<>(pendingDeltas);
+        }
+
+        @Override
+        protected void revertToSnapshot(Map<IItemKey, Long> snapshot) {
+            pendingDeltas = snapshot;
+        }
+
+        @Override
+        protected void onRootCommit(Map<IItemKey, Long> originalState) {
+            for (var entry : pendingDeltas.entrySet()) {
+                long original = originalState.getOrDefault(entry.getKey(), 0L);
+                long delta = entry.getValue() - original;
+                if (delta > 0) {
+                    storage.insert(entry.getKey(), delta, false);
+                } else if (delta < 0) {
+                    storage.extract(entry.getKey(), -delta, false);
+                }
+            }
+            pendingDeltas = new HashMap<>();
+        }
+
+        private static void checkIndex(int index) {
+            if (index != 0) {
+                throw new IndexOutOfBoundsException(index);
+            }
+        }
+    }
+}

--- a/neoforge/src/test/java/com/logistics/neoforge/ServiceLoaderSmokeTest.java
+++ b/neoforge/src/test/java/com/logistics/neoforge/ServiceLoaderSmokeTest.java
@@ -6,7 +6,6 @@ import com.logistics.core.lib.platform.CreativeTabRegistrar;
 import com.logistics.core.lib.platform.PlatformService;
 import com.logistics.core.lib.platform.ResourceReloadRegistrar;
 import com.logistics.core.lib.power.FuelHelper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,19 +15,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * ServiceLoader smoke tests — mirrors {@code fabric/ServiceLoaderSmokeTest}.
- *
- * <p>All tests are {@link Disabled} because the NeoForge test environment is not yet
- * configured to run unit tests (NeoForge MDG test support is not wired up). These stubs
- * document intent and serve as the target state once the test environment is set up.
- *
- * <p>When enabled, each test verifies that the corresponding META-INF/services/ file
- * exists in the neoforge subproject and the implementation class can be instantiated.
+ * Verifies that all META-INF/services/ registrations exist and implementations
+ * can be instantiated without a game bootstrap.
  */
 @DisplayName("ServiceLoader smoke tests (NeoForge)")
 class ServiceLoaderSmokeTest {
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("FuelHelper implementation is registered")
     void fuelHelper_isRegistered() {
         FuelHelper impl = ServiceLoader.load(FuelHelper.class).findFirst().orElseThrow(
@@ -37,7 +30,6 @@ class ServiceLoaderSmokeTest {
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("PlatformService implementation is registered")
     void platformService_isRegistered() {
         PlatformService impl = ServiceLoader.load(PlatformService.class).findFirst().orElseThrow(
@@ -46,7 +38,6 @@ class ServiceLoaderSmokeTest {
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("BlockEntityTypeFactory implementation is registered")
     void blockEntityTypeFactory_isRegistered() {
         BlockEntityTypeFactory impl = ServiceLoader.load(BlockEntityTypeFactory.class).findFirst().orElseThrow(
@@ -55,7 +46,6 @@ class ServiceLoaderSmokeTest {
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("EnergyCapabilityLookup implementation is registered")
     void energyCapabilityLookup_isRegistered() {
         EnergyCapabilityLookup impl = ServiceLoader.load(EnergyCapabilityLookup.class).findFirst().orElseThrow(
@@ -64,7 +54,6 @@ class ServiceLoaderSmokeTest {
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("CreativeTabRegistrar implementation is registered")
     void creativeTabRegistrar_isRegistered() {
         CreativeTabRegistrar impl = ServiceLoader.load(CreativeTabRegistrar.class).findFirst().orElseThrow(
@@ -73,7 +62,6 @@ class ServiceLoaderSmokeTest {
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("ResourceReloadRegistrar implementation is registered")
     void resourceReloadRegistrar_isRegistered() {
         ResourceReloadRegistrar impl = ServiceLoader.load(ResourceReloadRegistrar.class).findFirst().orElseThrow(


### PR DESCRIPTION
                                                                                                                                                                                             
     ## Summary                                                                                                                                                                              
                                                                                                                                                                                             
     Adds the NeoForge platform SPI implementations needed for configuration, creative tab registration, and registry alias support.                                                         
                                                                                                                                                                                             
     ## Changes                                                                                                                                                                              
                                                                                                                                                                                             
     - Implement `NeoForgePlatformService`.                                                                                                                                                  
     - Add `NeoForgeRegistryAliasHelper`.                                                                                                                                                    
     - Wire `NeoForgeCreativeTabRegistrar` to register the creative tab and insert tab entries.                                                                                              
     - Update NeoForge build configuration for the shared client source set.                                                                                                                 
     - Enable NeoForge ServiceLoader smoke tests.                                                                                                                                            
                                                                                                                                                                                             
     ## Notes                                                                                                                                                                                
                                                                                                                                                                                             
     This PR is intentionally limited to platform-level SPI wiring. Capability registration, networking, and client rendering are split into later PRs.                                      
                                                                                                                                                                                             
     ## Validation                                                                                                                                                                           
                                                                                                                                                                                             
     - `./gradlew :neoforge:build`                                                                                                                                                           
     - `./gradlew :fabric:build`                                                                                                                                                             
     - `./gradlew spotlessCheck`   