### PR TITLE
feat(core): add opt-in crash reporting

### DIFF
--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -15,8 +15,12 @@ enable anything on connected players' clients.
 | `/logistics crashreports` | Show current status |
 | `/logistics crashreports enable` | Opt in to sending sanitized reports |
 | `/logistics crashreports disable` | Stop sending reports |
+| `/logistics crashreports preview` | Print an example sanitized report **without sending it** |
 | `/logistics crashreports notify off` | Hide the one-time join invite |
 | `/logistics crashreports notify on` | Re-show the join invite |
+
+`preview` runs a synthetic error through the exact same sanitization pipeline used before sending,
+so you can see precisely what a report looks like (and confirm the scrubbing works) before opting in.
 
 All of these require operator (gamemaster) permission. Disabling is exactly as easy as enabling.
 

--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -1,0 +1,44 @@
+# Crash Reporting & Privacy
+
+Logistics can optionally send **sanitized** crash/error diagnostics to help identify and fix bugs.
+This is **disabled by default** and must be turned on explicitly by a server operator (or, in
+single-player, by you). Each install opts in independently — enabling it on a server does **not**
+enable anything on connected players' clients.
+
+> Logistics is not an official Minecraft product and is not approved by or associated with Mojang or
+> Microsoft.
+
+## Turning it on or off
+
+| Command | Effect |
+| --- | --- |
+| `/logistics crashreports` | Show current status |
+| `/logistics crashreports enable` | Opt in to sending sanitized reports |
+| `/logistics crashreports disable` | Stop sending reports |
+| `/logistics crashreports notify off` | Hide the one-time join invite |
+| `/logistics crashreports notify on` | Re-show the join invite |
+
+All of these require operator (gamemaster) permission. Disabling is exactly as easy as enabling.
+
+## What is collected (only when enabled)
+
+- Mod version, Minecraft version, mod-loader version
+- Java version and operating-system type
+- Stack traces and exception messages **originating from Logistics' own code** (`logistics` loggers)
+- Generic runtime context Sentry attaches automatically (e.g. OS family, JVM)
+
+## What is intentionally **not** collected
+
+- Player chat or world data
+- Player names, player UUIDs
+- IP addresses or server addresses / hostnames
+- Full configuration contents
+- Anything matched as a secret (`password`, `token`, `secret`, `key`, `dsn`, …)
+
+Before any report leaves the process, a `beforeSend` filter strips the host/server name and redacts
+home directories, IP addresses, UUIDs, and secret-like `key=value` pairs from the message and
+exception text. Sentry's `send-default-pii` is left **off**, so no PII is attached by default.
+
+This scrubbing is best-effort and biased toward over-redaction. Reports are processed by
+[Sentry](https://sentry.io) unless a custom DSN is configured via `crashReporting.dsnOverride` in
+`config/logistics.json`.

--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -1,48 +1,181 @@
 # Crash Reporting & Privacy
 
-Logistics can optionally send **sanitized** crash/error diagnostics to help identify and fix bugs.
-This is **disabled by default** and must be turned on explicitly by a server operator (or, in
-single-player, by you). Each install opts in independently — enabling it on a server does **not**
-enable anything on connected players' clients.
+Logistics includes an **optional** crash reporter that can send **sanitized** error diagnostics to
+the developers so bugs get found and fixed faster. We built it to respect you: it is **off by
+default**, it only ever looks at Logistics' own errors, and you can see exactly what it would send
+before you ever turn it on.
+
+This page explains, in plain language, what it does, what it collects, what it deliberately does
+**not** collect, and how to control it. If anything here is unclear or you spot something that looks
+sensitive, please [open an issue](https://github.com/Indemnity83/logistics/issues) — we take this
+seriously.
 
 > Logistics is not an official Minecraft product and is not approved by or associated with Mojang or
 > Microsoft.
 
-## Turning it on or off
+---
 
-| Command | Effect |
+## The short version
+
+- ✅ **Off by default.** Nothing is sent unless an operator turns it on.
+- ✅ **Opt-in, and easy to opt out.** One command on, one command off.
+- ✅ **Logistics only.** It reports errors from this mod's own code — not from Minecraft, your server,
+  or other mods.
+- ✅ **Sanitized.** No player names, UUIDs, IP addresses, server addresses, chat, or world data.
+- ✅ **You can verify it.** `/logistics crashreports preview` shows you a real, sanitized example
+  report without sending anything.
+- ✅ **Per-install.** Turning it on for a server does **not** turn it on for your players.
+
+If you do nothing, Logistics sends no diagnostics. That's the default, and it's a perfectly good
+choice.
+
+---
+
+## Why this exists
+
+When Logistics misbehaves in the real world, the developers usually never hear about it. Most players
+don't file bug reports, and even when they do, the useful details are buried in a log file that's
+hard to share. That means bugs can linger for weeks because there's simply no signal that they're
+happening.
+
+Opting in to crash reporting sends a small, sanitized diagnostic whenever Logistics hits an error.
+That gives the developers the one thing they're usually missing: a clear, actionable signal that
+something broke, what it was, and which version it happened on — so it can be fixed quickly. It is
+purely a debugging aid, not analytics, and it is intentionally narrow.
+
+---
+
+## Your choice, always
+
+Crash reporting is **disabled by default** and must be turned on explicitly. The toggle lives in your
+config (`config/logistics.json`) and is controlled with operator-level commands.
+
+**Single-player:** you are the operator, so you decide for your own game.
+
+**Multiplayer:** only a server operator can enable it, and when enabled it reports **server-side**
+Logistics errors. Each install has its own setting, so a server operator opting in does **not** opt
+in any connected player's client. If you run a client and want client-side reporting, that's a
+separate choice you make on your own machine.
+
+---
+
+## Commands
+
+All of these require operator (gamemaster) permission. Turning it off is exactly as easy as turning
+it on.
+
+| Command | What it does |
 | --- | --- |
-| `/logistics crashreports` | Show current status |
+| `/logistics crashreports` | Show whether reporting and the join notice are on or off |
 | `/logistics crashreports enable` | Opt in to sending sanitized reports |
 | `/logistics crashreports disable` | Stop sending reports |
 | `/logistics crashreports preview` | Print an example sanitized report **without sending it** |
-| `/logistics crashreports notify off` | Hide the one-time join invite |
-| `/logistics crashreports notify on` | Re-show the join invite |
+| `/logistics crashreports notify off` | Hide the one-time join invitation |
+| `/logistics crashreports notify on` | Show the join invitation again |
 
-`preview` runs a synthetic error through the exact same sanitization pipeline used before sending,
-so you can see precisely what a report looks like (and confirm the scrubbing works) before opting in.
+### See for yourself: `preview`
 
-All of these require operator (gamemaster) permission. Disabling is exactly as easy as enabling.
+The `preview` command is the heart of our "trust, but verify" approach. It builds a sample error and
+runs it through the **exact same sanitization** that a real report goes through, then prints the
+result to you — **nothing is sent.** The sample deliberately contains fake sensitive values (a home
+directory, an IP, a UUID, a token) so you can watch them get scrubbed in front of you. It works
+whether or not reporting is enabled, so you can inspect the output before deciding to opt in.
+
+---
 
 ## What is collected (only when enabled)
 
-- Mod version, Minecraft version, mod-loader version
-- Java version and operating-system type
-- Stack traces and exception messages **originating from Logistics' own code** (`logistics` loggers)
-- Generic runtime context Sentry attaches automatically (e.g. OS family, JVM)
+When reporting is on and Logistics hits an error, a report may include:
 
-## What is intentionally **not** collected
+- **Mod, Minecraft, and loader versions** — so a bug can be tied to a specific release.
+- **Java version and operating-system family** (e.g. "Windows", "Linux") — common environment context.
+- **The error itself** — the exception type, message, and stack trace, **originating from Logistics'
+  own code**.
+- **Generic runtime context** that the reporting library attaches automatically (e.g. JVM and OS
+  family). This does not include personal identifiers.
 
-- Player chat or world data
-- Player names, player UUIDs
-- IP addresses or server addresses / hostnames
-- Full configuration contents
-- Anything matched as a secret (`password`, `token`, `secret`, `key`, `dsn`, …)
+That's it. The goal is "what broke, where, and on what version" — nothing more.
 
-Before any report leaves the process, a `beforeSend` filter strips the host/server name and redacts
-home directories, IP addresses, UUIDs, and secret-like `key=value` pairs from the message and
-exception text. Sentry's `send-default-pii` is left **off**, so no PII is attached by default.
+## What is never collected
 
-This scrubbing is best-effort and biased toward over-redaction. Reports are processed by
-[Sentry](https://sentry.io) unless a custom DSN is configured via `crashReporting.dsnOverride` in
-`config/logistics.json`.
+We deliberately exclude, and actively scrub for:
+
+- ❌ Player names or player UUIDs
+- ❌ IP addresses
+- ❌ Server addresses or hostnames
+- ❌ Chat messages
+- ❌ World data, coordinates, or save contents
+- ❌ Your full configuration
+- ❌ Anything that looks like a secret (values labelled `password`, `token`, `secret`, `key`, `dsn`, …)
+
+We never intentionally send any of the above, and the sanitizer below is a second line of defense in
+case any of it ever slipped into an error message.
+
+---
+
+## How your data is protected
+
+Several safeguards work together:
+
+1. **Off by default.** No opt-in, no data. Ever.
+2. **Scoped capture.** Only errors logged by Logistics' own code are eligible. The reporter does
+   **not** install a global error handler, so errors from Minecraft, your server, or other mods are
+   never picked up.
+3. **No PII by default.** The reporting library's "send personal information" setting is left
+   **off**, and the host/server name is never attached.
+4. **Active scrubbing.** Before a report leaves your machine, a sanitizer rewrites the message and
+   error text to remove home-directory paths (e.g. `/Users/you/…` → `~`, Windows paths too), IP
+   addresses (→ `<ip>`), UUIDs (→ `<uuid>`), and secret-like `key=value` pairs (→ `key=<redacted>`).
+5. **Verifiable.** `/logistics crashreports preview` lets you see the sanitized output yourself.
+
+This sanitization is best-effort and intentionally biased toward over-redaction: when in doubt, it
+strips it.
+
+---
+
+## Where reports go
+
+Reports are processed by [Sentry](https://sentry.io), a widely used error-monitoring service, on a
+project owned by the mod's developers.
+
+**Self-hosting:** if you'd rather send reports to your own Sentry project (or a local endpoint of
+your choosing), set `crashReporting.dsnOverride` in `config/logistics.json` to your own DSN. When set,
+reports go there instead of the default project.
+
+---
+
+## How to check the current state, or turn it off
+
+- Run `/logistics crashreports` to see the current status at any time.
+- Run `/logistics crashreports disable` to stop immediately.
+- Or open `config/logistics.json` and set `crashReporting.enabled` to `false`.
+
+When disabled, the reporter sends nothing and runs no background networking.
+
+---
+
+## FAQ
+
+**Will this slow down my game or server?**
+No meaningful impact. Reports are only created on an actual error and are sent on a background thread,
+so the game thread isn't blocked.
+
+**Does enabling it on my server enable it for my players?**
+No. Settings are per-install. A server operator's choice only affects server-side Logistics errors.
+
+**Is it really "anonymous"?**
+We call it **sanitized**, not anonymous, on purpose. We don't intentionally collect identifiers and
+we actively scrub for them, but no scrubber is perfect, so we'd rather be precise than overstate it.
+That's also why `preview` exists — so you can check.
+
+**What if `preview` shows me something sensitive?**
+Please [open an issue](https://github.com/Indemnity83/logistics/issues) and tell us what you saw (you
+don't need to include the sensitive value itself). We'll tighten the sanitizer.
+
+**Can I turn off just the in-game invitation but leave reporting off?**
+Yes — `/logistics crashreports notify off` hides the prompt without changing anything else.
+
+---
+
+*Thank you for considering it. Opting in is genuinely helpful, and turning it down is completely
+fine — either way, you're in control.*

--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -69,17 +69,19 @@ it on.
 | `/logistics crashreports` | Show whether reporting and the join notice are on or off |
 | `/logistics crashreports enable` | Opt in to sending sanitized reports |
 | `/logistics crashreports disable` | Stop sending reports |
-| `/logistics crashreports preview` | Print an example sanitized report **without sending it** |
+| `/logistics crashreports preview` | Write an example sanitized report to the log **without sending it** |
 | `/logistics crashreports notify off` | Hide the one-time join invitation |
 | `/logistics crashreports notify on` | Show the join invitation again |
 
 ### See for yourself: `preview`
 
 The `preview` command is the heart of our "trust, but verify" approach. It builds a sample error and
-runs it through the **exact same sanitization** that a real report goes through, then prints the
-result to you — **nothing is sent.** The sample deliberately contains fake sensitive values (a home
-directory, an IP, a UUID, a token) so you can watch them get scrubbed in front of you. It works
-whether or not reporting is enabled, so you can inspect the output before deciding to opt in.
+runs it through the **exact same sanitization** that a real report goes through, then writes the
+result to the game log (`logs/latest.log`) with a short confirmation in chat — **nothing is sent.**
+The full report is written to the log because it's far too detailed to read in chat. The sample
+deliberately contains fake sensitive values (a home directory, an IP, a UUID, a token) so you can see
+them scrubbed in the output. It works whether or not reporting is enabled, so you can inspect it
+before deciding to opt in.
 
 ---
 

--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -22,7 +22,7 @@ seriously.
 - ✅ **Logistics only.** It reports errors from this mod's own code — not from Minecraft, your server,
   or other mods.
 - ✅ **Sanitized.** No player names, UUIDs, IP addresses, server addresses, chat, or world data.
-- ✅ **You can verify it.** `/logistics crashreports preview` shows you a real, sanitized example
+- ✅ **You can verify it.** `/logistics diagnostics preview` shows you a real, sanitized example
   report without sending anything.
 - ✅ **Per-install.** Turning it on for a server does **not** turn it on for your players.
 
@@ -66,12 +66,12 @@ it on.
 
 | Command | What it does |
 | --- | --- |
-| `/logistics crashreports` | Show whether reporting and the join notice are on or off |
-| `/logistics crashreports enable` | Opt in to sending sanitized reports |
-| `/logistics crashreports disable` | Stop sending reports |
-| `/logistics crashreports preview` | Write an example sanitized report to the log **without sending it** |
-| `/logistics crashreports notify off` | Hide the one-time join invitation |
-| `/logistics crashreports notify on` | Show the join invitation again |
+| `/logistics diagnostics` | Show whether reporting and the join notice are on or off |
+| `/logistics diagnostics enable` | Opt in to sending sanitized reports |
+| `/logistics diagnostics disable` | Stop sending reports |
+| `/logistics diagnostics preview` | Write an example sanitized report to the log **without sending it** |
+| `/logistics diagnostics notify off` | Hide the one-time join invitation |
+| `/logistics diagnostics notify on` | Show the join invitation again |
 
 ### See for yourself: `preview`
 
@@ -128,7 +128,7 @@ Several safeguards work together:
 4. **Active scrubbing.** Before a report leaves your machine, a sanitizer rewrites the message and
    error text to remove home-directory paths (e.g. `/Users/you/…` → `~`, Windows paths too), IP
    addresses (→ `<ip>`), UUIDs (→ `<uuid>`), and secret-like `key=value` pairs (→ `key=<redacted>`).
-5. **Verifiable.** `/logistics crashreports preview` lets you see the sanitized output yourself.
+5. **Verifiable.** `/logistics diagnostics preview` lets you see the sanitized output yourself.
 
 This sanitization is best-effort and intentionally biased toward over-redaction: when in doubt, it
 strips it.
@@ -148,8 +148,8 @@ reports go there instead of the default project.
 
 ## How to check the current state, or turn it off
 
-- Run `/logistics crashreports` to see the current status at any time.
-- Run `/logistics crashreports disable` to stop immediately.
+- Run `/logistics diagnostics` to see the current status at any time.
+- Run `/logistics diagnostics disable` to stop immediately.
 - Or open `config/logistics.json` and set `crashReporting.enabled` to `false`.
 
 When disabled, the reporter sends nothing and runs no background networking.
@@ -175,7 +175,7 @@ Please [open an issue](https://github.com/Indemnity83/logistics/issues) and tell
 don't need to include the sensitive value itself). We'll tighten the sanitizer.
 
 **Can I turn off just the in-game invitation but leave reporting off?**
-Yes — `/logistics crashreports notify off` hides the prompt without changing anything else.
+Yes — `/logistics diagnostics notify off` hides the prompt without changing anything else.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ RF energy generation and distribution:
 [Full installation guide →](https://indemnity83.github.io/logistics/getting-started/install/)
 
 
+## Crash Reporting & Privacy
+
+Logistics can optionally send **sanitized** crash diagnostics to help fix bugs. It is **off by
+default** and opt-in per install via `/logistics crashreports enable`. It never intentionally sends
+player names, UUIDs, IPs, server addresses, chat, or world data. See
+[CRASH_REPORTING.md](CRASH_REPORTING.md) for exactly what is and isn't collected.
+
+
 ## Quick Start
 
 1. **Craft pipes** - Start with stone or copper transport pipes

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ RF energy generation and distribution:
 ## Crash Reporting & Privacy
 
 Logistics can optionally send **sanitized** crash diagnostics to help fix bugs. It is **off by
-default** and opt-in per install via `/logistics crashreports enable`. It never intentionally sends
+default** and opt-in per install via `/logistics diagnostics enable`. It never intentionally sends
 player names, UUIDs, IPs, server addresses, chat, or world data. See
 [CRASH_REPORTING.md](CRASH_REPORTING.md) for exactly what is and isn't collected.
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     // Team Reborn Energy API (bundled into the Fabric jar via include in fabric/build.gradle)
     implementation("teamreborn:energy:${rootProject.fabric_energy_version}")
 
+    // Sentry crash reporting SDK. Pure Java, no MC dependency, so the SDK calls live in common.
+    // Bundled into each loader jar separately (Fabric include, NeoForge jarJar) since common
+    // sources are recompiled into each loader rather than shipped as a shared runtime jar.
+    implementation("io.sentry:sentry:${rootProject.sentry_version}")
+
     // JEI — compile only; players install separately at runtime
     compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
 

--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -2,6 +2,7 @@ package com.logistics;
 
 import com.logistics.core.LogisticsConfig;
 import com.logistics.core.bootstrap.DomainBootstrap;
+import com.logistics.core.crash.CrashReporting;
 import com.logistics.core.item.ProbeItem;
 import com.logistics.core.item.WrenchItem;
 import com.logistics.core.macerator.MaceratorBlock;
@@ -58,6 +59,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         LOGGER.info("Registering {}", domain());
 
         LogisticsConfig.load();
+        CrashReporting.bootstrap();
 
         BLOCK.register();
         ITEM.register();

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -156,14 +156,23 @@ public final class LogisticsCommandTree {
                 })
                 .then(Commands.literal("enable")
                     .executes(ctx -> {
+                        if (!CrashReporting.enableReporting()) {
+                            ctx.getSource().sendFailure(Component.literal(
+                                "Could not start crash reporting — no DSN configured or initialization failed. "
+                                + "See the log for details."));
+                            return 0;
+                        }
                         ctx.getSource().sendSuccess(
-                            () -> Component.literal(CrashReporting.setReportingEnabled(true)), true);
+                            () -> Component.literal(
+                                "Sanitized crash reporting enabled. Thank you for helping improve Logistics!"),
+                            true);
                         return 1;
                     }))
                 .then(Commands.literal("disable")
                     .executes(ctx -> {
+                        CrashReporting.disableReporting();
                         ctx.getSource().sendSuccess(
-                            () -> Component.literal(CrashReporting.setReportingEnabled(false)), true);
+                            () -> Component.literal("Crash reporting disabled."), true);
                         return 1;
                     }))
                 .then(Commands.literal("preview")

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -1,5 +1,6 @@
 package com.logistics.core;
 
+import com.logistics.core.crash.CrashReporting;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
@@ -147,6 +148,49 @@ public final class LogisticsCommandTree {
                         ctx.getSource().sendSuccess(
                             () -> Component.literal("Reloaded logistics config from disk"), true);
                         return 1;
-                    })));
+                    })))
+            .then(Commands.literal("crashreports")
+                .executes(ctx -> {
+                    LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
+                    String msg = "Anonymous crash reporting: " + (cfg.enabled ? "ON" : "off")
+                        + "\n  join notice: " + (cfg.notifyOperators ? "on" : "off");
+                    ctx.getSource().sendSuccess(() -> Component.literal(msg), false);
+                    return 1;
+                })
+                .then(Commands.literal("enable")
+                    .executes(ctx -> {
+                        LogisticsConfig.get().crashReporting.enabled = true;
+                        LogisticsConfig.save();
+                        CrashReporting.enable();
+                        ctx.getSource().sendSuccess(
+                            () -> Component.literal("Anonymous crash reporting enabled. Thank you!"), true);
+                        return 1;
+                    }))
+                .then(Commands.literal("disable")
+                    .executes(ctx -> {
+                        LogisticsConfig.get().crashReporting.enabled = false;
+                        LogisticsConfig.save();
+                        CrashReporting.disable();
+                        ctx.getSource().sendSuccess(
+                            () -> Component.literal("Anonymous crash reporting disabled."), true);
+                        return 1;
+                    }))
+                .then(Commands.literal("notify")
+                    .then(Commands.literal("on")
+                        .executes(ctx -> {
+                            LogisticsConfig.get().crashReporting.notifyOperators = true;
+                            LogisticsConfig.save();
+                            ctx.getSource().sendSuccess(
+                                () -> Component.literal("Crash reporting join notice: ON"), true);
+                            return 1;
+                        }))
+                    .then(Commands.literal("off")
+                        .executes(ctx -> {
+                            LogisticsConfig.get().crashReporting.notifyOperators = false;
+                            LogisticsConfig.save();
+                            ctx.getSource().sendSuccess(
+                                () -> Component.literal("Crash reporting join notice: OFF"), true);
+                            return 1;
+                        }))));
     }
 }

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -152,7 +152,7 @@ public final class LogisticsCommandTree {
             .then(Commands.literal("crashreports")
                 .executes(ctx -> {
                     LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
-                    String msg = "Anonymous crash reporting: " + (cfg.enabled ? "ON" : "off")
+                    String msg = "Sanitized crash reporting: " + (cfg.enabled ? "ON" : "off")
                         + "\n  join notice: " + (cfg.notifyOperators ? "on" : "off");
                     ctx.getSource().sendSuccess(() -> Component.literal(msg), false);
                     return 1;
@@ -163,7 +163,7 @@ public final class LogisticsCommandTree {
                         LogisticsConfig.save();
                         CrashReporting.enable();
                         ctx.getSource().sendSuccess(
-                            () -> Component.literal("Anonymous crash reporting enabled. Thank you!"), true);
+                            () -> Component.literal("Sanitized crash reporting enabled. Thank you for helping improve Logistics!"), true);
                         return 1;
                     }))
                 .then(Commands.literal("disable")
@@ -172,7 +172,7 @@ public final class LogisticsCommandTree {
                         LogisticsConfig.save();
                         CrashReporting.disable();
                         ctx.getSource().sendSuccess(
-                            () -> Component.literal("Anonymous crash reporting disabled."), true);
+                            () -> Component.literal("Crash reporting disabled."), true);
                         return 1;
                     }))
                 .then(Commands.literal("notify")

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -175,6 +175,15 @@ public final class LogisticsCommandTree {
                             () -> Component.literal("Crash reporting disabled."), true);
                         return 1;
                     }))
+                .then(Commands.literal("preview")
+                    .executes(ctx -> {
+                        String report = CrashReporting.previewReport();
+                        ctx.getSource().sendSuccess(
+                            () -> Component.literal(
+                                "Example sanitized report (NOT sent — this is a preview):\n" + report),
+                            false);
+                        return 1;
+                    }))
                 .then(Commands.literal("notify")
                     .then(Commands.literal("on")
                         .executes(ctx -> {

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -1,6 +1,7 @@
 package com.logistics.core;
 
 import com.logistics.core.crash.CrashReporting;
+import com.logistics.core.lib.platform.PlatformService;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
@@ -47,6 +48,68 @@ public final class LogisticsCommandTree {
     }
 
     public static LiteralArgumentBuilder<CommandSourceStack> build() {
+        LiteralArgumentBuilder<CommandSourceStack> diagnostics = Commands.literal("diagnostics")
+            .executes(ctx -> {
+                ctx.getSource().sendSuccess(() -> Component.literal(CrashReporting.statusText()), false);
+                return 1;
+            })
+            .then(Commands.literal("enable")
+                .executes(ctx -> {
+                    if (!CrashReporting.enableReporting()) {
+                        ctx.getSource().sendFailure(Component.literal(
+                            "Could not start crash reporting — no DSN configured or initialization failed. "
+                            + "See the log for details."));
+                        return 0;
+                    }
+                    ctx.getSource().sendSuccess(
+                        () -> Component.literal(
+                            "Sanitized crash reporting enabled. Thank you for helping improve Logistics!"),
+                        true);
+                    return 1;
+                }))
+            .then(Commands.literal("disable")
+                .executes(ctx -> {
+                    CrashReporting.disableReporting();
+                    ctx.getSource().sendSuccess(
+                        () -> Component.literal("Crash reporting disabled."), true);
+                    return 1;
+                }))
+            .then(Commands.literal("preview")
+                .executes(ctx -> {
+                    CrashReporting.logPreviewReport();
+                    ctx.getSource().sendSuccess(LogisticsCommandTree::diagnosticsPreviewSummary, false);
+                    return 1;
+                }))
+            .then(Commands.literal("notify")
+                .then(Commands.literal("on")
+                    .executes(ctx -> {
+                        ctx.getSource().sendSuccess(
+                            () -> Component.literal(CrashReporting.setJoinNotice(true)), true);
+                        return 1;
+                    }))
+                .then(Commands.literal("off")
+                    .executes(ctx -> {
+                        ctx.getSource().sendSuccess(
+                            () -> Component.literal(CrashReporting.setJoinNotice(false)), true);
+                        return 1;
+                    })));
+
+        // Dev-only: send a temporary test crash report to verify the Sentry pipeline.
+        if (PlatformService.INSTANCE.isDevelopmentEnvironment()) {
+            diagnostics.then(Commands.literal("test")
+                .executes(ctx -> {
+                    if (!CrashReporting.captureTestReport()) {
+                        ctx.getSource().sendFailure(Component.literal(
+                            "Crash reporting is not active. Run /logistics diagnostics enable first."));
+                        return 0;
+                    }
+                    ctx.getSource().sendSuccess(
+                        () -> Component.literal("Sent a temporary test crash report to Sentry."),
+                        false);
+                    return 1;
+                }));
+        }
+
         return Commands.literal("logistics")
             .requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
             .then(Commands.literal("debug")
@@ -150,55 +213,11 @@ public final class LogisticsCommandTree {
                             () -> Component.literal("Reloaded logistics config from disk"), true);
                         return 1;
                     })))
-            .then(Commands.literal("crashreports")
-                .executes(ctx -> {
-                    ctx.getSource().sendSuccess(() -> Component.literal(CrashReporting.statusText()), false);
-                    return 1;
-                })
-                .then(Commands.literal("enable")
-                    .executes(ctx -> {
-                        if (!CrashReporting.enableReporting()) {
-                            ctx.getSource().sendFailure(Component.literal(
-                                "Could not start crash reporting — no DSN configured or initialization failed. "
-                                + "See the log for details."));
-                            return 0;
-                        }
-                        ctx.getSource().sendSuccess(
-                            () -> Component.literal(
-                                "Sanitized crash reporting enabled. Thank you for helping improve Logistics!"),
-                            true);
-                        return 1;
-                    }))
-                .then(Commands.literal("disable")
-                    .executes(ctx -> {
-                        CrashReporting.disableReporting();
-                        ctx.getSource().sendSuccess(
-                            () -> Component.literal("Crash reporting disabled."), true);
-                        return 1;
-                    }))
-                .then(Commands.literal("preview")
-                    .executes(ctx -> {
-                        CrashReporting.logPreviewReport();
-                        ctx.getSource().sendSuccess(LogisticsCommandTree::crashreportsPreviewSummary, false);
-                        return 1;
-                    }))
-                .then(Commands.literal("notify")
-                    .then(Commands.literal("on")
-                        .executes(ctx -> {
-                            ctx.getSource().sendSuccess(
-                                () -> Component.literal(CrashReporting.setJoinNotice(true)), true);
-                            return 1;
-                        }))
-                    .then(Commands.literal("off")
-                        .executes(ctx -> {
-                            ctx.getSource().sendSuccess(
-                                () -> Component.literal(CrashReporting.setJoinNotice(false)), true);
-                            return 1;
-                        }))));
+            .then(diagnostics);
     }
 
-    /** Chat confirmation for {@code /logistics crashreports preview} — the full report goes to the log. */
-    private static Component crashreportsPreviewSummary() {
+    /** Chat confirmation for {@code /logistics diagnostics preview} — the full report goes to the log. */
+    private static Component diagnosticsPreviewSummary() {
         return Component.empty()
             .append(Component.literal("Wrote an example sanitized crash report to the log.\n")
                 .withStyle(ChatFormatting.GRAY))

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
@@ -177,11 +178,8 @@ public final class LogisticsCommandTree {
                     }))
                 .then(Commands.literal("preview")
                     .executes(ctx -> {
-                        ctx.getSource().sendSuccess(
-                            () -> Component.literal(
-                                "Example sanitized report (NOT sent — this is a preview):\n"
-                                + CrashReporting.previewReport()),
-                            false);
+                        CrashReporting.logPreviewReport();
+                        ctx.getSource().sendSuccess(LogisticsCommandTree::crashreportsPreviewSummary, false);
                         return 1;
                     }))
                 .then(Commands.literal("notify")
@@ -197,5 +195,18 @@ public final class LogisticsCommandTree {
                                 () -> Component.literal(CrashReporting.setJoinNotice(false)), true);
                             return 1;
                         }))));
+    }
+
+    /** Chat confirmation for {@code /logistics crashreports preview} — the full report goes to the log. */
+    private static Component crashreportsPreviewSummary() {
+        return Component.empty()
+            .append(Component.literal("Wrote an example sanitized crash report to the log.\n")
+                .withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("Includes: ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("mod/Minecraft/loader/Java/OS versions and a Logistics stack trace.\n")
+                .withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("Never includes: ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("names, UUIDs, IPs, server addresses, chat, or world data.")
+                .withStyle(ChatFormatting.WHITE));
     }
 }

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -11,6 +11,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,6 +36,8 @@ import java.util.Set;
  */
 public final class LogisticsCommandTree {
     private LogisticsCommandTree() {}
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("logistics/command");
 
     private static final SuggestionProvider<CommandSourceStack> DOMAIN_SUGGESTIONS =
         (ctx, builder) -> SharedSuggestionProvider.suggest(sortedDomains(), builder);
@@ -95,7 +99,7 @@ public final class LogisticsCommandTree {
                     })));
 
         // Dev-only: send a temporary test crash report to verify the Sentry pipeline.
-        if (PlatformService.INSTANCE.isDevelopmentEnvironment()) {
+        if (inDevelopmentEnvironment()) {
             diagnostics.then(Commands.literal("test")
                 .executes(ctx -> {
                     if (!CrashReporting.captureTestReport()) {
@@ -214,6 +218,19 @@ public final class LogisticsCommandTree {
                         return 1;
                     })))
             .then(diagnostics);
+    }
+
+    /**
+     * Resolves the development-environment flag defensively: any failure is treated as production
+     * (false) so dev-only command nodes can never abort registration of the whole command tree.
+     */
+    private static boolean inDevelopmentEnvironment() {
+        try {
+            return PlatformService.INSTANCE.isDevelopmentEnvironment();
+        } catch (Throwable t) {
+            LOGGER.warn("Could not determine development environment; treating as production", t);
+            return false;
+        }
     }
 
     /** Chat confirmation for {@code /logistics diagnostics preview} — the full report goes to the log. */

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -151,54 +151,41 @@ public final class LogisticsCommandTree {
                     })))
             .then(Commands.literal("crashreports")
                 .executes(ctx -> {
-                    LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
-                    String msg = "Sanitized crash reporting: " + (cfg.enabled ? "ON" : "off")
-                        + "\n  join notice: " + (cfg.notifyOperators ? "on" : "off");
-                    ctx.getSource().sendSuccess(() -> Component.literal(msg), false);
+                    ctx.getSource().sendSuccess(() -> Component.literal(CrashReporting.statusText()), false);
                     return 1;
                 })
                 .then(Commands.literal("enable")
                     .executes(ctx -> {
-                        LogisticsConfig.get().crashReporting.enabled = true;
-                        LogisticsConfig.save();
-                        CrashReporting.enable();
                         ctx.getSource().sendSuccess(
-                            () -> Component.literal("Sanitized crash reporting enabled. Thank you for helping improve Logistics!"), true);
+                            () -> Component.literal(CrashReporting.setReportingEnabled(true)), true);
                         return 1;
                     }))
                 .then(Commands.literal("disable")
                     .executes(ctx -> {
-                        LogisticsConfig.get().crashReporting.enabled = false;
-                        LogisticsConfig.save();
-                        CrashReporting.disable();
                         ctx.getSource().sendSuccess(
-                            () -> Component.literal("Crash reporting disabled."), true);
+                            () -> Component.literal(CrashReporting.setReportingEnabled(false)), true);
                         return 1;
                     }))
                 .then(Commands.literal("preview")
                     .executes(ctx -> {
-                        String report = CrashReporting.previewReport();
                         ctx.getSource().sendSuccess(
                             () -> Component.literal(
-                                "Example sanitized report (NOT sent — this is a preview):\n" + report),
+                                "Example sanitized report (NOT sent — this is a preview):\n"
+                                + CrashReporting.previewReport()),
                             false);
                         return 1;
                     }))
                 .then(Commands.literal("notify")
                     .then(Commands.literal("on")
                         .executes(ctx -> {
-                            LogisticsConfig.get().crashReporting.notifyOperators = true;
-                            LogisticsConfig.save();
                             ctx.getSource().sendSuccess(
-                                () -> Component.literal("Crash reporting join notice: ON"), true);
+                                () -> Component.literal(CrashReporting.setJoinNotice(true)), true);
                             return 1;
                         }))
                     .then(Commands.literal("off")
                         .executes(ctx -> {
-                            LogisticsConfig.get().crashReporting.notifyOperators = false;
-                            LogisticsConfig.save();
                             ctx.getSource().sendSuccess(
-                                () -> Component.literal("Crash reporting join notice: OFF"), true);
+                                () -> Component.literal(CrashReporting.setJoinNotice(false)), true);
                             return 1;
                         }))));
     }

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -38,6 +38,7 @@ public final class LogisticsConfig {
     public QuarryConfig quarry = new QuarryConfig();
     public PipeConfig pipe = new PipeConfig();
     public EngineConfig engine = new EngineConfig();
+    public CrashReportingConfig crashReporting = new CrashReportingConfig();
 
     public static final class QuarryConfig {
         public int area = 16;
@@ -76,6 +77,21 @@ public final class LogisticsConfig {
         public long redstoneOutput = 10L;
         public double stirlingMinOutput = 3.0;
         public double stirlingMaxOutput = 10.0;
+    }
+
+    /**
+     * Opt-in anonymous crash reporting (Sentry). Disabled by default; an operator opts in via
+     * {@code /logistics crashreports enable}. These are intentionally NOT in the {@link #ENTRIES}
+     * registry — the {@code /logistics crashreports} commands are the single source of truth so the
+     * persisted value and the live Sentry client never drift apart.
+     */
+    public static final class CrashReportingConfig {
+        /** Whether crash reports are sent. Opt-in: off until an operator enables it. */
+        public boolean enabled = false;
+        /** Whether operators are invited to opt in on join (until they silence it). */
+        public boolean notifyOperators = true;
+        /** Optional DSN override for self-hosting/testing; empty uses the bundled default. */
+        public String dsnOverride = "";
     }
 
     // ==================== Config Entry Registry (for commands) ====================
@@ -281,6 +297,13 @@ public final class LogisticsConfig {
         if (config.engine == null) {
             LOGGER.warn("Invalid logistics config group engine: missing; using defaults");
             config.engine = defaults.engine;
+        }
+        if (config.crashReporting == null) {
+            LOGGER.warn("Invalid logistics config group crashReporting: missing; using defaults");
+            config.crashReporting = defaults.crashReporting;
+        }
+        if (config.crashReporting.dsnOverride == null) {
+            config.crashReporting.dsnOverride = defaults.crashReporting.dsnOverride;
         }
 
         sanitizeInt("quarry_area", () -> (long) config.quarry.area, v -> config.quarry.area = v.intValue(),

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -80,7 +80,7 @@ public final class LogisticsConfig {
     }
 
     /**
-     * Opt-in anonymous crash reporting (Sentry). Disabled by default; an operator opts in via
+     * Opt-in sanitized crash reporting (Sentry). Disabled by default; an operator opts in via
      * {@code /logistics crashreports enable}. These are intentionally NOT in the {@link #ENTRIES}
      * registry — the {@code /logistics crashreports} commands are the single source of truth so the
      * persisted value and the live Sentry client never drift apart.

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -81,8 +81,8 @@ public final class LogisticsConfig {
 
     /**
      * Opt-in sanitized crash reporting (Sentry). Disabled by default; an operator opts in via
-     * {@code /logistics crashreports enable}. These are intentionally NOT in the {@link #ENTRIES}
-     * registry — the {@code /logistics crashreports} commands are the single source of truth so the
+     * {@code /logistics diagnostics enable}. These are intentionally NOT in the {@link #ENTRIES}
+     * registry — the {@code /logistics diagnostics} commands are the single source of truth so the
      * persisted value and the live Sentry client never drift apart.
      */
     public static final class CrashReportingConfig {

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -14,14 +14,14 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Sends operators a one-time (per launch) invite to opt in to sanitized crash reporting.
+ * Shows operators a once-per-server-session crash-reporting status line with clickable toggles.
  *
- * <p>Shared by both loaders; the loader-specific player-join hooks resolve the {@link ServerPlayer}
- * and call {@link #maybeNotify}. The message is suppressed once reporting is enabled or an operator
- * silences it via {@code /logistics crashreports notify off}.
+ * <p>Shared by both loaders; the loader-specific hooks call {@link #maybeNotify} on player join and
+ * {@link #reset()} when a server starts so each new world/server session shows the line once. It is
+ * suppressed when an operator silences it via {@code /logistics crashreports notify off}.
  */
 public final class CrashReportNotifier {
-    private static final Set<UUID> NOTIFIED_THIS_LAUNCH = ConcurrentHashMap.newKeySet();
+    private static final Set<UUID> NOTIFIED_THIS_SESSION = ConcurrentHashMap.newKeySet();
 
     private static final String ENABLE_COMMAND = "/logistics crashreports enable";
     private static final String DISABLE_COMMAND = "/logistics crashreports disable";
@@ -33,16 +33,21 @@ public final class CrashReportNotifier {
 
     private CrashReportNotifier() {}
 
-    /** Show operators the once-per-launch crash-reporting status line (unless they've silenced it). */
+    /** Show operators the once-per-session crash-reporting status line (unless they've silenced it). */
     public static void maybeNotify(ServerPlayer player) {
         LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
         boolean isOperator = Commands.LEVEL_GAMEMASTERS.check(player.permissions());
         if (!shouldNotify(cfg.notifyOperators, isOperator)) {
             return;
         }
-        if (NOTIFIED_THIS_LAUNCH.add(player.getUUID())) {
+        if (NOTIFIED_THIS_SESSION.add(player.getUUID())) {
             player.sendSystemMessage(buildInvite(cfg.enabled));
         }
+    }
+
+    /** Clear the per-session dedup so the next server session shows the status line again. */
+    public static void reset() {
+        NOTIFIED_THIS_SESSION.clear();
     }
 
     /** Pure gate: show the status line only to operators who haven't silenced the notice. */

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -3,9 +3,12 @@ package com.logistics.core.crash;
 import com.logistics.core.LogisticsConfig;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.server.level.ServerPlayer;
 
+import java.net.URI;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,42 +23,77 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class CrashReportNotifier {
     private static final Set<UUID> NOTIFIED_THIS_LAUNCH = ConcurrentHashMap.newKeySet();
 
-    /** Latest crash-reporting & privacy page. Bare URLs are auto-linkified by the client. */
+    private static final String ENABLE_COMMAND = "/logistics crashreports enable";
+    private static final String DISABLE_COMMAND = "/logistics crashreports disable";
+    private static final String HIDE_COMMAND = "/logistics crashreports notify off";
+
+    /** Latest crash-reporting & privacy page, opened by the [More Info] link. */
     private static final String DETAILS_URL =
             "https://github.com/Indemnity83/logistics/blob/mc/26.1/CRASH_REPORTING.md";
 
     private CrashReportNotifier() {}
 
-    /** Notify {@code player} if they are an operator who hasn't been invited yet this launch. */
+    /** Show operators the once-per-launch crash-reporting status line (unless they've silenced it). */
     public static void maybeNotify(ServerPlayer player) {
         LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
         boolean isOperator = Commands.LEVEL_GAMEMASTERS.check(player.permissions());
-        if (!shouldNotify(cfg.enabled, cfg.notifyOperators, isOperator)) {
+        if (!shouldNotify(cfg.notifyOperators, isOperator)) {
             return;
         }
         if (NOTIFIED_THIS_LAUNCH.add(player.getUUID())) {
-            player.sendSystemMessage(buildInvite());
+            player.sendSystemMessage(buildInvite(cfg.enabled));
         }
     }
 
-    /** Pure gate: invite only operators, and only when reporting is off but notices are enabled. */
-    static boolean shouldNotify(boolean reportingEnabled, boolean notifyOperators, boolean isOperator) {
-        return !reportingEnabled && notifyOperators && isOperator;
+    /** Pure gate: show the status line only to operators who haven't silenced the notice. */
+    static boolean shouldNotify(boolean notifyOperators, boolean isOperator) {
+        return notifyOperators && isOperator;
     }
 
-    static Component buildInvite() {
+    /** Status line whose toggle reflects the current state: [ON] turns it off, [OFF] turns it on. */
+    static Component buildInvite(boolean enabled) {
         return Component.empty()
                 .append(Component.literal("[Logistics] ").withStyle(ChatFormatting.AQUA))
-                .append(Component.literal(
-                        "Optional crash reporting is OFF. If enabled, Logistics sends sanitized mod "
-                        + "error diagnostics (mod/Minecraft/loader/Java/OS versions and stack traces) "
-                        + "to help fix bugs. It does not send chat, world data, player names, UUIDs, "
-                        + "IPs, or server addresses. ")
-                        .withStyle(ChatFormatting.GRAY))
-                .append(Component.literal("Opt in: /logistics crashreports enable").withStyle(ChatFormatting.WHITE))
-                .append(Component.literal("  •  hide this: ").withStyle(ChatFormatting.GRAY))
-                .append(Component.literal("/logistics crashreports notify off").withStyle(ChatFormatting.WHITE))
-                .append(Component.literal("\nWhat's collected: ").withStyle(ChatFormatting.GRAY))
-                .append(Component.literal(DETAILS_URL).withStyle(ChatFormatting.AQUA));
+                .append(Component.literal("Crash reporting is ").withStyle(ChatFormatting.GRAY))
+                .append(statusToggle(enabled))
+                .append(Component.literal(" "))
+                .append(hideNotificationLink())
+                .append(Component.literal(" "))
+                .append(moreInfoLink());
+    }
+
+    private static Component statusToggle(boolean enabled) {
+        if (enabled) {
+            return Component.literal("[ON]").withStyle(style -> style
+                    .withColor(ChatFormatting.GREEN)
+                    .withBold(true)
+                    .withClickEvent(new ClickEvent.RunCommand(DISABLE_COMMAND))
+                    .withHoverEvent(new HoverEvent.ShowText(
+                            Component.literal("Click to turn crash reporting off"))));
+        }
+        return Component.literal("[OFF]").withStyle(style -> style
+                .withColor(ChatFormatting.RED)
+                .withBold(true)
+                .withClickEvent(new ClickEvent.RunCommand(ENABLE_COMMAND))
+                .withHoverEvent(new HoverEvent.ShowText(
+                        Component.literal("Click to turn on sanitized crash reporting"))));
+    }
+
+    private static Component hideNotificationLink() {
+        return Component.literal("[Hide Notification]").withStyle(style -> style
+                .withColor(ChatFormatting.GRAY)
+                .withUnderlined(true)
+                .withClickEvent(new ClickEvent.RunCommand(HIDE_COMMAND))
+                .withHoverEvent(new HoverEvent.ShowText(
+                        Component.literal("Stop showing this on join (you can still use /logistics crashreports)"))));
+    }
+
+    private static Component moreInfoLink() {
+        return Component.literal("[More Info]").withStyle(style -> style
+                .withColor(ChatFormatting.AQUA)
+                .withUnderlined(true)
+                .withClickEvent(new ClickEvent.OpenUrl(URI.create(DETAILS_URL)))
+                .withHoverEvent(new HoverEvent.ShowText(
+                        Component.literal("Open the crash reporting & privacy page"))));
     }
 }

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -71,14 +71,12 @@ public final class CrashReportNotifier {
         if (enabled) {
             return Component.literal("[ON]").withStyle(style -> style
                     .withColor(ChatFormatting.GREEN)
-                    .withBold(true)
                     .withClickEvent(new ClickEvent.RunCommand(DISABLE_COMMAND))
                     .withHoverEvent(new HoverEvent.ShowText(
                             Component.literal("Click to turn crash reporting off"))));
         }
         return Component.literal("[OFF]").withStyle(style -> style
                 .withColor(ChatFormatting.RED)
-                .withBold(true)
                 .withClickEvent(new ClickEvent.RunCommand(ENABLE_COMMAND))
                 .withHoverEvent(new HoverEvent.ShowText(
                         Component.literal("Click to turn on sanitized crash reporting"))));

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -20,6 +20,10 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class CrashReportNotifier {
     private static final Set<UUID> NOTIFIED_THIS_LAUNCH = ConcurrentHashMap.newKeySet();
 
+    /** Latest crash-reporting & privacy page. Bare URLs are auto-linkified by the client. */
+    private static final String DETAILS_URL =
+            "https://github.com/Indemnity83/logistics/blob/mc/26.1/CRASH_REPORTING.md";
+
     private CrashReportNotifier() {}
 
     /** Notify {@code player} if they are an operator who hasn't been invited yet this launch. */
@@ -49,6 +53,7 @@ public final class CrashReportNotifier {
                 .append(Component.literal("Opt in: /logistics crashreports enable").withStyle(ChatFormatting.WHITE))
                 .append(Component.literal("  •  hide this: ").withStyle(ChatFormatting.GRAY))
                 .append(Component.literal("/logistics crashreports notify off").withStyle(ChatFormatting.WHITE))
-                .append(Component.literal(".").withStyle(ChatFormatting.GRAY));
+                .append(Component.literal("\nWhat's collected: ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(DETAILS_URL).withStyle(ChatFormatting.AQUA));
     }
 }

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -1,0 +1,51 @@
+package com.logistics.core.crash;
+
+import com.logistics.core.LogisticsConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Sends operators a one-time (per launch) invite to opt in to anonymous crash reporting.
+ *
+ * <p>Shared by both loaders; the loader-specific player-join hooks resolve the {@link ServerPlayer}
+ * and call {@link #maybeNotify}. The message is suppressed once reporting is enabled or an operator
+ * silences it via {@code /logistics crashreports notify off}.
+ */
+public final class CrashReportNotifier {
+    private static final Set<UUID> NOTIFIED_THIS_LAUNCH = ConcurrentHashMap.newKeySet();
+
+    private CrashReportNotifier() {}
+
+    /** Notify {@code player} if they are an operator who hasn't been invited yet this launch. */
+    public static void maybeNotify(ServerPlayer player) {
+        LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
+        if (cfg.enabled || !cfg.notifyOperators) {
+            return;
+        }
+        if (!Commands.LEVEL_GAMEMASTERS.check(player.permissions())) {
+            return;
+        }
+        if (!NOTIFIED_THIS_LAUNCH.add(player.getUUID())) {
+            return;
+        }
+        player.sendSystemMessage(buildInvite());
+    }
+
+    private static Component buildInvite() {
+        return Component.empty()
+                .append(Component.literal("[Logistics] ").withStyle(ChatFormatting.AQUA))
+                .append(Component.literal(
+                        "Anonymous crash reporting is OFF. Opt in to help fix bugs with ")
+                        .withStyle(ChatFormatting.GRAY))
+                .append(Component.literal("/logistics crashreports enable").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal(", or hide this with ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal("/logistics crashreports notify off").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal(".").withStyle(ChatFormatting.GRAY));
+    }
+}

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -18,14 +18,14 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Shared by both loaders; the loader-specific hooks call {@link #maybeNotify} on player join and
  * {@link #reset()} when a server starts so each new world/server session shows the line once. It is
- * suppressed when an operator silences it via {@code /logistics crashreports notify off}.
+ * suppressed when an operator silences it via {@code /logistics diagnostics notify off}.
  */
 public final class CrashReportNotifier {
     private static final Set<UUID> NOTIFIED_THIS_SESSION = ConcurrentHashMap.newKeySet();
 
-    private static final String ENABLE_COMMAND = "/logistics crashreports enable";
-    private static final String DISABLE_COMMAND = "/logistics crashreports disable";
-    private static final String HIDE_COMMAND = "/logistics crashreports notify off";
+    private static final String ENABLE_COMMAND = "/logistics diagnostics enable";
+    private static final String DISABLE_COMMAND = "/logistics diagnostics disable";
+    private static final String HIDE_COMMAND = "/logistics diagnostics notify off";
 
     /** Latest crash-reporting & privacy page, opened by the [More Info] link. */
     private static final String DETAILS_URL =
@@ -88,7 +88,7 @@ public final class CrashReportNotifier {
                 .withUnderlined(true)
                 .withClickEvent(new ClickEvent.RunCommand(HIDE_COMMAND))
                 .withHoverEvent(new HoverEvent.ShowText(
-                        Component.literal("Stop showing this on join (you can still use /logistics crashreports)"))));
+                        Component.literal("Stop showing this on join (you can still use /logistics diagnostics)"))));
     }
 
     private static Component moreInfoLink() {

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Sends operators a one-time (per launch) invite to opt in to anonymous crash reporting.
+ * Sends operators a one-time (per launch) invite to opt in to sanitized crash reporting.
  *
  * <p>Shared by both loaders; the loader-specific player-join hooks resolve the {@link ServerPlayer}
  * and call {@link #maybeNotify}. The message is suppressed once reporting is enabled or an operator
@@ -41,10 +41,13 @@ public final class CrashReportNotifier {
         return Component.empty()
                 .append(Component.literal("[Logistics] ").withStyle(ChatFormatting.AQUA))
                 .append(Component.literal(
-                        "Anonymous crash reporting is OFF. Opt in to help fix bugs with ")
+                        "Optional crash reporting is OFF. If enabled, Logistics sends sanitized mod "
+                        + "error diagnostics (mod/Minecraft/loader/Java/OS versions and stack traces) "
+                        + "to help fix bugs. It does not send chat, world data, player names, UUIDs, "
+                        + "IPs, or server addresses. ")
                         .withStyle(ChatFormatting.GRAY))
-                .append(Component.literal("/logistics crashreports enable").withStyle(ChatFormatting.WHITE))
-                .append(Component.literal(", or hide this with ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal("Opt in: /logistics crashreports enable").withStyle(ChatFormatting.WHITE))
+                .append(Component.literal("  •  hide this: ").withStyle(ChatFormatting.GRAY))
                 .append(Component.literal("/logistics crashreports notify off").withStyle(ChatFormatting.WHITE))
                 .append(Component.literal(".").withStyle(ChatFormatting.GRAY));
     }

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -29,19 +29,21 @@ public final class CrashReportNotifier {
     /** Notify {@code player} if they are an operator who hasn't been invited yet this launch. */
     public static void maybeNotify(ServerPlayer player) {
         LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
-        if (cfg.enabled || !cfg.notifyOperators) {
+        boolean isOperator = Commands.LEVEL_GAMEMASTERS.check(player.permissions());
+        if (!shouldNotify(cfg.enabled, cfg.notifyOperators, isOperator)) {
             return;
         }
-        if (!Commands.LEVEL_GAMEMASTERS.check(player.permissions())) {
-            return;
+        if (NOTIFIED_THIS_LAUNCH.add(player.getUUID())) {
+            player.sendSystemMessage(buildInvite());
         }
-        if (!NOTIFIED_THIS_LAUNCH.add(player.getUUID())) {
-            return;
-        }
-        player.sendSystemMessage(buildInvite());
     }
 
-    private static Component buildInvite() {
+    /** Pure gate: invite only operators, and only when reporting is off but notices are enabled. */
+    static boolean shouldNotify(boolean reportingEnabled, boolean notifyOperators, boolean isOperator) {
+        return !reportingEnabled && notifyOperators && isOperator;
+    }
+
+    static Component buildInvite() {
         return Component.empty()
                 .append(Component.literal("[Logistics] ").withStyle(ChatFormatting.AQUA))
                 .append(Component.literal(

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -11,9 +11,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 /**
- * Opt-in anonymous crash reporting via Sentry. Loader-agnostic — the SDK is pure Java, so all calls
+ * Opt-in sanitized crash reporting via Sentry. Loader-agnostic — the SDK is pure Java, so all calls
  * live in common; loaders only bundle the SDK and provide version/environment via {@link PlatformService}.
  *
  * <p>Design:
@@ -26,8 +27,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *       (no uncaught-exception handler, no shutdown hook); exceptions are captured solely through a
  *       {@link LogisticsErrorLogBridge} scoped to the Logistics loggers, so other mods and vanilla
  *       are never reported.</li>
- *   <li><b>Anonymous</b>: PII is off and the host name is not attached; messages are scrubbed of the
- *       local user name / home directory before send.</li>
+ *   <li><b>Sanitized</b>: PII is off and the host/server name is not attached; messages and exception
+ *       values are scrubbed of home directories, IPs, UUIDs, and secret-like values before send. We
+ *       never intentionally send player names, UUIDs, IPs, server addresses, chat, or world data.</li>
  * </ul>
  *
  * <p>Toggled by the {@code /logistics crashreports} commands, which persist {@link LogisticsConfig}
@@ -154,11 +156,23 @@ public final class CrashReporting {
         return override != null && !override.isBlank() ? override.trim() : DEFAULT_DSN;
     }
 
+    // Free-text identifiers to strip from any text that leaves the process.
+    private static final Pattern IPV4 = Pattern.compile("\\b\\d{1,3}(?:\\.\\d{1,3}){3}\\b");
+    private static final Pattern UUID = Pattern.compile(
+            "\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b");
+    private static final Pattern UNIX_HOME = Pattern.compile("(/(?:Users|home))/[^/\\s]+");
+    private static final Pattern WINDOWS_HOME = Pattern.compile("([A-Za-z]:\\\\Users\\\\)[^\\\\\\s]+");
+    private static final Pattern SECRET_KV = Pattern.compile(
+            "(?i)(password|passwd|token|secret|api[_-]?key|access[_-]?key|dsn)(\\s*[=:]\\s*)\\S+");
+
     /**
-     * Best-effort anonymization: strip the local user name and home directory from the event
-     * message and exception values before the event leaves the process.
+     * Sanitize an event before it leaves the process: drop the server name and strip identifying
+     * substrings (home directories, IPs, UUIDs, secret-like {@code key=value} pairs) from the event
+     * message and every exception value. Stack frames carry only source file names, not paths, so
+     * they need no scrubbing. Best-effort, biased toward over-redaction.
      */
     private static SentryEvent scrub(SentryEvent event) {
+        event.setServerName(null);
         Message message = event.getMessage();
         if (message != null) {
             message.setFormatted(redact(message.getFormatted()));
@@ -184,6 +198,11 @@ public final class CrashReporting {
         if (user != null && !user.isBlank()) {
             value = value.replace(user, "<user>");
         }
+        value = UNIX_HOME.matcher(value).replaceAll("$1/<user>");
+        value = WINDOWS_HOME.matcher(value).replaceAll("$1<user>");
+        value = UUID.matcher(value).replaceAll("<uuid>");
+        value = IPV4.matcher(value).replaceAll("<ip>");
+        value = SECRET_KV.matcher(value).replaceAll("$1$2<redacted>");
         return value;
     }
 }

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -2,8 +2,9 @@ package com.logistics.core.crash;
 
 import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.platform.PlatformService;
-import io.sentry.Sentry;
+import io.sentry.SentryClient;
 import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SentryException;
 import org.slf4j.Logger;
@@ -19,9 +20,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <ul>
  *   <li><b>Lazy</b>: nothing initializes until {@link #enable()} is called. A disabled install spins
  *       up no transport thread and makes no network calls.</li>
- *   <li><b>Logistics-only</b>: Sentry's global uncaught-exception handler is disabled; exceptions are
- *       captured solely through a {@link LogisticsErrorLogBridge} scoped to the Logistics loggers, so
- *       other mods and vanilla are never reported.</li>
+ *   <li><b>Logistics-only</b>: a dedicated {@link SentryClient} is used rather than the global
+ *       {@code Sentry.init()}/{@code Sentry.close()} static API, so we never mutate SDK state shared
+ *       with another mod that bundles Sentry. A standalone client installs no global integrations
+ *       (no uncaught-exception handler, no shutdown hook); exceptions are captured solely through a
+ *       {@link LogisticsErrorLogBridge} scoped to the Logistics loggers, so other mods and vanilla
+ *       are never reported.</li>
  *   <li><b>Anonymous</b>: PII is off and the host name is not attached; messages are scrubbed of the
  *       local user name / home directory before send.</li>
  * </ul>
@@ -39,7 +43,12 @@ public final class CrashReporting {
     private static final String DEFAULT_DSN =
             "https://677897aaa1709d6e63d47ebbed033218@o148290.ingest.us.sentry.io/4511488473169920";
 
+    /** How long the exit hook waits for queued events to flush, in milliseconds. */
+    private static final long FLUSH_TIMEOUT_MS = 2_000L;
+
     private static final AtomicBoolean ACTIVE = new AtomicBoolean(false);
+    private static final AtomicBoolean SHUTDOWN_HOOK_REGISTERED = new AtomicBoolean(false);
+    private static volatile SentryClient client;
     private static volatile LogisticsErrorLogBridge bridge;
 
     private CrashReporting() {}
@@ -62,20 +71,25 @@ public final class CrashReporting {
             return;
         }
         boolean dev = PlatformService.INSTANCE.isDevelopmentEnvironment();
-        Sentry.init(options -> {
-            options.setDsn(dsn);
-            // Only Logistics-scoped errors — never install a global handler that would capture
-            // other mods or vanilla.
-            options.setEnableUncaughtExceptionHandler(false);
-            options.setSendDefaultPii(false);
-            options.setAttachServerName(false);
-            // Ignore SENTRY_* env vars / sentry.properties so behavior is fully code-driven.
-            options.setEnableExternalConfiguration(false);
-            options.setRelease("logistics@" + PlatformService.INSTANCE.modVersion());
-            options.setEnvironment(dev ? "dev" : "prod");
-            options.setBeforeSend((event, hint) -> scrub(event));
-            options.setDebug(dev);
-        });
+        SentryOptions options = new SentryOptions();
+        options.setDsn(dsn);
+        // Belt-and-suspenders: a standalone client installs no integrations anyway, so there is
+        // never a global uncaught-exception handler that could capture other mods or vanilla.
+        options.setEnableUncaughtExceptionHandler(false);
+        options.setSendDefaultPii(false);
+        options.setAttachServerName(false);
+        // Ignore SENTRY_* env vars / sentry.properties so behavior is fully code-driven.
+        options.setEnableExternalConfiguration(false);
+        options.setRelease("logistics@" + PlatformService.INSTANCE.modVersion());
+        options.setEnvironment(dev ? "dev" : "prod");
+        options.setBeforeSend((event, hint) -> scrub(event));
+        options.setDebug(dev);
+
+        // Dedicated client — never Sentry.init(), which would replace the global SDK scope shared
+        // with any other mod bundling the same Sentry. The SentryClient constructor swaps in a real
+        // async HTTP transport on its own, so events are actually sent.
+        client = new SentryClient(options);
+        registerExitFlushHookOnce();
         bridge = newBridge();
         bridge.attach();
         ACTIVE.set(true);
@@ -91,7 +105,11 @@ public final class CrashReporting {
             bridge.detach();
             bridge = null;
         }
-        Sentry.close();
+        SentryClient current = client;
+        client = null;
+        if (current != null) {
+            current.close(); // flushes queued events
+        }
         LOGGER.info("Crash reporting disabled");
     }
 
@@ -104,11 +122,31 @@ public final class CrashReporting {
         if (throwable == null || !ACTIVE.get()) {
             return;
         }
-        Sentry.captureException(throwable);
+        SentryClient current = client;
+        if (current != null) {
+            current.captureException(throwable);
+        }
     }
 
     private static LogisticsErrorLogBridge newBridge() {
         return new Log4j2ErrorLogBridge(CrashReporting::capture);
+    }
+
+    /**
+     * Registers a single JVM shutdown hook that flushes the active client's queue on exit. Replaces
+     * the flush-on-exit that {@code Sentry.init()} used to provide via its global shutdown
+     * integration. Process-local and scoped to our own client — it touches no shared SDK state.
+     */
+    private static void registerExitFlushHookOnce() {
+        if (!SHUTDOWN_HOOK_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            SentryClient current = client;
+            if (current != null) {
+                current.flush(FLUSH_TIMEOUT_MS);
+            }
+        }, "logistics-sentry-flush"));
     }
 
     private static String resolveDsn() {

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -1,0 +1,151 @@
+package com.logistics.core.crash;
+
+import com.logistics.core.LogisticsConfig;
+import com.logistics.core.lib.platform.PlatformService;
+import io.sentry.Sentry;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Opt-in anonymous crash reporting via Sentry. Loader-agnostic — the SDK is pure Java, so all calls
+ * live in common; loaders only bundle the SDK and provide version/environment via {@link PlatformService}.
+ *
+ * <p>Design:
+ * <ul>
+ *   <li><b>Lazy</b>: nothing initializes until {@link #enable()} is called. A disabled install spins
+ *       up no transport thread and makes no network calls.</li>
+ *   <li><b>Logistics-only</b>: Sentry's global uncaught-exception handler is disabled; exceptions are
+ *       captured solely through a {@link LogisticsErrorLogBridge} scoped to the Logistics loggers, so
+ *       other mods and vanilla are never reported.</li>
+ *   <li><b>Anonymous</b>: PII is off and the host name is not attached; messages are scrubbed of the
+ *       local user name / home directory before send.</li>
+ * </ul>
+ *
+ * <p>Toggled by the {@code /logistics crashreports} commands, which persist {@link LogisticsConfig}
+ * and call {@link #enable()}/{@link #disable()} so stored and live state stay in sync.
+ */
+public final class CrashReporting {
+    private static final Logger LOGGER = LoggerFactory.getLogger("logistics/crash");
+
+    /**
+     * Public Sentry ingest key (DSN). NOT a secret — DSNs are designed to be embedded in shipped
+     * clients. Overridable per-install via {@code crashReporting.dsnOverride} in logistics.json.
+     */
+    private static final String DEFAULT_DSN =
+            "https://677897aaa1709d6e63d47ebbed033218@o148290.ingest.us.sentry.io/4511488473169920";
+
+    private static final AtomicBoolean ACTIVE = new AtomicBoolean(false);
+    private static volatile LogisticsErrorLogBridge bridge;
+
+    private CrashReporting() {}
+
+    /** Called once after config load. Enables reporting only if the operator opted in previously. */
+    public static void bootstrap() {
+        if (LogisticsConfig.get().crashReporting.enabled) {
+            enable();
+        }
+    }
+
+    /** Start sending reports. Idempotent. */
+    public static synchronized void enable() {
+        if (ACTIVE.get()) {
+            return;
+        }
+        String dsn = resolveDsn();
+        if (dsn.isBlank()) {
+            LOGGER.warn("Crash reporting enabled but no DSN is configured; not starting Sentry");
+            return;
+        }
+        boolean dev = PlatformService.INSTANCE.isDevelopmentEnvironment();
+        Sentry.init(options -> {
+            options.setDsn(dsn);
+            // Only Logistics-scoped errors — never install a global handler that would capture
+            // other mods or vanilla.
+            options.setEnableUncaughtExceptionHandler(false);
+            options.setSendDefaultPii(false);
+            options.setAttachServerName(false);
+            // Ignore SENTRY_* env vars / sentry.properties so behavior is fully code-driven.
+            options.setEnableExternalConfiguration(false);
+            options.setRelease("logistics@" + PlatformService.INSTANCE.modVersion());
+            options.setEnvironment(dev ? "dev" : "prod");
+            options.setBeforeSend((event, hint) -> scrub(event));
+            options.setDebug(dev);
+        });
+        bridge = newBridge();
+        bridge.attach();
+        ACTIVE.set(true);
+        LOGGER.info("Crash reporting enabled (environment={})", dev ? "dev" : "prod");
+    }
+
+    /** Stop sending reports and flush. Idempotent. */
+    public static synchronized void disable() {
+        if (!ACTIVE.getAndSet(false)) {
+            return;
+        }
+        if (bridge != null) {
+            bridge.detach();
+            bridge = null;
+        }
+        Sentry.close();
+        LOGGER.info("Crash reporting disabled");
+    }
+
+    public static boolean isActive() {
+        return ACTIVE.get();
+    }
+
+    /** Report a throwable when active; a no-op otherwise. */
+    public static void capture(Throwable throwable) {
+        if (throwable == null || !ACTIVE.get()) {
+            return;
+        }
+        Sentry.captureException(throwable);
+    }
+
+    private static LogisticsErrorLogBridge newBridge() {
+        return new Log4j2ErrorLogBridge(CrashReporting::capture);
+    }
+
+    private static String resolveDsn() {
+        String override = LogisticsConfig.get().crashReporting.dsnOverride;
+        return override != null && !override.isBlank() ? override.trim() : DEFAULT_DSN;
+    }
+
+    /**
+     * Best-effort anonymization: strip the local user name and home directory from the event
+     * message and exception values before the event leaves the process.
+     */
+    private static SentryEvent scrub(SentryEvent event) {
+        Message message = event.getMessage();
+        if (message != null) {
+            message.setFormatted(redact(message.getFormatted()));
+            message.setMessage(redact(message.getMessage()));
+        }
+        if (event.getExceptions() != null) {
+            for (SentryException ex : event.getExceptions()) {
+                ex.setValue(redact(ex.getValue()));
+            }
+        }
+        return event;
+    }
+
+    static String redact(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        String home = System.getProperty("user.home");
+        String user = System.getProperty("user.name");
+        if (home != null && !home.isBlank()) {
+            value = value.replace(home, "~");
+        }
+        if (user != null && !user.isBlank()) {
+            value = value.replace(user, "<user>");
+        }
+        return value;
+    }
+}

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -205,6 +205,15 @@ public final class CrashReporting {
     }
 
     /**
+     * Write an example sanitized report to the log so an operator can read/copy exactly what would
+     * be sent. Logged at INFO with no throwable, so the {@link LogisticsErrorLogBridge} never picks
+     * it up — previewing never sends anything, even while reporting is active.
+     */
+    public static void logPreviewReport() {
+        LOGGER.info("Example sanitized crash report (NOT sent — preview):\n{}", previewReport());
+    }
+
+    /**
      * Build a representative report for a synthetic Logistics error, run it through the exact
      * sanitization pipeline used before sending, and return it as JSON. Does NOT send and works
      * whether or not reporting is enabled, so an operator can inspect the output before opting in.

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  *       never intentionally send player names, UUIDs, IPs, server addresses, chat, or world data.</li>
  * </ul>
  *
- * <p>Toggled by the {@code /logistics crashreports} commands, which persist {@link LogisticsConfig}
+ * <p>Toggled by the {@code /logistics diagnostics} commands, which persist {@link LogisticsConfig}
  * and call {@link #enable()}/{@link #disable()} so stored and live state stay in sync.
  */
 public final class CrashReporting {
@@ -103,6 +103,9 @@ public final class CrashReporting {
         options.setEnableExternalConfiguration(false);
         options.setRelease("logistics@" + modVersion());
         options.setEnvironment(dev ? "dev" : "prod");
+        options.setTag("loader", loaderName());
+        options.setTag("minecraft_version", minecraftVersion());
+        options.setTag("mod_version", modVersion());
         options.setBeforeSend((event, hint) -> scrub(event));
         options.setDebug(dev);
         return options;
@@ -113,6 +116,22 @@ public final class CrashReporting {
     private static String modVersion() {
         try {
             return PlatformService.INSTANCE.modVersion();
+        } catch (Throwable t) {
+            return "unknown";
+        }
+    }
+
+    private static String loaderName() {
+        try {
+            return PlatformService.INSTANCE.loaderName();
+        } catch (Throwable t) {
+            return "unknown";
+        }
+    }
+
+    private static String minecraftVersion() {
+        try {
+            return PlatformService.INSTANCE.minecraftVersion();
         } catch (Throwable t) {
             return "unknown";
         }
@@ -148,7 +167,7 @@ public final class CrashReporting {
     }
 
     // ==================== Command actions ====================
-    // These back the /logistics crashreports subcommands. Kept here (not inline in the Brigadier
+    // These back the /logistics diagnostics subcommands. Kept here (not inline in the Brigadier
     // tree) so the persist-and-toggle logic is unit-testable without a command source.
 
     /**
@@ -202,6 +221,21 @@ public final class CrashReporting {
         if (current != null) {
             current.captureException(throwable);
         }
+    }
+
+    /** TEMPORARY: send a synthetic report so the Sentry project can be inspected manually. */
+    public static boolean captureTestReport() {
+        if (!ACTIVE.get()) {
+            return false;
+        }
+        SentryClient current = client;
+        if (current == null) {
+            return false;
+        }
+        current.captureException(new RuntimeException(
+                "Temporary Logistics Sentry test report; safe to ignore. marker=" + System.currentTimeMillis()));
+        current.flush(FLUSH_TIMEOUT_MS);
+        return true;
     }
 
     /**

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -2,14 +2,19 @@ package com.logistics.core.crash;
 
 import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.platform.PlatformService;
+import io.sentry.JsonSerializer;
 import io.sentry.SentryClient;
 import io.sentry.SentryEvent;
+import io.sentry.SentryExceptionFactory;
 import io.sentry.SentryOptions;
+import io.sentry.SentryStackTraceFactory;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SentryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -72,21 +77,7 @@ public final class CrashReporting {
             LOGGER.warn("Crash reporting enabled but no DSN is configured; not starting Sentry");
             return;
         }
-        boolean dev = PlatformService.INSTANCE.isDevelopmentEnvironment();
-        SentryOptions options = new SentryOptions();
-        options.setDsn(dsn);
-        // Belt-and-suspenders: a standalone client installs no integrations anyway, so there is
-        // never a global uncaught-exception handler that could capture other mods or vanilla.
-        options.setEnableUncaughtExceptionHandler(false);
-        options.setSendDefaultPii(false);
-        options.setAttachServerName(false);
-        // Ignore SENTRY_* env vars / sentry.properties so behavior is fully code-driven.
-        options.setEnableExternalConfiguration(false);
-        options.setRelease("logistics@" + PlatformService.INSTANCE.modVersion());
-        options.setEnvironment(dev ? "dev" : "prod");
-        options.setBeforeSend((event, hint) -> scrub(event));
-        options.setDebug(dev);
-
+        SentryOptions options = buildOptions();
         // Dedicated client — never Sentry.init(), which would replace the global SDK scope shared
         // with any other mod bundling the same Sentry. The SentryClient constructor swaps in a real
         // async HTTP transport on its own, so events are actually sent.
@@ -95,7 +86,44 @@ public final class CrashReporting {
         bridge = newBridge();
         bridge.attach();
         ACTIVE.set(true);
-        LOGGER.info("Crash reporting enabled (environment={})", dev ? "dev" : "prod");
+        LOGGER.info("Crash reporting enabled (environment={})", options.getEnvironment());
+    }
+
+    /** Build the Sentry options used for both the live client and the {@link #previewReport()}. */
+    private static SentryOptions buildOptions() {
+        boolean dev = isDevelopmentEnvironment();
+        SentryOptions options = new SentryOptions();
+        options.setDsn(resolveDsn());
+        // Belt-and-suspenders: a standalone client installs no integrations anyway, so there is
+        // never a global uncaught-exception handler that could capture other mods or vanilla.
+        options.setEnableUncaughtExceptionHandler(false);
+        options.setSendDefaultPii(false);
+        options.setAttachServerName(false);
+        // Ignore SENTRY_* env vars / sentry.properties so behavior is fully code-driven.
+        options.setEnableExternalConfiguration(false);
+        options.setRelease("logistics@" + modVersion());
+        options.setEnvironment(dev ? "dev" : "prod");
+        options.setBeforeSend((event, hint) -> scrub(event));
+        options.setDebug(dev);
+        return options;
+    }
+
+    // Platform lookups are defensive: crash reporting is non-critical, so if the SPI is somehow
+    // unavailable (e.g. a unit-test classloader) we fall back rather than failing to report.
+    private static String modVersion() {
+        try {
+            return PlatformService.INSTANCE.modVersion();
+        } catch (Throwable t) {
+            return "unknown";
+        }
+    }
+
+    private static boolean isDevelopmentEnvironment() {
+        try {
+            return PlatformService.INSTANCE.isDevelopmentEnvironment();
+        } catch (Throwable t) {
+            return false;
+        }
     }
 
     /** Stop sending reports and flush. Idempotent. */
@@ -127,6 +155,33 @@ public final class CrashReporting {
         SentryClient current = client;
         if (current != null) {
             current.captureException(throwable);
+        }
+    }
+
+    /**
+     * Build a representative report for a synthetic Logistics error, run it through the exact
+     * sanitization pipeline used before sending, and return it as JSON. Does NOT send and works
+     * whether or not reporting is enabled, so an operator can inspect the output before opting in.
+     * The sample message embeds mock sensitive values so the scrubbing is visible in the result.
+     */
+    public static String previewReport() {
+        SentryOptions options = buildOptions();
+        RuntimeException sample = new RuntimeException(
+                "Logistics crash-report preview (example, not a real crash). Sensitive values are "
+                + "scrubbed before send: home=" + System.getProperty("user.home")
+                + " ip=203.0.113.7 uuid=123e4567-e89b-12d3-a456-426614174000 token=hunter2");
+        SentryEvent event = new SentryEvent(sample);
+        event.setRelease(options.getRelease());
+        event.setEnvironment(options.getEnvironment());
+        SentryExceptionFactory exceptionFactory =
+                new SentryExceptionFactory(new SentryStackTraceFactory(options));
+        event.setExceptions(exceptionFactory.getSentryExceptions(sample));
+        scrub(event);
+        try (StringWriter writer = new StringWriter()) {
+            new JsonSerializer(options).serialize(event, writer);
+            return writer.toString();
+        } catch (IOException e) {
+            return "Failed to build preview: " + e;
         }
     }
 

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -147,6 +147,38 @@ public final class CrashReporting {
         return ACTIVE.get();
     }
 
+    // ==================== Command actions ====================
+    // These back the /logistics crashreports subcommands. Kept here (not inline in the Brigadier
+    // tree) so the persist-and-toggle logic is unit-testable without a command source.
+
+    /** Persist the operator's opt-in choice and toggle the live client. Returns operator feedback. */
+    public static String setReportingEnabled(boolean enabled) {
+        LogisticsConfig.get().crashReporting.enabled = enabled;
+        LogisticsConfig.save();
+        if (enabled) {
+            enable();
+        } else {
+            disable();
+        }
+        return enabled
+                ? "Sanitized crash reporting enabled. Thank you for helping improve Logistics!"
+                : "Crash reporting disabled.";
+    }
+
+    /** Persist whether the join invitation is shown. Returns operator feedback. */
+    public static String setJoinNotice(boolean show) {
+        LogisticsConfig.get().crashReporting.notifyOperators = show;
+        LogisticsConfig.save();
+        return "Crash reporting join notice: " + (show ? "ON" : "off");
+    }
+
+    /** Human-readable current state for the status command. */
+    public static String statusText() {
+        LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
+        return "Sanitized crash reporting: " + (cfg.enabled ? "ON" : "off")
+                + "\n  join notice: " + (cfg.notifyOperators ? "on" : "off");
+    }
+
     /** Report a throwable when active; a no-op otherwise. */
     public static void capture(Throwable throwable) {
         if (throwable == null || !ACTIVE.get()) {

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -151,18 +151,25 @@ public final class CrashReporting {
     // These back the /logistics crashreports subcommands. Kept here (not inline in the Brigadier
     // tree) so the persist-and-toggle logic is unit-testable without a command source.
 
-    /** Persist the operator's opt-in choice and toggle the live client. Returns operator feedback. */
-    public static String setReportingEnabled(boolean enabled) {
-        LogisticsConfig.get().crashReporting.enabled = enabled;
+    /**
+     * Turn reporting on, then persist {@code enabled} to match whether it actually activated.
+     * Returns true if reporting is now active. If activation fails (e.g. no DSN, or init throws
+     * before this returns), the persisted config is left disabled rather than claiming an active
+     * state — so the saved value never lies about a client that isn't running.
+     */
+    public static boolean enableReporting() {
+        enable();
+        boolean active = isActive();
+        LogisticsConfig.get().crashReporting.enabled = active;
         LogisticsConfig.save();
-        if (enabled) {
-            enable();
-        } else {
-            disable();
-        }
-        return enabled
-                ? "Sanitized crash reporting enabled. Thank you for helping improve Logistics!"
-                : "Crash reporting disabled.";
+        return active;
+    }
+
+    /** Turn reporting off and persist the disabled state. */
+    public static void disableReporting() {
+        disable();
+        LogisticsConfig.get().crashReporting.enabled = false;
+        LogisticsConfig.save();
     }
 
     /** Persist whether the join invitation is shown. Returns operator feedback. */

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -158,7 +158,14 @@ public final class CrashReporting {
      * state — so the saved value never lies about a client that isn't running.
      */
     public static boolean enableReporting() {
-        enable();
+        try {
+            enable();
+        } catch (Exception e) {
+            LOGGER.error("Failed to start crash reporting", e);
+            LogisticsConfig.get().crashReporting.enabled = false;
+            LogisticsConfig.save();
+            return false;
+        }
         boolean active = isActive();
         LogisticsConfig.get().crashReporting.enabled = active;
         LogisticsConfig.save();

--- a/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
+++ b/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
@@ -1,0 +1,96 @@
+package com.logistics.core.crash;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+import java.util.function.Consumer;
+
+/**
+ * {@link LogisticsErrorLogBridge} backed by Log4j2 (Minecraft's slf4j backend at runtime).
+ *
+ * <p>Adds a forwarding appender to the <em>root</em> logger config, filtered at runtime to ERROR
+ * events that (a) carry a {@link Throwable} and (b) originate from a Logistics logger. Attaching to
+ * root rather than creating a {@code com.logistics} logger config avoids changing any logger's
+ * effective level. All Log4j2-core access is guarded so a non-Log4j2 backend degrades to a no-op.
+ */
+final class Log4j2ErrorLogBridge implements LogisticsErrorLogBridge {
+    private static final Logger LOGGER = LoggerFactory.getLogger("logistics/crash");
+    private static final String APPENDER_NAME = "LogisticsSentryBridge";
+
+    private final Consumer<Throwable> sink;
+    private ForwardingAppender appender;
+
+    Log4j2ErrorLogBridge(Consumer<Throwable> sink) {
+        this.sink = sink;
+    }
+
+    /**
+     * True when an event should be reported: it carries a throwable and originates from a Logistics
+     * logger. Package-private and parameterized over primitives so it is unit-testable without
+     * constructing a Log4j2 {@link LogEvent}.
+     */
+    static boolean shouldForward(String loggerName, boolean hasThrowable) {
+        if (!hasThrowable || loggerName == null) {
+            return false;
+        }
+        String lower = loggerName.toLowerCase(Locale.ROOT);
+        return lower.startsWith("logistics") || lower.contains("com.logistics");
+    }
+
+    @Override
+    public void attach() {
+        try {
+            if (!(LogManager.getContext(false) instanceof LoggerContext ctx)) {
+                LOGGER.warn("Log4j2 backend unavailable; crash log capture disabled");
+                return;
+            }
+            Configuration config = ctx.getConfiguration();
+            appender = new ForwardingAppender(APPENDER_NAME, sink);
+            appender.start();
+            config.getRootLogger().addAppender(appender, Level.ERROR, null);
+            ctx.updateLoggers();
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to attach crash log capture: {}", t.toString());
+            appender = null;
+        }
+    }
+
+    @Override
+    public void detach() {
+        try {
+            if (appender == null || !(LogManager.getContext(false) instanceof LoggerContext ctx)) {
+                return;
+            }
+            ctx.getConfiguration().getRootLogger().removeAppender(APPENDER_NAME);
+            appender.stop();
+            ctx.updateLoggers();
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to detach crash log capture: {}", t.toString());
+        } finally {
+            appender = null;
+        }
+    }
+
+    private static final class ForwardingAppender extends AbstractAppender {
+        private final Consumer<Throwable> sink;
+
+        ForwardingAppender(String name, Consumer<Throwable> sink) {
+            super(name, null, null, true, null);
+            this.sink = sink;
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            if (shouldForward(event.getLoggerName(), event.getThrown() != null)) {
+                sink.accept(event.getThrown());
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/logistics/core/crash/LogisticsErrorLogBridge.java
+++ b/common/src/main/java/com/logistics/core/crash/LogisticsErrorLogBridge.java
@@ -1,0 +1,16 @@
+package com.logistics.core.crash;
+
+/**
+ * Bridges Logistics' own ERROR log events into a crash-report sink. Implementations attach to the
+ * logging backend (e.g. Log4j2) and forward only exceptions logged under the Logistics loggers.
+ *
+ * <p>Kept as an interface so {@link CrashReporting} stays free of logging-backend imports and so a
+ * missing/incompatible backend can degrade to a no-op.
+ */
+public interface LogisticsErrorLogBridge {
+    /** Begin forwarding Logistics ERROR-level exceptions to the sink. */
+    void attach();
+
+    /** Stop forwarding and detach from the logging backend. */
+    void detach();
+}

--- a/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
@@ -41,6 +41,22 @@ public interface PlatformService {
     }
 
     /**
+     * Returns the loader id used by this runtime (e.g. {@code "fabric"} or {@code "neoforge"}).
+     * Used for diagnostics tags such as Sentry grouping/search.
+     */
+    default String loaderName() {
+        return "unknown";
+    }
+
+    /**
+     * Returns the active Minecraft version string (e.g. {@code "1.21.11"}). Used for diagnostics
+     * tags so cross-version reports can be filtered without parsing the mod release string.
+     */
+    default String minecraftVersion() {
+        return "unknown";
+    }
+
+    /**
      * Returns {@code true} in a development/dev-runtime environment, {@code false} in a
      * production install. Used to pick the Sentry environment tag and enable SDK debug logging.
      * Defaults to {@code false} (production-safe) for any loader that doesn't override it.
@@ -58,7 +74,7 @@ public interface PlatformService {
      */
     default <T> void registerAlias(Registry<T> registry, Identifier oldId, T currentEntry) {}
 
-    PlatformService INSTANCE = ServiceLoader.load(PlatformService.class)
+    PlatformService INSTANCE = ServiceLoader.load(PlatformService.class, PlatformService.class.getClassLoader())
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("No PlatformService found"));
 }

--- a/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
@@ -33,6 +33,23 @@ public interface PlatformService {
     }
 
     /**
+     * Returns the Logistics mod version string (e.g. {@code "0.5.5"}), used as the Sentry
+     * release tag. Defaults to {@code "unknown"} when the loader cannot resolve it.
+     */
+    default String modVersion() {
+        return "unknown";
+    }
+
+    /**
+     * Returns {@code true} in a development/dev-runtime environment, {@code false} in a
+     * production install. Used to pick the Sentry environment tag and enable SDK debug logging.
+     * Defaults to {@code false} (production-safe) for any loader that doesn't override it.
+     */
+    default boolean isDevelopmentEnvironment() {
+        return false;
+    }
+
+    /**
      * Registers {@code oldId} as a legacy alias for the same registry entry as
      * {@code currentEntry}, so saves that used the old ID are remapped on load.
      *

--- a/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
@@ -1,5 +1,6 @@
 package com.logistics.core;
 
+import com.logistics.test.MinecraftTestEnvironment;
 import com.mojang.brigadier.tree.CommandNode;
 import net.minecraft.commands.CommandSourceStack;
 import org.junit.jupiter.api.DisplayName;
@@ -8,23 +9,33 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("LogisticsCommandTree")
-class LogisticsCommandTreeTest {
+class LogisticsCommandTreeTest extends MinecraftTestEnvironment {
 
     @Test
-    @DisplayName("builds /logistics with the crashreports subcommands")
-    void buildsCrashreportsSubtree() {
+    @DisplayName("builds /logistics with the diagnostics subcommands")
+    void buildsDiagnosticsSubtree() {
         CommandNode<CommandSourceStack> root = LogisticsCommandTree.build().build();
         assertThat(root.getName()).isEqualTo("logistics");
 
-        CommandNode<CommandSourceStack> crash = root.getChild("crashreports");
-        assertThat(crash).isNotNull();
-        assertThat(crash.getChild("enable")).isNotNull();
-        assertThat(crash.getChild("disable")).isNotNull();
-        assertThat(crash.getChild("preview")).isNotNull();
+        CommandNode<CommandSourceStack> diagnostics = root.getChild("diagnostics");
+        assertThat(diagnostics).isNotNull();
+        assertThat(diagnostics.getChild("enable")).isNotNull();
+        assertThat(diagnostics.getChild("disable")).isNotNull();
+        assertThat(diagnostics.getChild("preview")).isNotNull();
 
-        CommandNode<CommandSourceStack> notify = crash.getChild("notify");
+        CommandNode<CommandSourceStack> notify = diagnostics.getChild("notify");
         assertThat(notify).isNotNull();
         assertThat(notify.getChild("on")).isNotNull();
         assertThat(notify.getChild("off")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("exposes the dev-only test subcommand in a development environment")
+    void exposesTestSubcommandInDev() {
+        // TestPlatformService reports a development environment, so the dev-gated
+        // /logistics diagnostics test node is registered.
+        CommandNode<CommandSourceStack> root = LogisticsCommandTree.build().build();
+        CommandNode<CommandSourceStack> diagnostics = root.getChild("diagnostics");
+        assertThat(diagnostics.getChild("test")).isNotNull();
     }
 }

--- a/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
@@ -1,0 +1,30 @@
+package com.logistics.core;
+
+import com.mojang.brigadier.tree.CommandNode;
+import net.minecraft.commands.CommandSourceStack;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LogisticsCommandTree")
+class LogisticsCommandTreeTest {
+
+    @Test
+    @DisplayName("builds /logistics with the crashreports subcommands")
+    void buildsCrashreportsSubtree() {
+        CommandNode<CommandSourceStack> root = LogisticsCommandTree.build().build();
+        assertThat(root.getName()).isEqualTo("logistics");
+
+        CommandNode<CommandSourceStack> crash = root.getChild("crashreports");
+        assertThat(crash).isNotNull();
+        assertThat(crash.getChild("enable")).isNotNull();
+        assertThat(crash.getChild("disable")).isNotNull();
+        assertThat(crash.getChild("preview")).isNotNull();
+
+        CommandNode<CommandSourceStack> notify = crash.getChild("notify");
+        assertThat(notify).isNotNull();
+        assertThat(notify.getChild("on")).isNotNull();
+        assertThat(notify.getChild("off")).isNotNull();
+    }
+}

--- a/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
@@ -145,6 +145,49 @@ class LogisticsConfigTest {
     }
 
     @Test
+    @DisplayName("should default crash reporting to opt-in with the join notice on")
+    void crashReportingDefaultsToOptIn() {
+        LogisticsConfig.CrashReportingConfig cfg = new LogisticsConfig().crashReporting;
+
+        assertThat(cfg.enabled).isFalse();
+        assertThat(cfg.notifyOperators).isTrue();
+        assertThat(cfg.dsnOverride).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should recover a null crash reporting group and null dsn override")
+    void sanitizesNullCrashReportingGroup() {
+        LogisticsConfig parsed = new LogisticsConfig();
+        parsed.crashReporting = null;
+
+        LogisticsConfig sanitized = LogisticsConfig.sanitize(parsed);
+
+        assertThat(sanitized.crashReporting).isNotNull();
+        assertThat(sanitized.crashReporting.enabled).isFalse();
+        assertThat(sanitized.crashReporting.notifyOperators).isTrue();
+        assertThat(sanitized.crashReporting.dsnOverride).isEmpty();
+
+        LogisticsConfig withNullDsn = new LogisticsConfig();
+        withNullDsn.crashReporting.dsnOverride = null;
+        assertThat(LogisticsConfig.sanitize(withNullDsn).crashReporting.dsnOverride).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should preserve valid crash reporting values through sanitize")
+    void preservesValidCrashReportingValues() {
+        LogisticsConfig parsed = new LogisticsConfig();
+        parsed.crashReporting.enabled = true;
+        parsed.crashReporting.notifyOperators = false;
+        parsed.crashReporting.dsnOverride = "https://key@example.invalid/1";
+
+        LogisticsConfig sanitized = LogisticsConfig.sanitize(parsed);
+
+        assertThat(sanitized.crashReporting.enabled).isTrue();
+        assertThat(sanitized.crashReporting.notifyOperators).isFalse();
+        assertThat(sanitized.crashReporting.dsnOverride).isEqualTo("https://key@example.invalid/1");
+    }
+
+    @Test
     @DisplayName("should clamp quarry derived energy values to non-negative")
     void quarryDerivedEnergyValuesAreNonNegative() {
         LogisticsConfig.QuarryConfig quarry = new LogisticsConfig.QuarryConfig();

--- a/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
@@ -1,5 +1,7 @@
 package com.logistics.core.crash;
 
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -9,20 +11,50 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CrashReportNotifierTest {
 
     @Test
-    @DisplayName("invites only operators when reporting is off and notices are enabled")
+    @DisplayName("shows the status line only to operators who haven't silenced it")
     void gateLogic() {
-        assertThat(CrashReportNotifier.shouldNotify(false, true, true)).isTrue();   // off + notices + op
-        assertThat(CrashReportNotifier.shouldNotify(true, true, true)).isFalse();   // already reporting
-        assertThat(CrashReportNotifier.shouldNotify(false, false, true)).isFalse(); // notices silenced
-        assertThat(CrashReportNotifier.shouldNotify(false, true, false)).isFalse(); // not an operator
+        assertThat(CrashReportNotifier.shouldNotify(true, true)).isTrue();    // notices on + operator
+        assertThat(CrashReportNotifier.shouldNotify(false, true)).isFalse();  // notices silenced
+        assertThat(CrashReportNotifier.shouldNotify(true, false)).isFalse();  // not an operator
     }
 
     @Test
-    @DisplayName("invite text names the commands and links the details page")
-    void inviteContent() {
-        String text = CrashReportNotifier.buildInvite().getString();
-        assertThat(text).contains("/logistics crashreports enable");
-        assertThat(text).contains("/logistics crashreports notify off");
-        assertThat(text).contains("CRASH_REPORTING.md");
+    @DisplayName("OFF state shows [OFF] that enables, with a More Info link")
+    void inviteWhenOff() {
+        Component invite = CrashReportNotifier.buildInvite(false);
+        assertThat(invite.getString())
+                .contains("Crash reporting is").contains("[OFF]").contains("[Hide Notification]").contains("[More Info]");
+        assertThat(commandOf(invite, "[OFF]")).isEqualTo("/logistics crashreports enable");
+        assertThat(commandOf(invite, "[Hide Notification]")).isEqualTo("/logistics crashreports notify off");
+        assertThat(infoLinkPresent(invite)).isTrue();
+    }
+
+    @Test
+    @DisplayName("ON state shows [ON] that disables")
+    void inviteWhenOn() {
+        Component invite = CrashReportNotifier.buildInvite(true);
+        assertThat(invite.getString()).contains("[ON]");
+        assertThat(commandOf(invite, "[ON]")).isEqualTo("/logistics crashreports disable");
+    }
+
+    /** Command bound to the run-command click on the sibling whose visible text equals {@code label}. */
+    private static String commandOf(Component invite, String label) {
+        for (Component part : invite.getSiblings()) {
+            if (part.getString().equals(label)
+                    && part.getStyle().getClickEvent() instanceof ClickEvent.RunCommand run) {
+                return run.command();
+            }
+        }
+        return null;
+    }
+
+    private static boolean infoLinkPresent(Component invite) {
+        for (Component part : invite.getSiblings()) {
+            if (part.getStyle().getClickEvent() instanceof ClickEvent.OpenUrl open
+                    && open.uri().toString().contains("CRASH_REPORTING.md")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
@@ -24,8 +24,8 @@ class CrashReportNotifierTest {
         Component invite = CrashReportNotifier.buildInvite(false);
         assertThat(invite.getString())
                 .contains("Crash reporting is").contains("[OFF]").contains("[Hide Notification]").contains("[More Info]");
-        assertThat(commandOf(invite, "[OFF]")).isEqualTo("/logistics crashreports enable");
-        assertThat(commandOf(invite, "[Hide Notification]")).isEqualTo("/logistics crashreports notify off");
+        assertThat(commandOf(invite, "[OFF]")).isEqualTo("/logistics diagnostics enable");
+        assertThat(commandOf(invite, "[Hide Notification]")).isEqualTo("/logistics diagnostics notify off");
         assertThat(infoLinkPresent(invite)).isTrue();
     }
 
@@ -34,7 +34,7 @@ class CrashReportNotifierTest {
     void inviteWhenOn() {
         Component invite = CrashReportNotifier.buildInvite(true);
         assertThat(invite.getString()).contains("[ON]");
-        assertThat(commandOf(invite, "[ON]")).isEqualTo("/logistics crashreports disable");
+        assertThat(commandOf(invite, "[ON]")).isEqualTo("/logistics diagnostics disable");
     }
 
     /** Command bound to the run-command click on the sibling whose visible text equals {@code label}. */

--- a/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
@@ -1,0 +1,28 @@
+package com.logistics.core.crash;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CrashReportNotifier")
+class CrashReportNotifierTest {
+
+    @Test
+    @DisplayName("invites only operators when reporting is off and notices are enabled")
+    void gateLogic() {
+        assertThat(CrashReportNotifier.shouldNotify(false, true, true)).isTrue();   // off + notices + op
+        assertThat(CrashReportNotifier.shouldNotify(true, true, true)).isFalse();   // already reporting
+        assertThat(CrashReportNotifier.shouldNotify(false, false, true)).isFalse(); // notices silenced
+        assertThat(CrashReportNotifier.shouldNotify(false, true, false)).isFalse(); // not an operator
+    }
+
+    @Test
+    @DisplayName("invite text names the commands and links the details page")
+    void inviteContent() {
+        String text = CrashReportNotifier.buildInvite().getString();
+        assertThat(text).contains("/logistics crashreports enable");
+        assertThat(text).contains("/logistics crashreports notify off");
+        assertThat(text).contains("CRASH_REPORTING.md");
+    }
+}

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -1,5 +1,7 @@
 package com.logistics.core.crash;
 
+import com.logistics.core.LogisticsConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +10,19 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 @DisplayName("CrashReporting")
 class CrashReportingTest {
+
+    // A syntactically valid DSN on localhost so enabling never reaches the real Sentry project;
+    // any queued event just fails to connect and is dropped on a background thread.
+    private static final String LOCAL_DSN = "http://examplekey@localhost/1";
+
+    @AfterEach
+    void cleanup() {
+        CrashReporting.disable();
+        LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
+        cfg.enabled = false;
+        cfg.notifyOperators = true;
+        cfg.dsnOverride = "";
+    }
 
     @Test
     @DisplayName("is inactive by default and capture is a no-op when disabled")
@@ -73,6 +88,51 @@ class CrashReportingTest {
 
         // Previewing neither enables reporting nor sends anything.
         assertThat(CrashReporting.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("enable/disable toggles the live client and persists the choice")
+    void enableDisableLifecycle() {
+        LogisticsConfig.get().crashReporting.dsnOverride = LOCAL_DSN;
+
+        String enabledMsg = CrashReporting.setReportingEnabled(true);
+        assertThat(CrashReporting.isActive()).isTrue();
+        assertThat(LogisticsConfig.get().crashReporting.enabled).isTrue();
+        assertThat(enabledMsg).contains("enabled");
+
+        // Capturing on an active client is accepted without throwing (sent async to the dead DSN).
+        assertThatCode(() -> CrashReporting.capture(new RuntimeException("test")))
+                .doesNotThrowAnyException();
+
+        String disabledMsg = CrashReporting.setReportingEnabled(false);
+        assertThat(CrashReporting.isActive()).isFalse();
+        assertThat(LogisticsConfig.get().crashReporting.enabled).isFalse();
+        assertThat(disabledMsg).contains("disabled");
+    }
+
+    @Test
+    @DisplayName("bootstrap enables only when the config opted in")
+    void bootstrapHonorsConfig() {
+        LogisticsConfig.get().crashReporting.enabled = false;
+        CrashReporting.bootstrap();
+        assertThat(CrashReporting.isActive()).isFalse();
+
+        LogisticsConfig.get().crashReporting.enabled = true;
+        LogisticsConfig.get().crashReporting.dsnOverride = LOCAL_DSN;
+        CrashReporting.bootstrap();
+        assertThat(CrashReporting.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("join-notice and status actions update and report config")
+    void joinNoticeAndStatusActions() {
+        assertThat(CrashReporting.setJoinNotice(false)).contains("off");
+        assertThat(LogisticsConfig.get().crashReporting.notifyOperators).isFalse();
+
+        assertThat(CrashReporting.setJoinNotice(true)).contains("ON");
+        assertThat(LogisticsConfig.get().crashReporting.notifyOperators).isTrue();
+
+        assertThat(CrashReporting.statusText()).contains("Sanitized crash reporting");
     }
 
     @Test

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -91,23 +91,22 @@ class CrashReportingTest {
     }
 
     @Test
-    @DisplayName("enable/disable toggles the live client and persists the choice")
+    @DisplayName("enable/disable toggles the live client and persists the actual state")
     void enableDisableLifecycle() {
         LogisticsConfig.get().crashReporting.dsnOverride = LOCAL_DSN;
 
-        String enabledMsg = CrashReporting.setReportingEnabled(true);
+        assertThat(CrashReporting.enableReporting()).isTrue();
         assertThat(CrashReporting.isActive()).isTrue();
+        // Config is persisted only to reflect the real active state.
         assertThat(LogisticsConfig.get().crashReporting.enabled).isTrue();
-        assertThat(enabledMsg).contains("enabled");
 
         // Capturing on an active client is accepted without throwing (sent async to the dead DSN).
         assertThatCode(() -> CrashReporting.capture(new RuntimeException("test")))
                 .doesNotThrowAnyException();
 
-        String disabledMsg = CrashReporting.setReportingEnabled(false);
+        CrashReporting.disableReporting();
         assertThat(CrashReporting.isActive()).isFalse();
         assertThat(LogisticsConfig.get().crashReporting.enabled).isFalse();
-        assertThat(disabledMsg).contains("disabled");
     }
 
     @Test

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -110,6 +110,19 @@ class CrashReportingTest {
     }
 
     @Test
+    @DisplayName("enable failure leaves reporting off and persists the disabled state")
+    void enableFailureIsSafe() {
+        // A malformed DSN makes the Sentry client constructor throw inside enable().
+        LogisticsConfig.get().crashReporting.dsnOverride = "https://localhost";
+
+        boolean active = CrashReporting.enableReporting();
+
+        assertThat(active).isFalse();
+        assertThat(CrashReporting.isActive()).isFalse();
+        assertThat(LogisticsConfig.get().crashReporting.enabled).isFalse();
+    }
+
+    @Test
     @DisplayName("bootstrap enables only when the config opted in")
     void bootstrapHonorsConfig() {
         LogisticsConfig.get().crashReporting.enabled = false;

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -1,0 +1,60 @@
+package com.logistics.core.crash;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("CrashReporting")
+class CrashReportingTest {
+
+    @Test
+    @DisplayName("is inactive by default and capture is a no-op when disabled")
+    void captureIsNoOpWhenDisabled() {
+        assertThat(CrashReporting.isActive()).isFalse();
+        assertThatCode(() -> CrashReporting.capture(new RuntimeException("boom"))).doesNotThrowAnyException();
+        assertThatCode(() -> CrashReporting.capture(null)).doesNotThrowAnyException();
+        assertThat(CrashReporting.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("redacts the local user name and home directory")
+    void redactsLocalIdentity() {
+        String home = System.getProperty("user.home");
+        String user = System.getProperty("user.name");
+
+        String message = "failed to read " + home + "/saves by " + user;
+        String redacted = CrashReporting.redact(message);
+
+        assertThat(redacted).doesNotContain(home);
+        assertThat(redacted).contains("~");
+        if (user != null && !user.isBlank()) {
+            assertThat(redacted).doesNotContain("by " + user);
+            assertThat(redacted).contains("<user>");
+        }
+    }
+
+    @Test
+    @DisplayName("redact passes through null and empty unchanged")
+    void redactPassesThroughNullAndEmpty() {
+        assertThat(CrashReporting.redact(null)).isNull();
+        assertThat(CrashReporting.redact("")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("forwards only Logistics loggers that carry a throwable")
+    void forwardsOnlyLogisticsErrorsWithThrowable() {
+        // Matches the codebase's logger names (e.g. "logistics", "logistics/config", "Logistics/JEI")
+        assertThat(Log4j2ErrorLogBridge.shouldForward("logistics", true)).isTrue();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("logistics/config", true)).isTrue();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("Logistics/JEI", true)).isTrue();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("com.logistics.pipe.Pipe", true)).isTrue();
+
+        // No throwable, foreign loggers, or null name are not forwarded.
+        assertThat(Log4j2ErrorLogBridge.shouldForward("logistics", false)).isFalse();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("net.minecraft.server.Main", true)).isFalse();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("some.other.mod", true)).isFalse();
+        assertThat(Log4j2ErrorLogBridge.shouldForward(null, true)).isFalse();
+    }
+}

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -88,6 +88,10 @@ class CrashReportingTest {
 
         // Previewing neither enables reporting nor sends anything.
         assertThat(CrashReporting.isActive()).isFalse();
+
+        // The log-writing wrapper is also inert and must not throw.
+        assertThatCode(CrashReporting::logPreviewReport).doesNotThrowAnyException();
+        assertThat(CrashReporting.isActive()).isFalse();
     }
 
     @Test

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -43,6 +43,23 @@ class CrashReportingTest {
     }
 
     @Test
+    @DisplayName("redacts IPs, UUIDs, any-user home paths, and secret-like values")
+    void redactsCommonIdentifiers() {
+        assertThat(CrashReporting.redact("connect to 192.168.1.50:25565"))
+                .contains("<ip>").doesNotContain("192.168.1.50");
+        assertThat(CrashReporting.redact("player 123e4567-e89b-12d3-a456-426614174000 left"))
+                .contains("<uuid>").doesNotContain("123e4567");
+        assertThat(CrashReporting.redact("read /Users/alice/world"))
+                .contains("/Users/<user>").doesNotContain("alice");
+        assertThat(CrashReporting.redact("opening /home/bob/.minecraft"))
+                .contains("/home/<user>").doesNotContain("bob");
+        assertThat(CrashReporting.redact("C:\\Users\\Carol\\saves"))
+                .contains("C:\\Users\\<user>").doesNotContain("Carol");
+        assertThat(CrashReporting.redact("token=abc123secretvalue"))
+                .contains("<redacted>").doesNotContain("abc123secretvalue");
+    }
+
+    @Test
     @DisplayName("forwards only Logistics loggers that carry a throwable")
     void forwardsOnlyLogisticsErrorsWithThrowable() {
         // Matches the codebase's logger names (e.g. "logistics", "logistics/config", "Logistics/JEI")

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -60,6 +60,22 @@ class CrashReportingTest {
     }
 
     @Test
+    @DisplayName("preview builds a scrubbed report without sending or enabling")
+    void previewIsScrubbedAndInert() {
+        String json = CrashReporting.previewReport();
+
+        // Contains the synthetic exception, but the mock sensitive values are redacted.
+        assertThat(json).contains("RuntimeException").contains("preview");
+        assertThat(json).contains("<ip>").doesNotContain("203.0.113.7");
+        assertThat(json).contains("<uuid>").doesNotContain("123e4567-e89b-12d3-a456-426614174000");
+        assertThat(json).contains("<redacted>").doesNotContain("hunter2");
+        assertThat(json).doesNotContain(System.getProperty("user.home"));
+
+        // Previewing neither enables reporting nor sends anything.
+        assertThat(CrashReporting.isActive()).isFalse();
+    }
+
+    @Test
     @DisplayName("forwards only Logistics loggers that carry a throwable")
     void forwardsOnlyLogisticsErrorsWithThrowable() {
         // Matches the codebase's logger names (e.g. "logistics", "logistics/config", "Logistics/JEI")

--- a/common/src/test/java/com/logistics/core/crash/Log4j2ErrorLogBridgeTest.java
+++ b/common/src/test/java/com/logistics/core/crash/Log4j2ErrorLogBridgeTest.java
@@ -1,0 +1,41 @@
+package com.logistics.core.crash;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Log4j2ErrorLogBridge")
+class Log4j2ErrorLogBridgeTest {
+
+    @Test
+    @DisplayName("forwards Logistics ERROR exceptions while attached, and stops after detach")
+    void attachForwardsAndDetachStops() {
+        List<Throwable> captured = new ArrayList<>();
+        Log4j2ErrorLogBridge bridge = new Log4j2ErrorLogBridge(captured::add);
+        bridge.attach();
+        try {
+            Logger logistics = LogManager.getLogger("logistics");
+            Logger foreign = LogManager.getLogger("net.minecraft.Foo");
+
+            logistics.error("boom", new IllegalStateException("logistics error")); // forwarded
+            logistics.warn("noise", new RuntimeException("warn level"));            // below ERROR
+            logistics.error("no throwable");                                        // no throwable
+            foreign.error("not ours", new RuntimeException("foreign"));             // foreign logger
+
+            assertThat(captured).hasSize(1);
+            assertThat(captured.get(0)).isInstanceOf(IllegalStateException.class);
+        } finally {
+            bridge.detach();
+        }
+
+        captured.clear();
+        LogManager.getLogger("logistics").error("after detach", new RuntimeException("ignored"));
+        assertThat(captured).isEmpty();
+    }
+}

--- a/common/src/test/java/com/logistics/test/TestPlatformService.java
+++ b/common/src/test/java/com/logistics/test/TestPlatformService.java
@@ -1,0 +1,25 @@
+package com.logistics.test;
+
+import com.logistics.core.lib.platform.PlatformService;
+
+import java.nio.file.Path;
+
+/**
+ * Minimal {@link PlatformService} for unit tests, discovered via
+ * {@code META-INF/services} so {@code PlatformService.INSTANCE} resolves on the
+ * test classpath without a loader-specific (Fabric/NeoForge) implementation.
+ *
+ * <p>Reports a development environment so dev-gated command nodes (e.g.
+ * {@code /logistics diagnostics test}) are present and assertable in tests.
+ */
+public final class TestPlatformService implements PlatformService {
+    @Override
+    public Path configDir() {
+        return Path.of(System.getProperty("java.io.tmpdir"), "logistics-test-config");
+    }
+
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return true;
+    }
+}

--- a/common/src/test/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
+++ b/common/src/test/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
@@ -1,0 +1,1 @@
+com.logistics.test.TestPlatformService

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     include("teamreborn:energy:${rootProject.fabric_energy_version}")
     implementation("teamreborn:energy:${rootProject.fabric_energy_version}")
 
+    // Sentry crash reporting SDK — bundled into the Fabric jar via include (jar-in-jar)
+    include("io.sentry:sentry:${rootProject.sentry_version}")
+    implementation("io.sentry:sentry:${rootProject.sentry_version}")
+
     // JEI — compile against API only; players install separately at runtime
     compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
     runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
@@ -22,6 +22,19 @@ public final class FabricPlatformService implements PlatformService {
     }
 
     @Override
+    public String modVersion() {
+        return FabricLoader.getInstance()
+                .getModContainer("logistics")
+                .map(c -> c.getMetadata().getVersion().getFriendlyString())
+                .orElse("unknown");
+    }
+
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return FabricLoader.getInstance().isDevelopmentEnvironment();
+    }
+
+    @Override
     public <T> void registerAlias(Registry<T> registry, Identifier oldId, T currentEntry) {
         Identifier currentId = registry.getKey(currentEntry); // Fabric API extension
         if (currentId != null) {

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
@@ -30,6 +30,19 @@ public final class FabricPlatformService implements PlatformService {
     }
 
     @Override
+    public String loaderName() {
+        return "fabric";
+    }
+
+    @Override
+    public String minecraftVersion() {
+        return FabricLoader.getInstance()
+                .getModContainer("minecraft")
+                .map(c -> c.getMetadata().getVersion().getFriendlyString())
+                .orElse("unknown");
+    }
+
+    @Override
     public boolean isDevelopmentEnvironment() {
         return FabricLoader.getInstance().isDevelopmentEnvironment();
     }

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlayerJoinEvents.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlayerJoinEvents.java
@@ -1,16 +1,18 @@
 package com.logistics.fabric;
 
 import com.logistics.core.crash.CrashReportNotifier;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 
 /**
- * Invites operators to opt in to crash reporting when they join. Pure wiring — the gate and message
- * live in {@link CrashReportNotifier}.
+ * Shows operators the crash-reporting status line on join, resetting the once-per-session dedup when
+ * a server starts. Pure wiring — the gate and message live in {@link CrashReportNotifier}.
  */
 public final class FabricPlayerJoinEvents {
     private FabricPlayerJoinEvents() {}
 
     public static void register() {
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> CrashReportNotifier.reset());
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->
                 CrashReportNotifier.maybeNotify(handler.player));
     }

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlayerJoinEvents.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlayerJoinEvents.java
@@ -1,0 +1,17 @@
+package com.logistics.fabric;
+
+import com.logistics.core.crash.CrashReportNotifier;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+
+/**
+ * Invites operators to opt in to crash reporting when they join. Pure wiring — the gate and message
+ * live in {@link CrashReportNotifier}.
+ */
+public final class FabricPlayerJoinEvents {
+    private FabricPlayerJoinEvents() {}
+
+    public static void register() {
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->
+                CrashReportNotifier.maybeNotify(handler.player));
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -31,6 +31,7 @@ public final class LogisticsFabric implements ModInitializer {
         FabricNetworkTickHandler.register();
         FabricCommandRegistration.register();
         FabricServerLevelEvents.register();
+        FabricPlayerJoinEvents.register();
         FabricPacketRegistration.register();
         FabricBiomeModifications.register();
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,8 @@ moddev_version=2.0.141
 
 # Dependencies
 jei_version=29.2.0.20
+# Sentry crash reporting SDK (core only — no transitive deps; bundled per loader)
+sentry_version=8.43.0
 
 # Test Dependencies
 junit_version=5.11.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,6 @@ moddev_version=2.0.141
 
 # Dependencies
 jei_version=29.2.0.20
-# Sentry crash reporting SDK (core only — no transitive deps; bundled per loader)
 sentry_version=8.43.0
 
 # Test Dependencies

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -58,6 +58,16 @@ dependencies {
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"
     testImplementation "net.neoforged:neoforge:${rootProject.neoforge_version}"
+
+    // Sentry crash reporting SDK — compile against it (common sources are recompiled here) and
+    // embed it via jarJar (jar-in-jar). The version range lets JarJar dedupe against any copy
+    // another mod might ship; prefer our pinned version.
+    jarJar(implementation("io.sentry:sentry")) {
+        version {
+            strictly "[8.43.0,9.0.0)"
+            prefer "${rootProject.sentry_version}"
+        }
+    }
 }
 
 test {

--- a/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
@@ -32,6 +32,7 @@ public final class LogisticsNeoForge {
         NeoForgeChestLootModifier.register(NeoForge.EVENT_BUS);
         NeoForgeNetworkTickHandler.register(NeoForge.EVENT_BUS);
         NeoForgeServerLevelEvents.register(NeoForge.EVENT_BUS);
+        NeoForgePlayerJoinEvents.register(NeoForge.EVENT_BUS);
         if (FMLEnvironment.getDist().isClient()) {
             NeoForgeClientSetup.register(modBus);
         }

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgePlayerJoinEvents.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgePlayerJoinEvents.java
@@ -1,0 +1,24 @@
+package com.logistics.neoforge;
+
+import com.logistics.core.crash.CrashReportNotifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+/**
+ * Invites operators to opt in to crash reporting when they join. Pure wiring — the gate and message
+ * live in {@link CrashReportNotifier}.
+ */
+public final class NeoForgePlayerJoinEvents {
+    private NeoForgePlayerJoinEvents() {}
+
+    public static void register(IEventBus gameBus) {
+        gameBus.addListener(NeoForgePlayerJoinEvents::onLogin);
+    }
+
+    private static void onLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            CrashReportNotifier.maybeNotify(player);
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgePlayerJoinEvents.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgePlayerJoinEvents.java
@@ -4,16 +4,22 @@ import com.logistics.core.crash.CrashReportNotifier;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
 
 /**
- * Invites operators to opt in to crash reporting when they join. Pure wiring — the gate and message
- * live in {@link CrashReportNotifier}.
+ * Shows operators the crash-reporting status line on join, resetting the once-per-session dedup when
+ * a server starts. Pure wiring — the gate and message live in {@link CrashReportNotifier}.
  */
 public final class NeoForgePlayerJoinEvents {
     private NeoForgePlayerJoinEvents() {}
 
     public static void register(IEventBus gameBus) {
+        gameBus.addListener(NeoForgePlayerJoinEvents::onServerStarting);
         gameBus.addListener(NeoForgePlayerJoinEvents::onLogin);
+    }
+
+    private static void onServerStarting(ServerStartingEvent event) {
+        CrashReportNotifier.reset();
     }
 
     private static void onLogin(PlayerEvent.PlayerLoggedInEvent event) {

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
@@ -1,6 +1,7 @@
 package com.logistics.neoforge.platform;
 
 import com.logistics.core.lib.platform.PlatformService;
+import net.minecraft.SharedConstants;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.Identifier;
 import net.neoforged.fml.ModList;
@@ -31,6 +32,16 @@ public final class NeoForgePlatformService implements PlatformService {
         return ModList.get().getModContainerById("logistics")
                 .map(c -> c.getModInfo().getVersion().toString())
                 .orElse("unknown");
+    }
+
+    @Override
+    public String loaderName() {
+        return "neoforge";
+    }
+
+    @Override
+    public String minecraftVersion() {
+        return SharedConstants.getCurrentVersion().id();
     }
 
     @Override

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
@@ -4,6 +4,7 @@ import com.logistics.core.lib.platform.PlatformService;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.Identifier;
 import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.FMLPaths;
 
 import java.nio.file.Path;
@@ -23,6 +24,18 @@ public final class NeoForgePlatformService implements PlatformService {
         return ModList.get().getModContainerById(namespace)
                 .map(c -> c.getModInfo().getDisplayName())
                 .orElse(namespace);
+    }
+
+    @Override
+    public String modVersion() {
+        return ModList.get().getModContainerById("logistics")
+                .map(c -> c.getModInfo().getVersion().toString())
+                .orElse("unknown");
+    }
+
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return !FMLEnvironment.isProduction();
     }
 
     @Override


### PR DESCRIPTION
## Summary

Adds **opt-in, sanitized** crash reporting via the Sentry Java SDK to help identify and fix bugs in the mod. **Disabled by default.**

Crash reporting is disabled by default. Server operators may opt in with `/logistics crashreports enable`. When enabled, Logistics sends sanitized crash/error diagnostics related to the mod to help identify and fix bugs. Reports are intended **not** to include player chat, world data, player UUIDs, usernames, IP addresses, server addresses, or full configuration contents. Crash reports are processed by Sentry unless a custom DSN is configured. Config is per-install, so enabling on a server does not enable anything on players' clients.

See [CRASH_REPORTING.md](CRASH_REPORTING.md) for the full data-collection list.

## Changes

- **Commands** (operator-gated): `/logistics crashreports [enable|disable|notify on|off]`, plus a status view. Disabling is as easy as enabling.
- **Opt-in notice**: one-time-per-launch operator invite that states plainly what is and isn't sent.
- **Capture scope**: only exceptions logged under the `logistics` loggers — never a global uncaught-exception handler, so other mods and vanilla are never reported.
- **Dedicated Sentry client** (not the global `Sentry.init()` SDK), so we never clobber another mod that bundles Sentry; process-local flush-on-exit hook.
- **Sanitization**: `sendDefaultPii` off, server name not attached, and a `beforeSend` filter that strips home directories, IPs, UUIDs, and secret-like `key=value` pairs from messages and exception text.
- Bundled per loader (Fabric `include`, NeoForge `jarJar`); zero transitive deps.

## What is collected (only when enabled)

Mod / Minecraft / loader / Java versions, OS type, and stack traces + exception messages from Logistics' own code.

## What is not collected

Player chat or world data, player names/UUIDs, IP/server addresses, full config contents, or secret-like values.

## Notes

Logistics is not an official Minecraft product and is not approved by or associated with Mojang or Microsoft.
