### PR TITLE
fix: preserve item components in filter pipe slots across save/reload

### DIFF
--- a/common/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
@@ -2,6 +2,7 @@ package com.logistics.pipe.modules;
 
 import com.logistics.core.lib.pipe.RoutingModule;
 
+import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.compat.NbtCompat;
@@ -17,13 +18,18 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 
 /**
@@ -155,12 +161,97 @@ public class ItemFilterModule implements Module, RoutingModule {
         }
     }
 
+    /**
+     * Returns the filter stacks for {@code direction}, preserving full component data.
+     * Handles both old format (ListTag of StringTag item IDs) and new format
+     * (ListTag of CompoundTag full ItemStack). Always returns exactly
+     * {@link #FILTER_SLOTS_PER_SIDE} entries, padding with {@link ItemStack#EMPTY}.
+     */
+    public List<ItemStack> getFilterStacks(PipeContext ctx, Direction direction) {
+        CompoundTag filters = ctx.getCompoundTag(this, FILTERS);
+        List<ItemStack> result = new ArrayList<>(FILTER_SLOTS_PER_SIDE);
+
+        ListTag list = NbtCompat.getListOrEmpty(filters, direction.getName());
+        RegistryOps<Tag> ops = (ctx.world() != null)
+                ? ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE)
+                : null;
+
+        for (int i = 0; i < FILTER_SLOTS_PER_SIDE; i++) {
+            ItemStack stack = ItemStack.EMPTY;
+            if (i < list.size()) {
+                if (list.getElementType() == Tag.TAG_COMPOUND) {
+                    // New format: full ItemStack encoded with ItemStack.CODEC
+                    CompoundTag tag = list.getCompound(i);
+                    if (!tag.isEmpty() && ops != null) {
+                        stack = ItemStack.CODEC.parse(ops, tag).result().orElse(ItemStack.EMPTY);
+                    }
+                } else {
+                    // Old format: item registry ID string
+                    String id = NbtCompat.getStringAt(list, i, "");
+                    if (!id.isEmpty()) {
+                        ResourceId resource = ResourceId.tryParse(id);
+                        if (resource != null) {
+                            Item item = BuiltInRegistries.ITEM.get(resource.toIdentifier());
+                            if (item != null && item != Items.AIR) {
+                                stack = new ItemStack(item);
+                            }
+                        }
+                    }
+                }
+            }
+            result.add(stack);
+        }
+
+        return result;
+    }
+
+    /**
+     * Persists {@code stacks} for {@code direction} using full {@link ItemStack.CODEC} encoding,
+     * so component data (custom names, colors, NBT) survives save/reload.
+     */
+    public void setFilterStacks(PipeContext ctx, Direction direction, List<ItemStack> stacks) {
+        CompoundTag filters = ctx.getCompoundTag(this, FILTERS);
+        ListTag list = new ListTag();
+        boolean hasAny = false;
+
+        RegistryOps<Tag> ops = (ctx.world() != null)
+                ? ctx.world().registryAccess().createSerializationContext(NbtOps.INSTANCE)
+                : null;
+
+        for (int i = 0; i < FILTER_SLOTS_PER_SIDE; i++) {
+            ItemStack stack = (i < stacks.size() && stacks.get(i) != null) ? stacks.get(i) : ItemStack.EMPTY;
+            if (!stack.isEmpty() && ops != null) {
+                hasAny = true;
+                CompoundTag encoded = ItemStack.CODEC.encodeStart(ops, stack.copyWithCount(1))
+                        .result()
+                        .filter(t -> t instanceof CompoundTag)
+                        .map(t -> (CompoundTag) t)
+                        .orElse(new CompoundTag());
+                list.add(encoded);
+            } else {
+                list.add(new CompoundTag());
+            }
+        }
+
+        if (hasAny) {
+            filters.put(direction.getName(), list);
+        } else {
+            filters.remove(direction.getName());
+        }
+
+        if (!filters.isEmpty()) {
+            ctx.putCompoundTag(this, FILTERS, filters);
+        } else {
+            ctx.remove(this, FILTERS);
+        }
+    }
+
     private List<String> getFiltersForSide(PipeContext ctx, Direction direction) {
-        List<String> slots = getFilterSlots(ctx, direction);
-        List<String> ids = new ArrayList<>(slots.size());
-        for (String id : slots) {
-            if (!id.isEmpty()) {
-                ids.add(id);
+        List<ItemStack> filterStacks = getFilterStacks(ctx, direction);
+        List<String> ids = new ArrayList<>(filterStacks.size());
+        for (ItemStack stack : filterStacks) {
+            if (!stack.isEmpty()) {
+                ids.add(BuiltInRegistries.ITEM.getKey(stack.getItem()).toString());
             }
         }
         return ids;

--- a/common/src/main/java/com/logistics/pipe/ui/FilterInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/FilterInventory.java
@@ -8,11 +8,15 @@ import com.logistics.pipe.modules.ItemFilterModule;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -125,43 +129,46 @@ public class FilterInventory implements Container {
         int slotIndex = 0;
         PipeContext ctx = pipeEntity.createContext();
         for (Direction direction : ItemFilterModule.FILTER_ORDER) {
-            List<String> slots = module.getFilterSlots(ctx, direction);
+            List<ItemStack> filterStacks = module.getFilterStacks(ctx, direction);
             for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
-                String id = slots.get(i);
-                ItemStack stack = ItemStack.EMPTY;
-                if (!id.isEmpty()) {
-                    ResourceId resource = ResourceId.tryParse(id);
-                    if (resource != null) {
-                        Item item = BuiltInRegistries.ITEM.get(resource.toIdentifier());
-                        if (item != null && item != Items.AIR) {
-                            stack = new ItemStack(item);
-                        }
-                    }
-                }
-                stacks.set(slotIndex++, stack);
+                stacks.set(slotIndex++, filterStacks.get(i));
             }
         }
     }
 
-    public void loadFromItem(ItemStack stack) {
+    public void loadFromItem(ItemStack itemStack, HolderLookup.Provider registries) {
         for (int i = 0; i < stacks.size(); i++) stacks.set(i, ItemStack.EMPTY);
-        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        CustomData customData = itemStack.get(DataComponents.CUSTOM_DATA);
         if (customData == null) return;
         CompoundTag tag = customData.copyTag();
         CompoundTag filters = NbtCompat.getCompoundOrEmpty(tag, ItemFilterModule.FILTERS);
+        RegistryOps<Tag> ops = registries != null
+                ? registries.createSerializationContext(NbtOps.INSTANCE)
+                : null;
         int slotIndex = 0;
         for (Direction direction : ItemFilterModule.FILTER_ORDER) {
             ListTag list = NbtCompat.getListOrEmpty(filters, direction.getName());
             for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
-                String itemId = NbtCompat.getStringAt(list, i, "");
                 ItemStack resolved = ItemStack.EMPTY;
-                if (!itemId.isEmpty()) {
-                    ResourceId rid = ResourceId.tryParse(itemId);
-                    if (rid != null) {
-                        // MC 1.21.1: get() returns Item directly, not Optional<Holder<Item>>
-                        var itemOpt = BuiltInRegistries.ITEM.get(rid.toIdentifier());
-                        if (itemOpt != null && itemOpt != Items.AIR) {
-                            resolved = new ItemStack(itemOpt);
+                if (i < list.size()) {
+                    if (list.getElementType() == Tag.TAG_COMPOUND) {
+                        // New format: full ItemStack with components
+                        CompoundTag slotTag = list.getCompound(i);
+                        if (!slotTag.isEmpty() && ops != null) {
+                            resolved = ItemStack.CODEC.parse(ops, slotTag).result()
+                                    .orElse(ItemStack.EMPTY);
+                        }
+                    } else {
+                        // Old format: item registry ID string
+                        String itemId = NbtCompat.getStringAt(list, i, "");
+                        if (!itemId.isEmpty()) {
+                            ResourceId rid = ResourceId.tryParse(itemId);
+                            if (rid != null) {
+                                Item item = BuiltInRegistries.ITEM.get(rid.toIdentifier());
+                                if (item != null && item != Items.AIR) {
+                                    resolved = new ItemStack(item);
+                                }
+                            }
                         }
                     }
                 }
@@ -179,16 +186,11 @@ public class FilterInventory implements Container {
         int slotIndex = 0;
         PipeContext ctx = pipeEntity.createContext();
         for (Direction direction : ItemFilterModule.FILTER_ORDER) {
-            List<String> slots = new ArrayList<>(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
+            List<ItemStack> slots = new ArrayList<>(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
             for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
-                ItemStack stack = stacks.get(slotIndex++);
-                if (stack.isEmpty()) {
-                    slots.add("");
-                } else {
-                    slots.add(BuiltInRegistries.ITEM.getKey(stack.getItem()).toString());
-                }
+                slots.add(stacks.get(slotIndex++));
             }
-            module.setFilterSlots(ctx, direction, slots);
+            module.setFilterStacks(ctx, direction, slots);
         }
 
         pipeEntity.setChanged();

--- a/common/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
@@ -7,7 +7,9 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
@@ -71,7 +73,7 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
         this.originalStack = player.getItemInHand(hand);
         this.context = ContainerLevelAccess.NULL;
         this.filterInventory = new FilterInventory(null);
-        this.filterInventory.loadFromItem(this.originalStack);
+        this.filterInventory.loadFromItem(this.originalStack, player.level().registryAccess());
 
         addFilterSlots(filterInventory);
         addPlayerInventorySlots(playerInventory);
@@ -142,26 +144,37 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
         return ItemStack.EMPTY;
     }
 
-    /** Writes the full filter state to the held item's CUSTOM_DATA. */
+    /** Writes the full filter state to the held item's CUSTOM_DATA, preserving component data. */
     private void syncFiltersToItem() {
         if (itemConfigPlayer == null || itemConfigPlayer.getItemInHand(itemConfigHand) != originalStack) return;
         ItemStack stack = originalStack;
         CustomData existing = stack.get(DataComponents.CUSTOM_DATA);
         CompoundTag tag = existing != null ? existing.copyTag() : new CompoundTag();
 
+        RegistryOps<Tag> ops = itemConfigPlayer.level().registryAccess()
+                .createSerializationContext(NbtOps.INSTANCE);
         CompoundTag filtersTag = new CompoundTag();
         int slotIndex = 0;
         for (Direction direction : ItemFilterModule.FILTER_ORDER) {
             ListTag list = new ListTag();
+            boolean hasAny = false;
             for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
                 ItemStack slotItem = filterInventory.getItem(slotIndex++);
-                String itemId = slotItem.isEmpty()
-                        ? ""
-                        : net.minecraft.core.registries.BuiltInRegistries.ITEM
-                                .getKey(slotItem.getItem()).toString();
-                list.add(StringTag.valueOf(itemId));
+                if (!slotItem.isEmpty()) {
+                    hasAny = true;
+                    CompoundTag encoded = ItemStack.CODEC.encodeStart(ops, slotItem.copyWithCount(1))
+                            .result()
+                            .filter(t -> t instanceof CompoundTag)
+                            .map(t -> (CompoundTag) t)
+                            .orElse(new CompoundTag());
+                    list.add(encoded);
+                } else {
+                    list.add(new CompoundTag());
+                }
             }
-            filtersTag.put(direction.getName(), list);
+            if (hasAny) {
+                filtersTag.put(direction.getName(), list);
+            }
         }
         tag.put(ItemFilterModule.FILTERS, filtersTag);
 

--- a/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleSerializationGoldenTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleSerializationGoldenTest.java
@@ -12,9 +12,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * Golden-fixture regression tests for {@link ItemFilterModule} serialization.
@@ -170,14 +172,8 @@ class ItemFilterModuleSerializationGoldenTest {
     @Test
     @DisplayName("setFilterStacks with null world falls back gracefully (no NPE)")
     void setFilterStacks_nullWorldIsNoop() {
-        // ctx has null world — setFilterStacks should not throw
-        List<ItemStack> toSet = new java.util.ArrayList<>();
-        for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
-            toSet.add(ItemStack.EMPTY);
-        }
-        // Should not throw even with null world
-        org.junit.jupiter.api.Assertions.assertDoesNotThrow(
-                () -> module.setFilterStacks(ctx, Direction.NORTH, toSet));
+        List<ItemStack> toSet = Collections.nCopies(ItemFilterModule.FILTER_SLOTS_PER_SIDE, ItemStack.EMPTY);
+        assertDoesNotThrow(() -> module.setFilterStacks(ctx, Direction.NORTH, toSet));
     }
 
     // ---------------------------------------------------------------------------

--- a/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleSerializationGoldenTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleSerializationGoldenTest.java
@@ -7,6 +7,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
+import net.minecraft.world.item.ItemStack;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -129,6 +130,54 @@ class ItemFilterModuleSerializationGoldenTest {
         // This test intentionally checks the key string. If ItemFilterModule is ever
         // renamed, getStateKey() MUST be overridden to keep returning "itemfiltermodule".
         assertThat(module.getStateKey()).isEqualTo(MODULE_STATE_KEY);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Backward-compat: getFilterStacks() must read old StringTag format correctly.
+    // (New CompoundTag round-trip tests require RegistryAccess and run in-game.)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getFilterStacks: old StringTag format returns item-only stacks (no NPE)")
+    void getFilterStacks_readsOldStringFormat() {
+        injectFilters(filtersWithNorth("minecraft:diamond"));
+
+        // getFilterStacks() with null world falls back to item-ID only for old format
+        List<ItemStack> stacks = module.getFilterStacks(ctx, Direction.NORTH);
+
+        assertThat(stacks).hasSize(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
+        // First slot is non-empty (item loaded by ID)
+        assertThat(stacks.get(0).isEmpty()).isFalse();
+        // Component-less (components patch is empty for a plain stack)
+        assertThat(stacks.get(0).getComponentsPatch().isEmpty()).isTrue();
+        // Remaining slots are empty
+        for (int i = 1; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
+            assertThat(stacks.get(i).isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("getFilterStacks: missing direction returns all-empty list (no NPE)")
+    void getFilterStacks_missingDirectionIsAllEmpty() {
+        injectFilters(filtersWithNorth("minecraft:diamond"));
+
+        List<ItemStack> stacks = module.getFilterStacks(ctx, Direction.SOUTH);
+
+        assertThat(stacks).hasSize(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
+        assertThat(stacks).allMatch(ItemStack::isEmpty);
+    }
+
+    @Test
+    @DisplayName("setFilterStacks with null world falls back gracefully (no NPE)")
+    void setFilterStacks_nullWorldIsNoop() {
+        // ctx has null world — setFilterStacks should not throw
+        List<ItemStack> toSet = new java.util.ArrayList<>();
+        for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
+            toSet.add(ItemStack.EMPTY);
+        }
+        // Should not throw even with null world
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+                () -> module.setFilterStacks(ctx, Direction.NORTH, toSet));
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Items placed into filter pipe slots that have custom components (renamed items, colored/dyed books, enchanted tools, etc.) were silently reduced to their bare item type on save. On world reload, the slot would display a plain default item instead of the original.
- Root cause: filter slots stored only item registry ID strings — all component data was discarded at `syncToBlockEntity()` / `syncFiltersToItem()` time.

## Changes

- **`ItemFilterModule`**: Added `getFilterStacks()` / `setFilterStacks()` using `ItemStack.CODEC` + `RegistryOps` (same pattern as `ProviderDispatchQueue`). Backward-compatible format detection via `ListTag` element type: old saves (`ListTag<StringTag>`) load without components; new saves (`ListTag<CompoundTag>`) restore full component data.
- **`FilterInventory`**: `loadFromBlockEntity()` and `syncToBlockEntity()` delegate to the new stack-based API. `loadFromItem()` handles both old and new formats.
- **`ItemFilterScreenHandler`**: `syncFiltersToItem()` encodes each slot with `ItemStack.CODEC` instead of extracting a plain string ID.
- **Tests**: 3 new golden-fixture tests confirm old string format still loads (no regression) and null-world is safe.

## Notes

Routing behavior is **unchanged** — matching remains type-only (greedy), consistent with BuildCraft's historical `matchDamage=true, matchNBT=false` precedent. Component-aware routing (e.g., routing specifically blue books vs. red books) would require a dedicated future module.

Old saves continue to work. Components are restored once a player re-opens and re-saves the filter UI.