### PR TITLE
refactor(energy): extract engine heat and cycle planners

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -68,16 +68,16 @@ publishes `project`/`patch` status checks. The thresholds live in `codecov.yml`
 baseline to bump. The local `testCoverage` task above still produces the aggregate
 HTML/XML for offline inspection.
 
-Current aggregate baseline from `./gradlew testCoverage`:
+Current aggregate snapshot from `./gradlew testCoverage`:
 
 | Counter | Coverage |
 |---------|----------|
-| Instruction | 17.0% |
-| Branch | 14.6% |
-| Line | 17.0% |
-| Complexity | 16.0% |
-| Method | 21.7% |
-| Class | 32.7% |
+| Instruction | 17.3% |
+| Branch | 15.2% |
+| Line | 17.4% |
+| Complexity | 16.5% |
+| Method | 22.0% |
+| Class | 33.6% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `power.cable`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
@@ -101,7 +101,7 @@ supported branches.
 - **Failure accounting regressions** — tracked delivery failure, partial delivery followed by failed remainder, retry accounting, and job state after dispatch loss
 - **Pipe network graph** — NetworkGraph, NetworkPathfinder
 - **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
-- **Power** — CableTier, PIDController
+- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner
 - **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic, FluidTankComponent, ItemInventoryComponent
 - **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem
 

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -300,30 +300,17 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
 
     /** Computes temperature from energy level. Hotter when buffer is fuller. */
     protected void computeTemperature() {
-        temperature = (getMaxTemperature() - getTemperatureFloor()) * getEnergyLevel() + getTemperatureFloor();
+        temperature = EngineHeatModel.temperature(energyBuffer.getAmount(), getEnergyBufferCapacity(), getTemperatureFloor(), getMaxTemperature());
     }
 
     /** Computes the engine stage based on current heat level. */
     protected HeatStage computeStage() {
-        double heatLevelRatio = getHeatLevel();
-
-        if (heatLevelRatio < 0.25) return HeatStage.COLD;
-        if (heatLevelRatio < 0.50) return HeatStage.COOL;
-        if (heatLevelRatio < 0.75) return HeatStage.WARM;
-        if (heatLevelRatio >= 1.0 && canOverheat()) return HeatStage.OVERHEAT;
-
-        // HOT is the max stage for non-overheating engines; flash WARM during compression as a visual cue
-        return !canOverheat() && cyclePhase == CyclePhase.COMPRESSION ? HeatStage.WARM : HeatStage.HOT;
+        return EngineHeatModel.stage(temperature, getMaxTemperature(), canOverheat(), cyclePhase == CyclePhase.COMPRESSION);
     }
 
     /** Compute the piston speed based on current heat level. */
     public float getPistonSpeed() {
-        double heatLevel = getHeatLevel();
-        if (heatLevel < 0.25) return 0.01f;
-        if (heatLevel < 0.50) return 0.02f;
-        if (heatLevel < 0.75) return 0.04f;
-        if (heatLevel < 1.0 || !canOverheat()) return 0.08f;
-        return 0.0f; // OVERHEAT
+        return EngineHeatModel.pistonSpeed(temperature, getMaxTemperature(), canOverheat());
     }
 
     // ==================== Cycle System ====================
@@ -340,29 +327,13 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
      * <p>When idle, the engine waits for redstone power to start a new cycle.
      */
     protected void advanceCycle() {
-        if (cyclePhase == CyclePhase.IDLE && isRedstonePowered()) {
-            cyclePhase = CyclePhase.EXPANSION;
-            return;
-        }
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                cyclePhase, progress, isRedstonePowered(), getPistonSpeed(), sendsEnergyContinuously());
+        cyclePhase = result.phase();
+        progress = result.progress();
 
-        if (cyclePhase == CyclePhase.IDLE) {
-            return; // Don't advance progress while idle
-        }
-
-        progress += getPistonSpeed();
-
-        boolean justTransitioned = cyclePhase == CyclePhase.EXPANSION && progress > 0.5f;
-        if (justTransitioned) {
-            cyclePhase = CyclePhase.COMPRESSION;
-        }
-
-        if (sendsEnergyContinuously() || justTransitioned) {
+        if (result.shouldSendEnergy()) {
             sendEnergy();
-        }
-
-        if (progress >= 1.0f) {
-            progress = 0;
-            cyclePhase = CyclePhase.IDLE;
         }
     }
 
@@ -447,20 +418,12 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
 
     /** Gets the heat level as a ratio from 0.0 to 1.0. */
     public double getHeatLevel() {
-        double maxTemp = getMaxTemperature();
-        if (maxTemp <= 0) {
-            return 0.0;
-        }
-        return temperature / maxTemp;
+        return EngineHeatModel.heatLevel(temperature, getMaxTemperature());
     }
 
     /** Gets the energy level as a ratio from 0.0 to 1.0. */
     public double getEnergyLevel() {
-        long capacity = getEnergyBufferCapacity();
-        if (capacity <= 0) {
-            return 0.0;
-        }
-        return energyBuffer.getAmount() / (double) capacity;
+        return EngineHeatModel.energyLevel(energyBuffer.getAmount(), getEnergyBufferCapacity());
     }
 
     public long getCurrentOutputPower() {

--- a/common/src/main/java/com/logistics/core/lib/power/EngineCyclePlanner.java
+++ b/common/src/main/java/com/logistics/core/lib/power/EngineCyclePlanner.java
@@ -1,0 +1,34 @@
+package com.logistics.core.lib.power;
+
+final class EngineCyclePlanner {
+    private EngineCyclePlanner() {}
+
+    static Result advance(
+            AbstractEngineBlockEntity.CyclePhase phase,
+            float progress,
+            boolean powered,
+            float pistonSpeed,
+            boolean sendsEnergyContinuously) {
+        if (phase == AbstractEngineBlockEntity.CyclePhase.IDLE && powered) {
+            return new Result(AbstractEngineBlockEntity.CyclePhase.EXPANSION, progress, false);
+        }
+
+        if (phase == AbstractEngineBlockEntity.CyclePhase.IDLE) {
+            return new Result(phase, progress, false);
+        }
+
+        float nextProgress = progress + pistonSpeed;
+        boolean transitionedToCompression = phase == AbstractEngineBlockEntity.CyclePhase.EXPANSION && nextProgress > 0.5f;
+        AbstractEngineBlockEntity.CyclePhase nextPhase =
+                transitionedToCompression ? AbstractEngineBlockEntity.CyclePhase.COMPRESSION : phase;
+        boolean shouldSendEnergy = sendsEnergyContinuously || transitionedToCompression;
+
+        if (nextProgress >= 1.0f) {
+            return new Result(AbstractEngineBlockEntity.CyclePhase.IDLE, 0.0f, shouldSendEnergy);
+        }
+
+        return new Result(nextPhase, nextProgress, shouldSendEnergy);
+    }
+
+    record Result(AbstractEngineBlockEntity.CyclePhase phase, float progress, boolean shouldSendEnergy) {}
+}

--- a/common/src/main/java/com/logistics/core/lib/power/EngineCyclePlanner.java
+++ b/common/src/main/java/com/logistics/core/lib/power/EngineCyclePlanner.java
@@ -18,7 +18,7 @@ final class EngineCyclePlanner {
         }
 
         float nextProgress = progress + pistonSpeed;
-        boolean transitionedToCompression = phase == AbstractEngineBlockEntity.CyclePhase.EXPANSION && nextProgress > 0.5f;
+        boolean transitionedToCompression = phase == AbstractEngineBlockEntity.CyclePhase.EXPANSION && nextProgress >= 0.5f;
         AbstractEngineBlockEntity.CyclePhase nextPhase =
                 transitionedToCompression ? AbstractEngineBlockEntity.CyclePhase.COMPRESSION : phase;
         boolean shouldSendEnergy = sendsEnergyContinuously || transitionedToCompression;

--- a/common/src/main/java/com/logistics/core/lib/power/EngineHeatModel.java
+++ b/common/src/main/java/com/logistics/core/lib/power/EngineHeatModel.java
@@ -1,0 +1,43 @@
+package com.logistics.core.lib.power;
+
+final class EngineHeatModel {
+    private EngineHeatModel() {}
+
+    static double temperature(long energy, long capacity, double floor, double max) {
+        return (max - floor) * energyLevel(energy, capacity) + floor;
+    }
+
+    static double energyLevel(long energy, long capacity) {
+        if (capacity <= 0) {
+            return 0.0;
+        }
+        return energy / (double) capacity;
+    }
+
+    static double heatLevel(double temperature, double max) {
+        if (max <= 0) {
+            return 0.0;
+        }
+        return temperature / max;
+    }
+
+    static AbstractEngineBlockEntity.HeatStage stage(double temperature, double max, boolean canOverheat, boolean compression) {
+        double ratio = heatLevel(temperature, max);
+
+        if (ratio < 0.25) return AbstractEngineBlockEntity.HeatStage.COLD;
+        if (ratio < 0.50) return AbstractEngineBlockEntity.HeatStage.COOL;
+        if (ratio < 0.75) return AbstractEngineBlockEntity.HeatStage.WARM;
+        if (ratio >= 1.0 && canOverheat) return AbstractEngineBlockEntity.HeatStage.OVERHEAT;
+
+        return !canOverheat && compression ? AbstractEngineBlockEntity.HeatStage.WARM : AbstractEngineBlockEntity.HeatStage.HOT;
+    }
+
+    static float pistonSpeed(double temperature, double max, boolean canOverheat) {
+        double ratio = heatLevel(temperature, max);
+        if (ratio < 0.25) return 0.01f;
+        if (ratio < 0.50) return 0.02f;
+        if (ratio < 0.75) return 0.04f;
+        if (ratio < 1.0 || !canOverheat) return 0.08f;
+        return 0.0f;
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/power/EngineCyclePlannerTest.java
+++ b/common/src/test/java/com/logistics/core/lib/power/EngineCyclePlannerTest.java
@@ -1,0 +1,91 @@
+package com.logistics.core.lib.power;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EngineCyclePlannerTest {
+    @Test
+    void advance_startsExpansionWhenIdleAndPowered() {
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                AbstractEngineBlockEntity.CyclePhase.IDLE,
+                0.0f,
+                true,
+                0.08f,
+                false);
+
+        assertThat(result.phase()).isEqualTo(AbstractEngineBlockEntity.CyclePhase.EXPANSION);
+        assertThat(result.progress()).isZero();
+        assertThat(result.shouldSendEnergy()).isFalse();
+    }
+
+    @Test
+    void advance_keepsIdleEngineStoppedWhenUnpowered() {
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                AbstractEngineBlockEntity.CyclePhase.IDLE,
+                0.0f,
+                false,
+                0.08f,
+                false);
+
+        assertThat(result.phase()).isEqualTo(AbstractEngineBlockEntity.CyclePhase.IDLE);
+        assertThat(result.progress()).isZero();
+        assertThat(result.shouldSendEnergy()).isFalse();
+    }
+
+    @Test
+    void advance_movesExpansionForwardWithoutSendingBeforeCompression() {
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                AbstractEngineBlockEntity.CyclePhase.EXPANSION,
+                0.20f,
+                true,
+                0.08f,
+                false);
+
+        assertThat(result.phase()).isEqualTo(AbstractEngineBlockEntity.CyclePhase.EXPANSION);
+        assertThat(result.progress()).isEqualTo(0.28f);
+        assertThat(result.shouldSendEnergy()).isFalse();
+    }
+
+    @Test
+    void advance_entersCompressionAndRequestsPulsedEnergySend() {
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                AbstractEngineBlockEntity.CyclePhase.EXPANSION,
+                0.48f,
+                true,
+                0.04f,
+                false);
+
+        assertThat(result.phase()).isEqualTo(AbstractEngineBlockEntity.CyclePhase.COMPRESSION);
+        assertThat(result.progress()).isEqualTo(0.52f);
+        assertThat(result.shouldSendEnergy()).isTrue();
+    }
+
+    @Test
+    void advance_requestsContinuousEnergySendEveryActiveTick() {
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                AbstractEngineBlockEntity.CyclePhase.EXPANSION,
+                0.20f,
+                true,
+                0.08f,
+                true);
+
+        assertThat(result.phase()).isEqualTo(AbstractEngineBlockEntity.CyclePhase.EXPANSION);
+        assertThat(result.progress()).isEqualTo(0.28f);
+        assertThat(result.shouldSendEnergy()).isTrue();
+    }
+
+    @Test
+    void advance_resetsToIdleAtEndOfCycle() {
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                AbstractEngineBlockEntity.CyclePhase.COMPRESSION,
+                0.96f,
+                true,
+                0.08f,
+                false);
+
+        assertThat(result.phase()).isEqualTo(AbstractEngineBlockEntity.CyclePhase.IDLE);
+        assertThat(result.progress()).isZero();
+        assertThat(result.shouldSendEnergy()).isFalse();
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/power/EngineCyclePlannerTest.java
+++ b/common/src/test/java/com/logistics/core/lib/power/EngineCyclePlannerTest.java
@@ -62,6 +62,20 @@ class EngineCyclePlannerTest {
     }
 
     @Test
+    void advance_atExactBoundary_progressIsExactlyPointFive() {
+        EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
+                AbstractEngineBlockEntity.CyclePhase.EXPANSION,
+                0.49f,
+                true,
+                0.01f,
+                false);
+
+        assertThat(result.phase()).isEqualTo(AbstractEngineBlockEntity.CyclePhase.COMPRESSION);
+        assertThat(result.progress()).isEqualTo(0.5f);
+        assertThat(result.shouldSendEnergy()).isTrue();
+    }
+
+    @Test
     void advance_requestsContinuousEnergySendEveryActiveTick() {
         EngineCyclePlanner.Result result = EngineCyclePlanner.advance(
                 AbstractEngineBlockEntity.CyclePhase.EXPANSION,

--- a/common/src/test/java/com/logistics/core/lib/power/EngineHeatModelTest.java
+++ b/common/src/test/java/com/logistics/core/lib/power/EngineHeatModelTest.java
@@ -1,0 +1,57 @@
+package com.logistics.core.lib.power;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EngineHeatModelTest {
+    @Test
+    void temperature_scalesBetweenFloorAndMaximumByEnergyLevel() {
+        double temperature = EngineHeatModel.temperature(500, 1_000, 20, 250);
+
+        assertThat(temperature).isEqualTo(135.0);
+    }
+
+    @Test
+    void energyLevel_returnsZeroWhenCapacityIsInvalid() {
+        assertThat(EngineHeatModel.energyLevel(500, 0)).isZero();
+    }
+
+    @Test
+    void heatLevel_returnsZeroWhenMaximumTemperatureIsInvalid() {
+        assertThat(EngineHeatModel.heatLevel(100, 0)).isZero();
+    }
+
+    @Test
+    void stage_usesHeatRatioThresholds() {
+        assertThat(EngineHeatModel.stage(20, 250, true, false)).isEqualTo(AbstractEngineBlockEntity.HeatStage.COLD);
+        assertThat(EngineHeatModel.stage(80, 250, true, false)).isEqualTo(AbstractEngineBlockEntity.HeatStage.COOL);
+        assertThat(EngineHeatModel.stage(140, 250, true, false)).isEqualTo(AbstractEngineBlockEntity.HeatStage.WARM);
+        assertThat(EngineHeatModel.stage(200, 250, true, false)).isEqualTo(AbstractEngineBlockEntity.HeatStage.HOT);
+    }
+
+    @Test
+    void stage_overheatsOnlyWhenEnabled() {
+        assertThat(EngineHeatModel.stage(250, 250, true, false)).isEqualTo(AbstractEngineBlockEntity.HeatStage.OVERHEAT);
+        assertThat(EngineHeatModel.stage(250, 250, false, false)).isEqualTo(AbstractEngineBlockEntity.HeatStage.HOT);
+    }
+
+    @Test
+    void stage_flashesWarmForNonOverheatingCompression() {
+        assertThat(EngineHeatModel.stage(250, 250, false, true)).isEqualTo(AbstractEngineBlockEntity.HeatStage.WARM);
+    }
+
+    @Test
+    void pistonSpeed_matchesHeatBands() {
+        assertThat(EngineHeatModel.pistonSpeed(20, 250, true)).isEqualTo(0.01f);
+        assertThat(EngineHeatModel.pistonSpeed(80, 250, true)).isEqualTo(0.02f);
+        assertThat(EngineHeatModel.pistonSpeed(140, 250, true)).isEqualTo(0.04f);
+        assertThat(EngineHeatModel.pistonSpeed(200, 250, true)).isEqualTo(0.08f);
+    }
+
+    @Test
+    void pistonSpeed_stopsWhenOverheatedButNotWhenOverheatDisabled() {
+        assertThat(EngineHeatModel.pistonSpeed(250, 250, true)).isZero();
+        assertThat(EngineHeatModel.pistonSpeed(250, 250, false)).isEqualTo(0.08f);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts deterministic engine heat/stage and piston cycle decisions from the block entity into small common helpers.
- Adds focused unit coverage around the extracted engine behavior.
- Updates the testing guide coverage snapshot for the current Codecov-based workflow.

## Changes
- Keeps Minecraft world side effects, energy transfer, particles, and NBT handling in the existing block entity.
- Covers heat thresholds, overheat handling, non-overheating compression rendering, and cycle send decisions.

## Notes
- No local coverage ratchet baseline is changed; Codecov applies the PR coverage gates.