### PR TITLE
feat: wire NeoForge capabilities

### DIFF
--- a/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
@@ -1,35 +1,72 @@
 package com.logistics.neoforge;
 
 import com.logistics.core.bootstrap.LogisticsCommonBootstrap;
+import com.logistics.core.lib.platform.CreativeTabRegistrar;
+import com.logistics.core.lib.platform.ResourceReloadRegistrar;
+import com.logistics.core.lib.power.AbstractEngineBlock;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.neoforge.energy.NeoForgeEnergyStorage;
 import com.logistics.neoforge.platform.NeoForgeCreativeTabRegistrar;
 import com.logistics.neoforge.platform.NeoForgeResourceReloadRegistrar;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.registries.RegisterEvent;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
 
 @Mod("logistics")
 public final class LogisticsNeoForge {
 
     private static final LogisticsCommonBootstrap COMMON_BOOTSTRAP = new LogisticsCommonBootstrap();
+    private boolean commonInitialized;
 
     public LogisticsNeoForge(IEventBus modBus) {
-        COMMON_BOOTSTRAP.initialize();
+        modBus.addListener(this::onRegister);
+        registerEnergyServices();
+        NeoForgeCapabilityRegistration.register(modBus);
 
         // Wire deferred event registrations on the creative tab and reload registrars
         // (The SPI INSTANCE is the NeoForge impl because it's the only implementation on classpath)
-        var creativeTabRegistrar = com.logistics.core.lib.platform.CreativeTabRegistrar.INSTANCE;
+        var creativeTabRegistrar = CreativeTabRegistrar.INSTANCE;
         if (creativeTabRegistrar instanceof NeoForgeCreativeTabRegistrar nfRegistrar) {
             nfRegistrar.init(modBus);
         }
-        var reloadRegistrar = com.logistics.core.lib.platform.ResourceReloadRegistrar.INSTANCE;
+        var reloadRegistrar = ResourceReloadRegistrar.INSTANCE;
         if (reloadRegistrar instanceof NeoForgeResourceReloadRegistrar nfRegistrar) {
-            nfRegistrar.init(net.neoforged.neoforge.common.NeoForge.EVENT_BUS);
+            nfRegistrar.init(NeoForge.EVENT_BUS);
         }
-
-        modBus.addListener(this::commonSetup);
     }
 
-    private void commonSetup(FMLCommonSetupEvent event) {
-        // TODO(neoforge): capability registration via RegisterCapabilitiesEvent
+    private synchronized void onRegister(RegisterEvent event) {
+        if (commonInitialized) {
+            return;
+        }
+        // NeoForge unfreezes all BuiltInRegistries during RegisterEvent emission, so
+        // direct Registry.register() calls inside initialize() are safe regardless of which registry fired first.
+        COMMON_BOOTSTRAP.initialize();
+        commonInitialized = true;
+    }
+
+    private void registerEnergyServices() {
+        AbstractEngineBlockEntity.setEnergyPushService((level, targetPos, fromDirection, source, maxAmount) -> {
+            var target = level.getCapability(Capabilities.Energy.BLOCK, targetPos, fromDirection);
+            if (target == null) {
+                return 0L;
+            }
+            try (Transaction tx = Transaction.openRoot()) {
+                int inserted = target.insert((int) Math.min(maxAmount, Integer.MAX_VALUE), tx);
+                if (inserted > 0) {
+                    tx.commit();
+                }
+                return inserted;
+            }
+        });
+
+        AbstractEngineBlock.setEnergyPresenceChecker((world, pos, direction) -> {
+            var target = world.getCapability(Capabilities.Energy.BLOCK, pos.relative(direction), direction.getOpposite());
+            return NeoForgeEnergyStorage.wrap(target) instanceof com.logistics.core.lib.energy.IEnergyStorage storage
+                    && storage.canInsert();
+        });
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCapabilityRegistration.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCapabilityRegistration.java
@@ -1,26 +1,94 @@
 package com.logistics.neoforge;
 
-// TODO(multiloader): Register capabilities for NeoForge.
-// NeoForge equivalent of FabricCapabilityRegistration.
-//
-// @Mod.EventBusSubscriber(modid = "logistics", bus = Mod.EventBusSubscriber.Bus.MOD)
-// public final class NeoForgeCapabilityRegistration {
-//
-//     @SubscribeEvent
-//     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
-//         // Energy capability — registered for each block entity that implements HasEnergyStorage
-//         // event.registerBlockEntity(Capabilities.EnergyStorage.BLOCK,
-//         //     LogisticsPower.ENTITY.SOME_ENGINE_BLOCK_ENTITY,
-//         //     (be, side) -> new NeoForgeEnergyStorage(be.getEnergyStorage(side)));
-//
-//         // Item capability — registered for each block entity that implements HasItemStorage
-//         // event.registerBlockEntity(Capabilities.ItemHandler.BLOCK,
-//         //     LogisticsCore.ENTITY.SOME_MACHINE_BLOCK_ENTITY,
-//         //     (be, side) -> new NeoForgeItemHandler(be.itemStorage(side)));
-//
-//         // Pipe connection lookup — NeoForge equivalent TBD
-//     }
-// }
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsCore;
+import com.logistics.LogisticsPipe;
+import com.logistics.LogisticsPower;
+import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.block.capability.HasFluidStorage;
+import com.logistics.core.lib.block.capability.HasItemStorage;
+import com.logistics.core.lib.block.capability.PipeConnection;
+import com.logistics.core.lib.fluids.FluidStorageLookup;
+import com.logistics.core.lib.pipe.PipeConnectionLookup;
+import com.logistics.core.lib.storage.ItemStorageLookup;
+import com.logistics.neoforge.energy.NeoForgeEnergyStorage;
+import com.logistics.neoforge.fluids.NeoForgeFluidStorage;
+import com.logistics.neoforge.storage.NeoForgeItemKey;
+import com.logistics.neoforge.storage.NeoForgeItemStorage;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+
 public final class NeoForgeCapabilityRegistration {
     private NeoForgeCapabilityRegistration() {}
+
+    public static void register(IEventBus modBus) {
+        modBus.addListener(NeoForgeCapabilityRegistration::registerCapabilities);
+
+        ItemStorageLookup.register((world, pos, dir) ->
+                NeoForgeItemStorage.wrap(world.getCapability(Capabilities.Item.BLOCK, pos, dir)));
+        ItemStorageLookup.registerKeyFactory(NeoForgeItemKey::of);
+
+        FluidStorageLookup.register((world, pos, dir) ->
+                NeoForgeFluidStorage.wrap(world.getCapability(Capabilities.Fluid.BLOCK, pos, dir)));
+
+        PipeConnectionLookup.register((level, pos, direction) -> {
+            BlockEntity blockEntity = level.getBlockEntity(pos);
+            if (blockEntity instanceof PipeConnection connection
+                    && connection.getConnectionType(direction) != PipeConnection.Type.NONE) {
+                return connection;
+            }
+            return null;
+        });
+    }
+
+    private static void registerCapabilities(RegisterCapabilitiesEvent event) {
+        registerEnergy(event, LogisticsCore.ENTITY.MACERATOR_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsPower.ENTITY.REDSTONE_ENGINE_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsPower.ENTITY.STIRLING_ENGINE_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsPower.ENTITY.CREATIVE_ENGINE_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsPower.ENTITY.CREATIVE_SINK_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsPower.ENTITY.CABLE_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsPipe.ENTITY.PIPE_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsAutomation.ENTITY.LASER_QUARRY_BLOCK_ENTITY);
+        registerEnergy(event, LogisticsAutomation.ENTITY.KILN_BLOCK_ENTITY);
+
+        registerItems(event, LogisticsCore.ENTITY.MACERATOR_BLOCK_ENTITY);
+        registerItems(event, LogisticsPower.ENTITY.STIRLING_ENGINE_BLOCK_ENTITY);
+        registerItems(event, LogisticsPipe.ENTITY.PIPE_BLOCK_ENTITY);
+        registerItems(event, LogisticsAutomation.ENTITY.KILN_BLOCK_ENTITY);
+
+        // No current block entities implement HasFluidStorage, but keep this as the
+        // registration path for the first fluid-capable machine.
+    }
+
+    private static <BE extends BlockEntity & HasEnergyStorage> void registerEnergy(
+            RegisterCapabilitiesEvent event,
+            BlockEntityType<BE> type) {
+        event.registerBlockEntity(
+                Capabilities.Energy.BLOCK,
+                type,
+                (blockEntity, side) -> NeoForgeEnergyStorage.asNeoForge(blockEntity.energyStorage(side)));
+    }
+
+    private static <BE extends BlockEntity & HasItemStorage> void registerItems(
+            RegisterCapabilitiesEvent event,
+            BlockEntityType<BE> type) {
+        event.registerBlockEntity(
+                Capabilities.Item.BLOCK,
+                type,
+                (blockEntity, side) -> NeoForgeItemStorage.asNeoForge(blockEntity.itemStorage(side)));
+    }
+
+    @SuppressWarnings("unused")
+    private static <BE extends BlockEntity & HasFluidStorage> void registerFluids(
+            RegisterCapabilitiesEvent event,
+            BlockEntityType<BE> type) {
+        event.registerBlockEntity(
+                Capabilities.Fluid.BLOCK,
+                type,
+                (blockEntity, side) -> NeoForgeFluidStorage.asNeoForge(blockEntity.fluidStorage(side)));
+    }
 }


### PR DESCRIPTION
## Summary

Wires NeoForge capabilities and energy services so common loader-agnostic storage abstractions work against NeoForge providers.

Original work by @AdolfoCarneiro in #371. Applied as a resolved cherry-pick of the unique commit (`88c37886`) on top of the already-merged platform SPI work.

## Changes

- Register NeoForge capabilities for energy, item, and fluid storage.
- Wire `ItemStorageLookup`, `FluidStorageLookup`, and `PipeConnectionLookup` to NeoForge capability lookups.
- Add the NeoForge energy push and presence checker services.
- Connect the storage adapters to capability registration.

## Notes

Infrastructure-only PR. Networking, lifecycle events, and client rendering are in subsequent PRs.