### PR TITLE
refactor: extract QuarryBlockBreaker for mining drops and item output (#395)

### DIFF
--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/ActiveQuarryRegistry.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/ActiveQuarryRegistry.java
@@ -1,0 +1,78 @@
+package com.logistics.automation.laserquarry.entity;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+
+/**
+ * Per-dimension registry of active laser quarry positions, with TTL eviction so
+ * stale entries from unloaded quarries are cleaned up automatically on read.
+ */
+public final class ActiveQuarryRegistry {
+    public static final long REGISTRY_TTL_TICKS = 200L;
+
+    private static final Map<ResourceKey<Level>, Map<Long, Long>> ENTRIES = new HashMap<>();
+
+    private ActiveQuarryRegistry() {}
+
+    public static void register(ServerLevel world, BlockPos pos) {
+        register(world.dimension(), world.getGameTime(), pos);
+    }
+
+    public static void register(ResourceKey<Level> dimension, long gameTime, BlockPos pos) {
+        Map<Long, Long> entries = ENTRIES.computeIfAbsent(dimension, unused -> new HashMap<>());
+        entries.put(pos.asLong(), gameTime);
+    }
+
+    public static void unregister(ServerLevel world, BlockPos pos) {
+        unregister(world.dimension(), pos);
+    }
+
+    public static void unregister(ResourceKey<Level> dimension, BlockPos pos) {
+        Map<Long, Long> entries = ENTRIES.get(dimension);
+        if (entries == null) {
+            return;
+        }
+        entries.remove(pos.asLong());
+        if (entries.isEmpty()) {
+            ENTRIES.remove(dimension);
+        }
+    }
+
+    public static List<BlockPos> getAll(ServerLevel world) {
+        return getAll(world.dimension(), world.getGameTime());
+    }
+
+    public static List<BlockPos> getAll(ResourceKey<Level> dimension, long gameTime) {
+        Map<Long, Long> entries = ENTRIES.get(dimension);
+        if (entries == null || entries.isEmpty()) {
+            return List.of();
+        }
+
+        entries.entrySet().removeIf(entry -> gameTime - entry.getValue() > REGISTRY_TTL_TICKS);
+
+        if (entries.isEmpty()) {
+            ENTRIES.remove(dimension);
+            return List.of();
+        }
+
+        List<BlockPos> positions = new ArrayList<>(entries.size());
+        for (Long posLong : entries.keySet()) {
+            positions.add(BlockPos.of(posLong));
+        }
+        return positions;
+    }
+
+    public static void clear(ServerLevel world) {
+        clear(world.dimension());
+    }
+
+    public static void clear(ResourceKey<Level> dimension) {
+        ENTRIES.remove(dimension);
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/FrameLayout.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/FrameLayout.java
@@ -1,0 +1,164 @@
+package com.logistics.automation.laserquarry.entity;
+
+import com.logistics.LogisticsAutomation;
+import com.logistics.automation.laserquarry.LaserQuarryFrameBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Pure layout math for the laser quarry's frame: position sequence, ring traversal,
+ * and per-block arm-connection state.
+ *
+ * <p>Construction order is bottom ring → corner pillars → top ring, matching the
+ * historical {@code getNextFramePosition} sequence in the block entity.
+ */
+public final class FrameLayout {
+
+    /** Number of pillar blocks placed between the bottom and top rings (4 corners × 3 high). */
+    public static final int PILLAR_COUNT = 12;
+
+    private FrameLayout() {}
+
+    public static @Nullable BlockPos nextFramePosition(
+            Direction facing, BlockPos quarryPos, QuarryBounds bounds, int defaultArea, int frameBuildIndex) {
+        QuarryFrameRect rect = QuarryFrameRect.resolve(facing, quarryPos, bounds, defaultArea);
+        if (rect == null) {
+            return null;
+        }
+
+        int ringSize = ringSize(rect.width(), rect.depth());
+
+        // Phase 1: bottom ring
+        if (frameBuildIndex < ringSize) {
+            return ringPosition(frameBuildIndex, rect.startX(), rect.startZ(), rect.endX(), rect.endZ(), rect.bottomY());
+        }
+
+        // Phase 2: corner pillars (12 = 4 corners × 3 stories)
+        int pillarIndex = frameBuildIndex - ringSize;
+        if (pillarIndex < PILLAR_COUNT) {
+            int cornerIndex = pillarIndex / 3;
+            int yOffset = (pillarIndex % 3) + 1;
+            int y = rect.bottomY() + yOffset;
+            return switch (cornerIndex) {
+                case 0 -> new BlockPos(rect.startX(), y, rect.startZ());
+                case 1 -> new BlockPos(rect.endX(), y, rect.startZ());
+                case 2 -> new BlockPos(rect.endX(), y, rect.endZ());
+                case 3 -> new BlockPos(rect.startX(), y, rect.endZ());
+                default -> null;
+            };
+        }
+
+        // Phase 3: top ring
+        int topRingIndex = frameBuildIndex - ringSize - PILLAR_COUNT;
+        if (topRingIndex < ringSize) {
+            return ringPosition(topRingIndex, rect.startX(), rect.startZ(), rect.endX(), rect.endZ(), rect.topY());
+        }
+
+        return null;
+    }
+
+    /** Perimeter count for a rectangle of the given width and depth, with corners counted once. */
+    public static int ringSize(int width, int depth) {
+        return 2 * width + 2 * depth - 4;
+    }
+
+    /**
+     * Traverses the perimeter as: north edge (W→E), east edge (N→S), south edge (E→W), west edge (S→N).
+     * Returns {@code null} if {@code index} is out of range.
+     */
+    public static @Nullable BlockPos ringPosition(int index, int startX, int startZ, int endX, int endZ, int y) {
+        int width = endX - startX + 1;
+        int depth = endZ - startZ + 1;
+
+        if (index < width) {
+            return new BlockPos(startX + index, y, startZ);
+        }
+        index -= width;
+
+        int eastEdgeSize = depth - 1;
+        if (index < eastEdgeSize) {
+            return new BlockPos(endX, y, startZ + 1 + index);
+        }
+        index -= eastEdgeSize;
+
+        int southEdgeSize = width - 1;
+        if (index < southEdgeSize) {
+            return new BlockPos(endX - 1 - index, y, endZ);
+        }
+        index -= southEdgeSize;
+
+        int westEdgeSize = depth - 2;
+        if (index < westEdgeSize) {
+            return new BlockPos(startX, y, endZ - 1 - index);
+        }
+
+        return null;
+    }
+
+    /**
+     * Frame block state for the given frame position, with the arm-connection
+     * properties set to match the position's role (corner pillar / ring edge).
+     * Returns the default block state if the rectangle cannot be resolved.
+     */
+    public static BlockState frameBlockState(
+            Direction facing, BlockPos quarryPos, BlockPos framePos, QuarryBounds bounds, int defaultArea) {
+        LaserQuarryFrameBlock frameBlock = (LaserQuarryFrameBlock) LogisticsAutomation.BLOCK.LASER_QUARRY_FRAME;
+        QuarryFrameRect rect = QuarryFrameRect.resolve(facing, quarryPos, bounds, defaultArea);
+        if (rect == null) {
+            return frameBlock.defaultBlockState();
+        }
+        boolean[] arms = computeArms(rect, framePos);
+        return frameBlock.withArms(arms[0], arms[1], arms[2], arms[3], arms[4], arms[5]);
+    }
+
+    /**
+     * Returns {@code {north, south, east, west, up, down}} arm-connection flags
+     * for a frame block at {@code framePos} within the given rectangle. Exposes
+     * the pure side of {@link #frameBlockState} without the block-registry dependency,
+     * which keeps it directly unit-testable.
+     */
+    public static boolean[] computeArms(QuarryFrameRect rect, BlockPos framePos) {
+        int x = framePos.getX();
+        int y = framePos.getY();
+        int z = framePos.getZ();
+
+        boolean north = false;
+        boolean south = false;
+        boolean east = false;
+        boolean west = false;
+        boolean up = false;
+        boolean down = false;
+
+        boolean isCornerX = (x == rect.startX() || x == rect.endX());
+        boolean isCornerZ = (z == rect.startZ() || z == rect.endZ());
+        boolean isCorner = isCornerX && isCornerZ;
+
+        if (isCorner) {
+            if (y > rect.bottomY()) down = true;
+            if (y < rect.topY()) up = true;
+        }
+
+        if (y == rect.bottomY() || y == rect.topY()) {
+            if (z == rect.startZ()) {
+                if (x > rect.startX()) west = true;
+                if (x < rect.endX()) east = true;
+            }
+            if (z == rect.endZ()) {
+                if (x > rect.startX()) west = true;
+                if (x < rect.endX()) east = true;
+            }
+            if (x == rect.startX()) {
+                if (z > rect.startZ()) north = true;
+                if (z < rect.endZ()) south = true;
+            }
+            if (x == rect.endX()) {
+                if (z > rect.startZ()) north = true;
+                if (z < rect.endZ()) south = true;
+            }
+        }
+
+        return new boolean[] {north, south, east, west, up, down};
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/GridScanner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/GridScanner.java
@@ -1,0 +1,93 @@
+package com.logistics.automation.laserquarry.entity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Pure scan/position math for the laser quarry's clearing and mining phases.
+ * Resolves a grid index into a world-space target {@link BlockPos} given the
+ * quarry's facing and bounds, and decides whether a block is skippable.
+ */
+public final class GridScanner {
+
+    private GridScanner() {}
+
+    /**
+     * Target position for the clearing phase (area at and above the quarry level).
+     * Returns {@code null} when the grid index walks below the quarry level (clearing done).
+     */
+    public static @Nullable BlockPos clearingTarget(
+            Direction facing,
+            BlockPos quarryPos,
+            QuarryBounds bounds,
+            int defaultArea,
+            int gridX,
+            int gridY,
+            int gridZ) {
+        QuarryFrameRect rect = QuarryFrameRect.resolve(facing, quarryPos, bounds, defaultArea);
+        if (rect == null) {
+            return null;
+        }
+        int currentY = rect.topY() - gridY;
+        if (currentY < rect.bottomY()) {
+            return null;
+        }
+        return new BlockPos(rect.startX() + gridX, currentY, rect.startZ() + gridZ);
+    }
+
+    /**
+     * Target position for the mining phase (1-block-inset interior below the quarry level).
+     * Walks a 3D zigzag pattern that reverses each layer to minimize arm travel.
+     * Returns {@code null} when the world bottom or end of area is reached.
+     */
+    public static @Nullable BlockPos miningTarget(
+            Direction facing,
+            BlockPos quarryPos,
+            QuarryBounds bounds,
+            int defaultArea,
+            int worldMinY,
+            int gridX,
+            int gridY,
+            int gridZ) {
+        QuarryFrameRect rect = QuarryFrameRect.resolve(facing, quarryPos, bounds, defaultArea);
+        if (rect == null) {
+            return null;
+        }
+        int innerWidth = rect.innerWidth();
+        int innerDepth = rect.innerDepth();
+        if (innerWidth <= 0 || innerDepth <= 0) {
+            return null;
+        }
+
+        int startX = rect.startX() + 1;
+        int startZ = rect.startZ() + 1;
+        int currentY = rect.bottomY() - 1 - gridY;
+        if (currentY < worldMinY) {
+            return null;
+        }
+
+        int targetZ = (gridY % 2 == 0) ? startZ + gridZ : startZ + (innerDepth - 1 - gridZ);
+
+        int totalRows = gridY * innerDepth + gridZ;
+        int targetX = (totalRows % 2 == 0) ? startX + gridX : startX + (innerWidth - 1 - gridX);
+
+        return new BlockPos(targetX, currentY, targetZ);
+    }
+
+    /**
+     * True if the block at {@code pos} cannot or should not be broken by the quarry.
+     * Skips air, fluids, and unbreakable blocks (bedrock, barriers, etc.).
+     */
+    public static boolean shouldSkip(Level world, BlockPos pos, BlockState state) {
+        if (state.isAir()) {
+            return true;
+        }
+        if (!state.getFluidState().isEmpty()) {
+            return true;
+        }
+        return state.getDestroySpeed(world, pos) < 0;
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -1,8 +1,6 @@
 package com.logistics.automation.laserquarry.entity;
 
 import com.logistics.LogisticsAutomation;
-import com.logistics.api.LogisticsApi;
-import com.logistics.api.TransportApi;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.automation.render.ClientRenderCacheHooks;
 import com.logistics.core.LogisticsConfig;
@@ -20,13 +18,9 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.Container;
-import net.minecraft.world.WorldlyContainer;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 import com.logistics.core.lib.energy.IEnergyStorage;
@@ -500,109 +494,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     }
 
     private void mineBlock(ServerLevel world, BlockPos target, BlockState targetState) {
-        // Get drops before breaking the block
-        BlockEntity blockEntity = world.getBlockEntity(target);
-        List<ItemStack> drops = Block.getDrops(targetState, world, target, blockEntity, null, ItemStack.EMPTY);
-
-        // Break the block without natural drops (we handle drops manually)
-        world.destroyBlock(target, false);
-
-        // Output the calculated drops
-        for (ItemStack drop : drops) {
-            outputItem(world, drop);
-        }
-
-        // Fallback: if getDroppedStacks returned nothing but this wasn't air,
-        // or if this was a container (block entity), collect any spawned items
-        if (drops.isEmpty() || blockEntity != null) {
-            collectNearbyItems(world, target);
-        }
-    }
-
-    private void collectNearbyItems(ServerLevel world, BlockPos target) {
-        List<ItemEntity> itemEntities = world.getEntitiesOfClass(
-                ItemEntity.class, new net.minecraft.world.phys.AABB(target).inflate(2.0), item -> true);
-
-        for (ItemEntity itemEntity : itemEntities) {
-            ItemStack stack = itemEntity.getItem();
-            if (!stack.isEmpty()) {
-                outputItem(world, stack.copy());
-                itemEntity.discard();
-            }
-        }
-    }
-
-    private void outputItem(ServerLevel world, ItemStack stack) {
-        if (stack.isEmpty()) return;
-
-        BlockPos quarryPos = getBlockPos();
-        BlockPos abovePos = quarryPos.above();
-
-        // Check if there's a transport block above
-        BlockState aboveState = world.getBlockState(abovePos);
-        TransportApi transportApi = LogisticsApi.Registry.transport();
-        if (transportApi.isTransportBlock(aboveState)) {
-            transportApi.forceInsert(world, abovePos, stack.copy(), Direction.UP);
-            return;
-        }
-
-        // Check if there's an inventory above (chest, barrel, etc.)
-        if (!stack.isEmpty()) {
-            BlockEntity aboveEntity = world.getBlockEntity(abovePos);
-            if (aboveEntity instanceof Container inv) {
-                // Check if it's a sided inventory and respects insertion from below
-                if (aboveEntity instanceof WorldlyContainer sidedInv) {
-                    int[] availableSlots = sidedInv.getSlotsForFace(Direction.DOWN);
-                    for (int slot : availableSlots) {
-                        if (stack.isEmpty()) break;
-                        if (!sidedInv.canPlaceItemThroughFace(slot, stack, Direction.DOWN)) continue;
-                        stack = insertIntoSlot(inv, slot, stack);
-                    }
-                } else {
-                    // Regular inventory - try all slots
-                    for (int slot = 0; slot < inv.getContainerSize(); slot++) {
-                        if (stack.isEmpty()) break;
-                        if (!inv.canPlaceItem(slot, stack)) continue;
-                        stack = insertIntoSlot(inv, slot, stack);
-                    }
-                }
-            }
-        }
-
-        // Drop any remaining items
-        if (!stack.isEmpty()) {
-            double x = quarryPos.getX() + 0.5;
-            double y = quarryPos.getY() + 1.5;
-            double z = quarryPos.getZ() + 0.5;
-
-            ItemEntity itemEntity = new ItemEntity(world, x, y, z, stack);
-            itemEntity.setDeltaMovement(0, 0.2, 0); // Small upward velocity
-            world.addFreshEntity(itemEntity);
-        }
-    }
-
-    /**
-     * Try to insert a stack into a specific slot of an inventory.
-     * @return the remaining stack (may be empty if fully inserted)
-     */
-    private ItemStack insertIntoSlot(Container inv, int slot, ItemStack stack) {
-        ItemStack existing = inv.getItem(slot);
-
-        if (existing.isEmpty()) {
-            // Empty slot - insert up to max stack size
-            int maxInsert = Math.min(stack.getCount(), Math.min(inv.getMaxStackSize(), stack.getMaxStackSize()));
-            inv.setItem(slot, stack.split(maxInsert));
-        } else if (ItemStack.isSameItemSameComponents(existing, stack)) {
-            // Same item - try to merge
-            int space = Math.min(inv.getMaxStackSize(), existing.getMaxStackSize()) - existing.getCount();
-            if (space > 0) {
-                int toInsert = Math.min(space, stack.getCount());
-                existing.grow(toInsert);
-                stack.shrink(toInsert);
-            }
-        }
-
-        return stack;
+        QuarryBlockBreaker.mineBlock(world, getBlockPos(), target, targetState);
     }
 
     private void advanceToNextBlock() {

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -4,8 +4,6 @@ import com.logistics.LogisticsAutomation;
 import com.logistics.api.LogisticsApi;
 import com.logistics.api.TransportApi;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
-import com.logistics.automation.laserquarry.LaserQuarryGeometry;
-import com.logistics.automation.laserquarry.LaserQuarryFrameBlock;
 import com.logistics.automation.render.ClientRenderCacheHooks;
 import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.block.BaseBlockEntity;
@@ -498,20 +496,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     }
 
     private boolean shouldSkipBlock(Level world, BlockPos pos, BlockState state) {
-        // Skip air
-        if (state.isAir()) {
-            return true;
-        }
-        // Skip fluids (water, lava)
-        if (!state.getFluidState().isEmpty()) {
-            return true;
-        }
-        // Skip unbreakable blocks (bedrock, barriers, etc.)
-        float hardness = state.getDestroySpeed(world, pos);
-        if (hardness < 0) {
-            return true;
-        }
-        return false;
+        return GridScanner.shouldSkip(world, pos, state);
     }
 
     private void mineBlock(ServerLevel world, BlockPos target, BlockState targetState) {
@@ -636,132 +621,27 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         setChanged();
     }
 
-    /**
-     * Calculate target position for clearing phase (area at/above quarry level).
-     */
     private @Nullable BlockPos calculateClearingTargetPos(BlockState quarryState) {
-        BlockPos quarryPos = getBlockPos();
-
-        int startX;
-        int startZ;
-        if (bounds.isCustom()) {
-            startX = bounds.getMinX();
-            startZ = bounds.getMinZ();
-        } else {
-            int half = LogisticsConfig.get().quarry.area / 2;
-            Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
-            switch (facing) {
-                case NORTH:
-                    startX = quarryPos.getX() - half;
-                    startZ = quarryPos.getZ() - LogisticsConfig.get().quarry.area;
-                    break;
-                case SOUTH:
-                    startX = quarryPos.getX() - half;
-                    startZ = quarryPos.getZ() + 1;
-                    break;
-                case EAST:
-                    startX = quarryPos.getX() + 1;
-                    startZ = quarryPos.getZ() - half;
-                    break;
-                case WEST:
-                    startX = quarryPos.getX() - LogisticsConfig.get().quarry.area;
-                    startZ = quarryPos.getZ() - half;
-                    break;
-                default:
-                    return null;
-            }
-        }
-
-        // Clearing phase only works above and at quarry level
-        int startY = quarryPos.getY() + LaserQuarryGeometry.Y_OFFSET_ABOVE;
-        int currentY = startY - miningY;
-
-        // Stop when we go below quarry level
-        if (currentY < quarryPos.getY()) {
-            return null;
-        }
-
-        int targetX = startX + miningX;
-        int targetZ = startZ + miningZ;
-
-        return new BlockPos(targetX, currentY, targetZ);
+        return GridScanner.clearingTarget(
+                LaserQuarryBlock.getMiningDirection(quarryState),
+                getBlockPos(),
+                bounds,
+                LogisticsConfig.get().quarry.area,
+                miningX,
+                miningY,
+                miningZ);
     }
 
-    /**
-     * Calculate target position for mining phase (area below quarry level).
-     * The area is inset 1 block from the frame to stay within it.
-     */
     private @Nullable BlockPos calculateMiningTargetPos(BlockState quarryState) {
-        BlockPos quarryPos = getBlockPos();
-
-        int startX;
-        int startZ;
-        int innerSizeX;
-        int innerSizeZ;
-        if (bounds.isCustom()) {
-            // Custom bounds: mining area is inset 1 block from frame
-            startX = bounds.getMinX() + 1;
-            startZ = bounds.getMinZ() + 1;
-            innerSizeX = bounds.getMaxX() - bounds.getMinX() - 1; // frame size - 2 for inset
-            innerSizeZ = bounds.getMaxZ() - bounds.getMinZ() - 1;
-        } else {
-            int half = LogisticsConfig.get().quarry.area / 2;
-            Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
-            switch (facing) {
-                case NORTH:
-                    startX = quarryPos.getX() - half + 1; // Inset 1 from frame
-                    startZ = quarryPos.getZ() - LogisticsConfig.get().quarry.area + 1;
-                    break;
-                case SOUTH:
-                    startX = quarryPos.getX() - half + 1;
-                    startZ = quarryPos.getZ() + 1 + 1;
-                    break;
-                case EAST:
-                    startX = quarryPos.getX() + 1 + 1;
-                    startZ = quarryPos.getZ() - half + 1;
-                    break;
-                case WEST:
-                    startX = quarryPos.getX() - LogisticsConfig.get().quarry.area + 1;
-                    startZ = quarryPos.getZ() - half + 1;
-                    break;
-                default:
-                    return null;
-            }
-            innerSizeX = LogisticsConfig.get().quarry.area - 2;
-            innerSizeZ = LogisticsConfig.get().quarry.area - 2;
-        }
-        if (innerSizeX <= 0 || innerSizeZ <= 0) {
-            return null;
-        }
-
-        // Mining phase starts 1 block below quarry level
-        int startY = quarryPos.getY() - 1;
-        int currentY = startY - miningY;
-
-        // Stop at bedrock or world bottom
-        if (currentY < level.getMinY()) {
-            return null;
-        }
-
-        // 3D zigzag pattern: continuous movement across layers
-        // Z direction reverses each layer (even layers go forward, odd layers go backward)
-        int targetZ;
-        if (miningY % 2 == 0) {
-            targetZ = startZ + miningZ;
-        } else {
-            targetZ = startZ + (innerSizeZ - 1 - miningZ);
-        }
-
-        // X direction based on total rows traversed (continuous zigzag)
-        int totalRows = miningY * innerSizeZ + miningZ;
-        int targetX;
-        if (totalRows % 2 == 0) {
-            targetX = startX + miningX;
-        } else {
-            targetX = startX + (innerSizeX - 1 - miningX);
-        }
-
-        return new BlockPos(targetX, currentY, targetZ);
+        return GridScanner.miningTarget(
+                LaserQuarryBlock.getMiningDirection(quarryState),
+                getBlockPos(),
+                bounds,
+                LogisticsConfig.get().quarry.area,
+                level.getMinY(),
+                miningX,
+                miningY,
+                miningZ);
     }
 
     /**
@@ -827,220 +707,22 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         }
     }
 
-    /**
-     * Get the next frame position to build based on frameBuildIndex.
-     * Frame consists of:
-     * - Bottom ring at quarryY
-     * - Middle pillars at corners from quarryY+1 to quarryY+3 (4 corners × 3 = 12 blocks)
-     * - Top ring at quarryY+4
-     */
     private @Nullable BlockPos getNextFramePosition(BlockState quarryState) {
-        BlockPos quarryPos = getBlockPos();
-
-        // Calculate frame bounds
-        int startX;
-        int startZ;
-        int endX;
-        int endZ;
-        if (bounds.isCustom()) {
-            startX = bounds.getMinX();
-            startZ = bounds.getMinZ();
-            endX = bounds.getMaxX();
-            endZ = bounds.getMaxZ();
-        } else {
-            int half = LogisticsConfig.get().quarry.area / 2;
-            Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
-            switch (facing) {
-                case NORTH:
-                    startX = quarryPos.getX() - half;
-                    startZ = quarryPos.getZ() - LogisticsConfig.get().quarry.area;
-                    break;
-                case SOUTH:
-                    startX = quarryPos.getX() - half;
-                    startZ = quarryPos.getZ() + 1;
-                    break;
-                case EAST:
-                    startX = quarryPos.getX() + 1;
-                    startZ = quarryPos.getZ() - half;
-                    break;
-                case WEST:
-                    startX = quarryPos.getX() - LogisticsConfig.get().quarry.area;
-                    startZ = quarryPos.getZ() - half;
-                    break;
-                default:
-                    return null;
-            }
-            endX = startX + LogisticsConfig.get().quarry.area - 1;
-            endZ = startZ + LogisticsConfig.get().quarry.area - 1;
-        }
-
-        int bottomY = quarryPos.getY();
-        int topY = quarryPos.getY() + LaserQuarryGeometry.Y_OFFSET_ABOVE;
-
-        // Calculate ring size: perimeter of rectangle = 2*width + 2*depth - 4 corners
-        int width = endX - startX + 1;
-        int depth = endZ - startZ + 1;
-        int ringSize = 2 * width + 2 * depth - 4;
-
-        // Phase 1: Bottom ring
-        if (frameBuildIndex < ringSize) {
-            return getRingPosition(frameBuildIndex, startX, startZ, endX, endZ, bottomY);
-        }
-
-        // Phase 2: Middle pillars (12 blocks)
-        int pillarIndex = frameBuildIndex - ringSize;
-        if (pillarIndex < 12) {
-            int cornerIndex = pillarIndex / 3;
-            int yOffset = (pillarIndex % 3) + 1; // Y+1, Y+2, Y+3
-            int y = bottomY + yOffset;
-
-            return switch (cornerIndex) {
-                case 0 -> new BlockPos(startX, y, startZ);
-                case 1 -> new BlockPos(endX, y, startZ);
-                case 2 -> new BlockPos(endX, y, endZ);
-                case 3 -> new BlockPos(startX, y, endZ);
-                default -> null;
-            };
-        }
-
-        // Phase 3: Top ring
-        int topRingIndex = frameBuildIndex - ringSize - 12;
-        if (topRingIndex < ringSize) {
-            return getRingPosition(topRingIndex, startX, startZ, endX, endZ, topY);
-        }
-
-        // Done building frame
-        return null;
+        return FrameLayout.nextFramePosition(
+                LaserQuarryBlock.getMiningDirection(quarryState),
+                getBlockPos(),
+                bounds,
+                LogisticsConfig.get().quarry.area,
+                frameBuildIndex);
     }
 
-    /**
-     * Get a position on a frame ring given an index.
-     * Iterates around the perimeter: north edge, east edge, south edge, west edge.
-     */
-    private BlockPos getRingPosition(int index, int startX, int startZ, int endX, int endZ, int y) {
-        int width = endX - startX + 1;
-        int depth = endZ - startZ + 1;
-
-        // North edge: width blocks
-        if (index < width) {
-            return new BlockPos(startX + index, y, startZ);
-        }
-        index -= width;
-
-        // East edge: depth-1 blocks excluding NE corner
-        int eastEdgeSize = depth - 1;
-        if (index < eastEdgeSize) {
-            return new BlockPos(endX, y, startZ + 1 + index);
-        }
-        index -= eastEdgeSize;
-
-        // South edge: width-1 blocks excluding SE corner
-        int southEdgeSize = width - 1;
-        if (index < southEdgeSize) {
-            return new BlockPos(endX - 1 - index, y, endZ);
-        }
-        index -= southEdgeSize;
-
-        // West edge: depth-2 blocks excluding SW and NW corners
-        int westEdgeSize = depth - 2;
-        if (index < westEdgeSize) {
-            return new BlockPos(startX, y, endZ - 1 - index);
-        }
-
-        return null;
-    }
-
-    /**
-     * Calculate the frame block state with appropriate arm connections.
-     */
     private BlockState calculateFrameState(BlockState quarryState, BlockPos framePos) {
-        BlockPos quarryPos = getBlockPos();
-
-        // Calculate frame bounds
-        int startX;
-        int startZ;
-        int endX;
-        int endZ;
-        if (bounds.isCustom()) {
-            startX = bounds.getMinX();
-            startZ = bounds.getMinZ();
-            endX = bounds.getMaxX();
-            endZ = bounds.getMaxZ();
-        } else {
-            int half = LogisticsConfig.get().quarry.area / 2;
-            Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
-            switch (facing) {
-                case NORTH:
-                    startX = quarryPos.getX() - half;
-                    startZ = quarryPos.getZ() - LogisticsConfig.get().quarry.area;
-                    break;
-                case SOUTH:
-                    startX = quarryPos.getX() - half;
-                    startZ = quarryPos.getZ() + 1;
-                    break;
-                case EAST:
-                    startX = quarryPos.getX() + 1;
-                    startZ = quarryPos.getZ() - half;
-                    break;
-                case WEST:
-                    startX = quarryPos.getX() - LogisticsConfig.get().quarry.area;
-                    startZ = quarryPos.getZ() - half;
-                    break;
-                default:
-                    return LogisticsAutomation.BLOCK.LASER_QUARRY_FRAME.defaultBlockState();
-            }
-            endX = startX + LogisticsConfig.get().quarry.area - 1;
-            endZ = startZ + LogisticsConfig.get().quarry.area - 1;
-        }
-        int bottomY = quarryPos.getY();
-        int topY = quarryPos.getY() + LaserQuarryGeometry.Y_OFFSET_ABOVE;
-
-        int x = framePos.getX();
-        int y = framePos.getY();
-        int z = framePos.getZ();
-
-        // Determine which arms to enable based on position in frame
-        boolean north = false;
-        boolean south = false;
-        boolean east = false;
-        boolean west = false;
-        boolean up = false;
-        boolean down = false;
-
-        // Check if this is a corner position
-        boolean isCornerX = (x == startX || x == endX);
-        boolean isCornerZ = (z == startZ || z == endZ);
-        boolean isCorner = isCornerX && isCornerZ;
-
-        // Vertical connections (corners only, not at very top/bottom if ring exists)
-        if (isCorner) {
-            if (y > bottomY) down = true;
-            if (y < topY) up = true;
-        }
-
-        // Horizontal connections on edges
-        if (y == bottomY || y == topY) {
-            // We're on a ring - connect horizontally
-            if (z == startZ) { // North edge
-                if (x > startX) west = true;
-                if (x < endX) east = true;
-            }
-            if (z == endZ) { // South edge
-                if (x > startX) west = true;
-                if (x < endX) east = true;
-            }
-            if (x == startX) { // West edge
-                if (z > startZ) north = true;
-                if (z < endZ) south = true;
-            }
-            if (x == endX) { // East edge
-                if (z > startZ) north = true;
-                if (z < endZ) south = true;
-            }
-        }
-
-        LaserQuarryFrameBlock frameBlock = (LaserQuarryFrameBlock) LogisticsAutomation.BLOCK.LASER_QUARRY_FRAME;
-        return frameBlock.withArms(north, south, east, west, up, down);
+        return FrameLayout.frameBlockState(
+                LaserQuarryBlock.getMiningDirection(quarryState),
+                getBlockPos(),
+                framePos,
+                bounds,
+                LogisticsConfig.get().quarry.area);
     }
 
     /**

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -15,16 +15,12 @@ import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.power.EnergyDemandProvider;
 import com.logistics.core.lib.block.behavior.ProbeResult;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.WorldlyContainer;
@@ -38,8 +34,6 @@ import org.jetbrains.annotations.Nullable;
 import com.logistics.core.lib.energy.IEnergyStorage;
 
 public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConnection, HasEnergyStorage, EnergyDemandProvider {
-    private static final long REGISTRY_TTL_TICKS = 200L;
-    private static final Map<ResourceKey<Level>, Map<Long, Long>> ACTIVE_QUARRIES = new HashMap<>();
     private static final long FRAME_BUILD_COST = 240L;
     private static final long MOVE_COST_BUFFER_DIVISOR = 10L;
 
@@ -110,11 +104,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     private boolean finished = false;
 
     // Custom bounds from markers
-    private boolean useCustomBounds = false;
-    private int customMinX = 0;
-    private int customMinZ = 0;
-    private int customMaxX = 0;
-    private int customMaxZ = 0;
+    private final QuarryBounds bounds = new QuarryBounds();
 
     // Cached values for the current mining target
     private BlockPos currentTarget = null;
@@ -152,7 +142,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
             return;
         }
 
-        registerActiveQuarry((ServerLevel) world, pos);
+        ActiveQuarryRegistry.register((ServerLevel) world, pos);
 
         entity.energyReceivedLastTick = entity.energyReceivedThisTick;
         entity.energyReceivedThisTick = 0;
@@ -632,8 +622,8 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     private void advanceToNextBlock() {
         miningX++;
-        int maxX = useCustomBounds ? (customMaxX - customMinX + 1) : LogisticsConfig.get().quarry.area;
-        int maxZ = useCustomBounds ? (customMaxZ - customMinZ + 1) : LogisticsConfig.get().quarry.area;
+        int maxX = bounds.isCustom() ? (bounds.getMaxX() - bounds.getMinX() + 1) : LogisticsConfig.get().quarry.area;
+        int maxZ = bounds.isCustom() ? (bounds.getMaxZ() - bounds.getMinZ() + 1) : LogisticsConfig.get().quarry.area;
 
         if (miningX >= maxX) {
             miningX = 0;
@@ -654,9 +644,9 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
         int startX;
         int startZ;
-        if (useCustomBounds) {
-            startX = customMinX;
-            startZ = customMinZ;
+        if (bounds.isCustom()) {
+            startX = bounds.getMinX();
+            startZ = bounds.getMinZ();
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -708,12 +698,12 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         int startZ;
         int innerSizeX;
         int innerSizeZ;
-        if (useCustomBounds) {
+        if (bounds.isCustom()) {
             // Custom bounds: mining area is inset 1 block from frame
-            startX = customMinX + 1;
-            startZ = customMinZ + 1;
-            innerSizeX = customMaxX - customMinX - 1; // frame size - 2 for inset
-            innerSizeZ = customMaxZ - customMinZ - 1;
+            startX = bounds.getMinX() + 1;
+            startZ = bounds.getMinZ() + 1;
+            innerSizeX = bounds.getMaxX() - bounds.getMinX() - 1; // frame size - 2 for inset
+            innerSizeZ = bounds.getMaxZ() - bounds.getMinZ() - 1;
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -780,9 +770,9 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     private void advanceMiningPosition() {
         int innerSizeX;
         int innerSizeZ;
-        if (useCustomBounds) {
-            innerSizeX = customMaxX - customMinX - 1;
-            innerSizeZ = customMaxZ - customMinZ - 1;
+        if (bounds.isCustom()) {
+            innerSizeX = bounds.getMaxX() - bounds.getMinX() - 1;
+            innerSizeZ = bounds.getMaxZ() - bounds.getMinZ() - 1;
         } else {
             innerSizeX = LogisticsConfig.get().quarry.area - 2;
             innerSizeZ = LogisticsConfig.get().quarry.area - 2;
@@ -852,11 +842,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         int startZ;
         int endX;
         int endZ;
-        if (useCustomBounds) {
-            startX = customMinX;
-            startZ = customMinZ;
-            endX = customMaxX;
-            endZ = customMaxZ;
+        if (bounds.isCustom()) {
+            startX = bounds.getMinX();
+            startZ = bounds.getMinZ();
+            endX = bounds.getMaxX();
+            endZ = bounds.getMaxZ();
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -971,11 +961,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         int startZ;
         int endX;
         int endZ;
-        if (useCustomBounds) {
-            startX = customMinX;
-            startZ = customMinZ;
-            endX = customMaxX;
-            endZ = customMaxZ;
+        if (bounds.isCustom()) {
+            startX = bounds.getMinX();
+            startZ = bounds.getMinZ();
+            endX = bounds.getMaxX();
+            endZ = bounds.getMaxZ();
         } else {
             int half = LogisticsConfig.get().quarry.area / 2;
             Direction facing = LaserQuarryBlock.getMiningDirection(quarryState);
@@ -1058,11 +1048,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
      * The top Y is derived from the quarry's position + offset (same as default mining).
      */
     public void setCustomBounds(int minX, int minZ, int maxX, int maxZ) {
-        this.useCustomBounds = true;
-        this.customMinX = minX;
-        this.customMinZ = minZ;
-        this.customMaxX = maxX;
-        this.customMaxZ = maxZ;
+        bounds.setCustom(minX, minZ, maxX, maxZ);
         this.miningX = 0;
         this.miningY = 0;
         this.miningZ = 0;
@@ -1251,13 +1237,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         nbt.putFloat("ArmSyncedSpeed", syncedArmSpeed);
 
         // Save custom bounds
-        nbt.putBoolean("UseCustomBounds", useCustomBounds);
-        if (useCustomBounds) {
-            nbt.putInt("CustomBoundsMinX", customMinX);
-            nbt.putInt("CustomBoundsMinZ", customMinZ);
-            nbt.putInt("CustomBoundsMaxX", customMaxX);
-            nbt.putInt("CustomBoundsMaxZ", customMaxZ);
-        }
+        bounds.save(nbt);
     }
 
     @Override
@@ -1302,29 +1282,14 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         syncedArmSpeed = NbtCompat.getFloat(nbt, "ArmSyncedSpeed", 0.0f);
 
         // Load custom bounds
-        useCustomBounds = NbtCompat.getBoolean(nbt, "UseCustomBounds", false);
-        if (useCustomBounds) {
-            customMinX = NbtCompat.getInt(nbt, "CustomBoundsMinX", 0);
-            customMinZ = NbtCompat.getInt(nbt, "CustomBoundsMinZ", 0);
-            customMaxX = NbtCompat.getInt(nbt, "CustomBoundsMaxX", 0);
-            customMaxZ = NbtCompat.getInt(nbt, "CustomBoundsMaxZ", 0);
-        } else {
-            customMinX = 0;
-            customMinZ = 0;
-            customMaxX = 0;
-            customMaxZ = 0;
-        }
+        bounds.load(nbt);
     }
 
     @Override
     protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
         super.loadLegacyData(view);
 
-        useCustomBounds = false;
-        customMinX = 0;
-        customMinZ = 0;
-        customMaxX = 0;
-        customMaxZ = 0;
+        bounds.clear();
 
         // Load energy from old "Energy" tag
         view.read("Energy", CompoundTag.CODEC).ifPresent(energyState -> {
@@ -1365,11 +1330,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
         // Load custom bounds from old "CustomBounds" tag
         view.read("CustomBounds", CompoundTag.CODEC).ifPresent(customBoundsNbt -> {
-            useCustomBounds = true;
-            customMinX = NbtCompat.getInt(customBoundsNbt, "MinX", 0);
-            customMinZ = NbtCompat.getInt(customBoundsNbt, "MinZ", 0);
-            customMaxX = NbtCompat.getInt(customBoundsNbt, "MaxX", 0);
-            customMaxZ = NbtCompat.getInt(customBoundsNbt, "MaxZ", 0);
+            bounds.loadLegacy(
+                    NbtCompat.getInt(customBoundsNbt, "MinX", 0),
+                    NbtCompat.getInt(customBoundsNbt, "MinZ", 0),
+                    NbtCompat.getInt(customBoundsNbt, "MaxX", 0),
+                    NbtCompat.getInt(customBoundsNbt, "MaxZ", 0));
         });
     }
 
@@ -1382,7 +1347,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         }
 
         if (level != null && !level.isClientSide()) {
-            unregisterActiveQuarry((ServerLevel) level, pos);
+            ActiveQuarryRegistry.unregister((ServerLevel) level, pos);
             // Clear any active breaking animation
             if (currentTarget != null) {
                 ((ServerLevel) level).destroyBlockProgress(breakingEntityId, currentTarget, -1);
@@ -1437,23 +1402,23 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     // Custom bounds getters for frame decay logic
     public boolean hasCustomBounds() {
-        return useCustomBounds;
+        return bounds.isCustom();
     }
 
     public int getCustomMinX() {
-        return customMinX;
+        return bounds.getMinX();
     }
 
     public int getCustomMinZ() {
-        return customMinZ;
+        return bounds.getMinZ();
     }
 
     public int getCustomMaxX() {
-        return customMaxX;
+        return bounds.getMaxX();
     }
 
     public int getCustomMaxZ() {
-        return customMaxZ;
+        return bounds.getMaxZ();
     }
 
     /** True if the quarry has been placed but hasn't started any clearing yet. */
@@ -1463,54 +1428,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     }
 
     public static List<BlockPos> getActiveQuarries(ServerLevel world) {
-        ResourceKey<Level> key = world.dimension();
-        Map<Long, Long> entries = ACTIVE_QUARRIES.get(key);
-        if (entries == null || entries.isEmpty()) {
-            return List.of();
-        }
-
-        long now = world.getGameTime();
-        java.util.Iterator<java.util.Map.Entry<Long, Long>> iterator =
-                entries.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, Long> entry = iterator.next();
-            if (now - entry.getValue() > REGISTRY_TTL_TICKS) {
-                iterator.remove();
-            }
-        }
-
-        if (entries.isEmpty()) {
-            ACTIVE_QUARRIES.remove(key);
-            return List.of();
-        }
-
-        List<BlockPos> positions = new ArrayList<>(entries.size());
-        for (Long posLong : entries.keySet()) {
-            positions.add(BlockPos.of(posLong));
-        }
-        return positions;
+        return ActiveQuarryRegistry.getAll(world);
     }
 
     public static void clearActiveQuarries(ServerLevel world) {
-        ACTIVE_QUARRIES.remove(world.dimension());
-    }
-
-    private static void registerActiveQuarry(ServerLevel world, BlockPos pos) {
-        ResourceKey<Level> key = world.dimension();
-        Map<Long, Long> entries = ACTIVE_QUARRIES.computeIfAbsent(key, unused -> new HashMap<>());
-        entries.put(pos.asLong(), world.getGameTime());
-    }
-
-    private static void unregisterActiveQuarry(ServerLevel world, BlockPos pos) {
-        ResourceKey<Level> key = world.dimension();
-        Map<Long, Long> entries = ACTIVE_QUARRIES.get(key);
-        if (entries == null) {
-            return;
-        }
-        entries.remove(pos.asLong());
-        if (entries.isEmpty()) {
-            ACTIVE_QUARRIES.remove(key);
-        }
+        ActiveQuarryRegistry.clear(world);
     }
 
     // PipeConnection interface implementation

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBlockBreaker.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBlockBreaker.java
@@ -1,0 +1,126 @@
+package com.logistics.automation.laserquarry.entity;
+
+import com.logistics.api.LogisticsApi;
+import com.logistics.api.TransportApi;
+import java.util.List;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+
+/**
+ * Stateless helpers for the laser quarry's block-breaking and item-output side effects.
+ *
+ * <p>Mines a target block, collects its drops, and routes them through a pipe above
+ * the quarry, then a sided/regular inventory above, finally falling back to dropping
+ * an item entity. Also provides {@link #insertIntoSlot(Container, int, ItemStack)} as
+ * the pure inventory-merge primitive shared by both the inventory-output path and the
+ * fallback nearby-item collection used for container blocks.
+ */
+public final class QuarryBlockBreaker {
+
+    private QuarryBlockBreaker() {}
+
+    public static void mineBlock(ServerLevel world, BlockPos quarryPos, BlockPos target, BlockState targetState) {
+        BlockEntity blockEntity = world.getBlockEntity(target);
+        List<ItemStack> drops = Block.getDrops(targetState, world, target, blockEntity, null, ItemStack.EMPTY);
+
+        // Break the block without natural drops so we can route them ourselves.
+        world.destroyBlock(target, false);
+
+        for (ItemStack drop : drops) {
+            outputItem(world, quarryPos, drop);
+        }
+
+        // For container drops the engine spawns items separately — sweep them up.
+        if (drops.isEmpty() || blockEntity != null) {
+            collectNearbyItems(world, quarryPos, target);
+        }
+    }
+
+    public static void collectNearbyItems(ServerLevel world, BlockPos quarryPos, BlockPos target) {
+        List<ItemEntity> itemEntities =
+                world.getEntitiesOfClass(ItemEntity.class, new AABB(target).inflate(2.0), item -> true);
+
+        for (ItemEntity itemEntity : itemEntities) {
+            ItemStack stack = itemEntity.getItem();
+            if (!stack.isEmpty()) {
+                outputItem(world, quarryPos, stack.copy());
+                itemEntity.discard();
+            }
+        }
+    }
+
+    public static void outputItem(ServerLevel world, BlockPos quarryPos, ItemStack stack) {
+        if (stack.isEmpty()) return;
+
+        BlockPos abovePos = quarryPos.above();
+
+        // Prefer a transport block (pipe) directly above.
+        BlockState aboveState = world.getBlockState(abovePos);
+        TransportApi transportApi = LogisticsApi.Registry.transport();
+        if (transportApi.isTransportBlock(aboveState)) {
+            transportApi.forceInsert(world, abovePos, stack.copy(), Direction.UP);
+            return;
+        }
+
+        // Fall back to a regular or sided inventory above.
+        BlockEntity aboveEntity = world.getBlockEntity(abovePos);
+        if (aboveEntity instanceof Container inv) {
+            if (aboveEntity instanceof WorldlyContainer sidedInv) {
+                int[] availableSlots = sidedInv.getSlotsForFace(Direction.DOWN);
+                for (int slot : availableSlots) {
+                    if (stack.isEmpty()) break;
+                    if (!sidedInv.canPlaceItemThroughFace(slot, stack, Direction.DOWN)) continue;
+                    stack = insertIntoSlot(inv, slot, stack);
+                }
+            } else {
+                for (int slot = 0; slot < inv.getContainerSize(); slot++) {
+                    if (stack.isEmpty()) break;
+                    if (!inv.canPlaceItem(slot, stack)) continue;
+                    stack = insertIntoSlot(inv, slot, stack);
+                }
+            }
+        }
+
+        // Anything left over drops above the quarry.
+        if (!stack.isEmpty()) {
+            double x = quarryPos.getX() + 0.5;
+            double y = quarryPos.getY() + 1.5;
+            double z = quarryPos.getZ() + 0.5;
+
+            ItemEntity itemEntity = new ItemEntity(world, x, y, z, stack);
+            itemEntity.setDeltaMovement(0, 0.2, 0);
+            world.addFreshEntity(itemEntity);
+        }
+    }
+
+    /**
+     * Attempt to insert a stack into a single slot, returning the remainder.
+     * Pure stack arithmetic — no side effects beyond the container itself.
+     */
+    public static ItemStack insertIntoSlot(Container inv, int slot, ItemStack stack) {
+        ItemStack existing = inv.getItem(slot);
+
+        if (existing.isEmpty()) {
+            int maxInsert = Math.min(stack.getCount(), Math.min(inv.getMaxStackSize(), stack.getMaxStackSize()));
+            inv.setItem(slot, stack.split(maxInsert));
+        } else if (ItemStack.isSameItemSameComponents(existing, stack)) {
+            int space = Math.min(inv.getMaxStackSize(), existing.getMaxStackSize()) - existing.getCount();
+            if (space > 0) {
+                int toInsert = Math.min(space, stack.getCount());
+                existing.grow(toInsert);
+                stack.shrink(toInsert);
+            }
+        }
+
+        return stack;
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBounds.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBounds.java
@@ -1,0 +1,82 @@
+package com.logistics.automation.laserquarry.entity;
+
+import com.logistics.core.lib.compat.NbtCompat;
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Mutable holder for the laser quarry's marker-defined mining bounds.
+ * When {@link #isCustom()} is {@code false}, callers fall back to the default
+ * area defined in {@code LogisticsConfig}.
+ */
+public final class QuarryBounds {
+    private boolean custom = false;
+    private int minX = 0;
+    private int minZ = 0;
+    private int maxX = 0;
+    private int maxZ = 0;
+
+    public boolean isCustom() {
+        return custom;
+    }
+
+    public int getMinX() {
+        return minX;
+    }
+
+    public int getMinZ() {
+        return minZ;
+    }
+
+    public int getMaxX() {
+        return maxX;
+    }
+
+    public int getMaxZ() {
+        return maxZ;
+    }
+
+    public void setCustom(int minX, int minZ, int maxX, int maxZ) {
+        this.custom = true;
+        this.minX = minX;
+        this.minZ = minZ;
+        this.maxX = maxX;
+        this.maxZ = maxZ;
+    }
+
+    public void clear() {
+        this.custom = false;
+        this.minX = 0;
+        this.minZ = 0;
+        this.maxX = 0;
+        this.maxZ = 0;
+    }
+
+    public void save(CompoundTag nbt) {
+        nbt.putBoolean("UseCustomBounds", custom);
+        if (custom) {
+            nbt.putInt("CustomBoundsMinX", minX);
+            nbt.putInt("CustomBoundsMinZ", minZ);
+            nbt.putInt("CustomBoundsMaxX", maxX);
+            nbt.putInt("CustomBoundsMaxZ", maxZ);
+        }
+    }
+
+    public void load(CompoundTag nbt) {
+        custom = NbtCompat.getBoolean(nbt, "UseCustomBounds", false);
+        if (custom) {
+            minX = NbtCompat.getInt(nbt, "CustomBoundsMinX", 0);
+            minZ = NbtCompat.getInt(nbt, "CustomBoundsMinZ", 0);
+            maxX = NbtCompat.getInt(nbt, "CustomBoundsMaxX", 0);
+            maxZ = NbtCompat.getInt(nbt, "CustomBoundsMaxZ", 0);
+        } else {
+            minX = 0;
+            minZ = 0;
+            maxX = 0;
+            maxZ = 0;
+        }
+    }
+
+    public void loadLegacy(int minX, int minZ, int maxX, int maxZ) {
+        setCustom(minX, minZ, maxX, maxZ);
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryFrameRect.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryFrameRect.java
@@ -1,0 +1,72 @@
+package com.logistics.automation.laserquarry.entity;
+
+import com.logistics.automation.laserquarry.LaserQuarryGeometry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Resolved horizontal frame rectangle of a laser quarry, including its bottom and top
+ * Y coordinates. Encapsulates the facing-aware bounds math so {@link FrameLayout}
+ * and {@link GridScanner} can stay focused on layout/scan logic.
+ */
+public record QuarryFrameRect(int startX, int startZ, int endX, int endZ, int bottomY, int topY) {
+
+    public int width() {
+        return endX - startX + 1;
+    }
+
+    public int depth() {
+        return endZ - startZ + 1;
+    }
+
+    public int innerWidth() {
+        return width() - 2;
+    }
+
+    public int innerDepth() {
+        return depth() - 2;
+    }
+
+    public static @Nullable QuarryFrameRect resolve(
+            Direction facing, BlockPos quarryPos, QuarryBounds bounds, int defaultArea) {
+        int startX;
+        int startZ;
+        int endX;
+        int endZ;
+        if (bounds.isCustom()) {
+            startX = bounds.getMinX();
+            startZ = bounds.getMinZ();
+            endX = bounds.getMaxX();
+            endZ = bounds.getMaxZ();
+        } else {
+            int half = defaultArea / 2;
+            switch (facing) {
+                case NORTH:
+                    startX = quarryPos.getX() - half;
+                    startZ = quarryPos.getZ() - defaultArea;
+                    break;
+                case SOUTH:
+                    startX = quarryPos.getX() - half;
+                    startZ = quarryPos.getZ() + 1;
+                    break;
+                case EAST:
+                    startX = quarryPos.getX() + 1;
+                    startZ = quarryPos.getZ() - half;
+                    break;
+                case WEST:
+                    startX = quarryPos.getX() - defaultArea;
+                    startZ = quarryPos.getZ() - half;
+                    break;
+                default:
+                    return null;
+            }
+            endX = startX + defaultArea - 1;
+            endZ = startZ + defaultArea - 1;
+        }
+
+        int bottomY = quarryPos.getY();
+        int topY = quarryPos.getY() + LaserQuarryGeometry.Y_OFFSET_ABOVE;
+        return new QuarryFrameRect(startX, startZ, endX, endZ, bottomY, topY);
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
@@ -1,0 +1,125 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.ActiveQuarryRegistry;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ActiveQuarryRegistry")
+class ActiveQuarryRegistryTest extends MinecraftTestEnvironment {
+
+    private static final ResourceKey<Level> OVERWORLD =
+            ResourceKey.create(Registries.DIMENSION, Identifier.fromNamespaceAndPath("test", "overworld"));
+    private static final ResourceKey<Level> NETHER =
+            ResourceKey.create(Registries.DIMENSION, Identifier.fromNamespaceAndPath("test", "nether"));
+
+    @BeforeEach
+    @AfterEach
+    void resetRegistryState() {
+        ActiveQuarryRegistry.clear(OVERWORLD);
+        ActiveQuarryRegistry.clear(NETHER);
+    }
+
+    @Test
+    @DisplayName("returns empty list when no quarries are registered")
+    void emptyWhenNothingRegistered() {
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns registered positions for the given dimension")
+    void returnsRegisteredPositions() {
+        BlockPos a = new BlockPos(10, 64, 20);
+        BlockPos b = new BlockPos(-5, 70, 100);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, a);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, b);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).containsExactlyInAnyOrder(a, b);
+    }
+
+    @Test
+    @DisplayName("isolates entries per dimension")
+    void perDimensionIsolation() {
+        BlockPos overworldPos = new BlockPos(0, 64, 0);
+        BlockPos netherPos = new BlockPos(50, 32, 50);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, overworldPos);
+        ActiveQuarryRegistry.register(NETHER, 0L, netherPos);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).containsExactly(overworldPos);
+        assertThat(ActiveQuarryRegistry.getAll(NETHER, 0L)).containsExactly(netherPos);
+    }
+
+    @Test
+    @DisplayName("unregister removes a single entry without affecting others")
+    void unregisterRemovesOnlyTarget() {
+        BlockPos a = new BlockPos(0, 64, 0);
+        BlockPos b = new BlockPos(10, 64, 10);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, a);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, b);
+
+        ActiveQuarryRegistry.unregister(OVERWORLD, a);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).containsExactly(b);
+    }
+
+    @Test
+    @DisplayName("evicts entries older than the TTL on read")
+    void evictsStaleEntries() {
+        BlockPos fresh = new BlockPos(0, 64, 0);
+        BlockPos stale = new BlockPos(100, 64, 100);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, stale);
+        // Fresh is registered well after stale, but still within the TTL of the read time.
+        long freshRegisterTime = ActiveQuarryRegistry.REGISTRY_TTL_TICKS + 50L;
+        ActiveQuarryRegistry.register(OVERWORLD, freshRegisterTime, fresh);
+
+        long readTime = freshRegisterTime + (ActiveQuarryRegistry.REGISTRY_TTL_TICKS / 2);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, readTime)).containsExactly(fresh);
+    }
+
+    @Test
+    @DisplayName("returns empty list and drops the dimension entry when all are stale")
+    void dropsEmptyDimensionAfterEviction() {
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, new BlockPos(0, 64, 0));
+
+        long readTime = ActiveQuarryRegistry.REGISTRY_TTL_TICKS + 1L;
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, readTime)).isEmpty();
+        // A subsequent read at game time 0 should also be empty (entry was fully removed).
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("clear wipes all entries for the given dimension")
+    void clearWipesDimension() {
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, new BlockPos(0, 64, 0));
+        ActiveQuarryRegistry.register(NETHER, 0L, new BlockPos(0, 32, 0));
+
+        ActiveQuarryRegistry.clear(OVERWORLD);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, 0L)).isEmpty();
+        assertThat(ActiveQuarryRegistry.getAll(NETHER, 0L)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("re-registering the same position updates its timestamp")
+    void reregisterRefreshesTimestamp() {
+        BlockPos pos = new BlockPos(0, 64, 0);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, pos);
+
+        // Re-register at a later game time
+        ActiveQuarryRegistry.register(OVERWORLD, 1000L, pos);
+
+        long readTime = 1000L + ActiveQuarryRegistry.REGISTRY_TTL_TICKS;
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, readTime)).containsExactly(pos);
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/ActiveQuarryRegistryTest.java
@@ -72,6 +72,16 @@ class ActiveQuarryRegistryTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    @DisplayName("retains entries when age equals the TTL exactly (eviction is strict-greater-than)")
+    void retainsEntriesAtExactTTL() {
+        BlockPos pos = new BlockPos(0, 64, 0);
+        ActiveQuarryRegistry.register(OVERWORLD, 0L, pos);
+
+        assertThat(ActiveQuarryRegistry.getAll(OVERWORLD, ActiveQuarryRegistry.REGISTRY_TTL_TICKS))
+                .containsExactly(pos);
+    }
+
+    @Test
     @DisplayName("evicts entries older than the TTL on read")
     void evictsStaleEntries() {
         BlockPos fresh = new BlockPos(0, 64, 0);

--- a/common/src/test/java/com/logistics/automation/laserquarry/FrameLayoutTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/FrameLayoutTest.java
@@ -1,0 +1,207 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.FrameLayout;
+import com.logistics.automation.laserquarry.entity.QuarryBounds;
+import com.logistics.automation.laserquarry.entity.QuarryFrameRect;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FrameLayout")
+class FrameLayoutTest extends MinecraftTestEnvironment {
+
+    private static final BlockPos QUARRY = new BlockPos(0, 64, 0);
+    private static final int AREA = 16;
+
+    @Nested
+    @DisplayName("ringSize")
+    class RingSize {
+
+        @Test
+        @DisplayName("computes perimeter of a square (4×4 → 12)")
+        void square4x4() {
+            assertThat(FrameLayout.ringSize(4, 4)).isEqualTo(12);
+        }
+
+        @Test
+        @DisplayName("computes perimeter of the default 16×16 ring → 60")
+        void default16x16() {
+            assertThat(FrameLayout.ringSize(16, 16)).isEqualTo(60);
+        }
+
+        @Test
+        @DisplayName("handles non-square rectangles (4×8 → 20)")
+        void rect4x8() {
+            assertThat(FrameLayout.ringSize(4, 8)).isEqualTo(20);
+        }
+    }
+
+    @Nested
+    @DisplayName("ringPosition")
+    class RingPositionTraversal {
+
+        @Test
+        @DisplayName("starts at the NW corner, walks the north edge first (W→E)")
+        void firstStepIsNorthWestCorner() {
+            BlockPos p = FrameLayout.ringPosition(0, 0, 0, 3, 3, 5);
+
+            assertThat(p).isEqualTo(new BlockPos(0, 5, 0));
+        }
+
+        @Test
+        @DisplayName("walks east along the north edge")
+        void walksNorthEdge() {
+            BlockPos p = FrameLayout.ringPosition(2, 0, 0, 3, 3, 5);
+
+            assertThat(p).isEqualTo(new BlockPos(2, 5, 0));
+        }
+
+        @Test
+        @DisplayName("turns south at the NE corner")
+        void turnsSouthAtNECorner() {
+            // width=4, so index 4 is one past the north edge → east edge index 0 → z = startZ+1.
+            BlockPos p = FrameLayout.ringPosition(4, 0, 0, 3, 3, 5);
+
+            assertThat(p).isEqualTo(new BlockPos(3, 5, 1));
+        }
+
+        @Test
+        @DisplayName("walks west along the south edge from the SE corner")
+        void walksSouthEdgeWest() {
+            // After 4 (north) + 3 (east) = 7 entries, index 7 is south edge index 0 → endX-1.
+            BlockPos p = FrameLayout.ringPosition(7, 0, 0, 3, 3, 5);
+
+            assertThat(p).isEqualTo(new BlockPos(2, 5, 3));
+        }
+
+        @Test
+        @DisplayName("walks north along the west edge from the SW corner")
+        void walksWestEdgeNorth() {
+            // 4 + 3 + 3 = 10. Index 10 is west edge index 0 → z = endZ-1 = 2.
+            BlockPos p = FrameLayout.ringPosition(10, 0, 0, 3, 3, 5);
+
+            assertThat(p).isEqualTo(new BlockPos(0, 5, 2));
+        }
+
+        @Test
+        @DisplayName("returns null when index is past the perimeter")
+        void nullPastPerimeter() {
+            assertThat(FrameLayout.ringPosition(12, 0, 0, 3, 3, 5)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("nextFramePosition")
+    class NextFramePosition {
+
+        @Test
+        @DisplayName("first frame block is the NW corner of the bottom ring")
+        void firstIsBottomNWCorner() {
+            BlockPos p = FrameLayout.nextFramePosition(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, 0);
+
+            // NORTH: startX = -8, startZ = -16, bottomY = 64.
+            assertThat(p).isEqualTo(new BlockPos(-8, 64, -16));
+        }
+
+        @Test
+        @DisplayName("after the bottom ring, the first pillar starts at quarryY+1 at the NW corner")
+        void firstPillarStartsAboveNWCorner() {
+            int ringSize = FrameLayout.ringSize(AREA, AREA);
+            BlockPos p =
+                    FrameLayout.nextFramePosition(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, ringSize);
+
+            assertThat(p).isEqualTo(new BlockPos(-8, 65, -16));
+        }
+
+        @Test
+        @DisplayName("after pillars, the first top-ring block is the NW corner at quarryY+4")
+        void topRingStartsAtNWCornerY4() {
+            int ringSize = FrameLayout.ringSize(AREA, AREA);
+            int topRingStartIndex = ringSize + FrameLayout.PILLAR_COUNT;
+
+            BlockPos p = FrameLayout.nextFramePosition(
+                    Direction.NORTH, QUARRY, new QuarryBounds(), AREA, topRingStartIndex);
+
+            assertThat(p).isEqualTo(new BlockPos(-8, 68, -16));
+        }
+
+        @Test
+        @DisplayName("returns null past the full frame build sequence")
+        void nullPastEnd() {
+            int totalBlocks = FrameLayout.ringSize(AREA, AREA) * 2 + FrameLayout.PILLAR_COUNT;
+
+            assertThat(FrameLayout.nextFramePosition(
+                            Direction.NORTH, QUARRY, new QuarryBounds(), AREA, totalBlocks))
+                    .isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("computeArms")
+    class ComputeArms {
+
+        // A 4×4 rectangle at the bottom layer (y=0), so corners are (0,0,0), (3,0,0), (3,0,3), (0,0,3).
+        // bottomY = 0, topY = 4.
+        private final QuarryFrameRect rect = new QuarryFrameRect(0, 0, 3, 3, 0, 4);
+
+        @Test
+        @DisplayName("NW corner at the bottom ring exposes up (no down) and inward edges")
+        void bottomNWCorner() {
+            boolean[] arms = FrameLayout.computeArms(rect, new BlockPos(0, 0, 0));
+
+            // [north, south, east, west, up, down]
+            assertThat(arms[0]).as("north").isFalse();
+            assertThat(arms[1]).as("south").isTrue();
+            assertThat(arms[2]).as("east").isTrue();
+            assertThat(arms[3]).as("west").isFalse();
+            assertThat(arms[4]).as("up").isTrue();
+            assertThat(arms[5]).as("down").isFalse();
+        }
+
+        @Test
+        @DisplayName("NW corner at the top ring exposes down (no up) and inward edges")
+        void topNWCorner() {
+            boolean[] arms = FrameLayout.computeArms(rect, new BlockPos(0, 4, 0));
+
+            assertThat(arms[0]).as("north").isFalse();
+            assertThat(arms[1]).as("south").isTrue();
+            assertThat(arms[2]).as("east").isTrue();
+            assertThat(arms[3]).as("west").isFalse();
+            assertThat(arms[4]).as("up").isFalse();
+            assertThat(arms[5]).as("down").isTrue();
+        }
+
+        @Test
+        @DisplayName("mid-edge bottom block exposes only the two horizontal neighbours")
+        void midEdgeBottom() {
+            // (1,0,0) is on the north edge between corners.
+            boolean[] arms = FrameLayout.computeArms(rect, new BlockPos(1, 0, 0));
+
+            assertThat(arms[0]).as("north").isFalse();
+            assertThat(arms[1]).as("south").isFalse();
+            assertThat(arms[2]).as("east").isTrue();
+            assertThat(arms[3]).as("west").isTrue();
+            assertThat(arms[4]).as("up").isFalse();
+            assertThat(arms[5]).as("down").isFalse();
+        }
+
+        @Test
+        @DisplayName("mid-pillar between corners exposes up and down only")
+        void midPillar() {
+            // Corner column at y=2 (between bottomY=0 and topY=4).
+            boolean[] arms = FrameLayout.computeArms(rect, new BlockPos(0, 2, 0));
+
+            assertThat(arms[0]).as("north").isFalse();
+            assertThat(arms[1]).as("south").isFalse();
+            assertThat(arms[2]).as("east").isFalse();
+            assertThat(arms[3]).as("west").isFalse();
+            assertThat(arms[4]).as("up").isTrue();
+            assertThat(arms[5]).as("down").isTrue();
+        }
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/GridScannerTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/GridScannerTest.java
@@ -1,0 +1,182 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.GridScanner;
+import com.logistics.automation.laserquarry.entity.QuarryBounds;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("GridScanner")
+class GridScannerTest extends MinecraftTestEnvironment {
+
+    private static final BlockPos QUARRY = new BlockPos(0, 64, 0);
+    private static final int AREA = 16;
+
+    @Nested
+    @DisplayName("clearingTarget")
+    class ClearingTarget {
+
+        @Test
+        @DisplayName("returns top layer position above the quarry for NORTH facing at grid origin")
+        void northTopLayerAtOrigin() {
+            BlockPos target =
+                    GridScanner.clearingTarget(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, 0, 0, 0);
+
+            // NORTH: startX = -8, startZ = -16. topY = 64 + 4 = 68.
+            assertThat(target).isEqualTo(new BlockPos(-8, 68, -16));
+        }
+
+        @Test
+        @DisplayName("descends one block per gridY step")
+        void descendsWithGridY() {
+            BlockPos target =
+                    GridScanner.clearingTarget(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, 0, 3, 0);
+
+            assertThat(target.getY()).isEqualTo(65);
+        }
+
+        @Test
+        @DisplayName("returns null when gridY walks below the quarry's own level")
+        void nullWhenBelowQuarryLevel() {
+            // 5 layers down from topY=68 → currentY=63 < bottomY=64
+            BlockPos target =
+                    GridScanner.clearingTarget(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, 0, 5, 0);
+
+            assertThat(target).isNull();
+        }
+
+        @Test
+        @DisplayName("mirrors the area when facing SOUTH")
+        void southMirrors() {
+            BlockPos target =
+                    GridScanner.clearingTarget(Direction.SOUTH, QUARRY, new QuarryBounds(), AREA, 0, 0, 0);
+
+            // SOUTH: startX = -8, startZ = +1.
+            assertThat(target).isEqualTo(new BlockPos(-8, 68, 1));
+        }
+
+        @Test
+        @DisplayName("respects custom bounds, ignoring facing")
+        void usesCustomBounds() {
+            QuarryBounds bounds = new QuarryBounds();
+            bounds.setCustom(100, 100, 110, 115);
+
+            BlockPos target = GridScanner.clearingTarget(Direction.NORTH, QUARRY, bounds, AREA, 2, 0, 3);
+
+            assertThat(target).isEqualTo(new BlockPos(102, 68, 103));
+        }
+
+        @Test
+        @DisplayName("returns null for non-horizontal facings")
+        void nullForVerticalFacing() {
+            assertThat(GridScanner.clearingTarget(Direction.UP, QUARRY, new QuarryBounds(), AREA, 0, 0, 0))
+                    .isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("miningTarget")
+    class MiningTarget {
+
+        @Test
+        @DisplayName("starts one block below the quarry inset 1 from the NORTH frame")
+        void firstMiningPosition() {
+            BlockPos target =
+                    GridScanner.miningTarget(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, -64, 0, 0, 0);
+
+            // NORTH: startX_inner = -7, startZ_inner = -15, currentY = 63.
+            assertThat(target).isEqualTo(new BlockPos(-7, 63, -15));
+        }
+
+        @Test
+        @DisplayName("zigzags X back when totalRows is odd")
+        void xZigzagOnOddRow() {
+            // gridY=0, gridZ=1 → totalRows=1 (odd) → targetX = startX_inner + (innerWidth-1-gridX).
+            BlockPos target =
+                    GridScanner.miningTarget(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, -64, 0, 0, 1);
+
+            // innerWidth = 14, startX_inner=-7, so targetX = -7 + (14-1-0) = 6, targetZ = -15 + 1 = -14.
+            assertThat(target).isEqualTo(new BlockPos(6, 63, -14));
+        }
+
+        @Test
+        @DisplayName("zigzags Z back on odd layers")
+        void zZigzagOnOddLayer() {
+            // gridY=1 (odd layer) → targetZ = startZ_inner + (innerDepth-1-gridZ).
+            BlockPos target =
+                    GridScanner.miningTarget(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, -64, 0, 1, 0);
+
+            assertThat(target.getZ()).isEqualTo(-15 + (14 - 1 - 0));
+            assertThat(target.getY()).isEqualTo(62); // 63 - 1
+        }
+
+        @Test
+        @DisplayName("returns null when currentY drops below worldMinY")
+        void nullBelowWorldMin() {
+            BlockPos target =
+                    GridScanner.miningTarget(Direction.NORTH, QUARRY, new QuarryBounds(), AREA, 100, 0, 0, 0);
+
+            // currentY = 63 < 100 → null
+            assertThat(target).isNull();
+        }
+
+        @Test
+        @DisplayName("returns null when custom bounds leave no inner area")
+        void nullWhenInnerAreaEmpty() {
+            QuarryBounds bounds = new QuarryBounds();
+            bounds.setCustom(0, 0, 1, 1); // 2×2 frame → no interior
+
+            BlockPos target = GridScanner.miningTarget(Direction.NORTH, QUARRY, bounds, AREA, -64, 0, 0, 0);
+
+            assertThat(target).isNull();
+        }
+
+        @Test
+        @DisplayName("respects custom bounds for the mining inset")
+        void usesCustomBoundsForInset() {
+            QuarryBounds bounds = new QuarryBounds();
+            bounds.setCustom(100, 100, 105, 105); // 6×6 frame → 4×4 interior
+
+            BlockPos target = GridScanner.miningTarget(Direction.NORTH, QUARRY, bounds, AREA, -64, 0, 0, 0);
+
+            // startX_inner = 101, startZ_inner = 101, currentY = 63.
+            assertThat(target).isEqualTo(new BlockPos(101, 63, 101));
+        }
+    }
+
+    @Nested
+    @DisplayName("shouldSkip")
+    class ShouldSkip {
+
+        @Test
+        @DisplayName("skips air blocks")
+        void skipsAir() {
+            BlockState air = Blocks.AIR.defaultBlockState();
+
+            assertThat(GridScanner.shouldSkip(null, BlockPos.ZERO, air)).isTrue();
+        }
+
+        @Test
+        @DisplayName("skips fluid blocks (water)")
+        void skipsWater() {
+            BlockState water = Blocks.WATER.defaultBlockState();
+
+            assertThat(GridScanner.shouldSkip(null, BlockPos.ZERO, water)).isTrue();
+        }
+
+        @Test
+        @DisplayName("skips fluid blocks (lava)")
+        void skipsLava() {
+            BlockState lava = Blocks.LAVA.defaultBlockState();
+
+            assertThat(GridScanner.shouldSkip(null, BlockPos.ZERO, lava)).isTrue();
+        }
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryBlockBreakerTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryBlockBreakerTest.java
@@ -1,0 +1,86 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.QuarryBlockBreaker;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("QuarryBlockBreaker.insertIntoSlot")
+class QuarryBlockBreakerTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("fully inserts into an empty slot")
+    void insertsIntoEmptySlot() {
+        SimpleContainer container = new SimpleContainer(1);
+        ItemStack stack = new ItemStack(Items.IRON_INGOT, 5);
+
+        ItemStack remainder = QuarryBlockBreaker.insertIntoSlot(container, 0, stack);
+
+        assertThat(remainder.isEmpty()).isTrue();
+        assertThat(container.getItem(0).getItem()).isEqualTo(Items.IRON_INGOT);
+        assertThat(container.getItem(0).getCount()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("merges into a matching slot up to the stack size")
+    void mergesIntoMatchingSlot() {
+        SimpleContainer container = new SimpleContainer(1);
+        container.setItem(0, new ItemStack(Items.IRON_INGOT, 60));
+        ItemStack stack = new ItemStack(Items.IRON_INGOT, 10);
+
+        ItemStack remainder = QuarryBlockBreaker.insertIntoSlot(container, 0, stack);
+
+        // 64 - 60 = 4 fit, 6 remain.
+        assertThat(container.getItem(0).getCount()).isEqualTo(64);
+        assertThat(remainder.getCount()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("does not merge into a slot holding a different item")
+    void doesNotMergeDifferentItem() {
+        SimpleContainer container = new SimpleContainer(1);
+        container.setItem(0, new ItemStack(Items.COAL, 1));
+        ItemStack stack = new ItemStack(Items.IRON_INGOT, 5);
+
+        ItemStack remainder = QuarryBlockBreaker.insertIntoSlot(container, 0, stack);
+
+        assertThat(container.getItem(0).getItem()).isEqualTo(Items.COAL);
+        assertThat(container.getItem(0).getCount()).isEqualTo(1);
+        assertThat(remainder.getCount()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("inserts only up to the container's max stack size into an empty slot")
+    void respectsContainerMaxStackSize() {
+        SimpleContainer container = new SimpleContainer(1) {
+            @Override
+            public int getMaxStackSize() {
+                return 16;
+            }
+        };
+        ItemStack stack = new ItemStack(Items.IRON_INGOT, 40);
+
+        ItemStack remainder = QuarryBlockBreaker.insertIntoSlot(container, 0, stack);
+
+        assertThat(container.getItem(0).getCount()).isEqualTo(16);
+        assertThat(remainder.getCount()).isEqualTo(24);
+    }
+
+    @Test
+    @DisplayName("returns the original stack when the matching slot is already full")
+    void noChangeWhenMatchingSlotFull() {
+        SimpleContainer container = new SimpleContainer(1);
+        container.setItem(0, new ItemStack(Items.IRON_INGOT, 64));
+        ItemStack stack = new ItemStack(Items.IRON_INGOT, 5);
+
+        ItemStack remainder = QuarryBlockBreaker.insertIntoSlot(container, 0, stack);
+
+        assertThat(remainder.getCount()).isEqualTo(5);
+        assertThat(container.getItem(0).getCount()).isEqualTo(64);
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
@@ -106,6 +106,8 @@ class QuarryBoundsTest extends MinecraftTestEnvironment {
 
         assertThat(bounds.isCustom()).isFalse();
         assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMinZ()).isZero();
+        assertThat(bounds.getMaxX()).isZero();
         assertThat(bounds.getMaxZ()).isZero();
     }
 

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
@@ -1,0 +1,124 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.QuarryBounds;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("QuarryBounds")
+class QuarryBoundsTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("defaults to non-custom with zeroed values")
+    void defaultsToNonCustom() {
+        QuarryBounds bounds = new QuarryBounds();
+
+        assertThat(bounds.isCustom()).isFalse();
+        assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMinZ()).isZero();
+        assertThat(bounds.getMaxX()).isZero();
+        assertThat(bounds.getMaxZ()).isZero();
+    }
+
+    @Test
+    @DisplayName("setCustom stores the supplied bounds and flips isCustom to true")
+    void setCustomStoresValues() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(-5, 10, 15, 30);
+
+        assertThat(bounds.isCustom()).isTrue();
+        assertThat(bounds.getMinX()).isEqualTo(-5);
+        assertThat(bounds.getMinZ()).isEqualTo(10);
+        assertThat(bounds.getMaxX()).isEqualTo(15);
+        assertThat(bounds.getMaxZ()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("clear resets values and disables custom mode")
+    void clearResets() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(-5, 10, 15, 30);
+
+        bounds.clear();
+
+        assertThat(bounds.isCustom()).isFalse();
+        assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMinZ()).isZero();
+        assertThat(bounds.getMaxX()).isZero();
+        assertThat(bounds.getMaxZ()).isZero();
+    }
+
+    @Test
+    @DisplayName("round-trips custom bounds through NBT")
+    void roundTripsCustomBounds() {
+        QuarryBounds original = new QuarryBounds();
+        original.setCustom(-12, 5, 12, 33);
+        CompoundTag tag = new CompoundTag();
+        original.save(tag);
+
+        QuarryBounds loaded = new QuarryBounds();
+        loaded.load(tag);
+
+        assertThat(loaded.isCustom()).isTrue();
+        assertThat(loaded.getMinX()).isEqualTo(-12);
+        assertThat(loaded.getMinZ()).isEqualTo(5);
+        assertThat(loaded.getMaxX()).isEqualTo(12);
+        assertThat(loaded.getMaxZ()).isEqualTo(33);
+    }
+
+    @Test
+    @DisplayName("uses the existing CustomBounds* NBT keys for compatibility")
+    void usesExistingNbtKeys() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(1, 2, 3, 4);
+        CompoundTag tag = new CompoundTag();
+        bounds.save(tag);
+
+        assertThat(tag.getBoolean("UseCustomBounds")).hasValue(true);
+        assertThat(tag.getInt("CustomBoundsMinX")).hasValue(1);
+        assertThat(tag.getInt("CustomBoundsMinZ")).hasValue(2);
+        assertThat(tag.getInt("CustomBoundsMaxX")).hasValue(3);
+        assertThat(tag.getInt("CustomBoundsMaxZ")).hasValue(4);
+    }
+
+    @Test
+    @DisplayName("does not write bound values when not custom")
+    void omitsBoundValuesWhenNotCustom() {
+        QuarryBounds bounds = new QuarryBounds();
+        CompoundTag tag = new CompoundTag();
+        bounds.save(tag);
+
+        assertThat(tag.getBoolean("UseCustomBounds")).hasValue(false);
+        assertThat(tag.contains("CustomBoundsMinX")).isFalse();
+        assertThat(tag.contains("CustomBoundsMaxX")).isFalse();
+    }
+
+    @Test
+    @DisplayName("load with missing flag yields default non-custom bounds")
+    void loadFromEmptyTag() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.setCustom(7, 8, 9, 10);
+
+        bounds.load(new CompoundTag());
+
+        assertThat(bounds.isCustom()).isFalse();
+        assertThat(bounds.getMinX()).isZero();
+        assertThat(bounds.getMaxZ()).isZero();
+    }
+
+    @Test
+    @DisplayName("loadLegacy promotes raw values to a custom configuration")
+    void loadLegacyApplies() {
+        QuarryBounds bounds = new QuarryBounds();
+        bounds.loadLegacy(-1, -2, 5, 6);
+
+        assertThat(bounds.isCustom()).isTrue();
+        assertThat(bounds.getMinX()).isEqualTo(-1);
+        assertThat(bounds.getMinZ()).isEqualTo(-2);
+        assertThat(bounds.getMaxX()).isEqualTo(5);
+        assertThat(bounds.getMaxZ()).isEqualTo(6);
+    }
+}


### PR DESCRIPTION
## Summary
Third step of #395. Lifts the laser quarry's block-breaking and item-output side effects into a stateless helper, removing ~120 lines from the block entity.

## Changes
- New `QuarryBlockBreaker` owns `mineBlock`, `outputItem`, `collectNearbyItems`, and `insertIntoSlot`. All static — the quarry pos is passed in.
- Output routing is unchanged: prefer a transport block above (`TransportApi.forceInsert`), then a sided/regular inventory above, finally drop an item entity at quarry+0.5/+1.5/+0.5 with a small upward velocity.
- `LaserQuarryBlockEntity.mineBlock(...)` becomes a one-line delegate so existing tick logic doesn't move.
- Added `QuarryBlockBreakerTest` (5 cases for the pure `insertIntoSlot` primitive: empty-slot fill, matching-slot merge with overflow, different-item rejection, container-max-stack-size respect, full-slot no-op). The world-coupled paths are exercised in-game.

## Notes
- No behavior changes.
- Refs #395. Stacked on top of #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)