### PR TITLE
ci: update actions to skip draft PRs and title/body edits

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -43,11 +43,10 @@ jobs:
 
   lint:
     name: lint (${{ matrix.module }})
-    # Skip: draft PRs, release-please PRs
+    # Skip draft PRs and title/body edits.
     if: |
       github.event.action != 'edited' &&
-      github.event.pull_request.draft == false &&
-      !startsWith(github.head_ref, 'release-please--')
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -75,11 +74,10 @@ jobs:
 
   test:
     name: test (${{ matrix.module }})
-    # Skip: draft PRs, release-please PRs
+    # Skip draft PRs and title/body edits.
     if: |
       github.event.action != 'edited' &&
-      github.event.pull_request.draft == false &&
-      !startsWith(github.head_ref, 'release-please--')
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -43,7 +43,7 @@ jobs:
 
   lint:
     name: lint (${{ matrix.module }})
-    # Skip draft PRs and title/body edits.
+    # Skip draft PRs and PR edits (title/body/base).
     if: |
       github.event.action != 'edited' &&
       github.event.pull_request.draft == false
@@ -74,7 +74,7 @@ jobs:
 
   test:
     name: test (${{ matrix.module }})
-    # Skip draft PRs and title/body edits.
+    # Skip draft PRs and PR edits (title/body/base).
     if: |
       github.event.action != 'edited' &&
       github.event.pull_request.draft == false


### PR DESCRIPTION
### Summary
This update fixes the Check PR workflow behavior for release-please pull requests. Removing the `!startsWith(github.head_ref, 'release-please--')` exclusion allows the normal lint and test matrix jobs to run on release-please branches, so branch protection sees the expected module-specific check contexts.

### Changes
- Updated `check-pr.yml` so release-please PRs run the standard lint and test matrix jobs.
- Kept the existing skips for draft PRs and PR `edited` events, which include title, body, and base-branch edits.

### Notes
- No compatibility issues or migrations are needed with this change.