### PR TITLE
feat: add NeoForge platform SPI services

### DIFF
--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.neoforged.moddev'
 }
 
-version = System.getenv("MOD_VERSION") ?: "dev-neoforge"
+version = System.getenv("MOD_VERSION") ?: "0.0.0-dev.neoforge"
 group = rootProject.group
 
 base {
@@ -31,6 +31,15 @@ neoForge {
     mods {
         logistics {
             sourceSet sourceSets.main
+        }
+    }
+}
+
+tasks.named('compileJava', JavaCompile) {
+    dependsOn configurations.commonClientJava
+    source configurations.commonClientJava.files.collect {
+        fileTree(it) {
+            exclude '**/jei/**'
         }
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeCreativeTabRegistrar.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeCreativeTabRegistrar.java
@@ -2,33 +2,21 @@ package com.logistics.neoforge.platform;
 
 import com.logistics.core.lib.platform.CreativeTabRegistrar;
 import com.logistics.core.lib.platform.LogisticsCreativeTab;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
-/**
- * NeoForge implementation of {@link CreativeTabRegistrar}.
- *
- * <p>Custom tab registrations are collected at startup and applied when
- * {@code BuildCreativeModeTabContentsEvent} fires. Register the mod event bus via
- * {@link #init(IEventBus)} during mod construction.
- *
- * <p>TODO: {@link #registerTab} needs NeoForge's CreativeTabRegistry or Registry API —
- * the vanilla {@code Registry.register(BuiltInRegistries.CREATIVE_MODE_TAB, ...)} path
- * requires deferred registration on NeoForge.
- */
 public final class NeoForgeCreativeTabRegistrar implements CreativeTabRegistrar {
-
-    private record TabRegistration(LogisticsCreativeTab tab) {}
     private record TabModification(ResourceKey<CreativeModeTab> key, Consumer<TabEditor> editor) {}
 
-    private final List<TabRegistration> pendingTabs = new ArrayList<>();
     private final List<TabModification> pendingModifications = new ArrayList<>();
 
     public void init(IEventBus modBus) {
@@ -37,8 +25,14 @@ public final class NeoForgeCreativeTabRegistrar implements CreativeTabRegistrar 
 
     @Override
     public void registerTab(LogisticsCreativeTab tab) {
-        // TODO(neoforge): use DeferredRegister for CREATIVE_MODE_TAB on NeoForge
-        pendingTabs.add(new TabRegistration(tab));
+        Registry.register(
+                BuiltInRegistries.CREATIVE_MODE_TAB,
+                tab.id().toIdentifier(),
+                CreativeModeTab.builder()
+                        .title(tab.title())
+                        .icon(tab.icon())
+                        .displayItems((params, output) -> tab.populate(output))
+                        .build());
     }
 
     @Override
@@ -52,16 +46,22 @@ public final class NeoForgeCreativeTabRegistrar implements CreativeTabRegistrar 
             mod.editor().accept(new TabEditor() {
                 @Override
                 public void insertAfter(ItemLike anchor, ItemLike item) {
-                    throw new UnsupportedOperationException(
-                            "NeoForge creative tab ordering not yet implemented; "
-                                    + "wire event.insertAfter or equivalent NeoForge API");
+                    ItemStack newEntry = new ItemStack(item);
+                    try {
+                        event.insertAfter(new ItemStack(anchor), newEntry, CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
+                    } catch (IllegalArgumentException ignored) {
+                        event.accept(newEntry);
+                    }
                 }
 
                 @Override
                 public void insertBefore(ItemLike anchor, ItemLike item) {
-                    throw new UnsupportedOperationException(
-                            "NeoForge creative tab ordering not yet implemented; "
-                                    + "wire event.insertBefore or equivalent NeoForge API");
+                    ItemStack newEntry = new ItemStack(item);
+                    try {
+                        event.insertBefore(new ItemStack(anchor), newEntry, CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
+                    } catch (IllegalArgumentException ignored) {
+                        event.accept(newEntry);
+                    }
                 }
             });
         }

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
@@ -1,8 +1,10 @@
 package com.logistics.neoforge.platform;
 
 import com.logistics.core.lib.platform.PlatformService;
-import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
 import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLPaths;
 
 import java.nio.file.Path;
 
@@ -21,5 +23,13 @@ public final class NeoForgePlatformService implements PlatformService {
         return ModList.get().getModContainerById(namespace)
                 .map(c -> c.getModInfo().getDisplayName())
                 .orElse(namespace);
+    }
+
+    @Override
+    public <T> void registerAlias(Registry<T> registry, Identifier oldId, T currentEntry) {
+        Identifier currentId = registry.getKey(currentEntry);
+        if (currentId != null) {
+            NeoForgeRegistryAliasHelper.addAlias(registry, oldId, currentId);
+        }
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeRegistryAliasHelper.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgeRegistryAliasHelper.java
@@ -1,0 +1,14 @@
+package com.logistics.neoforge.platform;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+import net.neoforged.neoforge.registries.IRegistryExtension;
+
+final class NeoForgeRegistryAliasHelper {
+    private NeoForgeRegistryAliasHelper() {}
+
+    @SuppressWarnings("unchecked")
+    static <T> void addAlias(Registry<T> registry, Identifier from, Identifier to) {
+        ((IRegistryExtension<T>) registry).addAlias(from, to);
+    }
+}


### PR DESCRIPTION
## Summary

Adds NeoForge platform SPI implementations for configuration, creative tab registration, and registry alias support.

Original work by @AdolfoCarneiro in #370. Applied as a resolved cherry-pick because our test PR (#377) had already enabled the ServiceLoader smoke tests in a conflicting way — conflict was resolved by keeping the more precise `isInstanceOf` assertions from #377.

## Changes

- Implement `NeoForgePlatformService`.
- Add `NeoForgeRegistryAliasHelper`.
- Wire `NeoForgeCreativeTabRegistrar` to register the creative tab and insert tab entries.
- Update NeoForge build configuration for the shared client source set.

## Notes

Platform-level SPI wiring only. Capability registration, networking, and client rendering are in subsequent PRs.