### PR TITLE
fix: show Macerator recipe category in JEI on NeoForge

### DIFF
--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -46,9 +46,7 @@ tasks.named('compileJava', JavaCompile) {
 }
 
 dependencies {
-    // JEI — compile against API only; players install separately at runtime.
-    // Compiling the shared com.logistics.core.macerator.jei plugin lets NeoForge JEI
-    // discover the @JeiPlugin via classpath scanning, matching the Fabric integration.
+    // JEI — compile against API only; players install separately at runtime
     compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge-api:${rootProject.jei_version}")
     runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge:${rootProject.jei_version}")
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     // JEI — compile against API only; players install separately at runtime.
     // Compiling the shared com.logistics.core.macerator.jei plugin lets NeoForge JEI
     // discover the @JeiPlugin via classpath scanning, matching the Fabric integration.
-    compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge:${rootProject.jei_version}")
+    compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge-api:${rootProject.jei_version}")
     runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge:${rootProject.jei_version}")
 
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -11,6 +11,11 @@ base {
     archivesName = rootProject.archives_base_name
 }
 
+repositories {
+    maven { url = "https://maven.terraformersmc.com/releases/" }
+    maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
+}
+
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(rootProject.java_version.toInteger())
     withSourcesJar()
@@ -37,14 +42,16 @@ neoForge {
 
 tasks.named('compileJava', JavaCompile) {
     dependsOn configurations.commonClientJava
-    source configurations.commonClientJava.files.collect {
-        fileTree(it) {
-            exclude '**/jei/**'
-        }
-    }
+    source configurations.commonClientJava
 }
 
 dependencies {
+    // JEI — compile against API only; players install separately at runtime.
+    // Compiling the shared com.logistics.core.macerator.jei plugin lets NeoForge JEI
+    // discover the @JeiPlugin via classpath scanning, matching the Fabric integration.
+    compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge:${rootProject.jei_version}")
+    runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge:${rootProject.jei_version}")
+
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"


### PR DESCRIPTION
@
## Summary
The Macerator recipe category ("Processing Recipes using Macerator") was missing from JEI when running on NeoForge. It worked on Fabric.

## Cause
The NeoForge subproject compiled the shared common-client sources but explicitly excluded the `**/jei/**` package, and declared no JEI dependency or maven repo. As a result `MaceratorJeiPlugin` and `MaceratorRecipeCategory` were never compiled into the NeoForge jar, so JEI had no `@JeiPlugin` to discover and never registered the category.

## Changes
- Add the blamejared / terraformersmc maven repositories to `neoforge/build.gradle`.
- Add `compileOnly` + `runtimeOnly` dependencies on `mezz.jei:jei-26.1-neoforge`.
- Remove the `**/jei/**` source exclusion so the shared JEI plugin compiles into the NeoForge build.

NeoForge JEI discovers the `@JeiPlugin` via classpath scanning, so no `neoforge.mods.toml` entry is required — this mirrors the existing Fabric integration.

## Notes
- JEI remains compile/runtime-only; players install JEI separately.
- Verified `:neoforge:compileJava` and `:neoforge:build` succeed with the JEI package included.
@