### PR TITLE
fix: handle failed deliveries in logistics network tracking

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
+++ b/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
@@ -162,6 +162,18 @@ public interface ILogisticsNetwork {
         // Optional for implementations that do not track in-flight orders.
     }
 
+    /**
+     * Record failed delivery when no dispatch id is available. This is a fallback for legacy
+     * queued dispatches and should only release requester accounting.
+     *
+     * @param requester destination the item was intended for
+     * @param item      item variant that failed delivery
+     * @param amount    amount that failed delivery
+     */
+    default void notifyDeliveryFailedNoId(BlockPos requester, IItemKey item, long amount) {
+        // Optional for implementations that do not track requester accounting.
+    }
+
     // ===== Crafter Snapshot =====
 
     /**

--- a/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
+++ b/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
@@ -137,6 +137,31 @@ public interface ILogisticsNetwork {
      */
     void notifyDelivery(BlockPos requester, IItemKey item, long amount);
 
+    /**
+     * Record physical delivery of a tracked item to a requester inventory.
+     *
+     * @param deliveryId order/dispatch id carried by the traveling item
+     * @param requester  destination the item was delivered to
+     * @param item       item variant delivered
+     * @param amount     amount delivered
+     */
+    default void notifyDelivery(UUID deliveryId, BlockPos requester, IItemKey item, long amount) {
+        notifyDelivery(requester, item, amount);
+    }
+
+    /**
+     * Record failed delivery of a tracked item. Implementations should release in-flight
+     * accounting without counting the item as delivered.
+     *
+     * @param deliveryId order/dispatch id carried by the traveling item
+     * @param requester  destination the item was intended for
+     * @param item       item variant that failed delivery
+     * @param amount     amount that failed delivery
+     */
+    default void notifyDeliveryFailed(UUID deliveryId, BlockPos requester, IItemKey item, long amount) {
+        // Optional for implementations that do not track in-flight orders.
+    }
+
     // ===== Crafter Snapshot =====
 
     /**

--- a/common/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -868,7 +868,7 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
         if (item.getDeliveryId() != null) {
             ILogisticsNetwork network = ctx.network();
             if (network != null) {
-                network.notifyDelivery(ctx.pos(), ItemStorageLookup.of(item.getStack()), placed);
+                network.notifyDelivery(item.getDeliveryId(), ctx.pos(), ItemStorageLookup.of(item.getStack()), placed);
             }
         }
 

--- a/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -298,13 +298,11 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
                         head.remaining() - extracted);
             } else {
                 // Inventory empty or inaccessible — drop the entry so the queue doesn't block
-                // forever, but also notify the network so orderedForRequester is decremented.
-                // Without the notify call, orderedForRequester would stay elevated permanently
-                // (it only decrements on physical TravelingItem delivery), which would prevent
-                // suppliers from re-ordering these items.
+                // forever, but also notify the network so in-flight accounting is released and
+                // the request can be retried instead of being counted as delivered.
                 ILogisticsNetwork network = NetworkRegistry.getOrCreateNetwork(ctx.world(), ctx.pos());
-                if (network != null) {
-                    network.notifyDelivery(head.requester(), item, head.remaining());
+                if (network != null && head.deliveryId() != null) {
+                    network.notifyDeliveryFailed(head.deliveryId(), head.requester(), item, head.remaining());
                 }
                 NetDbg.out("[Provider @ {}] Queue drain failed (empty?): {}x {} — dropping entry",
                         ctx.pos(), head.remaining(), item.toStack(1).getItem());

--- a/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -301,8 +301,12 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
                 // forever, but also notify the network so in-flight accounting is released and
                 // the request can be retried instead of being counted as delivered.
                 ILogisticsNetwork network = NetworkRegistry.getOrCreateNetwork(ctx.world(), ctx.pos());
-                if (network != null && head.deliveryId() != null) {
-                    network.notifyDeliveryFailed(head.deliveryId(), head.requester(), item, head.remaining());
+                if (network != null) {
+                    if (head.deliveryId() != null) {
+                        network.notifyDeliveryFailed(head.deliveryId(), head.requester(), item, head.remaining());
+                    } else {
+                        network.notifyDeliveryFailedNoId(head.requester(), item, head.remaining());
+                    }
                 }
                 NetDbg.out("[Provider @ {}] Queue drain failed (empty?): {}x {} — dropping entry",
                         ctx.pos(), head.remaining(), item.toStack(1).getItem());

--- a/common/src/main/java/com/logistics/pipe/network/JobCoordinator.java
+++ b/common/src/main/java/com/logistics/pipe/network/JobCoordinator.java
@@ -4,6 +4,7 @@ import com.logistics.core.lib.network.ItemRequest;
 import com.logistics.core.lib.network.PlanningView;
 import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -166,6 +167,27 @@ public class JobCoordinator implements NetworkController.OrderFailureListener {
                 return;
             }
         }
+    }
+
+    /**
+     * Called when a tracked dispatch is lost after it was already sent into the pipe network.
+     * The controller has already released the old in-flight accounting and created a replacement
+     * order; this method keeps job-to-order indexes pointed at the retry.
+     */
+    public void onDeliveryFailed(UUID failedOrderId, @Nullable UUID replacementOrderId) {
+        UUID jobId = orderToJob.get(failedOrderId);
+        if (jobId == null || replacementOrderId == null) return;
+
+        NetworkJob job = jobs.get(jobId);
+        if (job == null || job.state().isTerminal()) return;
+
+        orderToJob.put(replacementOrderId, jobId);
+        jobToOrder.put(jobId, replacementOrderId);
+        job.transitionTo(JobState.REPLANNING);
+        job.transitionTo(JobState.ACTIVE);
+        NetDbg.out("[Jobs] Delivery failed for job {} | retry order {}",
+                job.id().toString().substring(0, 8),
+                replacementOrderId.toString().substring(0, 8));
     }
 
     /**

--- a/common/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/common/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -69,6 +69,9 @@ public class NetworkController implements PlanningView {
     // Standing orders in insertion order (FIFO)
     private final Map<UUID, Order> orderQueue = new LinkedHashMap<>();
 
+    // Dispatched orders that are physically traveling and can be retried if delivery fails.
+    private final Map<UUID, Order> inTransitOrders = new HashMap<>();
+
     // How many items each requester has outstanding (ordered but not yet delivered)
     private final Map<BlockPos, Map<IItemKey, Long>> orderedForRequester = new HashMap<>();
 
@@ -172,6 +175,11 @@ public class NetworkController implements PlanningView {
             decrementOrdered(order.requester(), order.item(), order.amount());
             reservationManager.releaseByOrder(id);
         }
+        Order inTransit = inTransitOrders.remove(id);
+        if (inTransit != null) {
+            decrementOrdered(inTransit.requester(), inTransit.item(), inTransit.amount());
+            reservationManager.releaseByOrder(id);
+        }
     }
 
     /**
@@ -180,6 +188,13 @@ public class NetworkController implements PlanningView {
      */
     public void cancelOrdersFor(BlockPos requester) {
         orderQueue.entrySet().removeIf(e -> {
+            if (e.getValue().requester().equals(requester)) {
+                reservationManager.releaseByOrder(e.getKey());
+                return true;
+            }
+            return false;
+        });
+        inTransitOrders.entrySet().removeIf(e -> {
             if (e.getValue().requester().equals(requester)) {
                 reservationManager.releaseByOrder(e.getKey());
                 return true;
@@ -321,6 +336,7 @@ public class NetworkController implements PlanningView {
         if (order == null) return;
         NetDbg.out("Recorded dispatch: {} | {} items shipped", orderId.toString().substring(0, 8), shipped);
         reservationManager.transitionByOrder(orderId, AllocationState.IN_TRANSIT);
+        trackInTransit(order, shipped);
         if (shipped >= order.amount()) {
             orderQueue.remove(orderId);
         } else {
@@ -351,6 +367,35 @@ public class NetworkController implements PlanningView {
         NetDbg.out("Delivery notified: {} received {}x {}", requester, amount, item.toStack(1).getItem());
         decrementOrdered(requester, item, amount);
         reservationManager.markDelivered(requester, item);
+    }
+
+    /**
+     * Record physical delivery for a tracked dispatch.
+     */
+    public void notifyDelivery(UUID orderId, BlockPos requester, IItemKey item, long amount) {
+        if (amount <= 0) return;
+        releaseInTransit(orderId, amount);
+        notifyDelivery(requester, item, amount);
+    }
+
+    /**
+     * Record failed delivery for a tracked dispatch and requeue the missing amount.
+     *
+     * @return replacement order id, or {@code null} when the amount is not positive
+     */
+    @Nullable
+    public UUID notifyDeliveryFailed(UUID orderId, BlockPos requester, IItemKey item, long amount) {
+        if (amount <= 0) return null;
+
+        Order tracked = releaseInTransit(orderId, amount);
+        FulfillmentMode mode = tracked == null ? FulfillmentMode.PARTIAL : tracked.fulfillmentMode();
+        long failedAmount = tracked == null ? amount : Math.min(amount, tracked.amount());
+
+        NetDbg.out("Delivery failed: {} lost {}x {}", requester, failedAmount, item.toStack(1).getItem());
+        decrementOrdered(requester, item, failedAmount);
+        reservationManager.releaseByOrder(orderId);
+
+        return placeOrder(item, failedAmount, requester, mode);
     }
 
     // ===== Ingredient Chain Validation =====
@@ -550,6 +595,11 @@ public class NetworkController implements PlanningView {
             orderQueue.putIfAbsent(entry.getKey(), entry.getValue());
         }
 
+        // Merge in-transit orders (preserve local entries on UUID collision)
+        for (Map.Entry<UUID, Order> entry : other.inTransitOrders.entrySet()) {
+            inTransitOrders.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+
         // Merge orderedForRequester
         for (Map.Entry<BlockPos, Map<IItemKey, Long>> entry : other.orderedForRequester.entrySet()) {
             Map<IItemKey, Long> myMap =
@@ -587,6 +637,39 @@ public class NetworkController implements PlanningView {
         if (map != null) {
             long remaining = map.merge(item, -amount, Long::sum);
             if (remaining <= 0) map.remove(item);
+            if (map.isEmpty()) orderedForRequester.remove(requester);
         }
+    }
+
+    private void trackInTransit(Order order, long shipped) {
+        if (shipped <= 0) return;
+        inTransitOrders.merge(
+                order.id(),
+                new Order(order.id(), order.item(), shipped, order.requester(), order.fulfillmentMode()),
+                (existing, added) -> new Order(
+                        existing.id(),
+                        existing.item(),
+                        existing.amount() + added.amount(),
+                        existing.requester(),
+                        existing.fulfillmentMode()));
+    }
+
+    @Nullable
+    private Order releaseInTransit(UUID orderId, long amount) {
+        Order tracked = inTransitOrders.get(orderId);
+        if (tracked == null || amount <= 0) return tracked;
+
+        if (amount >= tracked.amount()) {
+            inTransitOrders.remove(orderId);
+            return tracked;
+        }
+
+        inTransitOrders.put(orderId, new Order(
+                tracked.id(),
+                tracked.item(),
+                tracked.amount() - amount,
+                tracked.requester(),
+                tracked.fulfillmentMode()));
+        return new Order(tracked.id(), tracked.item(), amount, tracked.requester(), tracked.fulfillmentMode());
     }
 }

--- a/common/src/main/java/com/logistics/pipe/network/NetworkController.java
+++ b/common/src/main/java/com/logistics/pipe/network/NetworkController.java
@@ -388,14 +388,23 @@ public class NetworkController implements PlanningView {
         if (amount <= 0) return null;
 
         Order tracked = releaseInTransit(orderId, amount);
-        FulfillmentMode mode = tracked == null ? FulfillmentMode.PARTIAL : tracked.fulfillmentMode();
-        long failedAmount = tracked == null ? amount : Math.min(amount, tracked.amount());
+        if (tracked == null) return null;
 
-        NetDbg.out("Delivery failed: {} lost {}x {}", requester, failedAmount, item.toStack(1).getItem());
-        decrementOrdered(requester, item, failedAmount);
-        reservationManager.releaseByOrder(orderId);
+        NetDbg.out("Delivery failed: {} lost {}x {}",
+                tracked.requester(), tracked.amount(), tracked.item().toStack(1).getItem());
+        decrementOrdered(tracked.requester(), tracked.item(), tracked.amount());
 
-        return placeOrder(item, failedAmount, requester, mode);
+        return placeOrder(tracked.item(), tracked.amount(), tracked.requester(), tracked.fulfillmentMode());
+    }
+
+    /**
+     * Record failed delivery for a dispatch without an id. This only releases requester
+     * accounting because there is no reliable in-flight order to retry or reservation to match.
+     */
+    public void notifyDeliveryFailedNoId(BlockPos requester, IItemKey item, long amount) {
+        if (amount <= 0) return;
+        NetDbg.out("Untracked delivery failed: {} lost {}x {}", requester, amount, item.toStack(1).getItem());
+        decrementOrdered(requester, item, amount);
     }
 
     // ===== Ingredient Chain Validation =====

--- a/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -188,6 +188,18 @@ public class PipeNetwork implements ILogisticsNetwork {
         jobCoordinator.onDelivery(requester, item, amount);
     }
 
+    @Override
+    public void notifyDelivery(UUID deliveryId, BlockPos requester, IItemKey item, long amount) {
+        controller.notifyDelivery(deliveryId, requester, item, amount);
+        jobCoordinator.onDelivery(requester, item, amount);
+    }
+
+    @Override
+    public void notifyDeliveryFailed(UUID deliveryId, BlockPos requester, IItemKey item, long amount) {
+        UUID replacementOrderId = controller.notifyDeliveryFailed(deliveryId, requester, item, amount);
+        jobCoordinator.onDeliveryFailed(deliveryId, replacementOrderId);
+    }
+
     /**
      * Tick the network: dispatch all fulfillable standing orders synchronously.
      * Provider modules extract items and inject TravelingItems before returning.

--- a/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -200,6 +200,11 @@ public class PipeNetwork implements ILogisticsNetwork {
         jobCoordinator.onDeliveryFailed(deliveryId, replacementOrderId);
     }
 
+    @Override
+    public void notifyDeliveryFailedNoId(BlockPos requester, IItemKey item, long amount) {
+        controller.notifyDeliveryFailedNoId(requester, item, amount);
+    }
+
     /**
      * Tick the network: dispatch all fulfillable standing orders synchronously.
      * Provider modules extract items and inject TravelingItems before returning.

--- a/common/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
+++ b/common/src/main/java/com/logistics/pipe/runtime/PipeRuntime.java
@@ -247,7 +247,7 @@ public final class PipeRuntime {
     private static void executeRoutePlan(TickContext ctx, TravelingItem item, RoutePlan plan, ItemTickState itemState) {
         switch (plan.getType()) {
             case DROP -> dropItem(ctx, item, itemState);
-            case DISCARD -> discardItem(item, itemState);
+            case DISCARD -> discardItem(ctx, item, itemState);
             case REROUTE -> rerouteItem(ctx, item, plan, itemState);
             case SPLIT -> splitItem(ctx, item, plan, itemState);
             default -> {} // PASS should have been converted in resolveRoutePlan
@@ -256,23 +256,16 @@ public final class PipeRuntime {
 
     private static void dropItem(TickContext ctx, TravelingItem item, ItemTickState itemState) {
         if (ctx.isServer()) {
-            // If item had delivery tracking, notify network before dropping so
-            // orderedForRequester doesn't stay permanently elevated.
-            if (item.getDeliveryId() != null && item.getDestination() != null) {
-                PipeNetwork network = NetworkRegistry.getNetwork(ctx.world(), ctx.pos());
-                if (network != null) {
-                    network.notifyDelivery(
-                            item.getDestination(),
-                            ItemStorageLookup.of(item.getStack()),
-                            item.getStack().getCount());
-                }
-            }
+            notifyDeliveryFailed(ctx.world(), ctx.pos(), item, item.getStack().getCount());
             PipeBlockEntity.dropItem(ctx.world(), ctx.pos(), item);
         }
         itemState.markForDiscard(item);
     }
 
-    private static void discardItem(TravelingItem item, ItemTickState itemState) {
+    private static void discardItem(TickContext ctx, TravelingItem item, ItemTickState itemState) {
+        if (ctx.isServer()) {
+            notifyDeliveryFailed(ctx.world(), ctx.pos(), item, item.getStack().getCount());
+        }
         itemState.markForDiscard(item);
     }
 
@@ -418,6 +411,7 @@ public final class PipeRuntime {
                     PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
                     if (network != null) {
                         network.notifyDelivery(
+                                item.getDeliveryId(),
                                 item.getDestination(),
                                 ItemStorageLookup.of(item.getStack()),
                                 inserted);
@@ -427,6 +421,22 @@ public final class PipeRuntime {
                     }
                 }
                 if (inserted < item.getStack().getCount()) {
+                    long failed = item.getStack().getCount() - inserted;
+                    if (item.getDeliveryId() != null && item.getDestination() != null) {
+                        PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
+                        if (network != null) {
+                            network.notifyDelivery(
+                                    item.getDeliveryId(),
+                                    item.getDestination(),
+                                    ItemStorageLookup.of(item.getStack()),
+                                    inserted);
+                            network.notifyDeliveryFailed(
+                                    item.getDeliveryId(),
+                                    item.getDestination(),
+                                    ItemStorageLookup.of(item.getStack()),
+                                    failed);
+                        }
+                    }
                     item.getStack().shrink((int) inserted);
                     PipeBlockEntity.dropItem(world, pos, item);
                 }
@@ -439,16 +449,22 @@ public final class PipeRuntime {
     }
 
     private static void notifyDropAndDrop(Level world, BlockPos pos, TravelingItem item) {
-        if (item.getDeliveryId() != null && item.getDestination() != null) {
-            PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
-            if (network != null) {
-                network.notifyDelivery(
-                        item.getDestination(),
-                        ItemStorageLookup.of(item.getStack()),
-                        item.getStack().getCount());
-            }
-        }
+        notifyDeliveryFailed(world, pos, item, item.getStack().getCount());
         PipeBlockEntity.dropItem(world, pos, item);
+    }
+
+    private static void notifyDeliveryFailed(Level world, BlockPos pos, TravelingItem item, long amount) {
+        if (item.getDeliveryId() == null || item.getDestination() == null || amount <= 0) {
+            return;
+        }
+        PipeNetwork network = NetworkRegistry.getNetwork(world, pos);
+        if (network != null) {
+            network.notifyDeliveryFailed(
+                    item.getDeliveryId(),
+                    item.getDestination(),
+                    ItemStorageLookup.of(item.getStack()),
+                    amount);
+        }
     }
 
     private static List<Direction> getValidDirections(

--- a/common/src/test/java/com/logistics/pipe/network/JobCoordinatorTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/JobCoordinatorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -125,6 +126,30 @@ class JobCoordinatorTest extends MinecraftTestEnvironment {
         assertEquals(JobState.COMPLETE, job.state());
         assertEquals(16, job.deliveredAmount());
         assertEquals(0, job.outstanding());
+    }
+
+    @Test
+    void testOnDeliveryFailed_retriesWithoutCountingDelivery() {
+        controller.registerSupply(PROVIDER, Map.of(diamond(), 64L), 1);
+        NetworkJob job = coordinator.submit(partialRequest(diamond(), 16, DESTINATION));
+
+        NetworkController.DispatchCommand cmd = controller.nextDispatchable();
+        assertNotNull(cmd);
+        controller.recordDispatched(cmd.orderId(), 16);
+
+        UUID replacementOrderId = controller.notifyDeliveryFailed(cmd.orderId(), DESTINATION, diamond(), 16);
+        coordinator.onDeliveryFailed(cmd.orderId(), replacementOrderId);
+
+        assertEquals(JobState.ACTIVE, job.state());
+        assertEquals(0, job.deliveredAmount());
+        assertEquals(16, job.outstanding());
+        assertTrue(coordinator.activeJobs().contains(job));
+
+        controller.registerSupply(PROVIDER, Map.of(diamond(), 16L), 1);
+        NetworkController.DispatchCommand retry = controller.nextDispatchable();
+        assertNotNull(retry, "Failed delivery should create a replacement order");
+        assertEquals(replacementOrderId, retry.orderId());
+        assertEquals(16, retry.amount());
     }
 
     @Test

--- a/common/src/test/java/com/logistics/pipe/network/JobCoordinatorTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/JobCoordinatorTest.java
@@ -25,6 +25,7 @@ class JobCoordinatorTest extends MinecraftTestEnvironment {
     private JobCoordinator coordinator;
 
     private static final BlockPos PROVIDER = new BlockPos(0, 0, 0);
+    private static final BlockPos PROVIDER2 = new BlockPos(1, 0, 0);
     private static final BlockPos DESTINATION = new BlockPos(5, 0, 0);
     private static final BlockPos DESTINATION2 = new BlockPos(6, 0, 0);
 
@@ -145,9 +146,9 @@ class JobCoordinatorTest extends MinecraftTestEnvironment {
         assertEquals(16, job.outstanding());
         assertTrue(coordinator.activeJobs().contains(job));
 
-        controller.registerSupply(PROVIDER, Map.of(diamond(), 16L), 1);
+        controller.registerSupply(PROVIDER2, Map.of(diamond(), 16L), 1);
         NetworkController.DispatchCommand retry = controller.nextDispatchable();
-        assertNotNull(retry, "Failed delivery should create a replacement order");
+        assertNotNull(retry, "Failed delivery should create a replacement order for fresh supply");
         assertEquals(replacementOrderId, retry.orderId());
         assertEquals(16, retry.amount());
     }

--- a/common/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
@@ -256,11 +256,56 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
         assertEquals(32L, controller.getOrderedAmountFor(REQUESTER, diamond()),
                 "Failed delivery should be replaced by a new pending order");
 
-        controller.registerSupply(PROVIDER1, Map.of(diamond(), 32L), 1);
+        controller.registerSupply(PROVIDER2, Map.of(diamond(), 32L), 1);
+        NetworkController.DispatchCommand retry = controller.nextDispatchable();
+        assertNotNull(retry, "Replacement order should be dispatchable from fresh supply");
+        assertEquals(replacementOrderId, retry.orderId());
+        assertEquals(32L, retry.amount());
+    }
+
+    @Test
+    void testNotifyDeliveryFailed_ignoresUnknownTrackedDispatch() {
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 64L), 1);
+        controller.placeOrder(diamond(), 32L, REQUESTER);
+
+        UUID replacementOrderId = controller.notifyDeliveryFailed(UUID.randomUUID(), REQUESTER, diamond(), 32L);
+
+        assertNull(replacementOrderId);
+        assertEquals(32L, controller.getOrderedAmountFor(REQUESTER, diamond()));
+    }
+
+    @Test
+    void testNotifyDeliveryFailedNoId_releasesAccountingWithoutRetry() {
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 64L), 1);
+        controller.placeOrder(diamond(), 32L, REQUESTER);
+
+        controller.notifyDeliveryFailedNoId(REQUESTER, diamond(), 32L);
+
+        assertEquals(0L, controller.getOrderedAmountFor(REQUESTER, diamond()));
+    }
+
+    @Test
+    void testNotifyDeliveryFailed_requeuesRemainderAfterPartialTrackedDelivery() {
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 64L), 1);
+        UUID orderId = controller.placeOrder(diamond(), 32L, REQUESTER);
+
+        NetworkController.DispatchCommand cmd = controller.nextDispatchable();
+        assertNotNull(cmd);
+        controller.recordDispatched(cmd.orderId(), 32L);
+
+        controller.notifyDelivery(orderId, REQUESTER, diamond(), 12L);
+        UUID replacementOrderId = controller.notifyDeliveryFailed(orderId, REQUESTER, diamond(), 20L);
+
+        assertNotNull(replacementOrderId);
+        assertNotEquals(orderId, replacementOrderId);
+        assertEquals(20L, controller.getOrderedAmountFor(REQUESTER, diamond()),
+                "Only the failed remainder should stay ordered");
+
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 20L), 1);
         NetworkController.DispatchCommand retry = controller.nextDispatchable();
         assertNotNull(retry, "Replacement order should be dispatchable when supply returns");
         assertEquals(replacementOrderId, retry.orderId());
-        assertEquals(32L, retry.amount());
+        assertEquals(20L, retry.amount());
     }
 
     // ===== cancelOrder =====

--- a/common/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/NetworkControllerTest.java
@@ -226,6 +226,43 @@ class NetworkControllerTest extends MinecraftTestEnvironment {
         assertEquals(16L, controller.getOrderedAmountFor(REQUESTER, diamond()));
     }
 
+    @Test
+    void testNotifyDelivery_trackedDeliveryReleasesInTransitOrder() {
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 64L), 1);
+        UUID orderId = controller.placeOrder(diamond(), 32L, REQUESTER);
+
+        NetworkController.DispatchCommand cmd = controller.nextDispatchable();
+        assertNotNull(cmd);
+        controller.recordDispatched(cmd.orderId(), 32L);
+
+        controller.notifyDelivery(orderId, REQUESTER, diamond(), 32L);
+
+        assertEquals(0L, controller.getOrderedAmountFor(REQUESTER, diamond()));
+    }
+
+    @Test
+    void testNotifyDeliveryFailed_requeuesTrackedDispatch() {
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 64L), 1);
+        UUID orderId = controller.placeOrder(diamond(), 32L, REQUESTER);
+
+        NetworkController.DispatchCommand cmd = controller.nextDispatchable();
+        assertNotNull(cmd);
+        controller.recordDispatched(cmd.orderId(), 32L);
+
+        UUID replacementOrderId = controller.notifyDeliveryFailed(orderId, REQUESTER, diamond(), 32L);
+
+        assertNotNull(replacementOrderId);
+        assertNotEquals(orderId, replacementOrderId);
+        assertEquals(32L, controller.getOrderedAmountFor(REQUESTER, diamond()),
+                "Failed delivery should be replaced by a new pending order");
+
+        controller.registerSupply(PROVIDER1, Map.of(diamond(), 32L), 1);
+        NetworkController.DispatchCommand retry = controller.nextDispatchable();
+        assertNotNull(retry, "Replacement order should be dispatchable when supply returns");
+        assertEquals(replacementOrderId, retry.orderId());
+        assertEquals(32L, retry.amount());
+    }
+
     // ===== cancelOrder =====
 
     @Test


### PR DESCRIPTION
## Summary
This update introduces enhanced delivery failure handling within the logistics network, allowing for improved tracking of in-transit items and better management of any delivery failures. This change is crucial for maintaining the accuracy of the logistics system by ensuring that failed delivery attempts do not unduly hinder item supply and order processing.

## Changes
- **Enhanced Delivery Failure Handling**
  - Implemented a new mechanism to track in-transit orders and manage delivery failures.
  - Introduced `notifyDeliveryFailed` method to account for failed deliveries without counting items as delivered.
  - Updated existing delivery tracking methods to integrate with the new failure handling logic.

- **Network Adjustments**
  - Modified network and job coordination processes to accommodate retry logic for failed deliveries.
  - Enhanced the way delivery notifications interface with job coordination, ensuring that failed deliveries prompt the creation of replacement orders.
 
- **Code Structure Improvements**
  - Added additional test cases to confirm the behavior of delivery and failure handling logic.
  - Cleaned up and organized notification methods to better reflect functional responsibilities.

## Notes
- This update may require adjustments in user-defined workflows that interact with the delivery system, as item delivery behavior now includes failure notifications and possible retries. Users should test their setups to ensure compatibility with new failure handling.
- Closes #391 