### PR TITLE
refactor: extract ArmController and QuarryPhaseRunner (#395)

### DIFF
--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/ArmController.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/ArmController.java
@@ -1,0 +1,225 @@
+package com.logistics.automation.laserquarry.entity;
+
+import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity.ArmState;
+import com.logistics.core.LogisticsConfig;
+import com.logistics.core.lib.compat.NbtCompat;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.Level;
+
+/**
+ * Tracks the laser quarry arm's world-space position, movement state, and timing
+ * for client interpolation catch-up. All math is pure; the controller does not
+ * directly trigger sync — callers (typically {@link QuarryPhaseRunner}) decide
+ * when to push state to clients.
+ */
+public final class ArmController {
+    private ArmState state = ArmState.MOVING;
+    private float x = 0f;
+    private float y = 0f;
+    private float z = 0f;
+    private boolean initialized = false;
+    private int settlingTicksRemaining = 0;
+    private int expectedTravelTicks = 0;
+    private float syncedSpeed = 0.0f;
+
+    // ==================== Public getters ====================
+
+    public ArmState getState() {
+        return state;
+    }
+
+    public float getX() {
+        return x;
+    }
+
+    public float getY() {
+        return y;
+    }
+
+    public float getZ() {
+        return z;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public float getSyncedSpeed() {
+        return syncedSpeed;
+    }
+
+    public void setSyncedSpeed(float speed) {
+        this.syncedSpeed = speed;
+    }
+
+    // ==================== State transitions ====================
+
+    public void initializeAt(float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.initialized = true;
+        this.state = ArmState.MOVING;
+        this.expectedTravelTicks = 0;
+    }
+
+    public void enterMoving() {
+        this.state = ArmState.MOVING;
+    }
+
+    /** Drop the initialized flag so the next mining tick re-anchors at the first target. */
+    public void markUninitialized() {
+        this.initialized = false;
+    }
+
+    public void enterSettling(int ticks) {
+        this.state = ArmState.SETTLING;
+        this.settlingTicksRemaining = Math.max(1, ticks);
+    }
+
+    public void enterBreaking() {
+        this.state = ArmState.BREAKING;
+    }
+
+    /** Decrement the settling timer; returns {@code true} when it reaches zero. */
+    public boolean tickSettling() {
+        settlingTicksRemaining--;
+        return settlingTicksRemaining <= 0;
+    }
+
+    public int getExpectedTravelTicks() {
+        return expectedTravelTicks;
+    }
+
+    public void setExpectedTravelTicks(int ticks) {
+        this.expectedTravelTicks = ticks;
+    }
+
+    public void resetExpectedTravelTicks() {
+        this.expectedTravelTicks = 0;
+    }
+
+    /**
+     * Jumps the arm to the supplied position without interpolation and computes
+     * the matching settling-tick count for the given speed.
+     */
+    public void warpTo(float tx, float ty, float tz, float speed) {
+        float dx = tx - this.x;
+        float dy = ty - this.y;
+        float dz = tz - this.z;
+        float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+        this.x = tx;
+        this.y = ty;
+        this.z = tz;
+        this.expectedTravelTicks = (int) Math.ceil(distance / speed);
+    }
+
+    // ==================== Kinematics ====================
+
+    /** Move the arm one tick toward the target at the given speed; returns {@code true} on snap-to-target. */
+    public boolean moveTowards(float tx, float ty, float tz, float speed) {
+        float dx = tx - x;
+        float dy = ty - y;
+        float dz = tz - z;
+
+        float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+        if (distance <= speed) {
+            x = tx;
+            y = ty;
+            z = tz;
+            return true;
+        }
+
+        float factor = speed / distance;
+        x += dx * factor;
+        y += dy * factor;
+        z += dz * factor;
+
+        return false;
+    }
+
+    public boolean isAt(float tx, float ty, float tz, float speed) {
+        float dx = tx - x;
+        float dy = ty - y;
+        float dz = tz - z;
+        float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+        return distance <= speed;
+    }
+
+    public int travelTicksFor(float tx, float ty, float tz, float speed) {
+        float dx = tx - x;
+        float dy = ty - y;
+        float dz = tz - z;
+        float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+        return (int) Math.ceil(distance / speed);
+    }
+
+    // ==================== Cost + speed (depend on energy buffer / world) ====================
+
+    /** Move cost per tick — scales with current buffer to drain excess energy faster. */
+    public static long moveCost(long bufferAmount, long moveCostDivisor) {
+        return (long) Math
+                .ceil(LogisticsConfig.get().quarry.armEnergy + (double) bufferAmount / moveCostDivisor);
+    }
+
+    /** Effective arm speed in blocks/tick, including the rain penalty when applicable. */
+    public static float effectiveSpeed(long bufferAmount, long moveCostDivisor, Level level, BlockPos quarryPos) {
+        long mc = moveCost(bufferAmount, moveCostDivisor);
+        float speed = LogisticsConfig.get().quarry.armSpeed + (mc / LogisticsConfig.get().quarry.armSpeedScaling);
+        if (level != null && level.isRainingAt(quarryPos.above())) {
+            speed *= LogisticsConfig.get().quarry.rainPenalty;
+        }
+        return speed;
+    }
+
+    // ==================== NBT ====================
+
+    public void save(CompoundTag tag) {
+        tag.putString("ArmState", state.name());
+        tag.putFloat("ArmX", x);
+        tag.putFloat("ArmY", y);
+        tag.putFloat("ArmZ", z);
+        tag.putBoolean("ArmInitialized", initialized);
+        tag.putInt("ArmSettlingTicks", settlingTicksRemaining);
+        tag.putInt("ArmExpectedTravelTicks", expectedTravelTicks);
+        tag.putFloat("ArmSyncedSpeed", syncedSpeed);
+    }
+
+    public void load(CompoundTag tag) {
+        String armStateName = NbtCompat.getString(tag, "ArmState", "MOVING");
+        try {
+            state = ArmState.valueOf(armStateName);
+        } catch (IllegalArgumentException e) {
+            state = ArmState.MOVING;
+        }
+        x = NbtCompat.getFloat(tag, "ArmX", 0f);
+        y = NbtCompat.getFloat(tag, "ArmY", 0f);
+        z = NbtCompat.getFloat(tag, "ArmZ", 0f);
+        initialized = NbtCompat.getBoolean(tag, "ArmInitialized", false);
+        settlingTicksRemaining = NbtCompat.getInt(tag, "ArmSettlingTicks", 0);
+        expectedTravelTicks = NbtCompat.getInt(tag, "ArmExpectedTravelTicks", 0);
+        syncedSpeed = NbtCompat.getFloat(tag, "ArmSyncedSpeed", 0.0f);
+    }
+
+    /**
+     * Load from the legacy {@code MiningState} compound, which used different keys
+     * for the settling and travel-tick fields than the current top-level format.
+     */
+    public void loadLegacy(CompoundTag miningStateTag) {
+        String armStateName = NbtCompat.getString(miningStateTag, "ArmState", "MOVING");
+        try {
+            state = ArmState.valueOf(armStateName);
+        } catch (IllegalArgumentException e) {
+            state = ArmState.MOVING;
+        }
+        x = NbtCompat.getFloat(miningStateTag, "ArmX", 0f);
+        y = NbtCompat.getFloat(miningStateTag, "ArmY", 0f);
+        z = NbtCompat.getFloat(miningStateTag, "ArmZ", 0f);
+        initialized = NbtCompat.getBoolean(miningStateTag, "ArmInitialized", false);
+        settlingTicksRemaining = NbtCompat.getInt(miningStateTag, "SettlingTicks", 0);
+        expectedTravelTicks = NbtCompat.getInt(miningStateTag, "ExpectedTravelTicks", 0);
+        syncedSpeed = NbtCompat.getFloat(miningStateTag, "SyncedArmSpeed", 0.0f);
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -1,16 +1,16 @@
 package com.logistics.automation.laserquarry.entity;
 
 import com.logistics.LogisticsAutomation;
-import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.automation.render.ClientRenderCacheHooks;
 import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.block.BaseBlockEntity;
-import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.block.behavior.ProbeResult;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.EnergyDemandProvider;
-import com.logistics.core.lib.block.behavior.ProbeResult;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -23,37 +23,32 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
-import com.logistics.core.lib.energy.IEnergyStorage;
 
-public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConnection, HasEnergyStorage, EnergyDemandProvider {
-    private static final long FRAME_BUILD_COST = 240L;
+public class LaserQuarryBlockEntity extends BaseBlockEntity
+        implements PipeConnection, HasEnergyStorage, EnergyDemandProvider {
+    static final long FRAME_BUILD_COST = 240L;
     private static final long MOVE_COST_BUFFER_DIVISOR = 10L;
 
-    /**
-     * Quarry operation phases.
-     */
+    /** Quarry operation phases. */
     public enum Phase {
-        CLEARING, // Clearing the area above and at quarry level
-        BUILDING_FRAME, // Building the frame around the quarry area
-        MINING // Mining below quarry level
+        CLEARING,
+        BUILDING_FRAME,
+        MINING
     }
 
-    /**
-     * Arm movement sub-states during mining phase.
-     */
+    /** Arm movement sub-states during mining phase. */
     public enum ArmState {
-        MOVING, // Arm is moving to target position
-        SETTLING, // Arm reached target, waiting for client to catch up
-        BREAKING // Arm is at target, breaking the block
+        MOVING,
+        SETTLING,
+        BREAKING
     }
 
-    // Energy storage
+    // Energy storage — kept on the BE because it's part of the capability surface.
     private final EnergyComponent energy = new EnergyComponent(
             LogisticsConfig.get().quarry.energyCapacity(),
             LogisticsConfig.get().quarry.maxEnergyInput(),
             0,
-            this::setChanged
-    );
+            this::setChanged);
     private long energyReceivedLastTick = 0;
     private long energyReceivedThisTick = 0;
     private final IEnergyStorage trackingStorage = new IEnergyStorage() {
@@ -70,54 +65,38 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         }
 
         @Override
-        public long getAmount() { return energy.getAmount(); }
+        public long getAmount() {
+            return energy.getAmount();
+        }
 
         @Override
-        public long getCapacity() { return energy.getCapacity(); }
+        public long getCapacity() {
+            return energy.getCapacity();
+        }
 
         @Override
-        public boolean canInsert() { return energy.canInsert(); }
+        public boolean canInsert() {
+            return energy.canInsert();
+        }
 
         @Override
-        public boolean canExtract() { return energy.canExtract(); }
+        public boolean canExtract() {
+            return energy.canExtract();
+        }
     };
-    private long lastSyncedEnergy = 0; // For client sync
-    private boolean consumedEnergyThisTick = false; // For LED when buffer is low
+    private long lastSyncedEnergy = 0;
+    private boolean consumedEnergyThisTick = false;
 
-    // Phase state
-    private Phase currentPhase = Phase.CLEARING;
-    private int frameBuildIndex = 0;
-
-    // Mining state
-    private int miningX = 0;
-    private int miningY = 0;
-    private int miningZ = 0;
-    private float breakProgress = 0f;
-    private boolean finished = false;
-
-    // Custom bounds from markers
+    // Extracted collaborators — see ArmController/QuarryPhaseRunner/QuarryBounds.
     private final QuarryBounds bounds = new QuarryBounds();
+    private final ArmController armController = new ArmController();
+    private final QuarryPhaseRunner phaseRunner = new QuarryPhaseRunner();
 
-    // Cached values for the current mining target
-    private BlockPos currentTarget = null;
-    private float currentBreakTime = -1f;
-
-    // Block breaking animation entity ID (use position hash for uniqueness)
-    private int breakingEntityId = -1;
-
-    // Arm position tracking for smooth movement
-    private ArmState armState = ArmState.MOVING;
-    private float armX = 0f; // Current arm X position (absolute world coords)
-    private float armY = 0f; // Current arm Y position (absolute world coords)
-    private float armZ = 0f; // Current arm Z position (absolute world coords)
-    private boolean armInitialized = false; // Whether arm position has been set
-    private int settlingTicksRemaining = 0; // Countdown for SETTLING state
-    private int expectedTravelTicks = 0; // Expected ticks to reach target (for settling calculation)
-    private float syncedArmSpeed = 0.0f; // Pre-sync default; overwritten each tick by getEffectiveArmSpeed()
+    // Block breaking animation entity ID (use position hash for uniqueness).
+    private final int breakingEntityId;
 
     public LaserQuarryBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsAutomation.ENTITY.LASER_QUARRY_BLOCK_ENTITY, pos, state);
-        // Use position hash as unique entity ID for breaking animation
         this.breakingEntityId = pos.hashCode();
     }
 
@@ -125,9 +104,10 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     @Override
     public IEnergyStorage energyStorage(@Nullable Direction side) {
-        // Quarry accepts energy from all sides
         return trackingStorage;
     }
+
+    // ==================== Tick ====================
 
     public static void tick(Level world, BlockPos pos, BlockState state, LaserQuarryBlockEntity entity) {
         if (world.isClientSide()) {
@@ -139,38 +119,29 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         entity.energyReceivedLastTick = entity.energyReceivedThisTick;
         entity.energyReceivedThisTick = 0;
 
-        if (entity.finished) {
+        if (entity.phaseRunner.isFinished()) {
             return;
         }
 
         ServerLevel serverWorld = (ServerLevel) world;
 
-        // Track previous state for sync detection
         boolean wasConsumedEnergy = entity.consumedEnergyThisTick;
-
-        // Reset consumption flag at start of tick - will be set by consumeEnergy()
         entity.consumedEnergyThisTick = false;
 
-        switch (entity.currentPhase) {
-            case CLEARING -> tickClearing(serverWorld, pos, state, entity);
-            case BUILDING_FRAME -> tickBuildingFrame(serverWorld, pos, state, entity);
-            case MINING -> tickMining(serverWorld, pos, state, entity);
-            default -> {}
-        }
+        entity.phaseRunner.tick(entity, serverWorld, pos, state);
 
-        // Idle power consumption: 1 RF every 4 ticks (5 RF/second) to slowly drain buffer
+        // Idle power consumption: 1 RF every 4 ticks (5 RF/second) to slowly drain buffer.
         if (world.getGameTime() % 4 == 0 && entity.energy.getAmount() > 0) {
             entity.energy.setAmount(Math.max(0, entity.energy.getAmount() - 1));
-            entity.setChanged(); // Mark chunk dirty for persistence
+            entity.setChanged();
         }
 
-        // Sync when energy OR consumption flag changes
         boolean needsSync = entity.energy.getAmount() != entity.lastSyncedEnergy
                 || entity.consumedEnergyThisTick != wasConsumedEnergy;
 
         if (needsSync) {
             entity.lastSyncedEnergy = entity.energy.getAmount();
-            entity.syncedArmSpeed = entity.getEffectiveArmSpeed();
+            entity.armController.setSyncedSpeed(entity.getEffectiveArmSpeed());
             entity.syncToClients();
         }
     }
@@ -178,543 +149,100 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     /**
      * Sync arm state to clients. Called on arm state transitions.
      *
-     * Note: Does not call setChanged() - chunk dirty is managed separately by tick(),
-     * which marks dirty when energy is consumed or mining advances. This avoids
-     * redundant chunk dirty marks on every arm position update (per-tick).
+     * <p>Does not call {@code setChanged()} — chunk dirty is managed separately by
+     * {@link #tick}, which marks dirty when energy is consumed or mining advances.
      */
-    private void syncToClients() {
+    void syncToClients() {
         if (level != null && !level.isClientSide()) {
             BlockState state = getBlockState();
             level.sendBlockUpdated(worldPosition, state, state, Block.UPDATE_ALL);
         }
     }
 
-    private static void tickClearing(ServerLevel world, BlockPos pos, BlockState state, LaserQuarryBlockEntity entity) {
-        // Need at least some energy to operate
-        if (entity.energy.getAmount() == 0) {
-            entity.resetBreakProgress();
-            return;
-        }
+    // ==================== Package-private accessors for collaborators ====================
 
-        // Skip quickly through blocks at or above quarry level
-        BlockPos target = null;
-        BlockState targetState = null;
-        for (int skipped = 0; skipped < LogisticsConfig.get().quarry.scanRate; skipped++) {
-            target = entity.calculateClearingTargetPos(state);
-            if (target == null) {
-                // Finished clearing, move to building phase
-                entity.currentPhase = Phase.BUILDING_FRAME;
-                entity.frameBuildIndex = 0;
-                entity.setChanged();
-                return;
-            }
-
-            targetState = world.getBlockState(target);
-
-            if (!entity.shouldSkipBlock(world, target, targetState)) {
-                break;
-            }
-
-            entity.advanceToNextBlock();
-            entity.resetBreakProgress();
-        }
-
-        if (entity.shouldSkipBlock(world, target, targetState)) {
-            return;
-        }
-
-        // Calculate energy required if target changed
-        if (!target.equals(entity.currentTarget) || entity.currentBreakTime < 0) {
-            entity.currentTarget = target;
-            float hardness = targetState.getDestroySpeed(world, target);
-            entity.currentBreakTime = (float) (LogisticsConfig.get().quarry.energyPerBlockMultiplier() * (hardness + 1));
-            entity.breakProgress = 0;
-        }
-
-        // Consume as much energy as possible towards breaking (like BC)
-        long energyNeeded = (long) Math.ceil(entity.currentBreakTime - entity.breakProgress);
-        long energyToUse = Math.min(entity.energy.getAmount(), energyNeeded);
-        if (energyToUse > 0) {
-            entity.consumeEnergy(energyToUse);
-            entity.breakProgress += energyToUse;
-        }
-
-        if (entity.breakProgress >= entity.currentBreakTime) {
-            entity.mineBlock(world, target, targetState);
-            entity.advanceToNextBlock();
-            entity.resetBreakProgress();
-        }
+    QuarryBounds getBounds() {
+        return bounds;
     }
 
-    private static void tickBuildingFrame(
-            ServerLevel world, BlockPos pos, BlockState state, LaserQuarryBlockEntity entity) {
-        // Check for energy before building
-        if (!entity.hasEnergy(FRAME_BUILD_COST)) {
-            return;
-        }
-
-        // Build one frame block per tick
-        BlockPos framePos = entity.getNextFramePosition(state);
-        if (framePos == null) {
-            // Finished building frame, move to mining phase
-            entity.currentPhase = Phase.MINING;
-            entity.miningX = 0;
-            entity.miningY = 0;
-            entity.miningZ = 0;
-            entity.armInitialized = false; // Will be initialized on first mining tick
-            entity.armState = ArmState.MOVING;
-            entity.syncToClients();
-            entity.setChanged();
-            return;
-        }
-
-        // Consume energy for frame building
-        entity.consumeEnergy(FRAME_BUILD_COST);
-
-        // Only place frame if the position is air or replaceable
-        BlockState existingState = world.getBlockState(framePos);
-        if (existingState.isAir() || existingState.canBeReplaced()) {
-            BlockState frameState = entity.calculateFrameState(state, framePos);
-            world.setBlockAndUpdate(framePos, frameState);
-        }
-
-        entity.frameBuildIndex++;
-        entity.setChanged();
+    ArmController getArmController() {
+        return armController;
     }
 
-    private static void tickMining(ServerLevel world, BlockPos pos, BlockState state, LaserQuarryBlockEntity entity) {
-        // Energy is consumed per-state:
-        // - MOVING: move cost per tick
-        // - SETTLING: no cost (waiting for client sync)
-        // - BREAKING: break cost once when block breaks
-
-        // Skip air/fluid/bedrock blocks without moving the arm there
-        BlockPos target = null;
-        boolean skippedAny = false;
-        for (int skipped = 0; skipped < LogisticsConfig.get().quarry.scanRate; skipped++) {
-            target = entity.calculateMiningTargetPos(state);
-            if (target == null) {
-                entity.clearBreakingAnimation(world);
-                entity.finished = true;
-                entity.setChanged();
-                entity.syncToClients();
-                return;
-            }
-
-            BlockState targetState = world.getBlockState(target);
-            if (!entity.shouldSkipBlock(world, target, targetState)) {
-                break; // Found a block to mine
-            }
-
-            entity.advanceMiningPosition();
-            target = null; // Mark as skipped
-            skippedAny = true;
-        }
-
-        if (target == null) {
-            // All blocks this tick were skippable, continue next tick
-            return;
-        }
-
-        // If we skipped blocks, sync so client knows about the new target
-        if (skippedAny) {
-            entity.syncToClients();
-        }
-
-        // Target position (center of block, just above it for the drill tip)
-        float targetX = target.getX() + 0.5f;
-        float targetY = target.getY() + 1.0f;
-        float targetZ = target.getZ() + 0.5f;
-
-        // Initialize arm position if needed
-        if (!entity.armInitialized) {
-            entity.armX = targetX;
-            entity.armY = targetY;
-            entity.armZ = targetZ;
-            entity.armInitialized = true;
-            entity.armState = ArmState.MOVING;
-            entity.expectedTravelTicks = 0; // Already at target
-            entity.syncToClients();
-        }
-
-        if (entity.armState == ArmState.MOVING) {
-            // Consume move cost while arm is moving
-            long moveCost = entity.getMoveCost();
-            if (!entity.hasEnergy(moveCost)) {
-                return; // Wait for energy
-            }
-            entity.consumeEnergy(moveCost);
-
-            // Calculate expected travel time on first tick of movement (for settling)
-            if (entity.expectedTravelTicks == 0 && !entity.isAtTarget(targetX, targetY, targetZ)) {
-                entity.expectedTravelTicks = entity.calculateTravelTicks(targetX, targetY, targetZ);
-            }
-
-            // Move arm towards target
-            boolean reachedTarget = entity.moveArmTowards(targetX, targetY, targetZ);
-
-            if (reachedTarget) {
-                // Start settling - wait for client interpolation to catch up
-                // Use the pre-calculated travel time so client has enough time to animate
-                entity.armState = ArmState.SETTLING;
-                entity.settlingTicksRemaining = Math.max(1, entity.expectedTravelTicks);
-                entity.expectedTravelTicks = 0; // Reset for next movement
-                entity.syncToClients();
-                entity.currentTarget = target;
-            }
-        } else if (entity.armState == ArmState.SETTLING) {
-            // Wait for client interpolation to catch up
-            entity.settlingTicksRemaining--;
-            if (entity.settlingTicksRemaining <= 0) {
-                // Start breaking - energy requirement will be calculated in BREAKING state
-                entity.armState = ArmState.BREAKING;
-            }
-        } else if (entity.armState == ArmState.BREAKING) {
-            BlockState targetState = world.getBlockState(target);
-
-            // Calculate energy required if target changed
-            if (!target.equals(entity.currentTarget) || entity.currentBreakTime < 0) {
-                entity.currentTarget = target;
-                float hardness = targetState.getDestroySpeed(world, target);
-                // BC formula: BREAK_ENERGY * miningMultiplier * ((hardness + 1) * 2)
-                entity.currentBreakTime = (float) (LogisticsConfig.get().quarry.energyPerBlockMultiplier() * (hardness + 1));
-                entity.breakProgress = 0;
-            }
-
-            // Consume as much energy as possible towards breaking (like BC)
-            long energyNeeded = (long) Math.ceil(entity.currentBreakTime - entity.breakProgress);
-            long energyToUse = Math.min(entity.energy.getAmount(), energyNeeded);
-            if (energyToUse > 0) {
-                entity.consumeEnergy(energyToUse);
-                entity.breakProgress += energyToUse;
-            }
-
-            // Update block breaking animation (0-9 progress stages)
-            int breakStage = (int) ((entity.breakProgress / entity.currentBreakTime) * 10f);
-            breakStage = Math.min(breakStage, 9);
-            world.destroyBlockProgress(entity.breakingEntityId, target, breakStage);
-
-            if (entity.breakProgress >= entity.currentBreakTime) {
-                // Clear breaking animation
-                world.destroyBlockProgress(entity.breakingEntityId, target, -1);
-
-                entity.mineBlock(world, target, targetState);
-                entity.advanceMiningPosition();
-                entity.resetBreakProgress();
-
-                // Skip air blocks immediately to find the next real target
-                entity.skipToNextSolidBlock(world, state);
-
-                // Calculate the new target position and set arm there immediately
-                // The client handles smooth interpolation, so we can set the target directly
-                BlockPos nextTarget = entity.calculateMiningTargetPos(state);
-                if (nextTarget != null) {
-                    float oldArmX = entity.armX;
-                    float oldArmY = entity.armY;
-                    float oldArmZ = entity.armZ;
-
-                    // Set arm to new target position
-                    entity.armX = nextTarget.getX() + 0.5f;
-                    entity.armY = nextTarget.getY() + 1.0f;
-                    entity.armZ = nextTarget.getZ() + 0.5f;
-
-                    // Calculate travel time for settling (client interpolation catch-up)
-                    float dx = entity.armX - oldArmX;
-                    float dy = entity.armY - oldArmY;
-                    float dz = entity.armZ - oldArmZ;
-                    float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
-                    entity.expectedTravelTicks = (int) Math.ceil(distance / entity.getEffectiveArmSpeed());
-
-                    // Go directly to SETTLING to wait for client interpolation
-                    entity.armState = ArmState.SETTLING;
-                    entity.settlingTicksRemaining = Math.max(1, entity.expectedTravelTicks);
-                    entity.currentTarget = nextTarget;
-                } else {
-                    // No more targets - finished
-                    entity.armState = ArmState.MOVING;
-                }
-                entity.syncToClients();
-            }
-        }
+    int getBreakingEntityId() {
+        return breakingEntityId;
     }
 
-    /**
-     * Move the arm towards the target position.
-     * @return true if the arm has reached the target
-     */
-    private boolean moveArmTowards(float targetX, float targetY, float targetZ) {
-        float dx = targetX - armX;
-        float dy = targetY - armY;
-        float dz = targetZ - armZ;
-
-        float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
-        float speed = getEffectiveArmSpeed();
-
-        if (distance <= speed) {
-            // Close enough, snap to target
-            armX = targetX;
-            armY = targetY;
-            armZ = targetZ;
-            return true;
-        }
-
-        // Normalize and move at effective speed
-        float factor = speed / distance;
-        armX += dx * factor;
-        armY += dy * factor;
-        armZ += dz * factor;
-
-        return false;
+    int getLevelMinY() {
+        return level.getMinY();
     }
 
-    /**
-     * Check if the arm is at the target position.
-     */
-    private boolean isAtTarget(float targetX, float targetY, float targetZ) {
-        float dx = targetX - armX;
-        float dy = targetY - armY;
-        float dz = targetZ - armZ;
-        float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
-        return distance <= getEffectiveArmSpeed();
+    long getEnergyAmount() {
+        return energy.getAmount();
     }
 
-    /**
-     * Calculate how many ticks it will take to reach the target at current speed.
-     */
-    private int calculateTravelTicks(float targetX, float targetY, float targetZ) {
-        float dx = targetX - armX;
-        float dy = targetY - armY;
-        float dz = targetZ - armZ;
-        float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
-        return (int) Math.ceil(distance / getEffectiveArmSpeed());
-    }
-
-    private boolean shouldSkipBlock(Level world, BlockPos pos, BlockState state) {
-        return GridScanner.shouldSkip(world, pos, state);
-    }
-
-    private void mineBlock(ServerLevel world, BlockPos target, BlockState targetState) {
-        QuarryBlockBreaker.mineBlock(world, getBlockPos(), target, targetState);
-    }
-
-    private void advanceToNextBlock() {
-        miningX++;
-        int maxX = bounds.isCustom() ? (bounds.getMaxX() - bounds.getMinX() + 1) : LogisticsConfig.get().quarry.area;
-        int maxZ = bounds.isCustom() ? (bounds.getMaxZ() - bounds.getMinZ() + 1) : LogisticsConfig.get().quarry.area;
-
-        if (miningX >= maxX) {
-            miningX = 0;
-            miningZ++;
-            if (miningZ >= maxZ) {
-                miningZ = 0;
-                miningY++;
-            }
-        }
-        setChanged();
-    }
-
-    private @Nullable BlockPos calculateClearingTargetPos(BlockState quarryState) {
-        return GridScanner.clearingTarget(
-                LaserQuarryBlock.getMiningDirection(quarryState),
-                getBlockPos(),
-                bounds,
-                LogisticsConfig.get().quarry.area,
-                miningX,
-                miningY,
-                miningZ);
-    }
-
-    private @Nullable BlockPos calculateMiningTargetPos(BlockState quarryState) {
-        return GridScanner.miningTarget(
-                LaserQuarryBlock.getMiningDirection(quarryState),
-                getBlockPos(),
-                bounds,
-                LogisticsConfig.get().quarry.area,
-                level.getMinY(),
-                miningX,
-                miningY,
-                miningZ);
-    }
-
-    /**
-     * Advance mining position for the mining area.
-     */
-    private void advanceMiningPosition() {
-        int innerSizeX;
-        int innerSizeZ;
-        if (bounds.isCustom()) {
-            innerSizeX = bounds.getMaxX() - bounds.getMinX() - 1;
-            innerSizeZ = bounds.getMaxZ() - bounds.getMinZ() - 1;
-        } else {
-            innerSizeX = LogisticsConfig.get().quarry.area - 2;
-            innerSizeZ = LogisticsConfig.get().quarry.area - 2;
-        }
-        if (innerSizeX <= 0 || innerSizeZ <= 0) {
-            return;
-        }
-
-        miningX++;
-        if (miningX >= innerSizeX) {
-            miningX = 0;
-            miningZ++;
-            if (miningZ >= innerSizeZ) {
-                miningZ = 0;
-                miningY++;
-            }
-        }
-        setChanged();
-    }
-
-    /**
-     * Skip past air/fluid/bedrock blocks to find the next solid target.
-     * Called after mining a block to immediately find the next real target
-     * before syncing to clients (prevents arm hiccup).
-     */
-    private void skipToNextSolidBlock(ServerLevel world, BlockState quarryState) {
-        for (int skipped = 0; skipped < LogisticsConfig.get().quarry.scanRate; skipped++) {
-            BlockPos target = calculateMiningTargetPos(quarryState);
-            if (target == null) {
-                // Reached end of mining area
-                finished = true;
-                return;
-            }
-
-            BlockState targetState = world.getBlockState(target);
-            if (!shouldSkipBlock(world, target, targetState)) {
-                // Found a solid block to mine next
-                return;
-            }
-
-            advanceMiningPosition();
-        }
-    }
-
-    /**
-     * Clear any active block breaking animation.
-     * Called when the quarry stops or changes target.
-     */
-    private void clearBreakingAnimation(ServerLevel world) {
-        if (currentTarget != null) {
-            world.destroyBlockProgress(breakingEntityId, currentTarget, -1);
-        }
-    }
-
-    private @Nullable BlockPos getNextFramePosition(BlockState quarryState) {
-        return FrameLayout.nextFramePosition(
-                LaserQuarryBlock.getMiningDirection(quarryState),
-                getBlockPos(),
-                bounds,
-                LogisticsConfig.get().quarry.area,
-                frameBuildIndex);
-    }
-
-    private BlockState calculateFrameState(BlockState quarryState, BlockPos framePos) {
-        return FrameLayout.frameBlockState(
-                LaserQuarryBlock.getMiningDirection(quarryState),
-                getBlockPos(),
-                framePos,
-                bounds,
-                LogisticsConfig.get().quarry.area);
-    }
-
-    /**
-     * Set custom mining bounds from markers.
-     * The top Y is derived from the quarry's position + offset (same as default mining).
-     */
-    public void setCustomBounds(int minX, int minZ, int maxX, int maxZ) {
-        bounds.setCustom(minX, minZ, maxX, maxZ);
-        this.miningX = 0;
-        this.miningY = 0;
-        this.miningZ = 0;
-        this.finished = false;
-        setChanged();
-    }
-
-    private void resetBreakProgress() {
-        breakProgress = 0f;
-        currentTarget = null;
-        currentBreakTime = -1f;
-    }
-
-    // ==================== Energy Storage Access ====================
-
-    /**
-     * Consumes energy from the buffer if available.
-     * Sets consumedEnergyThisTick flag for LED rendering.
-     */
-    private void consumeEnergy(long amount) {
-        if (energy.getAmount() >= amount) {
-            energy.consume(amount);
-            consumedEnergyThisTick = true; // Flag for LED when buffer is low
-            setChanged();
-        }
-    }
-
-    /**
-     * Checks if the quarry has at least the specified amount of energy.
-     *
-     * @param amount the amount to check
-     * @return true if enough energy is available
-     */
-    private boolean hasEnergy(long amount) {
+    boolean hasEnergy(long amount) {
         return energy.getAmount() >= amount;
     }
 
     /**
-     * Gets the energy level as a ratio from 0.0 to 1.0.
+     * Consumes energy from the buffer if available. Sets the consumed-this-tick flag
+     * so the LED ring renders correctly.
      */
+    void consumeEnergy(long amount) {
+        if (energy.getAmount() >= amount) {
+            energy.consume(amount);
+            consumedEnergyThisTick = true;
+            setChanged();
+        }
+    }
+
+    /** Move cost per tick — scales with current buffer to drain excess energy faster. */
+    long getMoveCost() {
+        return ArmController.moveCost(energy.getAmount(), MOVE_COST_BUFFER_DIVISOR);
+    }
+
+    /** Effective arm speed in blocks/tick, including the rain penalty when applicable. */
+    float getEffectiveArmSpeed() {
+        return ArmController.effectiveSpeed(energy.getAmount(), MOVE_COST_BUFFER_DIVISOR, level, worldPosition);
+    }
+
+    // ==================== Marker / bounds API ====================
+
+    public void setCustomBounds(int minX, int minZ, int maxX, int maxZ) {
+        bounds.setCustom(minX, minZ, maxX, maxZ);
+        phaseRunner.onCustomBoundsSet();
+        setChanged();
+    }
+
+    // ==================== Energy diagnostics ====================
+
     public double getEnergyLevel() {
         return (double) energy.getAmount() / LogisticsConfig.get().quarry.energyCapacity();
     }
 
-    /**
-     * Gets the current move cost based on buffer level.
-     * Formula: ceil(20 + buffer/10) RF/tick
-     */
-    private long getMoveCost() {
-        return (long) Math.ceil(
-                LogisticsConfig.get().quarry.armEnergy + (double) energy.getAmount() / MOVE_COST_BUFFER_DIVISOR);
-    }
-
     private long getCurrentBufferDraw() {
-        if (finished) {
+        if (phaseRunner.isFinished()) {
             return 0;
         }
 
-        return switch (currentPhase) {
-            case CLEARING -> currentBreakTime < 0
+        return switch (phaseRunner.getPhase()) {
+            case CLEARING -> phaseRunner.getCurrentBreakTime() < 0
                     ? LogisticsConfig.get().quarry.maxEnergyInput()
-                    : currentBreakTime > breakProgress
-                            ? (long) Math.ceil(currentBreakTime - breakProgress)
+                    : phaseRunner.getCurrentBreakTime() > phaseRunner.getBreakProgress()
+                            ? (long) Math.ceil(phaseRunner.getCurrentBreakTime() - phaseRunner.getBreakProgress())
                             : 0;
             case BUILDING_FRAME -> FRAME_BUILD_COST;
-            case MINING -> switch (armState) {
+            case MINING -> switch (armController.getState()) {
                 case MOVING -> getMoveCost();
                 case SETTLING -> 0;
-                case BREAKING -> currentBreakTime < 0
+                case BREAKING -> phaseRunner.getCurrentBreakTime() < 0
                         ? LogisticsConfig.get().quarry.maxEnergyInput()
-                        : currentBreakTime > breakProgress
-                                ? (long) Math.ceil(currentBreakTime - breakProgress)
+                        : phaseRunner.getCurrentBreakTime() > phaseRunner.getBreakProgress()
+                                ? (long) Math.ceil(phaseRunner.getCurrentBreakTime() - phaseRunner.getBreakProgress())
                                 : 0;
             };
         };
-    }
-
-    /**
-     * Gets the effective arm speed based on energy consumption.
-     * Formula: 0.1 + (energyUsed / 2000) blocks/tick
-     * Applies rain penalty if exposed to rain.
-     */
-    private float getEffectiveArmSpeed() {
-        long moveCost = getMoveCost();
-        float speed = LogisticsConfig.get().quarry.armSpeed + (moveCost / LogisticsConfig.get().quarry.armSpeedScaling);
-
-        // Apply rain penalty if quarry is exposed to rain
-        if (level != null && level.isRainingAt(worldPosition.above())) {
-            speed *= LogisticsConfig.get().quarry.rainPenalty;
-        }
-
-        return speed;
     }
 
     @Override
@@ -728,44 +256,42 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         return energyReceivedLastTick;
     }
 
-    // ==================== Probe Support ====================
+    // ==================== Probe ====================
 
-    /**
-     * Creates probe result with quarry diagnostic information.
-     */
     public ProbeResult getProbeResult() {
         ProbeResult.Builder builder = ProbeResult.builder("Laser Quarry Status");
 
-        // Phase with required energy
-        String phaseName =
-                switch (currentPhase) {
-                    case CLEARING -> "Clearing";
-                    case BUILDING_FRAME -> "Building Frame";
-                    case MINING -> "Mining";
-                };
-        if (finished) {
+        String phaseName = switch (phaseRunner.getPhase()) {
+            case CLEARING -> "Clearing";
+            case BUILDING_FRAME -> "Building Frame";
+            case MINING -> "Mining";
+        };
+        if (phaseRunner.isFinished()) {
             builder.entry("Phase", "Finished", ChatFormatting.AQUA);
-        } else if (currentPhase == Phase.BUILDING_FRAME) {
+        } else if (phaseRunner.getPhase() == Phase.BUILDING_FRAME) {
             builder.entry("Phase", phaseName + " (need 240 RF)", ChatFormatting.AQUA);
         } else {
             builder.entry("Phase", phaseName, ChatFormatting.AQUA);
         }
 
-        // Energy
         double energyPercent = getEnergyLevel() * 100;
-        ChatFormatting energyColor =
-                energyPercent > 50 ? ChatFormatting.GREEN : energyPercent > 20 ? ChatFormatting.YELLOW : ChatFormatting.RED;
+        ChatFormatting energyColor = energyPercent > 50
+                ? ChatFormatting.GREEN
+                : energyPercent > 20 ? ChatFormatting.YELLOW : ChatFormatting.RED;
         builder.entry(
                 "Energy",
-                String.format("%,d / %,d RF (%.1f%%)", energy.getAmount(), LogisticsConfig.get().quarry.energyCapacity(), energyPercent),
+                String.format(
+                        "%,d / %,d RF (%.1f%%)",
+                        energy.getAmount(),
+                        LogisticsConfig.get().quarry.energyCapacity(),
+                        energyPercent),
                 energyColor);
 
-        // Power consumption and speed (only during active phases)
-        if (!finished) {
+        if (!phaseRunner.isFinished()) {
             builder.entry("Power In", String.format("%,d RF/t", energyReceivedLastTick), ChatFormatting.GREEN);
             builder.entry("Buffer Draw", String.format("%,d RF/t", getCurrentBufferDraw()), ChatFormatting.GOLD);
 
-            if (currentPhase == Phase.MINING) {
+            if (phaseRunner.getPhase() == Phase.MINING) {
                 float speed = getEffectiveArmSpeed();
                 String speedText = String.format("%.2f blocks/tick", speed);
                 if (level != null && level.isRainingAt(worldPosition.above())) {
@@ -775,42 +301,22 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
             }
         }
 
-        // Warnings
-        if (energy.getAmount() == 0 && !finished) {
+        if (energy.getAmount() == 0 && !phaseRunner.isFinished()) {
             builder.warning("No power!");
         }
 
         return builder.build();
     }
 
-    // NBT serialization
+    // ==================== NBT ====================
+
     @Override
     protected void saveLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
         super.saveLogisticsData(nbt, registries);
 
-        // Save energy
         energy.writeNbt(nbt, "Energy");
-
-        // Save mining state
-        nbt.putInt("MiningX", miningX);
-        nbt.putInt("MiningY", miningY);
-        nbt.putInt("MiningZ", miningZ);
-        nbt.putFloat("BreakProgress", breakProgress);
-        nbt.putBoolean("MiningFinished", finished);
-        nbt.putString("CurrentPhase", currentPhase.name());
-        nbt.putInt("FrameBuildIndex", frameBuildIndex);
-
-        // Save arm state
-        nbt.putString("ArmState", armState.name());
-        nbt.putFloat("ArmX", armX);
-        nbt.putFloat("ArmY", armY);
-        nbt.putFloat("ArmZ", armZ);
-        nbt.putBoolean("ArmInitialized", armInitialized);
-        nbt.putInt("ArmSettlingTicks", settlingTicksRemaining);
-        nbt.putInt("ArmExpectedTravelTicks", expectedTravelTicks);
-        nbt.putFloat("ArmSyncedSpeed", syncedArmSpeed);
-
-        // Save custom bounds
+        phaseRunner.save(nbt);
+        armController.save(nbt);
         bounds.save(nbt);
     }
 
@@ -818,44 +324,14 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
     protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
         super.loadLogisticsData(nbt, registries);
 
-        // Load energy (try new key first, fall back to legacy)
         if (nbt.contains("Energy")) {
             energy.readNbt(nbt, "Energy");
         } else {
             energy.setAmount(NbtCompat.getLong(nbt, "StoredEnergy", 0L));
         }
 
-        // Load mining state
-        miningX = NbtCompat.getInt(nbt, "MiningX", 0);
-        miningY = NbtCompat.getInt(nbt, "MiningY", 0);
-        miningZ = NbtCompat.getInt(nbt, "MiningZ", 0);
-        breakProgress = NbtCompat.getFloat(nbt, "BreakProgress", 0f);
-        finished = NbtCompat.getBoolean(nbt, "MiningFinished", false);
-        frameBuildIndex = NbtCompat.getInt(nbt, "FrameBuildIndex", 0);
-
-        String phaseName = NbtCompat.getString(nbt, "CurrentPhase", "CLEARING");
-        try {
-            currentPhase = Phase.valueOf(phaseName);
-        } catch (IllegalArgumentException e) {
-            currentPhase = Phase.CLEARING;
-        }
-
-        // Load arm state
-        String armStateName = NbtCompat.getString(nbt, "ArmState", "MOVING");
-        try {
-            armState = ArmState.valueOf(armStateName);
-        } catch (IllegalArgumentException e) {
-            armState = ArmState.MOVING;
-        }
-        armX = NbtCompat.getFloat(nbt, "ArmX", 0f);
-        armY = NbtCompat.getFloat(nbt, "ArmY", 0f);
-        armZ = NbtCompat.getFloat(nbt, "ArmZ", 0f);
-        armInitialized = NbtCompat.getBoolean(nbt, "ArmInitialized", false);
-        settlingTicksRemaining = NbtCompat.getInt(nbt, "ArmSettlingTicks", 0);
-        expectedTravelTicks = NbtCompat.getInt(nbt, "ArmExpectedTravelTicks", 0);
-        syncedArmSpeed = NbtCompat.getFloat(nbt, "ArmSyncedSpeed", 0.0f);
-
-        // Load custom bounds
+        phaseRunner.load(nbt);
+        armController.load(nbt);
         bounds.load(nbt);
     }
 
@@ -865,52 +341,23 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
         bounds.clear();
 
-        // Load energy from old "Energy" tag
-        view.read("Energy", CompoundTag.CODEC).ifPresent(energyState -> {
-            energy.setAmount(NbtCompat.getLong(energyState, "Amount", 0L));
-        });
+        view.read("Energy", CompoundTag.CODEC)
+                .ifPresent(energyState -> energy.setAmount(NbtCompat.getLong(energyState, "Amount", 0L)));
 
-        // Load mining state from old "MiningState" tag
         view.read("MiningState", CompoundTag.CODEC).ifPresent(miningState -> {
-            miningX = NbtCompat.getInt(miningState, "X", 0);
-            miningY = NbtCompat.getInt(miningState, "Y", 0);
-            miningZ = NbtCompat.getInt(miningState, "Z", 0);
-            breakProgress = NbtCompat.getFloat(miningState, "Progress", 0f);
-            finished = NbtCompat.getBoolean(miningState, "Finished", false);
-            frameBuildIndex = NbtCompat.getInt(miningState, "FrameBuildIndex", 0);
-
-            String phaseName = NbtCompat.getString(miningState, "Phase", "CLEARING");
-            try {
-                currentPhase = Phase.valueOf(phaseName);
-            } catch (IllegalArgumentException e) {
-                currentPhase = Phase.CLEARING;
-            }
-
-            // Load arm state
-            String armStateName = NbtCompat.getString(miningState, "ArmState", "MOVING");
-            try {
-                armState = ArmState.valueOf(armStateName);
-            } catch (IllegalArgumentException e) {
-                armState = ArmState.MOVING;
-            }
-            armX = NbtCompat.getFloat(miningState, "ArmX", 0f);
-            armY = NbtCompat.getFloat(miningState, "ArmY", 0f);
-            armZ = NbtCompat.getFloat(miningState, "ArmZ", 0f);
-            armInitialized = NbtCompat.getBoolean(miningState, "ArmInitialized", false);
-            settlingTicksRemaining = NbtCompat.getInt(miningState, "SettlingTicks", 0);
-            expectedTravelTicks = NbtCompat.getInt(miningState, "ExpectedTravelTicks", 0);
-            syncedArmSpeed = NbtCompat.getFloat(miningState, "SyncedArmSpeed", 0.0f);
+            phaseRunner.loadLegacy(miningState);
+            armController.loadLegacy(miningState);
         });
 
-        // Load custom bounds from old "CustomBounds" tag
-        view.read("CustomBounds", CompoundTag.CODEC).ifPresent(customBoundsNbt -> {
-            bounds.loadLegacy(
-                    NbtCompat.getInt(customBoundsNbt, "MinX", 0),
-                    NbtCompat.getInt(customBoundsNbt, "MinZ", 0),
-                    NbtCompat.getInt(customBoundsNbt, "MaxX", 0),
-                    NbtCompat.getInt(customBoundsNbt, "MaxZ", 0));
-        });
+        view.read("CustomBounds", CompoundTag.CODEC)
+                .ifPresent(customBoundsNbt -> bounds.loadLegacy(
+                        NbtCompat.getInt(customBoundsNbt, "MinX", 0),
+                        NbtCompat.getInt(customBoundsNbt, "MinZ", 0),
+                        NbtCompat.getInt(customBoundsNbt, "MaxX", 0),
+                        NbtCompat.getInt(customBoundsNbt, "MaxZ", 0)));
     }
+
+    // ==================== Lifecycle ====================
 
     @Override
     public void preRemoveSideEffects(BlockPos pos, BlockState oldState) {
@@ -922,7 +369,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
         if (level != null && !level.isClientSide()) {
             ActiveQuarryRegistry.unregister((ServerLevel) level, pos);
-            // Clear any active breaking animation
+            BlockPos currentTarget = phaseRunner.getCurrentTarget();
             if (currentTarget != null) {
                 ((ServerLevel) level).destroyBlockProgress(breakingEntityId, currentTarget, -1);
             }
@@ -937,44 +384,44 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         }
     }
 
+    // ==================== Public getters (renderer / frame block / probe) ====================
+
     public Phase getCurrentPhase() {
-        return currentPhase;
+        return phaseRunner.getPhase();
     }
 
-    // Arm position getters for renderer
     public float getArmX() {
-        return armX;
+        return armController.getX();
     }
 
     public float getArmY() {
-        return armY;
+        return armController.getY();
     }
 
     public float getArmZ() {
-        return armZ;
+        return armController.getZ();
     }
 
     public ArmState getArmState() {
-        return armState;
+        return armController.getState();
     }
 
     public float getSyncedArmSpeed() {
-        return syncedArmSpeed;
+        return armController.getSyncedSpeed();
     }
 
     public boolean isArmInitialized() {
-        return armInitialized;
+        return armController.isInitialized();
     }
 
     public boolean isFinished() {
-        return finished;
+        return phaseRunner.isFinished();
     }
 
     public boolean consumedEnergyThisTick() {
         return consumedEnergyThisTick;
     }
 
-    // Custom bounds getters for frame decay logic
     public boolean hasCustomBounds() {
         return bounds.isCustom();
     }
@@ -997,8 +444,7 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
 
     /** True if the quarry has been placed but hasn't started any clearing yet. */
     public boolean isFreshlyPlaced() {
-        return currentPhase == Phase.CLEARING
-                && miningX == 0 && miningY == 0 && miningZ == 0 && breakProgress == 0;
+        return phaseRunner.isFreshlyPlaced();
     }
 
     public static List<BlockPos> getActiveQuarries(ServerLevel world) {
@@ -1009,30 +455,23 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity implements PipeConne
         ActiveQuarryRegistry.clear(world);
     }
 
-    // PipeConnection interface implementation
+    // ==================== PipeConnection ====================
 
     /**
-     * Quarry accepts pipe connections from above.
-     * Returns PIPE connection type so pipes render arms to the quarry.
-     * Returns NONE for all other directions.
+     * Quarry accepts pipe connections from above so pipes render arms to it.
+     * Other directions report no connection.
      */
     @Override
     public PipeConnection.Type getConnectionType(Direction direction) {
         return direction == Direction.UP ? PipeConnection.Type.PIPE : PipeConnection.Type.NONE;
     }
 
-    /**
-     * Quarry does not accept items from pipes.
-     * It only pushes items out.
-     */
+    /** Quarry never accepts items from pipes — it only pushes them out. */
     @Override
     public boolean addItem(Direction from, ItemStack stack) {
         return false;
     }
 
-    /**
-     * Quarry never accepts items from any direction.
-     */
     @Override
     public boolean canAcceptFrom(Direction from, ItemStack stack) {
         return false;

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -1,0 +1,447 @@
+package com.logistics.automation.laserquarry.entity;
+
+import com.logistics.automation.laserquarry.LaserQuarryBlock;
+import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity.ArmState;
+import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity.Phase;
+import com.logistics.core.LogisticsConfig;
+import com.logistics.core.lib.compat.NbtCompat;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Owns the laser quarry's per-phase execution state — {@code Phase} dispatch,
+ * the frame-build cursor, the mining grid cursor, and the in-flight break
+ * progress — plus the {@code tick} routines that drive {@link ArmController}
+ * and call back into the block entity for energy/world side effects.
+ *
+ * <p>All NBT keys remain identical to the pre-refactor block entity layout so
+ * existing worlds load unchanged.
+ */
+public final class QuarryPhaseRunner {
+
+    private Phase phase = Phase.CLEARING;
+    private int frameBuildIndex = 0;
+
+    private int miningX = 0;
+    private int miningY = 0;
+    private int miningZ = 0;
+    private float breakProgress = 0f;
+    private boolean finished = false;
+
+    private @Nullable BlockPos currentTarget = null;
+    private float currentBreakTime = -1f;
+
+    // ==================== Getters used by BE / probe / save ====================
+
+    public Phase getPhase() {
+        return phase;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public int getMiningX() {
+        return miningX;
+    }
+
+    public int getMiningY() {
+        return miningY;
+    }
+
+    public int getMiningZ() {
+        return miningZ;
+    }
+
+    public float getBreakProgress() {
+        return breakProgress;
+    }
+
+    public float getCurrentBreakTime() {
+        return currentBreakTime;
+    }
+
+    public @Nullable BlockPos getCurrentTarget() {
+        return currentTarget;
+    }
+
+    public void clearCurrentTarget() {
+        this.currentTarget = null;
+    }
+
+    /** Marker callback: bounds changed, restart the mining cursor and finished flag. */
+    public void onCustomBoundsSet() {
+        miningX = 0;
+        miningY = 0;
+        miningZ = 0;
+        finished = false;
+    }
+
+    /** True if the quarry has been placed but hasn't started any clearing yet. */
+    public boolean isFreshlyPlaced() {
+        return phase == Phase.CLEARING && miningX == 0 && miningY == 0 && miningZ == 0 && breakProgress == 0;
+    }
+
+    // ==================== Tick dispatch ====================
+
+    public void tick(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
+        switch (phase) {
+            case CLEARING -> tickClearing(be, world, pos, state);
+            case BUILDING_FRAME -> tickBuildingFrame(be, world, state);
+            case MINING -> tickMining(be, world, state);
+            default -> {}
+        }
+    }
+
+    private void tickClearing(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
+        if (be.getEnergyAmount() == 0) {
+            resetBreakProgress();
+            return;
+        }
+
+        BlockPos target = null;
+        BlockState targetState = null;
+        for (int skipped = 0; skipped < LogisticsConfig.get().quarry.scanRate; skipped++) {
+            target = clearingTargetPos(be, state);
+            if (target == null) {
+                phase = Phase.BUILDING_FRAME;
+                frameBuildIndex = 0;
+                be.setChanged();
+                return;
+            }
+
+            targetState = world.getBlockState(target);
+            if (!GridScanner.shouldSkip(world, target, targetState)) {
+                break;
+            }
+
+            advanceToNextBlock(be);
+            resetBreakProgress();
+        }
+
+        if (GridScanner.shouldSkip(world, target, targetState)) {
+            return;
+        }
+
+        if (!target.equals(currentTarget) || currentBreakTime < 0) {
+            currentTarget = target;
+            float hardness = targetState.getDestroySpeed(world, target);
+            currentBreakTime = (float) (LogisticsConfig.get().quarry.energyPerBlockMultiplier() * (hardness + 1));
+            breakProgress = 0;
+        }
+
+        long energyNeeded = (long) Math.ceil(currentBreakTime - breakProgress);
+        long energyToUse = Math.min(be.getEnergyAmount(), energyNeeded);
+        if (energyToUse > 0) {
+            be.consumeEnergy(energyToUse);
+            breakProgress += energyToUse;
+        }
+
+        if (breakProgress >= currentBreakTime) {
+            QuarryBlockBreaker.mineBlock(world, be.getBlockPos(), target, targetState);
+            advanceToNextBlock(be);
+            resetBreakProgress();
+        }
+    }
+
+    private void tickBuildingFrame(LaserQuarryBlockEntity be, ServerLevel world, BlockState state) {
+        if (!be.hasEnergy(LaserQuarryBlockEntity.FRAME_BUILD_COST)) {
+            return;
+        }
+
+        BlockPos framePos = FrameLayout.nextFramePosition(
+                LaserQuarryBlock.getMiningDirection(state),
+                be.getBlockPos(),
+                be.getBounds(),
+                LogisticsConfig.get().quarry.area,
+                frameBuildIndex);
+        if (framePos == null) {
+            // Frame built — transition to mining.
+            phase = Phase.MINING;
+            miningX = 0;
+            miningY = 0;
+            miningZ = 0;
+            be.getArmController().resetExpectedTravelTicks();
+            // armInitialized flips false so first MINING tick re-anchors the arm.
+            be.getArmController().enterMoving();
+            be.getArmController().markUninitialized();
+            be.syncToClients();
+            be.setChanged();
+            return;
+        }
+
+        be.consumeEnergy(LaserQuarryBlockEntity.FRAME_BUILD_COST);
+
+        BlockState existingState = world.getBlockState(framePos);
+        if (existingState.isAir() || existingState.canBeReplaced()) {
+            BlockState frameState = FrameLayout.frameBlockState(
+                    LaserQuarryBlock.getMiningDirection(state),
+                    be.getBlockPos(),
+                    framePos,
+                    be.getBounds(),
+                    LogisticsConfig.get().quarry.area);
+            world.setBlockAndUpdate(framePos, frameState);
+        }
+
+        frameBuildIndex++;
+        be.setChanged();
+    }
+
+    private void tickMining(LaserQuarryBlockEntity be, ServerLevel world, BlockState state) {
+        ArmController arm = be.getArmController();
+
+        BlockPos target = null;
+        boolean skippedAny = false;
+        for (int skipped = 0; skipped < LogisticsConfig.get().quarry.scanRate; skipped++) {
+            target = miningTargetPos(be, state);
+            if (target == null) {
+                if (currentTarget != null) {
+                    world.destroyBlockProgress(be.getBreakingEntityId(), currentTarget, -1);
+                }
+                finished = true;
+                be.setChanged();
+                be.syncToClients();
+                return;
+            }
+
+            BlockState targetState = world.getBlockState(target);
+            if (!GridScanner.shouldSkip(world, target, targetState)) {
+                break;
+            }
+
+            advanceMiningPosition(be);
+            target = null;
+            skippedAny = true;
+        }
+
+        if (target == null) {
+            return;
+        }
+
+        if (skippedAny) {
+            be.syncToClients();
+        }
+
+        float targetX = target.getX() + 0.5f;
+        float targetY = target.getY() + 1.0f;
+        float targetZ = target.getZ() + 0.5f;
+
+        if (!arm.isInitialized()) {
+            arm.initializeAt(targetX, targetY, targetZ);
+            be.syncToClients();
+        }
+
+        if (arm.getState() == ArmState.MOVING) {
+            long moveCost = be.getMoveCost();
+            if (!be.hasEnergy(moveCost)) {
+                return;
+            }
+            be.consumeEnergy(moveCost);
+
+            float speed = be.getEffectiveArmSpeed();
+            if (arm.getExpectedTravelTicks() == 0 && !arm.isAt(targetX, targetY, targetZ, speed)) {
+                arm.setExpectedTravelTicks(arm.travelTicksFor(targetX, targetY, targetZ, speed));
+            }
+
+            boolean reachedTarget = arm.moveTowards(targetX, targetY, targetZ, speed);
+
+            if (reachedTarget) {
+                arm.enterSettling(arm.getExpectedTravelTicks());
+                arm.resetExpectedTravelTicks();
+                be.syncToClients();
+                currentTarget = target;
+            }
+        } else if (arm.getState() == ArmState.SETTLING) {
+            if (arm.tickSettling()) {
+                arm.enterBreaking();
+            }
+        } else if (arm.getState() == ArmState.BREAKING) {
+            BlockState targetState = world.getBlockState(target);
+
+            if (!target.equals(currentTarget) || currentBreakTime < 0) {
+                currentTarget = target;
+                float hardness = targetState.getDestroySpeed(world, target);
+                currentBreakTime = (float) (LogisticsConfig.get().quarry.energyPerBlockMultiplier() * (hardness + 1));
+                breakProgress = 0;
+            }
+
+            long energyNeeded = (long) Math.ceil(currentBreakTime - breakProgress);
+            long energyToUse = Math.min(be.getEnergyAmount(), energyNeeded);
+            if (energyToUse > 0) {
+                be.consumeEnergy(energyToUse);
+                breakProgress += energyToUse;
+            }
+
+            int breakStage = (int) ((breakProgress / currentBreakTime) * 10f);
+            breakStage = Math.min(breakStage, 9);
+            world.destroyBlockProgress(be.getBreakingEntityId(), target, breakStage);
+
+            if (breakProgress >= currentBreakTime) {
+                world.destroyBlockProgress(be.getBreakingEntityId(), target, -1);
+
+                QuarryBlockBreaker.mineBlock(world, be.getBlockPos(), target, targetState);
+                advanceMiningPosition(be);
+                resetBreakProgress();
+
+                skipToNextSolidBlock(be, world, state);
+
+                BlockPos nextTarget = miningTargetPos(be, state);
+                if (nextTarget != null) {
+                    float newX = nextTarget.getX() + 0.5f;
+                    float newY = nextTarget.getY() + 1.0f;
+                    float newZ = nextTarget.getZ() + 0.5f;
+
+                    arm.warpTo(newX, newY, newZ, be.getEffectiveArmSpeed());
+                    arm.enterSettling(arm.getExpectedTravelTicks());
+                    currentTarget = nextTarget;
+                } else {
+                    arm.enterMoving();
+                }
+                be.syncToClients();
+            }
+        }
+    }
+
+    // ==================== Internal grid math ====================
+
+    private @Nullable BlockPos clearingTargetPos(LaserQuarryBlockEntity be, BlockState quarryState) {
+        return GridScanner.clearingTarget(
+                LaserQuarryBlock.getMiningDirection(quarryState),
+                be.getBlockPos(),
+                be.getBounds(),
+                LogisticsConfig.get().quarry.area,
+                miningX,
+                miningY,
+                miningZ);
+    }
+
+    private @Nullable BlockPos miningTargetPos(LaserQuarryBlockEntity be, BlockState quarryState) {
+        return GridScanner.miningTarget(
+                LaserQuarryBlock.getMiningDirection(quarryState),
+                be.getBlockPos(),
+                be.getBounds(),
+                LogisticsConfig.get().quarry.area,
+                be.getLevelMinY(),
+                miningX,
+                miningY,
+                miningZ);
+    }
+
+    private void advanceToNextBlock(LaserQuarryBlockEntity be) {
+        miningX++;
+        int maxX = be.getBounds().isCustom()
+                ? (be.getBounds().getMaxX() - be.getBounds().getMinX() + 1)
+                : LogisticsConfig.get().quarry.area;
+        int maxZ = be.getBounds().isCustom()
+                ? (be.getBounds().getMaxZ() - be.getBounds().getMinZ() + 1)
+                : LogisticsConfig.get().quarry.area;
+
+        if (miningX >= maxX) {
+            miningX = 0;
+            miningZ++;
+            if (miningZ >= maxZ) {
+                miningZ = 0;
+                miningY++;
+            }
+        }
+        be.setChanged();
+    }
+
+    private void advanceMiningPosition(LaserQuarryBlockEntity be) {
+        int innerSizeX;
+        int innerSizeZ;
+        QuarryBounds bounds = be.getBounds();
+        if (bounds.isCustom()) {
+            innerSizeX = bounds.getMaxX() - bounds.getMinX() - 1;
+            innerSizeZ = bounds.getMaxZ() - bounds.getMinZ() - 1;
+        } else {
+            innerSizeX = LogisticsConfig.get().quarry.area - 2;
+            innerSizeZ = LogisticsConfig.get().quarry.area - 2;
+        }
+        if (innerSizeX <= 0 || innerSizeZ <= 0) {
+            return;
+        }
+
+        miningX++;
+        if (miningX >= innerSizeX) {
+            miningX = 0;
+            miningZ++;
+            if (miningZ >= innerSizeZ) {
+                miningZ = 0;
+                miningY++;
+            }
+        }
+        be.setChanged();
+    }
+
+    private void skipToNextSolidBlock(LaserQuarryBlockEntity be, ServerLevel world, BlockState quarryState) {
+        for (int skipped = 0; skipped < LogisticsConfig.get().quarry.scanRate; skipped++) {
+            BlockPos target = miningTargetPos(be, quarryState);
+            if (target == null) {
+                finished = true;
+                return;
+            }
+
+            BlockState targetState = world.getBlockState(target);
+            if (!GridScanner.shouldSkip(world, target, targetState)) {
+                return;
+            }
+
+            advanceMiningPosition(be);
+        }
+    }
+
+    private void resetBreakProgress() {
+        breakProgress = 0f;
+        currentTarget = null;
+        currentBreakTime = -1f;
+    }
+
+    // ==================== NBT ====================
+
+    public void save(CompoundTag tag) {
+        tag.putInt("MiningX", miningX);
+        tag.putInt("MiningY", miningY);
+        tag.putInt("MiningZ", miningZ);
+        tag.putFloat("BreakProgress", breakProgress);
+        tag.putBoolean("MiningFinished", finished);
+        tag.putString("CurrentPhase", phase.name());
+        tag.putInt("FrameBuildIndex", frameBuildIndex);
+    }
+
+    public void load(CompoundTag tag) {
+        miningX = NbtCompat.getInt(tag, "MiningX", 0);
+        miningY = NbtCompat.getInt(tag, "MiningY", 0);
+        miningZ = NbtCompat.getInt(tag, "MiningZ", 0);
+        breakProgress = NbtCompat.getFloat(tag, "BreakProgress", 0f);
+        finished = NbtCompat.getBoolean(tag, "MiningFinished", false);
+        frameBuildIndex = NbtCompat.getInt(tag, "FrameBuildIndex", 0);
+
+        String phaseName = NbtCompat.getString(tag, "CurrentPhase", "CLEARING");
+        try {
+            phase = Phase.valueOf(phaseName);
+        } catch (IllegalArgumentException e) {
+            phase = Phase.CLEARING;
+        }
+    }
+
+    /** Load from the legacy {@code MiningState} compound. */
+    public void loadLegacy(CompoundTag miningStateTag) {
+        miningX = NbtCompat.getInt(miningStateTag, "X", 0);
+        miningY = NbtCompat.getInt(miningStateTag, "Y", 0);
+        miningZ = NbtCompat.getInt(miningStateTag, "Z", 0);
+        breakProgress = NbtCompat.getFloat(miningStateTag, "Progress", 0f);
+        finished = NbtCompat.getBoolean(miningStateTag, "Finished", false);
+        frameBuildIndex = NbtCompat.getInt(miningStateTag, "FrameBuildIndex", 0);
+
+        String phaseName = NbtCompat.getString(miningStateTag, "Phase", "CLEARING");
+        try {
+            phase = Phase.valueOf(phaseName);
+        } catch (IllegalArgumentException e) {
+            phase = Phase.CLEARING;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Final step of #395. Pulls the laser quarry's arm kinematics + state and the per-phase tick logic into two focused classes. `LaserQuarryBlockEntity` drops from 1545 lines to roughly 430 — it now owns only energy, bounds, the breaking-animation entity id, and delegation glue.

## Changes
- New `ArmController` owns `armState`, `armX/Y/Z`, `armInitialized`, `settlingTicksRemaining`, `expectedTravelTicks`, `syncedSpeed`. Methods: `moveTowards`, `isAt`, `travelTicksFor`, `enterMoving/Settling/Breaking`, `tickSettling`, `warpTo`, `initializeAt`, `markUninitialized`, plus static `moveCost`/`effectiveSpeed` for the rain-aware speed math.
- New `QuarryPhaseRunner` owns `currentPhase`, `frameBuildIndex`, `miningX/Y/Z`, `breakProgress`, `finished`, `currentTarget`, `currentBreakTime`. Implements `tick(...)` dispatching to private `tickClearing` / `tickBuildingFrame` / `tickMining`, plus `advanceToNextBlock`, `advanceMiningPosition`, `skipToNextSolidBlock`, `resetBreakProgress`, and the marker callback `onCustomBoundsSet`.
- `LaserQuarryBlockEntity.tick(...)` is now a thin shim: reset per-tick energy counters → `phaseRunner.tick(this, world, pos, state)` → idle drain → sync when energy/consumption changed.
- BE keeps `energy`, the per-tick energy tracking + capability surface, `bounds`, and `breakingEntityId`. Package-private accessors (`getBounds`, `getArmController`, `getEnergyAmount`, `consumeEnergy`, `hasEnergy`, `getBreakingEntityId`, `getLevelMinY`, `getMoveCost`, `getEffectiveArmSpeed`, `syncToClients`) wire the collaborators back to BE-owned state.
- All public getters (`getArmX/Y/Z`, `getArmState`, `getSyncedArmSpeed`, `isArmInitialized`, `getCurrentPhase`, `isFinished`, `isFreshlyPlaced`) become one-line delegates. `Phase` and `ArmState` enums stay on `LaserQuarryBlockEntity` so the renderer's imports don't change.
- NBT keys preserved exactly (`MiningX/Y/Z`, `BreakProgress`, `MiningFinished`, `CurrentPhase`, `FrameBuildIndex`, `ArmState`, `ArmX/Y/Z`, `ArmInitialized`, `ArmSettlingTicks`, `ArmExpectedTravelTicks`, `ArmSyncedSpeed`, `CustomBounds*`, `Energy`). Legacy `MiningState` and `CustomBounds` compound migrations route through `ArmController.loadLegacy` / `QuarryPhaseRunner.loadLegacy` / `QuarryBounds.loadLegacy`.

## Notes
- No new tests in this PR — the tick logic is entangled with `ServerLevel` and is best exercised via `runClient` smoke (CLEARING → BUILDING_FRAME → MINING transitions, arm movement, custom-bounds marker placement, save/reload).
- No behavior changes intended. The full sequence — energy gating, arm settling, BC-style break-energy accounting, post-break warp + settling to next target — matches the pre-refactor flow line-for-line.
- Refs #395. Stacked on top of #405. Closes #395 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)