### PR TITLE
fix: correct laser quarry edge case regressions

### DIFF
--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -119,14 +119,17 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity
         entity.energyReceivedLastTick = entity.energyReceivedThisTick;
         entity.energyReceivedThisTick = 0;
 
+        boolean wasConsumedEnergy = entity.consumedEnergyThisTick;
+        entity.consumedEnergyThisTick = false;
+
         if (entity.phaseRunner.isFinished()) {
+            if (wasConsumedEnergy) {
+                entity.syncToClients();
+            }
             return;
         }
 
         ServerLevel serverWorld = (ServerLevel) world;
-
-        boolean wasConsumedEnergy = entity.consumedEnergyThisTick;
-        entity.consumedEnergyThisTick = false;
 
         entity.phaseRunner.tick(entity, serverWorld, pos, state);
 

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBlockBreaker.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBlockBreaker.java
@@ -67,8 +67,9 @@ public final class QuarryBlockBreaker {
         BlockState aboveState = world.getBlockState(abovePos);
         TransportApi transportApi = LogisticsApi.Registry.transport();
         if (transportApi.isTransportBlock(aboveState)) {
-            transportApi.forceInsert(world, abovePos, stack.copy(), Direction.UP);
-            return;
+            if (transportApi.forceInsert(world, abovePos, stack.copy(), Direction.UP)) {
+                return;
+            }
         }
 
         // Fall back to a regular or sided inventory above.
@@ -112,12 +113,14 @@ public final class QuarryBlockBreaker {
         if (existing.isEmpty()) {
             int maxInsert = Math.min(stack.getCount(), Math.min(inv.getMaxStackSize(), stack.getMaxStackSize()));
             inv.setItem(slot, stack.split(maxInsert));
+            inv.setChanged();
         } else if (ItemStack.isSameItemSameComponents(existing, stack)) {
             int space = Math.min(inv.getMaxStackSize(), existing.getMaxStackSize()) - existing.getCount();
             if (space > 0) {
                 int toInsert = Math.min(space, stack.getCount());
                 existing.grow(toInsert);
                 stack.shrink(toInsert);
+                inv.setChanged();
             }
         }
 

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -72,12 +72,15 @@ public final class QuarryPhaseRunner {
         this.currentTarget = null;
     }
 
-    /** Marker callback: bounds changed, restart the mining cursor and finished flag. */
+    /** Marker callback: bounds changed, restart the full clear -> frame -> mine sequence. */
     public void onCustomBoundsSet() {
+        phase = Phase.CLEARING;
+        frameBuildIndex = 0;
         miningX = 0;
         miningY = 0;
         miningZ = 0;
         finished = false;
+        resetBreakProgress();
     }
 
     /** True if the quarry has been placed but hasn't started any clearing yet. */
@@ -107,9 +110,7 @@ public final class QuarryPhaseRunner {
         for (int skipped = 0; skipped < LogisticsConfig.get().quarry.scanRate; skipped++) {
             target = clearingTargetPos(be, state);
             if (target == null) {
-                phase = Phase.BUILDING_FRAME;
-                frameBuildIndex = 0;
-                be.setChanged();
+                transitionFromClearingToBuildingFrame(be);
                 return;
             }
 
@@ -120,6 +121,11 @@ public final class QuarryPhaseRunner {
 
             advanceToNextBlock(be);
             resetBreakProgress();
+        }
+
+        if (target == null) {
+            transitionFromClearingToBuildingFrame(be);
+            return;
         }
 
         if (GridScanner.shouldSkip(world, target, targetState)) {
@@ -348,6 +354,14 @@ public final class QuarryPhaseRunner {
             }
         }
         be.setChanged();
+    }
+
+    private void transitionFromClearingToBuildingFrame(LaserQuarryBlockEntity be) {
+        phase = Phase.BUILDING_FRAME;
+        frameBuildIndex = 0;
+        resetBreakProgress();
+        be.setChanged();
+        be.syncToClients();
     }
 
     private void advanceMiningPosition(LaserQuarryBlockEntity be) {

--- a/common/src/main/java/com/logistics/pipe/PipeApi.java
+++ b/common/src/main/java/com/logistics/pipe/PipeApi.java
@@ -22,9 +22,12 @@ public final class PipeApi implements TransportApi {
     public boolean tryInsert(ServerLevel world, BlockPos targetPos, ItemStack stack, Direction from) {
         BlockEntity aboveEntity = world.getBlockEntity(targetPos);
         if (aboveEntity instanceof PipeBlockEntity pipeEntity) {
+            if (!pipeEntity.canAcceptEntireStack(stack, from.getOpposite(), false)) {
+                return false;
+            }
+
             TravelingItem travelingItem = new TravelingItem(stack.copy(), from, LogisticsConfig.get().pipe.minSpeed);
-            pipeEntity.addItem(travelingItem, from.getOpposite(), false);
-            return true;
+            return pipeEntity.addItem(travelingItem, from.getOpposite(), false);
         }
         return false;
     }
@@ -33,9 +36,12 @@ public final class PipeApi implements TransportApi {
     public boolean forceInsert(ServerLevel world, BlockPos targetPos, ItemStack stack, Direction from) {
         BlockEntity aboveEntity = world.getBlockEntity(targetPos);
         if (aboveEntity instanceof PipeBlockEntity pipeEntity) {
+            if (!pipeEntity.canAcceptEntireStack(stack, from.getOpposite(), true)) {
+                return false;
+            }
+
             TravelingItem travelingItem = new TravelingItem(stack.copy(), from, LogisticsConfig.get().pipe.minSpeed);
-            pipeEntity.addItem(travelingItem, from.getOpposite(), true);
-            return true;
+            return pipeEntity.addItem(travelingItem, from.getOpposite(), true);
         }
         return false;
     }

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -488,6 +488,14 @@ public class PipeBlockEntity extends BaseBlockEntity
         return Math.min(maxAmount, remaining);
     }
 
+    public boolean canAcceptEntireStack(ItemStack stack, Direction fromDirection, boolean bypassIngress) {
+        if (stack.isEmpty()) {
+            return true;
+        }
+
+        return getInsertableAmount(stack.getCount(), fromDirection, stack, bypassIngress) >= stack.getCount();
+    }
+
     void acceptInsertedStack(ItemStack stack, Direction fromDirection, @Nullable Float speedOverride) {
         acceptInsertedStack(stack, fromDirection, speedOverride, null);
     }

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryBlockBreakerTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryBlockBreakerTest.java
@@ -27,6 +27,17 @@ class QuarryBlockBreakerTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    @DisplayName("marks the container changed when inserting into an empty slot")
+    void marksChangedWhenInsertingIntoEmptySlot() {
+        TrackingContainer container = new TrackingContainer(1);
+        ItemStack stack = new ItemStack(Items.IRON_INGOT, 5);
+
+        QuarryBlockBreaker.insertIntoSlot(container, 0, stack);
+
+        assertThat(container.changedCount).isPositive();
+    }
+
+    @Test
     @DisplayName("merges into a matching slot up to the stack size")
     void mergesIntoMatchingSlot() {
         SimpleContainer container = new SimpleContainer(1);
@@ -38,6 +49,19 @@ class QuarryBlockBreakerTest extends MinecraftTestEnvironment {
         // 64 - 60 = 4 fit, 6 remain.
         assertThat(container.getItem(0).getCount()).isEqualTo(64);
         assertThat(remainder.getCount()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("marks the container changed when merging into a matching slot")
+    void marksChangedWhenMergingIntoMatchingSlot() {
+        TrackingContainer container = new TrackingContainer(1);
+        container.setItem(0, new ItemStack(Items.IRON_INGOT, 60));
+        container.changedCount = 0;
+        ItemStack stack = new ItemStack(Items.IRON_INGOT, 10);
+
+        QuarryBlockBreaker.insertIntoSlot(container, 0, stack);
+
+        assertThat(container.changedCount).isEqualTo(1);
     }
 
     @Test
@@ -82,5 +106,19 @@ class QuarryBlockBreakerTest extends MinecraftTestEnvironment {
 
         assertThat(remainder.getCount()).isEqualTo(5);
         assertThat(container.getItem(0).getCount()).isEqualTo(64);
+    }
+
+    private static final class TrackingContainer extends SimpleContainer {
+        private int changedCount = 0;
+
+        private TrackingContainer(int size) {
+            super(size);
+        }
+
+        @Override
+        public void setChanged() {
+            changedCount++;
+            super.setChanged();
+        }
     }
 }

--- a/common/src/test/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunnerTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunnerTest.java
@@ -1,0 +1,41 @@
+package com.logistics.automation.laserquarry.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity.Phase;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("QuarryPhaseRunner")
+class QuarryPhaseRunnerTest {
+
+    @Test
+    @DisplayName("custom bounds reset restarts clearing from the first frame block")
+    void customBoundsResetRestartsFullSequence() {
+        QuarryPhaseRunner runner = new QuarryPhaseRunner();
+        CompoundTag state = new CompoundTag();
+        state.putInt("MiningX", 3);
+        state.putInt("MiningY", 4);
+        state.putInt("MiningZ", 5);
+        state.putFloat("BreakProgress", 12f);
+        state.putBoolean("MiningFinished", true);
+        state.putString("CurrentPhase", Phase.MINING.name());
+        state.putInt("FrameBuildIndex", 42);
+        runner.load(state);
+
+        runner.onCustomBoundsSet();
+
+        CompoundTag saved = new CompoundTag();
+        runner.save(saved);
+        assertThat(saved.getString("CurrentPhase").orElseThrow()).isEqualTo(Phase.CLEARING.name());
+        assertThat(saved.getInt("FrameBuildIndex").orElseThrow()).isZero();
+        assertThat(saved.getInt("MiningX").orElseThrow()).isZero();
+        assertThat(saved.getInt("MiningY").orElseThrow()).isZero();
+        assertThat(saved.getInt("MiningZ").orElseThrow()).isZero();
+        assertThat(saved.getFloat("BreakProgress").orElseThrow()).isZero();
+        assertThat(saved.getBoolean("MiningFinished").orElseThrow()).isFalse();
+        assertThat(runner.getCurrentTarget()).isNull();
+        assertThat(runner.getCurrentBreakTime()).isEqualTo(-1f);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes several laser quarry edge cases that could lose mined drops, leave stale client state, or resume old phase/cursor state after bounds changes.

## Changes
- Fall back to inventory/drop output when pipe force insertion rejects quarry drops.
- Mark target containers changed after slot insertions and merges.
- Reset phase, frame cursor, mining cursor, break progress, and targets when custom bounds are set.
- Sync the clearing-to-frame transition immediately and guard clearing scans that reach the end of the area.
- Clear the consumed-energy render flag after the quarry finishes.
- Add regression coverage for container dirtying and custom-bounds reset state.

## Notes
- closes #407
- closes #408
- closes #409
- closes #410
- closes #411
- closes #423