### PR TITLE
fix: enable custom Minecraft version range in build workflows

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -91,6 +91,7 @@ jobs:
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
           game-version-filter: releases
+          game-versions: ${{ steps.version.outputs.minecraft_version }}
           version-type: beta
           version: ${{ steps.version.outputs.full_version }}
           name: "Logistics v${{ steps.version.outputs.pre_version }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -209,6 +209,7 @@ jobs:
           github-tag: ${{ steps.version.outputs.tag }}
 
           game-version-filter: ${{ steps.version.outputs.game_version_filter }}
+          game-versions: ${{ steps.version.outputs.minecraft_version }}
           version-type: ${{ steps.version.outputs.version_type }}
           name: "Logistics v${{ steps.version.outputs.version }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"
           version: "${{ steps.version.outputs.full_version }}"

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -114,6 +114,7 @@ jobs:
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
           game-version-filter: ${{ steps.version.outputs.game_version_filter }}
+          game-versions: ${{ steps.version.outputs.minecraft_version }}
           version-type: beta
           version: ${{ steps.version.outputs.full_version }}
           name: "Logistics ${{ steps.version.outputs.pre_id }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 processResources {
     inputs.property "version", project.version
     inputs.property "minecraft_version", rootProject.minecraft_version
+    inputs.property "fabric_minecraft_version_range", rootProject.fabric_minecraft_version_range
     inputs.property "fabric_version", rootProject.fabric_version
     inputs.property "fabric_loader_version", rootProject.fabric_loader_version
     inputs.property "java_version", rootProject.java_version

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     "fabric-api": ">=${fabric_version}",
     "fabricloader": ">=${fabric_loader_version}",
     "java": ">=${java_version}",
-    "minecraft": ">=${minecraft_version}"
+    "minecraft": "${fabric_minecraft_version_range}"
   },
   "description": "A modern logistics and pipe mod with authentic in-pipe item motion, mod interoperability, and request/autocrafting systems.",
   "entrypoints": {
@@ -31,4 +31,3 @@
   },
   "version": "${version}"
 }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ archives_base_name=logistics
 
 # Minecraft
 minecraft_version=26.1
+fabric_minecraft_version_range=>=26.1 <26.2
 java_version=25
 
 # Fabric


### PR DESCRIPTION
## Summary
This update enhances the build workflows by introducing support for custom Minecraft version ranges. This change enables greater flexibility in managing version compatibility within the logistics mod ecosystem, ensuring smoother integration with varying Minecraft versions.

## Changes
- **Build Workflows**:
  - Modified `.github/workflows/build-prerelease.yml`, `.github/workflows/build-release.yml`, and `.github/workflows/build-snapshot.yml` to support custom Minecraft version ranges in workflow configurations.
  
- **Gradle Configuration**:
  - Updated `fabric/build.gradle` to incorporate the new `fabric_minecraft_version_range` property, allowing dynamic version handling during builds.
  
- **Fabric Mod Descriptor**:
  - Adjusted `fabric/src/main/resources/fabric.mod.json` to utilize a custom version range for the Minecraft dependency, improving version compatibility checks.

- **Gradle Properties**:
  - Introduced `fabric_minecraft_version_range` in `gradle.properties` to define valid version ranges for Minecraft, enhancing build accuracy according to target Minecraft versions.

## Notes
- This update may require maintainers to adjust their environment configurations to align with the new Minecraft version range settings in their build workflows.