### PR TITLE
ci: enable NeoForge publishing in build workflows

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.loader == 'neoforge' }}
     strategy:
       fail-fast: false
       matrix:
@@ -82,8 +81,6 @@ jobs:
           path: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
       - name: Publish
-        # NeoForge publishing deferred until multiloader-loader integration is complete
-        if: matrix.loader == 'fabric'
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.tag || github.ref }}
+          persist-credentials: false
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,28 +27,33 @@ jobs:
         loader: [fabric, neoforge]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: '25'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Extract version information
         id: version
+        env:
+          GH_EVENT: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          MATRIX_LOADER: ${{ matrix.loader }}
         run: |
           # Get tag name
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ inputs.tag }}"
+          if [[ "$GH_EVENT" == "workflow_dispatch" ]]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$RELEASE_TAG"
           fi
 
           # Extract version from tag
@@ -69,8 +74,7 @@ jobs:
           # Extract MC version from gradle.properties
           MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
 
-          # Get loader from matrix
-          LOADER="${{ matrix.loader }}"
+          LOADER="$MATRIX_LOADER"
 
           # Build full version string with SemVer build metadata: VERSION+mcMC_VERSION.LOADER
           # Tag: mc1.21.11-v0.4.0 (for release-please tracking)
@@ -105,7 +109,7 @@ jobs:
           ls -lh ${{ matrix.loader }}/build/libs/
 
       - name: Upload JAR
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: logistics-${{ matrix.loader }}-${{ steps.version.outputs.full_version }}
           path: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
@@ -121,18 +125,24 @@ jobs:
         loader: [fabric, neoforge]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Extract version information
         id: version
+        env:
+          GH_EVENT: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          MATRIX_LOADER: ${{ matrix.loader }}
         run: |
           # Get tag name
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ inputs.tag }}"
+          if [[ "$GH_EVENT" == "workflow_dispatch" ]]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$RELEASE_TAG"
           fi
 
           # Extract version from tag
@@ -145,7 +155,7 @@ jobs:
           VERSION="${VERSION#v}"
 
           MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
-          LOADER="${{ matrix.loader }}"
+          LOADER="$MATRIX_LOADER"
 
           FULL_VERSION="${VERSION}+mc${MC_VERSION}.${LOADER}"
 
@@ -178,13 +188,13 @@ jobs:
           echo "modrinth_featured=$MODRINTH_FEATURED" >> "$GITHUB_OUTPUT"
 
       - name: Download JAR
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: logistics-${{ matrix.loader }}-${{ steps.version.outputs.full_version }}
           path: artifacts/
 
       - name: Publish to Modrinth and CurseForge
-        uses: Kir-Antipov/mc-publish@v3.3
+        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659 # v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         loader: [fabric, neoforge]
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.loader == 'neoforge' }}
     strategy:
       fail-fast: false
       matrix:
@@ -142,8 +141,7 @@ jobs:
           path: ${{ matrix.loader }}/build/libs/logistics-*.jar
 
       - name: Publish to Modrinth and CurseForge
-        # NeoForge publishing deferred until multiloader-loader integration is complete
-        if: (github.event_name != 'workflow_dispatch' || inputs.publish) && matrix.loader == 'fabric'
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         loader: [fabric, neoforge]
 
@@ -81,15 +80,81 @@ jobs:
 
           GRADLE_TASK=":${LOADER}:jar"
 
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "full_version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "minecraft_version=$MC_VERSION" >> "$GITHUB_OUTPUT"
+          echo "loader=$LOADER" >> "$GITHUB_OUTPUT"
+          echo "gradle_task=$GRADLE_TASK" >> "$GITHUB_OUTPUT"
+          echo "📦 Tag: $TAG"
+          echo "📦 Version: $VERSION"
+          echo "📦 Built for MC: $MC_VERSION"
+          echo "📦 Loader: $LOADER"
+          echo "📦 Full version: $FULL_VERSION (will be passed to Gradle as MOD_VERSION)"
+          echo "📦 Expected artifact: logistics-$FULL_VERSION.jar"
+          echo "🔨 Gradle task: $GRADLE_TASK"
+
+      - name: Build with Gradle
+        run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
+        env:
+          MOD_VERSION: ${{ steps.version.outputs.full_version }}
+
+      - name: List build artifacts
+        run: |
+          echo "📦 Build artifacts created:"
+          ls -lh ${{ matrix.loader }}/build/libs/
+
+      - name: Upload JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: logistics-${{ matrix.loader }}-${{ steps.version.outputs.full_version }}
+          path: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+
+  publish:
+    needs: build
+    if: github.event_name != 'workflow_dispatch' || inputs.publish
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        loader: [fabric, neoforge]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Extract version information
+        id: version
+        run: |
+          # Get tag name
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+
+          # Extract version from tag
+          if [[ "$TAG" =~ ^mc([0-9.]+)-v(.+)$ ]]; then
+            VERSION="${BASH_REMATCH[2]}"
+          else
+            VERSION="${TAG#v}"
+          fi
+
+          VERSION="${VERSION#v}"
+
+          MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
+          LOADER="${{ matrix.loader }}"
+
+          FULL_VERSION="${VERSION}+mc${MC_VERSION}.${LOADER}"
+
           # Detect snapshot/alpha/beta versions for publishing configuration
           if [[ "$MC_VERSION" =~ (snapshot|alpha|beta) ]]; then
-            IS_SNAPSHOT="true"
             VERSION_TYPE="beta"
             GAME_VERSION_FILTER="none"
             MODRINTH_FEATURED="false"
-            echo "📦 Snapshot/alpha/beta detected - will publish as beta, not featured"
           else
-            IS_SNAPSHOT="false"
             VERSION_TYPE="release"
             GAME_VERSION_FILTER="releases"
             MODRINTH_FEATURED="true"
@@ -108,41 +173,17 @@ jobs:
           echo "full_version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
           echo "minecraft_version=$MC_VERSION" >> "$GITHUB_OUTPUT"
           echo "loader=$LOADER" >> "$GITHUB_OUTPUT"
-          echo "gradle_task=$GRADLE_TASK" >> "$GITHUB_OUTPUT"
-          echo "is_snapshot=$IS_SNAPSHOT" >> "$GITHUB_OUTPUT"
           echo "version_type=$VERSION_TYPE" >> "$GITHUB_OUTPUT"
           echo "game_version_filter=$GAME_VERSION_FILTER" >> "$GITHUB_OUTPUT"
           echo "modrinth_featured=$MODRINTH_FEATURED" >> "$GITHUB_OUTPUT"
-          echo "📦 Tag: $TAG"
-          echo "📦 Version: $VERSION"
-          echo "📦 Built for MC: $MC_VERSION"
-          echo "📦 Loader: $LOADER"
-          echo "📦 Full version: $FULL_VERSION (will be passed to Gradle as MOD_VERSION)"
-          echo "📦 Modrinth version: $MODRINTH_VERSION (shortened for 32 char limit)"
-          echo "📦 Expected artifact: logistics-$FULL_VERSION.jar"
-          echo "🔨 Gradle task: $GRADLE_TASK"
-          echo "📦 Version type: $VERSION_TYPE"
-          echo "📦 Game version filter: $GAME_VERSION_FILTER"
-          echo "📦 Modrinth featured: $MODRINTH_FEATURED"
 
-      - name: Build with Gradle
-        run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
-        env:
-          MOD_VERSION: ${{ steps.version.outputs.full_version }}
-
-      - name: List build artifacts
-        run: |
-          echo "📦 Build artifacts created:"
-          ls -lh ${{ matrix.loader }}/build/libs/
-
-      - name: Upload JAR
-        uses: actions/upload-artifact@v7
+      - name: Download JAR
+        uses: actions/download-artifact@v4
         with:
           name: logistics-${{ matrix.loader }}-${{ steps.version.outputs.full_version }}
-          path: ${{ matrix.loader }}/build/libs/logistics-*.jar
+          path: artifacts/
 
       - name: Publish to Modrinth and CurseForge
-        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
@@ -161,6 +202,6 @@ jobs:
           name: "Logistics v${{ steps.version.outputs.version }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"
           version: "${{ steps.version.outputs.full_version }}"
 
-          files: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
+          files: artifacts/logistics-${{ steps.version.outputs.full_version }}.jar
 
           changelog: ${{ github.event.release.body || format('Release {0}', steps.version.outputs.full_version) }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.loader == 'neoforge' }}
     strategy:
       fail-fast: false
       matrix:
@@ -105,8 +104,6 @@ jobs:
           path: ${{ matrix.loader }}/build/libs/logistics-${{ steps.version.outputs.full_version }}.jar
 
       - name: Publish
-        # NeoForge publishing deferred until multiloader-loader integration is complete
-        if: matrix.loader == 'fabric'
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}


### PR DESCRIPTION
## Summary

- Removes the `continue-on-error: neoforge` safety net — NeoForge builds now fail the workflow if they break
- Removes the `if: matrix.loader == 'fabric'` publish gate from all three build workflows (`build-prerelease`, `build-snapshot`, `build-release`)
- NeoForge artifacts will now be published to Modrinth and CurseForge alongside Fabric on every snapshot, pre-release, and release build

The Discord beta-testing notification in `build-prerelease` remains fabric-only (one ping per release is sufficient since both loaders publish to the same Modrinth project page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)