### PR TITLE
ci(build): add coverage ratchet to Check Code

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -78,3 +78,37 @@ jobs:
         with:
           name: test-reports-${{ matrix.module }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ matrix.module }}/build/reports/tests/test/
+
+  coverage:
+    name: coverage
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          token: ${{ github.token }}
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Check aggregate coverage
+        run: ./gradlew checkTestCoverageRatchet --console=plain
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: coverage-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            build/reports/jacoco/testCoverage/html/
+            build/reports/jacoco/testCoverage/testCoverage.xml

--- a/TESTING.md
+++ b/TESTING.md
@@ -34,12 +34,15 @@ The same `lint`/`fix` aliases are available for `fabric` and `neoforge`.
 
 ### CI
 
-Pull request CI runs under the **Check PR** workflow:
+Pull request CI runs under two workflows:
 
-- `lint (pr)` checks the PR title.
-- `lint (common)` checks repository-level formatting, common Java formatting, and import boundaries.
-- `lint (fabric|neoforge)` checks module Java formatting.
-- `test (common|fabric|neoforge)` runs module unit tests.
+- **Check PR**:
+  - `lint (pr)` checks the PR title.
+- **Check Code**:
+  - `lint (common)` checks repository-level formatting, common Java formatting, and import boundaries.
+  - `lint (fabric|neoforge)` checks module Java formatting.
+  - `test (common|fabric|neoforge)` runs module unit tests.
+  - `coverage` runs aggregate JaCoCo coverage and verifies the coverage ratchet.
 
 PR CI does not build preview jars automatically. Use the manual **Build PR Artifacts**
 workflow when a branch needs downloadable Fabric or NeoForge jars for smoke testing.
@@ -52,6 +55,16 @@ Local aggregate coverage is generated with:
 ./gradlew testCoverage
 ```
 
+To run the same aggregate coverage ratchet that CI uses:
+
+```bash
+./gradlew checkTestCoverageRatchet
+```
+
+The ratchet baseline lives in `gradle/coverage-baseline.properties`. Update it
+only upward after a PR improves coverage, or deliberately when the coverage
+scope changes.
+
 The HTML report is written to `build/reports/jacoco/testCoverage/html/index.html`.
 The XML report is written to `build/reports/jacoco/testCoverage/testCoverage.xml`.
 
@@ -59,17 +72,23 @@ Current aggregate baseline from `./gradlew testCoverage`:
 
 | Counter | Coverage |
 |---------|----------|
-| Instruction | 14.2% |
-| Branch | 12.1% |
-| Line | 14.3% |
-| Method | 19.9% |
-| Class | 29.3% |
+| Instruction | 15.6% |
+| Branch | 13.2% |
+| Line | 15.7% |
+| Complexity | 15.0% |
+| Method | 20.7% |
+| Class | 30.6% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
 The aggregate percentage is still low because the report includes block entities,
 blocks, menus, live-world runtime paths, bootstrap code, and loader entrypoints
 that are documented below as requiring restructuring or integration tests.
+
+When adding new tests, prefer extracting deterministic logic into plain common
+classes and keeping Minecraft `Level`, block entity, menu, networking, and
+loader APIs in thin adapters. This keeps coverage cherry-pickable across
+supported branches.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'jacoco'
 }
 
+import groovy.xml.XmlSlurper
+
 version = System.getenv("MOD_VERSION") ?: "dev"
 group = project.maven_group
 
@@ -175,6 +177,63 @@ tasks.register('testCoverage', JacocoReport) {
         html.outputLocation = layout.buildDirectory.dir('reports/jacoco/testCoverage/html')
         xml.required = true
         xml.outputLocation = layout.buildDirectory.file('reports/jacoco/testCoverage/testCoverage.xml')
+    }
+}
+
+tasks.register('checkTestCoverageRatchet') {
+    description = 'Verify aggregate unit test coverage has not regressed'
+    group = 'verification'
+    dependsOn 'testCoverage'
+
+    inputs.file(layout.projectDirectory.file('gradle/coverage-baseline.properties'))
+    inputs.file(layout.buildDirectory.file('reports/jacoco/testCoverage/testCoverage.xml'))
+
+    doLast {
+        def baselineFile = layout.projectDirectory.file('gradle/coverage-baseline.properties').asFile
+        if (!baselineFile.isFile()) {
+            throw new GradleException("Coverage baseline not found: ${baselineFile}")
+        }
+
+        def reportFile = layout.buildDirectory.file('reports/jacoco/testCoverage/testCoverage.xml').get().asFile
+        if (!reportFile.isFile()) {
+            throw new GradleException("Coverage report not found: ${reportFile}. Run ./gradlew testCoverage first.")
+        }
+
+        def baselines = new Properties()
+        baselineFile.withInputStream { baselines.load(it) }
+
+        def parser = new XmlSlurper(false, false)
+        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+        parser.setFeature("http://xml.org/sax/features/external-general-entities", false)
+        parser.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        parser.setEntityResolver { String publicId, String systemId ->
+            new org.xml.sax.InputSource(new StringReader(""))
+        }
+        def report = parser.parse(reportFile)
+        def failures = []
+
+        report.counter.each { counter ->
+            String type = counter.@type.text()
+            if (!baselines.containsKey(type)) {
+                return
+            }
+
+            BigDecimal missed = new BigDecimal(counter.@missed.text())
+            BigDecimal covered = new BigDecimal(counter.@covered.text())
+            BigDecimal total = missed + covered
+            BigDecimal actual = total == 0
+                    ? new BigDecimal('100.0')
+                    : covered.multiply(new BigDecimal('100')).divide(total, 1, java.math.RoundingMode.DOWN)
+            BigDecimal expected = new BigDecimal(baselines.getProperty(type))
+
+            if (actual < expected) {
+                failures << "${type}: ${actual}% is below baseline ${expected}%"
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException("Coverage ratchet failed:\n" + failures.join('\n'))
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -211,10 +211,14 @@ tasks.register('checkTestCoverageRatchet') {
         }
         def report = parser.parse(reportFile)
         def failures = []
+        def baselineTypes = baselines.stringPropertyNames() as Set
+        def reportedTypes = [] as Set
 
         report.counter.each { counter ->
             String type = counter.@type.text()
+            reportedTypes << type
             if (!baselines.containsKey(type)) {
+                failures << "${type}: coverage report has no baseline entry"
                 return
             }
 
@@ -229,6 +233,10 @@ tasks.register('checkTestCoverageRatchet') {
             if (actual < expected) {
                 failures << "${type}: ${actual}% is below baseline ${expected}%"
             }
+        }
+
+        (baselineTypes - reportedTypes).sort().each { type ->
+            failures << "${type}: coverage baseline has no matching report counter"
         }
 
         if (!failures.isEmpty()) {

--- a/gradle/coverage-baseline.properties
+++ b/gradle/coverage-baseline.properties
@@ -1,0 +1,9 @@
+# Aggregate JaCoCo coverage ratchet for ./gradlew testCoverage.
+# Values are percentages. Raise these after coverage improves; do not lower them
+# unless the coverage scope intentionally changes.
+INSTRUCTION=15.6
+BRANCH=13.2
+LINE=15.7
+COMPLEXITY=15.0
+METHOD=20.7
+CLASS=30.6


### PR DESCRIPTION
Summary
- Adds an aggregate JaCoCo coverage ratchet for unit test coverage.
- Runs the coverage ratchet from the Check Code workflow after module tests pass.
- Documents the current coverage baseline and update process in TESTING.md.

Changes
- Adds gradle/coverage-baseline.properties with the current branch baseline.
- Adds ./gradlew checkTestCoverageRatchet for local and CI verification.
- Uploads aggregate coverage reports from Check Code for PR inspection.

Notes
- The ratchet only prevents coverage regressions; it does not introduce a broad hard target yet.