### PR TITLE
test: add NeoForge ServiceLoader and energy adapter tests

### DIFF
--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"
+    testImplementation "net.neoforged:neoforge:${rootProject.neoforge_version}"
 }
 
 test {

--- a/neoforge/src/test/java/com/logistics/neoforge/ServiceLoaderSmokeTest.java
+++ b/neoforge/src/test/java/com/logistics/neoforge/ServiceLoaderSmokeTest.java
@@ -6,7 +6,10 @@ import com.logistics.core.lib.platform.CreativeTabRegistrar;
 import com.logistics.core.lib.platform.PlatformService;
 import com.logistics.core.lib.platform.ResourceReloadRegistrar;
 import com.logistics.core.lib.power.FuelHelper;
-import org.junit.jupiter.api.Disabled;
+import com.logistics.neoforge.energy.NeoForgeEnergyCapabilityLookup;
+import com.logistics.neoforge.platform.NeoForgeBlockEntityTypeFactory;
+import com.logistics.neoforge.platform.NeoForgeCreativeTabRegistrar;
+import com.logistics.neoforge.platform.NeoForgeResourceReloadRegistrar;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,18 +20,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * ServiceLoader smoke tests — mirrors {@code fabric/ServiceLoaderSmokeTest}.
  *
- * <p>All tests are {@link Disabled} because the NeoForge test environment is not yet
- * configured to run unit tests (NeoForge MDG test support is not wired up). These stubs
- * document intent and serve as the target state once the test environment is set up.
- *
- * <p>When enabled, each test verifies that the corresponding META-INF/services/ file
- * exists in the neoforge subproject and the implementation class can be instantiated.
+ * <p>Verifies that all META-INF/services/ registrations exist and the implementation
+ * classes can be found and instantiated without a full NeoForge runtime bootstrap.
+ * These tests would catch a missing services file that causes startup failure while
+ * build CI passes.
  */
 @DisplayName("ServiceLoader smoke tests (NeoForge)")
 class ServiceLoaderSmokeTest {
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("FuelHelper implementation is registered")
     void fuelHelper_isRegistered() {
         FuelHelper impl = ServiceLoader.load(FuelHelper.class).findFirst().orElseThrow(
@@ -37,7 +37,6 @@ class ServiceLoaderSmokeTest {
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("PlatformService implementation is registered")
     void platformService_isRegistered() {
         PlatformService impl = ServiceLoader.load(PlatformService.class).findFirst().orElseThrow(
@@ -46,38 +45,34 @@ class ServiceLoaderSmokeTest {
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("BlockEntityTypeFactory implementation is registered")
     void blockEntityTypeFactory_isRegistered() {
         BlockEntityTypeFactory impl = ServiceLoader.load(BlockEntityTypeFactory.class).findFirst().orElseThrow(
                 () -> new AssertionError("No BlockEntityTypeFactory found in META-INF/services/"));
-        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+        assertThat(impl).isInstanceOf(NeoForgeBlockEntityTypeFactory.class);
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("EnergyCapabilityLookup implementation is registered")
     void energyCapabilityLookup_isRegistered() {
         EnergyCapabilityLookup impl = ServiceLoader.load(EnergyCapabilityLookup.class).findFirst().orElseThrow(
                 () -> new AssertionError("No EnergyCapabilityLookup found in META-INF/services/"));
-        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+        assertThat(impl).isInstanceOf(NeoForgeEnergyCapabilityLookup.class);
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("CreativeTabRegistrar implementation is registered")
     void creativeTabRegistrar_isRegistered() {
         CreativeTabRegistrar impl = ServiceLoader.load(CreativeTabRegistrar.class).findFirst().orElseThrow(
                 () -> new AssertionError("No CreativeTabRegistrar found in META-INF/services/"));
-        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+        assertThat(impl).isInstanceOf(NeoForgeCreativeTabRegistrar.class);
     }
 
     @Test
-    @Disabled("NeoForge test environment not yet configured")
     @DisplayName("ResourceReloadRegistrar implementation is registered")
     void resourceReloadRegistrar_isRegistered() {
         ResourceReloadRegistrar impl = ServiceLoader.load(ResourceReloadRegistrar.class).findFirst().orElseThrow(
                 () -> new AssertionError("No ResourceReloadRegistrar found in META-INF/services/"));
-        assertThat(impl.getClass().getName()).startsWith("com.logistics.neoforge");
+        assertThat(impl).isInstanceOf(NeoForgeResourceReloadRegistrar.class);
     }
 }

--- a/neoforge/src/test/java/com/logistics/neoforge/energy/NeoForgeEnergyStorageTest.java
+++ b/neoforge/src/test/java/com/logistics/neoforge/energy/NeoForgeEnergyStorageTest.java
@@ -1,0 +1,187 @@
+package com.logistics.neoforge.energy;
+
+import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.energy.IEnergyStorage;
+import net.neoforged.neoforge.transfer.energy.EnergyHandler;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NeoForgeEnergyStorage adapter")
+class NeoForgeEnergyStorageTest {
+
+    private static EnergyComponent component(long capacity) {
+        return new EnergyComponent(capacity, capacity, capacity, () -> {});
+    }
+
+    @Nested
+    @DisplayName("null safety")
+    class NullSafety {
+
+        @Test
+        @DisplayName("wrap(null) returns null")
+        void wrap_null_returnsNull() {
+            assertThat(NeoForgeEnergyStorage.wrap(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("asNeoForge(null) returns null")
+        void asNeoForge_null_returnsNull() {
+            assertThat(NeoForgeEnergyStorage.asNeoForge(null)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("CommonEnergyHandler (common → NeoForge)")
+    class CommonEnergyHandlerTests {
+
+        @Test
+        @DisplayName("insert commits energy to backing storage on root commit")
+        void insert_commitsOnRootCommit() {
+            EnergyComponent backing = component(100);
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(backing);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                assertThat(handler.insert(60, tx)).isEqualTo(60);
+                tx.commit();
+            }
+
+            assertThat(backing.getAmount()).isEqualTo(60);
+        }
+
+        @Test
+        @DisplayName("insert respects pendingDelta within a transaction (regression: insert ignored staged amount)")
+        void insert_respectsPendingDelta() {
+            EnergyComponent backing = component(100);
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(backing);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                int first = handler.insert(60, tx);
+                // Before the fix, second insert returned 100 (ignored the pending 60).
+                // After the fix, only 40 capacity remains.
+                int second = handler.insert(100, tx);
+                assertThat(first).isEqualTo(60);
+                assertThat(second).isEqualTo(40);
+                tx.commit();
+            }
+
+            assertThat(backing.getAmount()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("insert rollback does not mutate backing storage")
+        void insert_rollback_doesNotMutate() {
+            EnergyComponent backing = component(100);
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(backing);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                handler.insert(60, tx);
+                // tx closes without commit → rollback
+            }
+
+            assertThat(backing.getAmount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("getAmountAsLong reflects pending inserts within a transaction")
+        void getAmountAsLong_reflectsPendingInserts() {
+            EnergyComponent backing = component(100);
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(backing);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                handler.insert(40, tx);
+                assertThat(handler.getAmountAsLong()).isEqualTo(40);
+                // rollback
+            }
+
+            assertThat(handler.getAmountAsLong()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("extract commits energy removal on root commit")
+        void extract_commitsOnRootCommit() {
+            EnergyComponent backing = component(100);
+            backing.insert(80, false);
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(backing);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                assertThat(handler.extract(50, tx)).isEqualTo(50);
+                tx.commit();
+            }
+
+            assertThat(backing.getAmount()).isEqualTo(30);
+        }
+
+        @Test
+        @DisplayName("extract rollback does not mutate backing storage")
+        void extract_rollback_doesNotMutate() {
+            EnergyComponent backing = component(100);
+            backing.insert(80, false);
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(backing);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                handler.extract(50, tx);
+                // rollback
+            }
+
+            assertThat(backing.getAmount()).isEqualTo(80);
+        }
+
+        @Test
+        @DisplayName("getCapacityAsLong returns backing capacity")
+        void getCapacityAsLong_returnsBackingCapacity() {
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(component(500));
+            assertThat(handler.getCapacityAsLong()).isEqualTo(500);
+        }
+    }
+
+    @Nested
+    @DisplayName("NeoForgeEnergyStorage (NeoForge → common wrapper)")
+    class WrapperTests {
+
+        @Test
+        @DisplayName("insert(simulate=false) commits to backing storage")
+        void insert_simulate_false_commits() {
+            EnergyComponent backing = component(100);
+            IEnergyStorage wrapped = NeoForgeEnergyStorage.wrap(NeoForgeEnergyStorage.asNeoForge(backing));
+
+            assertThat(wrapped.insert(70, false)).isEqualTo(70);
+            assertThat(backing.getAmount()).isEqualTo(70);
+        }
+
+        @Test
+        @DisplayName("insert(simulate=true) does not mutate backing storage")
+        void insert_simulate_true_doesNotMutate() {
+            EnergyComponent backing = component(100);
+            IEnergyStorage wrapped = NeoForgeEnergyStorage.wrap(NeoForgeEnergyStorage.asNeoForge(backing));
+
+            assertThat(wrapped.insert(70, true)).isEqualTo(70);
+            assertThat(backing.getAmount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("extract(simulate=false) commits removal from backing storage")
+        void extract_simulate_false_commits() {
+            EnergyComponent backing = component(100);
+            backing.insert(80, false);
+            IEnergyStorage wrapped = NeoForgeEnergyStorage.wrap(NeoForgeEnergyStorage.asNeoForge(backing));
+
+            assertThat(wrapped.extract(50, false)).isEqualTo(50);
+            assertThat(backing.getAmount()).isEqualTo(30);
+        }
+
+        @Test
+        @DisplayName("extract(simulate=true) does not mutate backing storage")
+        void extract_simulate_true_doesNotMutate() {
+            EnergyComponent backing = component(100);
+            backing.insert(80, false);
+            IEnergyStorage wrapped = NeoForgeEnergyStorage.wrap(NeoForgeEnergyStorage.asNeoForge(backing));
+
+            assertThat(wrapped.extract(50, true)).isEqualTo(50);
+            assertThat(backing.getAmount()).isEqualTo(80);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Enables all 6 previously-disabled NeoForge ServiceLoader smoke tests and adds 13 new energy adapter unit tests.

## Changes

- Enable all 6 `@Disabled` ServiceLoader smoke tests in `ServiceLoaderSmokeTest` — the `@Disabled` annotation was overly conservative; plain JUnit needs no special NeoForge bootstrap to verify `META-INF/services/` wiring.
- Improve assertions to use `isInstanceOf(ConcreteClass.class)` where the concrete type is known, matching the Fabric smoke test style.
- Add `NeoForgeEnergyStorageTest` with 13 cases covering:
  - Null safety for `wrap()` and `asNeoForge()`
  - `CommonEnergyHandler` insert/extract commit and rollback behavior
  - Regression test for the `pendingDelta` bug fix (staged inserts were not subtracted from available capacity)
  - `NeoForgeEnergyStorage` simulate-boolean semantics for both insert and extract
- Wire `net.neoforged:neoforge` to `testImplementation` so tests can directly reference NeoForge transfer API types.