### PR TITLE
ci: infer Modrinth/CurseForge game versions from jar metadata

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -49,7 +49,6 @@ jobs:
           PRE_VERSION="${BASE_VERSION}-pre.${NUMBER}"
 
           MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
-          GAME_VERSIONS="$(printf '1.21\n1.21.1')"
           LOADER="${{ matrix.loader }}"
 
           FULL_VERSION="${PRE_VERSION}+mc${MC_VERSION}.${LOADER}"
@@ -70,9 +69,6 @@ jobs:
             echo "modrinth_version=$MODRINTH_VERSION"
             echo "full_version=$FULL_VERSION"
             echo "minecraft_version=$MC_VERSION"
-            echo "game_versions<<EOF"
-            printf '%s\n' "$GAME_VERSIONS"
-            echo "EOF"
             echo "loader=$LOADER"
             echo "gradle_task=$GRADLE_TASK"
           } >> "$GITHUB_OUTPUT"
@@ -101,7 +97,6 @@ jobs:
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
           game-version-filter: releases
-          game-versions: ${{ steps.version.outputs.game_versions }}
           version-type: beta
           version: ${{ steps.version.outputs.full_version }}
           name: "Logistics v${{ steps.version.outputs.pre_version }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -160,7 +160,6 @@ jobs:
           VERSION="${VERSION#v}"
 
           MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
-          GAME_VERSIONS="$(printf '1.21\n1.21.1')"
           LOADER="$MATRIX_LOADER"
 
           FULL_VERSION="${VERSION}+mc${MC_VERSION}.${LOADER}"
@@ -189,9 +188,6 @@ jobs:
             echo "version=$VERSION"
             echo "full_version=$FULL_VERSION"
             echo "minecraft_version=$MC_VERSION"
-            echo "game_versions<<EOF"
-            printf '%s\n' "$GAME_VERSIONS"
-            echo "EOF"
             echo "loader=$LOADER"
             echo "version_type=$VERSION_TYPE"
             echo "game_version_filter=$GAME_VERSION_FILTER"
@@ -219,7 +215,6 @@ jobs:
           github-tag: ${{ steps.version.outputs.tag }}
 
           game-version-filter: ${{ steps.version.outputs.game_version_filter }}
-          game-versions: ${{ steps.version.outputs.game_versions }}
           version-type: ${{ steps.version.outputs.version_type }}
           name: "Logistics v${{ steps.version.outputs.version }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"
           version: "${{ steps.version.outputs.full_version }}"

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -62,7 +62,6 @@ jobs:
           PRE_ID="${YY}w${WW}${REV}"
 
           MC_VERSION="$(grep '^minecraft_version=' gradle.properties | cut -d'=' -f2)"
-          GAME_VERSIONS="$(printf '1.21\n1.21.1')"
           LOADER="${{ matrix.loader }}"
 
           FULL_VERSION="${PRE_ID}+mc${MC_VERSION}.${LOADER}"
@@ -91,9 +90,6 @@ jobs:
             echo "modrinth_version=$MODRINTH_VERSION"
             echo "full_version=$FULL_VERSION"
             echo "minecraft_version=$MC_VERSION"
-            echo "game_versions<<EOF"
-            printf '%s\n' "$GAME_VERSIONS"
-            echo "EOF"
             echo "loader=$LOADER"
             echo "gradle_task=$GRADLE_TASK"
             echo "game_version_filter=$GAME_VERSION_FILTER"
@@ -124,7 +120,6 @@ jobs:
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
           game-version-filter: ${{ steps.version.outputs.game_version_filter }}
-          game-versions: ${{ steps.version.outputs.game_versions }}
           version-type: beta
           version: ${{ steps.version.outputs.full_version }}
           name: "Logistics ${{ steps.version.outputs.pre_id }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"


### PR DESCRIPTION
## Summary

The publish workflows passed an explicit `game-versions` list to `mc-publish`, duplicating compatibility information already baked into the published jar. This drops the explicit list and lets `mc-publish` infer game versions from the jar's `minecraft` dependency range.

## Why

`fabric.mod.json` already declares `minecraft: ">=1.21 <1.21.2"` (derived from `minecraft_compatibility_versions=1.21,1.21.2` in `gradle.properties`). When `game-versions` is omitted, `mc-publish` reads that range and expands it to the matching versions (`1.21`, `1.21.1`) — so the hardcoded `GAME_VERSIONS="$(printf '1.21\n1.21.1')"` was redundant and a second place to keep in sync.

## Changes

- Remove the `GAME_VERSIONS` computation, the `game_versions` step output, and the `game-versions:` field from `build-release.yml`, `build-snapshot.yml`, and `build-prerelease.yml`.
- Keep `game-version-filter` — it still constrains the inferred set (releases vs. snapshots).

## Notes

- This is the first of a set; the same change will be ported forward to `mc/1.21.11` and `mc/26.1`. It's landed here first because `mc/1.21.1` carried the most game-version machinery (the multi-version `1.21`/`1.21.1` list).