### PR TITLE
fix: update Minecraft version compatibility range for NeoForge

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -60,9 +60,15 @@ dependencies {
 }
 
 processResources {
+    def compatibilityBounds = rootProject.minecraft_compatibility_versions.split(',', 2).collect { it.trim() }
+    if (compatibilityBounds.size() != 2 || compatibilityBounds.any { it.isEmpty() }) {
+        throw new GradleException("minecraft_compatibility_versions must be formatted as '<min>,<next>'")
+    }
+    def fabricMinecraftVersionRange = ">=${compatibilityBounds[0]} <${compatibilityBounds[1]}"
+
     inputs.property "version", project.version
     inputs.property "minecraft_version", rootProject.minecraft_version
-    inputs.property "fabric_minecraft_version_range", rootProject.fabric_minecraft_version_range
+    inputs.property "fabric_minecraft_version_range", fabricMinecraftVersionRange
     inputs.property "fabric_version", rootProject.fabric_version
     inputs.property "fabric_loader_version", rootProject.fabric_loader_version
     inputs.property "java_version", rootProject.java_version

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 }
 
 processResources {
-    def compatibilityBounds = rootProject.minecraft_compatibility_versions.split(',', 2).collect { it.trim() }
+    def compatibilityBounds = rootProject.minecraft_compatibility_versions.split(',').collect { it.trim() }
     if (compatibilityBounds.size() != 2 || compatibilityBounds.any { it.isEmpty() }) {
         throw new GradleException("minecraft_compatibility_versions must be formatted as '<min>,<next>'")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ archives_base_name=logistics
 
 # Minecraft
 minecraft_version=26.1
-fabric_minecraft_version_range=>=26.1 <26.2
+minecraft_compatibility_versions=26.1,26.2
 java_version=25
 
 # Fabric
@@ -25,7 +25,6 @@ fabric_energy_version=5.0.0
 # check versions at https://projects.neoforged.net/neoforged/neoforge
 neoforge_version=26.1.0.5-beta
 neoforge_loader_version_range=[4,)
-minecraft_version_range=[26.1, 26.2)
 neo_form_version=26.1-1
 moddev_version=2.0.141
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ archives_base_name=logistics
 
 # Minecraft
 minecraft_version=26.1
+# Half-open compatibility range as exactly "<min>,<next>" with no spaces; min is inclusive, next is exclusive.
 minecraft_compatibility_versions=26.1,26.2
 java_version=25
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -70,12 +70,18 @@ test {
 }
 
 processResources {
+    def compatibilityBounds = minecraft_compatibility_versions.split(',', 2).collect { it.trim() }
+    if (compatibilityBounds.size() != 2 || compatibilityBounds.any { it.isEmpty() }) {
+        throw new GradleException("minecraft_compatibility_versions must be formatted as '<min>,<next>'")
+    }
+    def neoforgeMinecraftVersionRange = "[${compatibilityBounds[0]}, ${compatibilityBounds[1]})"
+
     var expandProps = [
-        'version'                      : version,
-        'minecraft_version'            : minecraft_version,
-        'minecraft_version_range'      : minecraft_version_range,
-        'neoforge_version'             : neoforge_version,
-        'neoforge_loader_version_range': neoforge_loader_version_range,
+        'version'                         : version,
+        'minecraft_version'               : minecraft_version,
+        'neoforge_minecraft_version_range': neoforgeMinecraftVersionRange,
+        'neoforge_version'                : neoforge_version,
+        'neoforge_loader_version_range'   : neoforge_loader_version_range,
     ]
     filesMatching('META-INF/neoforge.mods.toml') {
         expand expandProps

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -70,18 +70,18 @@ test {
 }
 
 processResources {
-    def compatibilityBounds = minecraft_compatibility_versions.split(',', 2).collect { it.trim() }
+    def compatibilityBounds = rootProject.minecraft_compatibility_versions.split(',').collect { it.trim() }
     if (compatibilityBounds.size() != 2 || compatibilityBounds.any { it.isEmpty() }) {
         throw new GradleException("minecraft_compatibility_versions must be formatted as '<min>,<next>'")
     }
     def neoforgeMinecraftVersionRange = "[${compatibilityBounds[0]}, ${compatibilityBounds[1]})"
 
     var expandProps = [
-        'version'                         : version,
-        'minecraft_version'               : minecraft_version,
+        'version'                         : project.version,
+        'minecraft_version'               : rootProject.minecraft_version,
         'neoforge_minecraft_version_range': neoforgeMinecraftVersionRange,
-        'neoforge_version'                : neoforge_version,
-        'neoforge_loader_version_range'   : neoforge_loader_version_range,
+        'neoforge_version'                : rootProject.neoforge_version,
+        'neoforge_loader_version_range'   : rootProject.neoforge_loader_version_range,
     ]
     filesMatching('META-INF/neoforge.mods.toml') {
         expand expandProps

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -21,6 +21,6 @@ side="BOTH"
 [[dependencies.logistics]]
 modId="minecraft"
 type="required"
-versionRange="${minecraft_version_range}"
+versionRange="${neoforge_minecraft_version_range}"
 ordering="NONE"
 side="BOTH"


### PR DESCRIPTION
**Summary**  
This update incorporates shared compatibility bounds for Minecraft versions into the build configuration, enhancing the clarity and accuracy of version management across multiple platforms. This is particularly important for ensuring a seamless experience for users integrating new versions.

**Changes**  
- **Minecraft Compatibility:**  
  - Added shared compatibility bounds for Minecraft versions, allowing for better range definition in the project setup.
  - Updated build scripts to ensure compatibility bounds are formatted and managed correctly for both Fabric and NeoForge integrations.
  
- **Build Configuration Updates:**  
  - Adjusted `gradle.properties` to define and streamline the Minecraft version compatibility, replacing the previous specific range setup.
  - Updated NeoForge's `build.gradle` for dynamic inclusion of version ranges derived from the new properties, ensuring better cross-version support.  

**Notes**  
- Users are encouraged to verify compatibility settings after updating as changes may impact how mods interact across different Minecraft versions.  
- This enhancement lays the groundwork for future multi-loader support and compatibility improvements, contributing to a more robust logistics framework.