### PR TITLE
refactor: extract ActiveQuarryRegistry and QuarryBounds (#395)

### DIFF
--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/ActiveQuarryRegistry.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/ActiveQuarryRegistry.java
@@ -1,0 +1,78 @@
+package com.logistics.automation.laserquarry.entity;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+
+/**
+ * Per-dimension registry of active laser quarry positions, with TTL eviction so
+ * stale entries from unloaded quarries are cleaned up automatically on read.
+ */
+public final class ActiveQuarryRegistry {
+    public static final long REGISTRY_TTL_TICKS = 200L;
+
+    private static final Map<ResourceKey<Level>, Map<Long, Long>> ENTRIES = new HashMap<>();
+
+    private ActiveQuarryRegistry() {}
+
+    public static void register(ServerLevel world, BlockPos pos) {
+        register(world.dimension(), world.getGameTime(), pos);
+    }
+
+    public static void register(ResourceKey<Level> dimension, long gameTime, BlockPos pos) {
+        Map<Long, Long> entries = ENTRIES.computeIfAbsent(dimension, unused -> new HashMap<>());
+        entries.put(pos.asLong(), gameTime);
+    }
+
+    public static void unregister(ServerLevel world, BlockPos pos) {
+        unregister(world.dimension(), pos);
+    }
+
+    public static void unregister(ResourceKey<Level> dimension, BlockPos pos) {
+        Map<Long, Long> entries = ENTRIES.get(dimension);
+        if (entries == null) {
+            return;
+        }
+        entries.remove(pos.asLong());
+        if (entries.isEmpty()) {
+            ENTRIES.remove(dimension);
+        }
+    }
+
+    public static List<BlockPos> getAll(ServerLevel world) {
+        return getAll(world.dimension(), world.getGameTime());
+    }
+
+    public static List<BlockPos> getAll(ResourceKey<Level> dimension, long gameTime) {
+        Map<Long, Long> entries = ENTRIES.get(dimension);
+        if (entries == null || entries.isEmpty()) {
+            return List.of();
+        }
+
+        entries.entrySet().removeIf(entry -> gameTime - entry.getValue() > REGISTRY_TTL_TICKS);
+
+        if (entries.isEmpty()) {
+            ENTRIES.remove(dimension);
+            return List.of();
+        }
+
+        List<BlockPos> positions = new ArrayList<>(entries.size());
+        for (Long posLong : entries.keySet()) {
+            positions.add(BlockPos.of(posLong));
+        }
+        return positions;
+    }
+
+    public static void clear(ServerLevel world) {
+        clear(world.dimension());
+    }
+
+    public static void clear(ResourceKey<Level> dimension) {
+        ENTRIES.remove(dimension);
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -15,16 +15,12 @@ import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.power.EnergyDemandProvider;
 import com.logistics.core.lib.block.behavior.ProbeResult;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.WorldlyContainer;
@@ -38,8 +34,6 @@ import org.jetbrains.annotations.Nullable;
 import com.logistics.core.lib.energy.IEnergyStorage;
 
 public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConnection, HasEnergyStorage, EnergyDemandProvider {
-    private static final long REGISTRY_TTL_TICKS = 200L;
-    private static final Map<ResourceKey<Level>, Map<Long, Long>> ACTIVE_QUARRIES = new HashMap<>();
     private static final long FRAME_BUILD_COST = 240L;
     private static final long MOVE_COST_BUFFER_DIVISOR = 10L;
 
@@ -110,11 +104,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     private boolean finished = false;
 
     // Custom bounds from markers
-    private boolean useCustomBounds = false;
-    private int customMinX = 0;
-    private int customMinZ = 0;
-    private int customMaxX = 0;
-    private int customMaxZ = 0;
+    private final QuarryBounds bounds = new QuarryBounds();
 
     // Cached values for the current mining target
     private BlockPos currentTarget = null;
@@ -152,7 +142,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
             return;
         }
 
-        registerActiveQuarry((ServerLevel) world, pos);
+        ActiveQuarryRegistry.register((ServerLevel) world, pos);
 
         entity.energyReceivedLastTick = entity.energyReceivedThisTick;
         entity.energyReceivedThisTick = 0;
@@ -632,8 +622,8 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     private void advanceToNextBlock() {
         miningX++;
-        int maxX = useCustomBounds ? (customMaxX - customMinX + 1) : LogisticsConfig.get().quarry.area;
-        int maxZ = useCustomBounds ? (customMaxZ - customMinZ + 1) : LogisticsConfig.get().quarry.area;
+        int maxX = bounds.isCustom() ? (bounds.getMaxX() - bounds.getMinX() + 1) : LogisticsConfig.get().quarry.area;
+        int maxZ = bounds.isCustom() ? (bounds.getMaxZ() - bounds.getMinZ() + 1) : LogisticsConfig.get().quarry.area;
 
         if (miningX >= maxX) {
             miningX = 0;
@@ -654,9 +644,9 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
         int startX;
         int startZ;
-        if (useCustomBounds) {
-            startX = customMinX;
-            startZ = customMinZ;
+        if (bounds.isCustom()) {
+            startX = bounds.getMinX();
+            startZ = bounds.getMinZ();
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -708,12 +698,12 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         int startZ;
         int innerSizeX;
         int innerSizeZ;
-        if (useCustomBounds) {
+        if (bounds.isCustom()) {
             // Custom bounds: mining area is inset 1 block from frame
-            startX = customMinX + 1;
-            startZ = customMinZ + 1;
-            innerSizeX = customMaxX - customMinX - 1; // frame size - 2 for inset
-            innerSizeZ = customMaxZ - customMinZ - 1;
+            startX = bounds.getMinX() + 1;
+            startZ = bounds.getMinZ() + 1;
+            innerSizeX = bounds.getMaxX() - bounds.getMinX() - 1; // frame size - 2 for inset
+            innerSizeZ = bounds.getMaxZ() - bounds.getMinZ() - 1;
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -780,9 +770,9 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     private void advanceMiningPosition() {
         int innerSizeX;
         int innerSizeZ;
-        if (useCustomBounds) {
-            innerSizeX = customMaxX - customMinX - 1;
-            innerSizeZ = customMaxZ - customMinZ - 1;
+        if (bounds.isCustom()) {
+            innerSizeX = bounds.getMaxX() - bounds.getMinX() - 1;
+            innerSizeZ = bounds.getMaxZ() - bounds.getMinZ() - 1;
         } else {
             innerSizeX = LogisticsConfig.get().quarry.area - 2;
             innerSizeZ = LogisticsConfig.get().quarry.area - 2;
@@ -852,11 +842,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         int startZ;
         int endX;
         int endZ;
-        if (useCustomBounds) {
-            startX = customMinX;
-            startZ = customMinZ;
-            endX = customMaxX;
-            endZ = customMaxZ;
+        if (bounds.isCustom()) {
+            startX = bounds.getMinX();
+            startZ = bounds.getMinZ();
+            endX = bounds.getMaxX();
+            endZ = bounds.getMaxZ();
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -971,11 +961,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         int startZ;
         int endX;
         int endZ;
-        if (useCustomBounds) {
-            startX = customMinX;
-            startZ = customMinZ;
-            endX = customMaxX;
-            endZ = customMaxZ;
+        if (bounds.isCustom()) {
+            startX = bounds.getMinX();
+            startZ = bounds.getMinZ();
+            endX = bounds.getMaxX();
+            endZ = bounds.getMaxZ();
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -1058,11 +1048,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
      * The top Y is derived from the quarry's position + offset (same as default mining).
      */
     public void setCustomBounds(int minX, int minZ, int maxX, int maxZ) {
-        this.useCustomBounds = true;
-        this.customMinX = minX;
-        this.customMinZ = minZ;
-        this.customMaxX = maxX;
-        this.customMaxZ = maxZ;
+        bounds.setCustom(minX, minZ, maxX, maxZ);
         this.miningX = 0;
         this.miningY = 0;
         this.miningZ = 0;
@@ -1251,13 +1237,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         nbt.putFloat("ArmSyncedSpeed", syncedArmSpeed);
 
         // Save custom bounds
-        nbt.putBoolean("UseCustomBounds", useCustomBounds);
-        if (useCustomBounds) {
-            nbt.putInt("CustomBoundsMinX", customMinX);
-            nbt.putInt("CustomBoundsMinZ", customMinZ);
-            nbt.putInt("CustomBoundsMaxX", customMaxX);
-            nbt.putInt("CustomBoundsMaxZ", customMaxZ);
-        }
+        bounds.save(nbt);
     }
 
     @Override
@@ -1302,29 +1282,14 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         syncedArmSpeed = NbtCompat.getFloat(nbt, "ArmSyncedSpeed", 0.0f);
 
         // Load custom bounds
-        useCustomBounds = NbtCompat.getBoolean(nbt, "UseCustomBounds", false);
-        if (useCustomBounds) {
-            customMinX = NbtCompat.getInt(nbt, "CustomBoundsMinX", 0);
-            customMinZ = NbtCompat.getInt(nbt, "CustomBoundsMinZ", 0);
-            customMaxX = NbtCompat.getInt(nbt, "CustomBoundsMaxX", 0);
-            customMaxZ = NbtCompat.getInt(nbt, "CustomBoundsMaxZ", 0);
-        } else {
-            customMinX = 0;
-            customMinZ = 0;
-            customMaxX = 0;
-            customMaxZ = 0;
-        }
+        bounds.load(nbt);
     }
 
     @Override
     protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
         super.loadLegacyData(view);
 
-        useCustomBounds = false;
-        customMinX = 0;
-        customMinZ = 0;
-        customMaxX = 0;
-        customMaxZ = 0;
+        bounds.clear();
 
         // Load energy from old "Energy" tag
         view.read("Energy", CompoundTag.CODEC).ifPresent(energyState -> {
@@ -1365,11 +1330,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
         // Load custom bounds from old "CustomBounds" tag
         view.read("CustomBounds", CompoundTag.CODEC).ifPresent(customBoundsNbt -> {
-            useCustomBounds = true;
-            customMinX = NbtCompat.getInt(customBoundsNbt, "MinX", 0);
-            customMinZ = NbtCompat.getInt(customBoundsNbt, "MinZ", 0);
-            customMaxX = NbtCompat.getInt(customBoundsNbt, "MaxX", 0);
-            customMaxZ = NbtCompat.getInt(customBoundsNbt, "MaxZ", 0);
+            bounds.loadLegacy(
+                    NbtCompat.getInt(customBoundsNbt, "MinX", 0),
+                    NbtCompat.getInt(customBoundsNbt, "MinZ", 0),
+                    NbtCompat.getInt(customBoundsNbt, "MaxX", 0),
+                    NbtCompat.getInt(customBoundsNbt, "MaxZ", 0));
         });
     }
 
@@ -1382,7 +1347,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         }
 
         if (level != null && !level.isClientSide()) {
-            unregisterActiveQuarry((ServerLevel) level, pos);
+            ActiveQuarryRegistry.unregister((ServerLevel) level, pos);
             // Clear any active breaking animation
             if (currentTarget != null) {
                 ((ServerLevel) level).destroyBlockProgress(breakingEntityId, currentTarget, -1);
@@ -1437,23 +1402,23 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     // Custom bounds getters for frame decay logic
     public boolean hasCustomBounds() {
-        return useCustomBounds;
+        return bounds.isCustom();
     }
 
     public int getCustomMinX() {
-        return customMinX;
+        return bounds.getMinX();
     }
 
     public int getCustomMinZ() {
-        return customMinZ;
+        return bounds.getMinZ();
     }
 
     public int getCustomMaxX() {
-        return customMaxX;
+        return bounds.getMaxX();
     }
 
     public int getCustomMaxZ() {
-        return customMaxZ;
+        return bounds.getMaxZ();
     }
 
     /** True if the quarry has been placed but hasn't started any clearing yet. */
@@ -1463,54 +1428,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     }
 
     public static List<BlockPos> getActiveQuarries(ServerLevel world) {
-        ResourceKey<Level> key = world.dimension();
-        Map<Long, Long> entries = ACTIVE_QUARRIES.get(key);
-        if (entries == null || entries.isEmpty()) {
-            return List.of();
-        }
-
-        long now = world.getGameTime();
-        java.util.Iterator<java.util.Map.Entry<Long, Long>> iterator =
-                entries.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, Long> entry = iterator.next();
-            if (now - entry.getValue() > REGISTRY_TTL_TICKS) {
-                iterator.remove();
-            }
-        }
-
-        if (entries.isEmpty()) {
-            ACTIVE_QUARRIES.remove(key);
-            return List.of();
-        }
-
-        List<BlockPos> positions = new ArrayList<>(entries.size());
-        for (Long posLong : entries.keySet()) {
-            positions.add(BlockPos.of(posLong));
-        }
-        return positions;
+        return ActiveQuarryRegistry.getAll(world);
     }
 
     public static void clearActiveQuarries(ServerLevel world) {
-        ACTIVE_QUARRIES.remove(world.dimension());
-    }
-
-    private static void registerActiveQuarry(ServerLevel world, BlockPos pos) {
-        ResourceKey<Level> key = world.dimension();
-        Map<Long, Long> entries = ACTIVE_QUARRIES.computeIfAbsent(key, unused -> new HashMap<>());
-        entries.put(pos.asLong(), world.getGameTime());
-    }
-
-    private static void unregisterActiveQuarry(ServerLevel world, BlockPos pos) {
-        ResourceKey<Level> key = world.dimension();
-        Map<Long, Long> entries = ACTIVE_QUARRIES.get(key);
-        if (entries == null) {
-            return;
-        }
-        entries.remove(pos.asLong());
-        if (entries.isEmpty()) {
-            ACTIVE_QUARRIES.remove(key);
-        }
+        ActiveQuarryRegistry.clear(world);
     }
 
     // PipeConnection interface implementation

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBounds.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBounds.java
@@ -1,0 +1,82 @@
+package com.logistics.automation.laserquarry.entity;
+
+import com.logistics.core.lib.compat.NbtCompat;
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Mutable holder for the laser quarry's marker-defined mining bounds.
+ * When {@link #isCustom()} is {@code false}, callers fall back to the default
+ * area defined in {@code LogisticsConfig}.
+ */
+public final class QuarryBounds {
+    private boolean custom = false;
+    private int minX = 0;
+    private int minZ = 0;
+    private int maxX = 0;
+    private int maxZ = 0;
+
+    public boolean isCustom() {
+        return custom;
+    }
+
+    public int getMinX() {
+        return minX;
+    }
+
+    public int getMinZ() {
+        return minZ;
+    }
+
+    public int getMaxX() {
+        return maxX;
+    }
+
+    public int getMaxZ() {
+        return maxZ;
+    }
+
+    public void setCustom(int minX, int minZ, int maxX, int maxZ) {
+        this.custom = true;
+        this.minX = minX;
+        this.minZ = minZ;
+        this.maxX = maxX;
+        this.maxZ = maxZ;
+    }
+
+    public void clear() {
+        this.custom = false;
+        this.minX = 0;
+        this.minZ = 0;
+        this.maxX = 0;
+        this.maxZ = 0;
+    }
+
+    public void save(CompoundTag nbt) {
+        nbt.putBoolean("UseCustomBounds", custom);
+        if (custom) {
+            nbt.putInt("CustomBoundsMinX", minX);
+            nbt.putInt("CustomBoundsMinZ", minZ);
+            nbt.putInt("CustomBoundsMaxX", maxX);
+            nbt.putInt("CustomBoundsMaxZ", maxZ);
+        }
+    }
+
+    public void load(CompoundTag nbt) {
+        custom = NbtCompat.getBoolean(nbt, "UseCustomBounds", false);
+        if (custom) {
+            minX = NbtCompat.getInt(nbt, "CustomBoundsMinX", 0);
+            minZ = NbtCompat.getInt(nbt, "CustomBoundsMinZ", 0);
+            maxX = NbtCompat.getInt(nbt, "CustomBoundsMaxX", 0);
+            maxZ = NbtCompat.getInt(nbt, "CustomBoundsMaxZ", 0);
+        } else {
+            minX = 0;
+            minZ = 0;
+            maxX = 0;
+            maxZ = 0;
+        }
+    }
+
+    public void loadLegacy(int minX, int minZ, int maxX, int maxZ) {
+        setCustom(minX, minZ, maxX, maxZ);
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
@@ -1,0 +1,125 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.ActiveQuarryRegistry;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ActiveQuarryRegistry")
+class ActiveQuarryRegistryTest extends MinecraftTestEnvironment {
+
+    private static final ResourceKey<Level> OVERWORLD =
+            ResourceKey.create(Registries.DIMENSION, Identifier.fromNamespaceAndPath("test", "overworld"));
+    private static final ResourceKey<Level> NETHER =
+            ResourceKey.create(Registries.DIMENSION, Identifier.fromNamespaceAndPath("test", "nether"));
+
+    @BeforeEach
+    @AfterEach
+    void resetRegistryState() {
+        ActiveQuarryRegistry.clear(OVERWORLD);
+        ActiveQuarryRegistry.clear(NETHER);
+    }
+
+    @Test
+    @DisplayName("returns empty list when no quarries are registered")
+    void emptyWhenNothingRegistered() {
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns registered positions for the given dimension")
+    void returnsRegisteredPositions() {
+        BlockPos a = new BlockPos(10, 64, 20);
+        BlockPos b = new BlockPos(-5, 70, 100);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, a);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, b);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).containsExactlyInAnyOrder(a, b);
+    }
+
+    @Test
+    @DisplayName("isolates entries per dimension")
+    void perDimensionIsolation() {
+        BlockPos overworldPos = new BlockPos(0, 64, 0);
+        BlockPos netherPos = new BlockPos(50, 32, 50);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, overworldPos);
+        ActiveQuarryRegistry.register(NETHER, 0L, netherPos);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).containsExactly(overworldPos);
+        assertThat(ActiveQuarryRegistry.getAll(NETHER, 0L)).containsExactly(netherPos);
+    }
+
+    @Test
+    @DisplayName("unregister removes a single entry without affecting others")
+    void unregisterRemovesOnlyTarget() {
+        BlockPos a = new BlockPos(0, 64, 0);
+        BlockPos b = new BlockPos(10, 64, 10);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, a);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, b);
+
+        ActiveQuarryRegistry.unregister(OVERWORLD, a);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).containsExactly(b);
+    }
+
+    @Test
+    @DisplayName("evicts entries older than the TTL on read")
+    void evictsStaleEntries() {
+        BlockPos fresh = new BlockPos(0, 64, 0);
+        BlockPos stale = new BlockPos(100, 64, 100);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, stale);
+        // Fresh is registered well after stale, but still within the TTL of the read time.
+        long freshRegisterTime = ActiveQuarryRegistry.REGISTRY_TTL_TICKS + 50L;
+        ActiveQuarryRegistry.register(OVERWORLD, freshRegisterTime, fresh);
+
+        long readTime = freshRegisterTime + (ActiveQuarryRegistry.REGISTRY_TTL_TICKS / 2);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, readTime)).containsExactly(fresh);
+    }
+
+    @Test
+    @DisplayName("returns empty list and drops the dimension entry when all are stale")
+    void dropsEmptyDimensionAfterEviction() {
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, new BlockPos(0, 64, 0));
+
+        long readTime = ActiveQuarryRegistry.REGISTRY_TTL_TICKS + 1L;
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, readTime)).isEmpty();
+        // A subsequent read at game time 0 should also be empty (entry was fully removed).
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("clear wipes all entries for the given dimension")
+    void clearWipesDimension() {
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, new BlockPos(0, 64, 0));
+        ActiveQuarryRegistry.register(NETHER, 0L, new BlockPos(0, 32, 0));
+
+        ActiveQuarryRegistry.clear(OVERWORLD);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).isEmpty();
+        assertThat(ActiveQuarryRegistry.getAll(NETHER, 0L)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("re-registering the same position updates its timestamp")
+    void reregisterRefreshesTimestamp() {
+        BlockPos pos = new BlockPos(0, 64, 0);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, pos);
+
+        // Re-register at a later game time
+        ActiveQuarryRegistry.register(OVERWORLD, 1000L, pos);
+
+        long readTime = 1000L + ActiveQuarryRegistry.REGISTRY_TTL_TICKS;
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, readTime)).containsExactly(pos);
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
@@ -72,6 +72,16 @@ class ActiveQuarryRegistryTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    @DisplayName("retains entries when age equals the TTL exactly (eviction is strict-greater-than)")
+    void retainsEntriesAtExactTTL() {
+        BlockPos pos = new BlockPos(0, 64, 0);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, pos);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, ActiveQuarryRegistry.REGISTRY_TTL_TICKS))
+                .containsExactly(pos);
+    }
+
+    @Test
     @DisplayName("evicts entries older than the TTL on read")
     void evictsStaleEntries() {
         BlockPos fresh = new BlockPos(0, 64, 0);

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
@@ -106,6 +106,8 @@ class QuarryBoundsTest extends MinecraftTestEnvironment {
 
         assertThat(bounds.isCustom()).isFalse();
         assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMinZ()).isZero();
+        assertThat(bounds.getMaxX()).isZero();
         assertThat(bounds.getMaxZ()).isZero();
     }
 

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
@@ -1,0 +1,124 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.QuarryBounds;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("QuarryBounds")
+class QuarryBoundsTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("defaults to non-custom with zeroed values")
+    void defaultsToNonCustom() {
+        QuarryBounds bounds = new QuarryBounds();
+
+        assertThat(bounds.isCustom()).isFalse();
+        assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMinZ()).isZero();
+        assertThat(bounds.getMaxX()).isZero();
+        assertThat(bounds.getMaxZ()).isZero();
+    }
+
+    @Test
+    @DisplayName("setCustom stores the supplied bounds and flips isCustom to true")
+    void setCustomStoresValues() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(-5, 10, 15, 30);
+
+        assertThat(bounds.isCustom()).isTrue();
+        assertThat(bounds.getMinX()).isEqualTo(-5);
+        assertThat(bounds.getMinZ()).isEqualTo(10);
+        assertThat(bounds.getMaxX()).isEqualTo(15);
+        assertThat(bounds.getMaxZ()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("clear resets values and disables custom mode")
+    void clearResets() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(-5, 10, 15, 30);
+
+        bounds.clear();
+
+        assertThat(bounds.isCustom()).isFalse();
+        assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMinZ()).isZero();
+        assertThat(bounds.getMaxX()).isZero();
+        assertThat(bounds.getMaxZ()).isZero();
+    }
+
+    @Test
+    @DisplayName("round-trips custom bounds through NBT")
+    void roundTripsCustomBounds() {
+        QuarryBounds original = new QuarryBounds();
+        original.setCustom(-12, 5, 12, 33);
+        CompoundTag tag = new CompoundTag();
+        original.save(tag);
+
+        QuarryBounds loaded = new QuarryBounds();
+        loaded.load(tag);
+
+        assertThat(loaded.isCustom()).isTrue();
+        assertThat(loaded.getMinX()).isEqualTo(-12);
+        assertThat(loaded.getMinZ()).isEqualTo(5);
+        assertThat(loaded.getMaxX()).isEqualTo(12);
+        assertThat(loaded.getMaxZ()).isEqualTo(33);
+    }
+
+    @Test
+    @DisplayName("uses the existing CustomBounds* NBT keys for compatibility")
+    void usesExistingNbtKeys() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(1, 2, 3, 4);
+        CompoundTag tag = new CompoundTag();
+        bounds.save(tag);
+
+        assertThat(tag.getBoolean("UseCustomBounds")).hasValue(true);
+        assertThat(tag.getInt("CustomBoundsMinX")).hasValue(1);
+        assertThat(tag.getInt("CustomBoundsMinZ")).hasValue(2);
+        assertThat(tag.getInt("CustomBoundsMaxX")).hasValue(3);
+        assertThat(tag.getInt("CustomBoundsMaxZ")).hasValue(4);
+    }
+
+    @Test
+    @DisplayName("does not write bound values when not custom")
+    void omitsBoundValuesWhenNotCustom() {
+        QuarryBounds bounds = new QuarryBounds();
+        CompoundTag tag = new CompoundTag();
+        bounds.save(tag);
+
+        assertThat(tag.getBoolean("UseCustomBounds")).hasValue(false);
+        assertThat(tag.contains("CustomBoundsMinX")).isFalse();
+        assertThat(tag.contains("CustomBoundsMaxX")).isFalse();
+    }
+
+    @Test
+    @DisplayName("load with missing flag yields default non-custom bounds")
+    void loadFromEmptyTag() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(7, 8, 9, 10);
+
+        bounds.load(new CompoundTag());
+
+        assertThat(bounds.isCustom()).isFalse();
+        assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMaxZ()).isZero();
+    }
+
+    @Test
+    @DisplayName("loadLegacy promotes raw values to a custom configuration")
+    void loadLegacyApplies() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.loadLegacy(-1, -2, 5, 6);
+
+        assertThat(bounds.isCustom()).isTrue();
+        assertThat(bounds.getMinX()).isEqualTo(-1);
+        assertThat(bounds.getMinZ()).isEqualTo(-2);
+        assertThat(bounds.getMaxX()).isEqualTo(5);
+        assertThat(bounds.getMaxZ()).isEqualTo(6);
+    }
+}


### PR DESCRIPTION
## Summary
First step of the LaserQuarryBlockEntity decomposition tracked in #395. Pulls the two cleanest seams — the per-dimension active-quarry registry and the marker-defined custom bounds — out of the 1500-line block entity into focused classes alongside it.

## Changes
- New `ActiveQuarryRegistry` owns the per-dimension `Map<ResourceKey<Level>, Map<Long, Long>>` and the TTL eviction logic. Offers both `ServerLevel`-flavored and pure `(ResourceKey, gameTime)`-flavored overloads so it's unit-testable.
- New `QuarryBounds` is a small mutable holder for the marker bounds; owns its NBT serialization with the same `CustomBounds*` keys as before.
- `LaserQuarryBlockEntity` keeps `setCustomBounds`, `hasCustomBounds`, `getCustomMinX/MinZ/MaxX/MaxZ`, `getActiveQuarries`, and `clearActiveQuarries` as one-line delegates so external callers (`LaserQuarryBlock`, `LaserQuarryFrameBlock`, the renderer, fabric/neoforge unload hooks, gametest) need no changes.
- Added `ActiveQuarryRegistryTest` (8 cases — register/unregister, TTL eviction, multi-dimension isolation) and `QuarryBoundsTest` (8 cases — defaults, custom bounds, NBT round-trip, legacy migration).

## Notes
- No behavior changes: NBT keys, public API, and tick logic are identical.
- Refs #395. This is PR 1 of 4 in a `git town` stack — subsequent PRs target this branch in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)