### PR TITLE
ci(build): report coverage via Codecov, drop local ratchet

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -101,14 +101,13 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Check aggregate coverage
-        run: ./gradlew checkTestCoverageRatchet --console=plain
+      - name: Generate aggregate coverage report
+        run: ./gradlew testCoverage --console=plain
 
-      - name: Upload coverage reports
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
-          name: coverage-reports-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            build/reports/jacoco/testCoverage/html/
-            build/reports/jacoco/testCoverage/testCoverage.xml
+          files: build/reports/jacoco/testCoverage/testCoverage.xml
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -49,6 +49,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each module uploads one Codecov report. When changing this list, update
+        # after_n_builds (notify and comment) in codecov.yml to match the count.
         module: [common, fabric, neoforge]
 
     steps:

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -67,8 +67,10 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Run ${{ matrix.module }} tests
-        run: ./gradlew :${{ matrix.module }}:test --console=plain
+      - name: Run ${{ matrix.module }} tests with coverage
+        run: ./gradlew :${{ matrix.module }}:jacocoTestReport --console=plain
+        # jacocoTestReport depends on the module's test task, so this runs the
+        # tests once and emits the JaCoCo XML in the same step.
         # Note: Game tests (./gradlew :fabric:runGameTest) are not run in CI due to resource
         # constraints and long execution time. Run locally before merging if testing game mechanics.
 
@@ -79,35 +81,11 @@ jobs:
           name: test-reports-${{ matrix.module }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ matrix.module }}/build/reports/tests/test/
 
-  coverage:
-    name: coverage
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Upload ${{ matrix.module }} coverage to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
-          persist-credentials: false
-          token: ${{ github.token }}
-
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-      - name: Generate aggregate coverage report
-        run: ./gradlew testCoverage --console=plain
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
-        with:
-          files: build/reports/jacoco/testCoverage/testCoverage.xml
+          files: ${{ matrix.module }}/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: ${{ matrix.module }}
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![GitHub](https://img.shields.io/badge/GitHub-indemnity83%2Flogistics-blue?logo=github)](https://github.com/indemnity83/logistics)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![codecov](https://codecov.io/gh/Indemnity83/logistics/branch/mc%2F26.1/graph/badge.svg)](https://codecov.io/gh/Indemnity83/logistics)
 [![Minecraft](https://img.shields.io/badge/Minecraft-26.1-brightgreen.svg)](https://www.minecraft.net/)
 [![Fabric](https://img.shields.io/badge/Fabric-0.18.6-orange.svg)](https://fabricmc.net/)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/94DP3CVNVt)

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,8 +41,9 @@ Pull request CI runs under two workflows:
 - **Check Code**:
   - `lint (common)` checks repository-level formatting, common Java formatting, and import boundaries.
   - `lint (fabric|neoforge)` checks module Java formatting.
-  - `test (common|fabric|neoforge)` runs module unit tests.
-  - `coverage` runs aggregate JaCoCo coverage and uploads it to Codecov.
+  - `test (common|fabric|neoforge)` runs module unit tests and uploads that
+    module's JaCoCo coverage to Codecov (tagged with a per-module flag). Codecov
+    merges the three uploads into the combined coverage for the commit.
 
 PR CI does not build preview jars automatically. Use the manual **Build PR Artifacts**
 workflow when a branch needs downloadable Fabric or NeoForge jars for smoke testing.
@@ -59,10 +60,13 @@ The HTML report is written to `build/reports/jacoco/testCoverage/html/index.html
 The XML report is written to `build/reports/jacoco/testCoverage/testCoverage.xml`.
 
 Coverage is reported and gated by [Codecov](https://codecov.io/gh/Indemnity83/logistics).
-CI uploads the aggregate XML report on every PR; Codecov posts a summary comment,
-flags uncovered changed lines inline, and publishes `project`/`patch` status checks.
-The thresholds live in `codecov.yml` (project: no drop beyond 0.5%; patch target 70%),
-so there is no hand-maintained baseline to bump.
+On every PR each `test` matrix job uploads its module's JaCoCo report (tagged with a
+`common` / `fabric` / `neoforge` flag) and Codecov merges them, so the suite runs only
+once. Codecov posts a summary comment, flags uncovered changed lines inline, and
+publishes `project`/`patch` status checks. The thresholds live in `codecov.yml`
+(project: no drop beyond 0.5%; patch target 70%), so there is no hand-maintained
+baseline to bump. The local `testCoverage` task above still produces the aggregate
+HTML/XML for offline inspection.
 
 Current aggregate baseline from `./gradlew testCoverage`:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,7 +42,7 @@ Pull request CI runs under two workflows:
   - `lint (common)` checks repository-level formatting, common Java formatting, and import boundaries.
   - `lint (fabric|neoforge)` checks module Java formatting.
   - `test (common|fabric|neoforge)` runs module unit tests.
-  - `coverage` runs aggregate JaCoCo coverage and verifies the coverage ratchet.
+  - `coverage` runs aggregate JaCoCo coverage and uploads it to Codecov.
 
 PR CI does not build preview jars automatically. Use the manual **Build PR Artifacts**
 workflow when a branch needs downloadable Fabric or NeoForge jars for smoke testing.
@@ -55,18 +55,14 @@ Local aggregate coverage is generated with:
 ./gradlew testCoverage
 ```
 
-To run the same aggregate coverage ratchet that CI uses:
-
-```bash
-./gradlew checkTestCoverageRatchet
-```
-
-The ratchet baseline lives in `gradle/coverage-baseline.properties`. Update it
-only upward after a PR improves coverage, or deliberately when the coverage
-scope changes.
-
 The HTML report is written to `build/reports/jacoco/testCoverage/html/index.html`.
 The XML report is written to `build/reports/jacoco/testCoverage/testCoverage.xml`.
+
+Coverage is reported and gated by [Codecov](https://codecov.io/gh/Indemnity83/logistics).
+CI uploads the aggregate XML report on every PR; Codecov posts a summary comment,
+flags uncovered changed lines inline, and publishes `project`/`patch` status checks.
+The thresholds live in `codecov.yml` (project: no drop beyond 0.5%; patch target 70%),
+so there is no hand-maintained baseline to bump.
 
 Current aggregate baseline from `./gradlew testCoverage`:
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,6 @@ plugins {
     id 'jacoco'
 }
 
-import groovy.xml.XmlSlurper
-
 version = System.getenv("MOD_VERSION") ?: "dev"
 group = project.maven_group
 
@@ -177,71 +175,6 @@ tasks.register('testCoverage', JacocoReport) {
         html.outputLocation = layout.buildDirectory.dir('reports/jacoco/testCoverage/html')
         xml.required = true
         xml.outputLocation = layout.buildDirectory.file('reports/jacoco/testCoverage/testCoverage.xml')
-    }
-}
-
-tasks.register('checkTestCoverageRatchet') {
-    description = 'Verify aggregate unit test coverage has not regressed'
-    group = 'verification'
-    dependsOn 'testCoverage'
-
-    inputs.file(layout.projectDirectory.file('gradle/coverage-baseline.properties'))
-    inputs.file(layout.buildDirectory.file('reports/jacoco/testCoverage/testCoverage.xml'))
-
-    doLast {
-        def baselineFile = layout.projectDirectory.file('gradle/coverage-baseline.properties').asFile
-        if (!baselineFile.isFile()) {
-            throw new GradleException("Coverage baseline not found: ${baselineFile}")
-        }
-
-        def reportFile = layout.buildDirectory.file('reports/jacoco/testCoverage/testCoverage.xml').get().asFile
-        if (!reportFile.isFile()) {
-            throw new GradleException("Coverage report not found: ${reportFile}. Run ./gradlew testCoverage first.")
-        }
-
-        def baselines = new Properties()
-        baselineFile.withInputStream { baselines.load(it) }
-
-        def parser = new XmlSlurper(false, false)
-        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
-        parser.setFeature("http://xml.org/sax/features/external-general-entities", false)
-        parser.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-        parser.setEntityResolver { String publicId, String systemId ->
-            new org.xml.sax.InputSource(new StringReader(""))
-        }
-        def report = parser.parse(reportFile)
-        def failures = []
-        def baselineTypes = baselines.stringPropertyNames() as Set
-        def reportedTypes = [] as Set
-
-        report.counter.each { counter ->
-            String type = counter.@type.text()
-            reportedTypes << type
-            if (!baselines.containsKey(type)) {
-                failures << "${type}: coverage report has no baseline entry"
-                return
-            }
-
-            BigDecimal missed = new BigDecimal(counter.@missed.text())
-            BigDecimal covered = new BigDecimal(counter.@covered.text())
-            BigDecimal total = missed + covered
-            BigDecimal actual = total == 0
-                    ? new BigDecimal('100.0')
-                    : covered.multiply(new BigDecimal('100')).divide(total, 1, java.math.RoundingMode.DOWN)
-            BigDecimal expected = new BigDecimal(baselines.getProperty(type))
-
-            if (actual < expected) {
-                failures << "${type}: ${actual}% is below baseline ${expected}%"
-            }
-        }
-
-        (baselineTypes - reportedTypes).sort().each { type ->
-            failures << "${type}: coverage baseline has no matching report counter"
-        }
-
-        if (!failures.isEmpty()) {
-            throw new GradleException("Coverage ratchet failed:\n" + failures.join('\n'))
-        }
     }
 }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  notify:
+    # Each PR uploads three reports (common, fabric, neoforge matrix jobs).
+    # Wait for all of them before computing status so the merged total is used.
+    after_n_builds: 3
+
 coverage:
   status:
     project:
@@ -10,6 +16,17 @@ coverage:
         # New / changed lines in a PR should be reasonably covered.
         target: 70%
 
+# Per-module uploads are tagged with a flag so Codecov can report coverage
+# per loader as well as merged together.
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: common
+    - name: fabric
+    - name: neoforge
+
 comment:
   layout: "reach, diff, flags, files"
   require_changes: true
+  after_n_builds: 3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        # Compare against the parent commit's coverage; allow tiny rounding noise.
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        # New / changed lines in a PR should be reasonably covered.
+        target: 70%
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,4 +29,6 @@ flag_management:
 comment:
   layout: "reach, diff, flags, files"
   require_changes: true
+  # Keep in sync with codecov.notify.after_n_builds and the test matrix size in
+  # .github/workflows/check-code.yml (one upload per module).
   after_n_builds: 3

--- a/gradle/coverage-baseline.properties
+++ b/gradle/coverage-baseline.properties
@@ -1,9 +1,0 @@
-# Aggregate JaCoCo coverage ratchet for ./gradlew testCoverage.
-# Values are percentages. Raise these after coverage improves; do not lower them
-# unless the coverage scope intentionally changes.
-INSTRUCTION=17.0
-BRANCH=14.6
-LINE=17.0
-COMPLEXITY=16.0
-METHOD=21.7
-CLASS=32.7


### PR DESCRIPTION
## Summary

Replaces the local JaCoCo coverage ratchet (#431) with [Codecov](https://codecov.io/gh/Indemnity83/logistics) for hosted coverage reporting, inline PR annotations of uncovered changed lines, and automatic project/patch status checks — no hand-maintained baseline file.

## Changes

- **CI:** each `test (common|fabric|neoforge)` matrix job now runs `jacocoTestReport` and uploads that module's coverage to Codecov tagged with a per-module flag. Codecov merges the three uploads, so the test suite runs **once** instead of twice — the separate `coverage` job (which re-ran the whole suite via `testCoverage`) is removed.
- **Gradle:** removed the `checkTestCoverageRatchet` task and the unused `XmlSlurper` import. The aggregate `testCoverage` task stays for local HTML/XML inspection.
- **Config:** new `codecov.yml` — `project` status `target: auto` with a 0.5% tolerance (no-drop), `patch` target 70%, per-module flags, and `after_n_builds: 3` so status/comment wait for all three uploads.
- **Docs:** `TESTING.md` Coverage/CI sections updated; `README.md` gains a coverage badge.
- Deleted `gradle/coverage-baseline.properties`.

## Notes

- Requires a `CODECOV_TOKEN` Actions secret and the repo enabled on codecov.io. Public-repo tokenless upload is rate-limited/flaky on forked PRs, so the token is recommended here.
- The `codecov/codecov-action` pin follows the repo convention: full commit SHA + `# v6.0.1` comment so Dependabot can track and bump it.
- After merge, the Codecov `project`/`patch` checks can be added to `mc/*` branch protection once a baseline run reports them.
- Cherry-pick to `mc/1.21.11` and `mc/1.21.1` if they also carry the #431 ratchet (adjust the README badge branch segment per branch).