### PR TITLE
refactor(energy): extract Stirling generation planner

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,12 +72,12 @@ Current aggregate snapshot from `./gradlew testCoverage`:
 
 | Counter | Coverage |
 |---------|----------|
-| Instruction | 17.3% |
-| Branch | 15.2% |
-| Line | 17.4% |
-| Complexity | 16.5% |
-| Method | 22.0% |
-| Class | 33.6% |
+| Instruction | 17.5% |
+| Branch | 15.3% |
+| Line | 17.5% |
+| Complexity | 16.6% |
+| Method | 22.1% |
+| Class | 33.8% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `power.cable`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
@@ -101,7 +101,7 @@ supported branches.
 - **Failure accounting regressions** — tracked delivery failure, partial delivery followed by failed remainder, retry accounting, and job state after dispatch loss
 - **Pipe network graph** — NetworkGraph, NetworkPathfinder
 - **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
-- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner
+- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner
 - **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic, FluidTankComponent, ItemInventoryComponent
 - **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem
 

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -8,7 +8,6 @@ import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.core.lib.power.FuelHelper;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.block.behavior.ProbeResult;
-import com.logistics.power.engine.PIDController;
 import com.logistics.power.engine.block.StirlingEngineBlock;
 import com.logistics.power.engine.ui.StirlingEngineScreenHandler;
 import com.logistics.LogisticsPower;
@@ -86,10 +85,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     private int burnTime = 0;
     private int fuelTime = 0;
 
-    // PID controller for output regulation
-    private final PIDController pidController = new PIDController(PID_KP, PID_KI, PID_KD);
-    private double currentGeneration = DEFAULT_MIN_GENERATION;
-    private double generationCarry = 0.0;
+    private final StirlingGenerationPlanner generationPlanner = new StirlingGenerationPlanner(
+            PID_KP, PID_KI, PID_KD, TARGET_TEMPERATURE, DEFAULT_MIN_GENERATION);
 
     // Inventory (single fuel slot)
     private final ItemInventoryComponent inventory = new ItemInventoryComponent(1, this::setChanged);
@@ -103,7 +100,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
                 case PROPERTY_FUEL_TIME -> fuelTime;
                 case PROPERTY_HEAT -> (int) getTemperature();
                 case PROPERTY_ENERGY -> (int) (getEnergy() / 100);
-                case PROPERTY_GENERATION -> (int) (currentGeneration * 100);
+                case PROPERTY_GENERATION -> (int) (generationPlanner.currentGeneration() * 100);
                 default -> 0;
             };
         }
@@ -115,7 +112,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
                 case PROPERTY_FUEL_TIME -> fuelTime = value;
                 case PROPERTY_HEAT -> {} // Read-only on client, computed from energy level
                 case PROPERTY_ENERGY -> energyBuffer.setAmount(value * 100L);
-                case PROPERTY_GENERATION -> currentGeneration = value / 100.0;
+                case PROPERTY_GENERATION -> generationPlanner.restore(
+                        value / 100.0, generationPlanner.generationCarry(), generationPlanner.pidIntegral());
                 default -> {}
             }
         }
@@ -215,13 +213,11 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
     @Override
     protected long getOutputPower() {
-        double temp = getTemperature();
-        double minGen = LogisticsConfig.get().engine.stirlingMinOutput;
-        double maxGen = LogisticsConfig.get().engine.stirlingMaxOutput;
-        double tempRatio =
-                Math.min(1.0, (temp - getTemperatureFloor()) / (TARGET_TEMPERATURE - getTemperatureFloor()));
-        double output = minGen + tempRatio * (maxGen - minGen);
-        return Math.round(output);
+        return generationPlanner.outputPower(
+                getTemperature(),
+                getTemperatureFloor(),
+                LogisticsConfig.get().engine.stirlingMinOutput,
+                LogisticsConfig.get().engine.stirlingMaxOutput);
     }
 
     @Override
@@ -261,9 +257,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
     @Override
     protected void onShutdown() {
-        pidController.reset();
-        currentGeneration = DEFAULT_MIN_GENERATION;
-        generationCarry = 0.0;
+        generationPlanner.reset();
     }
 
     // ==================== Fuel & Generation ====================
@@ -304,27 +298,15 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     }
 
     private void generateWithCarry() {
-        double temp = getTemperature();
-        currentGeneration = pidController.compute(TARGET_TEMPERATURE, temp,
+        long toAdd = generationPlanner.generate(
+                getTemperature(),
+                getEnergy(),
+                getEnergyBufferCapacity(),
                 LogisticsConfig.get().engine.stirlingMinOutput,
                 LogisticsConfig.get().engine.stirlingMaxOutput);
-        generationCarry += currentGeneration;
-
-        long whole = (long) Math.floor(generationCarry);
-        if (whole <= 0) {
-            return;
-        }
-
-        long space = getEnergyBufferCapacity() - getEnergy();
-        long toAdd = Math.min(whole, space);
 
         if (toAdd > 0) {
             addEnergy(toAdd);
-            generationCarry -= toAdd;
-        }
-
-        if (space <= 0) {
-            generationCarry = 0.0;
         }
     }
 
@@ -339,7 +321,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     }
 
     public double getCurrentGenerationRate() {
-        return currentGeneration;
+        return generationPlanner.currentGeneration();
     }
 
     public ContainerData getPropertyDelegate() {
@@ -351,7 +333,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         super.addProbeEntries(builder);
 
         // Generation rate (PID controlled)
-        builder.entry("Generation", String.format("%.2f RF/t", currentGeneration), ChatFormatting.GREEN);
+        builder.entry("Generation", String.format("%.2f RF/t", generationPlanner.currentGeneration()), ChatFormatting.GREEN);
 
         // Fuel burn time
         if (fuelTime > 0) {
@@ -452,9 +434,9 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         // Save Stirling-specific data
         nbt.putInt("BurnTimeRemaining", burnTime);
         nbt.putInt("TotalFuelTime", fuelTime);
-        nbt.putDouble("CurrentGeneration", currentGeneration);
-        nbt.putDouble("GenerationCarryover", generationCarry);
-        nbt.putDouble("PIDIntegral", pidController.getIntegral());
+        nbt.putDouble("CurrentGeneration", generationPlanner.currentGeneration());
+        nbt.putDouble("GenerationCarryover", generationPlanner.generationCarry());
+        nbt.putDouble("PIDIntegral", generationPlanner.pidIntegral());
 
         // Save fuel inventory
         inventory.writeNbt(nbt, "Inventory", registries);
@@ -467,10 +449,10 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         // Load Stirling-specific data
         burnTime = NbtCompat.getInt(nbt, "BurnTimeRemaining", 0);
         fuelTime = NbtCompat.getInt(nbt, "TotalFuelTime", 0);
-        currentGeneration = NbtCompat.getDouble(nbt, "CurrentGeneration", DEFAULT_MIN_GENERATION);
-        generationCarry = NbtCompat.getDouble(nbt, "GenerationCarryover", 0.0);
-        double pidIntegral = NbtCompat.getDouble(nbt, "PIDIntegral", 0.0);
-        pidController.setIntegral(pidIntegral);
+        generationPlanner.restore(
+                NbtCompat.getDouble(nbt, "CurrentGeneration", DEFAULT_MIN_GENERATION),
+                NbtCompat.getDouble(nbt, "GenerationCarryover", 0.0),
+                NbtCompat.getDouble(nbt, "PIDIntegral", 0.0));
 
         // Load fuel inventory (try new key first, fall back to legacy)
         if (nbt.contains("Inventory")) {
@@ -493,10 +475,10 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         view.read("StirlingData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(stirlingData -> {
             burnTime = NbtCompat.getInt(stirlingData, "burnTime", 0);
             fuelTime = NbtCompat.getInt(stirlingData, "fuelTime", 0);
-            currentGeneration = NbtCompat.getDouble(stirlingData, "currentGeneration", DEFAULT_MIN_GENERATION);
-            generationCarry = NbtCompat.getDouble(stirlingData, "generationCarry", 0.0);
-            double pidIntegral = NbtCompat.getDouble(stirlingData, "pidIntegral", 0.0);
-            pidController.setIntegral(pidIntegral);
+            generationPlanner.restore(
+                    NbtCompat.getDouble(stirlingData, "currentGeneration", DEFAULT_MIN_GENERATION),
+                    NbtCompat.getDouble(stirlingData, "generationCarry", 0.0),
+                    NbtCompat.getDouble(stirlingData, "pidIntegral", 0.0));
         });
 
         // Load fuel from old "Fuel" tag at root level

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingGenerationPlanner.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingGenerationPlanner.java
@@ -1,0 +1,86 @@
+package com.logistics.power.engine.block.entity;
+
+import com.logistics.power.engine.PIDController;
+
+final class StirlingGenerationPlanner {
+    private final PIDController pidController;
+    private final double targetTemperature;
+    private final double defaultGeneration;
+
+    private double currentGeneration;
+    private double generationCarry;
+
+    StirlingGenerationPlanner(
+            double kp,
+            double ki,
+            double kd,
+            double targetTemperature,
+            double defaultGeneration) {
+        this.pidController = new PIDController(kp, ki, kd);
+        this.targetTemperature = targetTemperature;
+        this.defaultGeneration = defaultGeneration;
+        currentGeneration = defaultGeneration;
+    }
+
+    long generate(
+            double temperature,
+            long storedEnergy,
+            long capacity,
+            double minGeneration,
+            double maxGeneration) {
+        currentGeneration = pidController.compute(targetTemperature, temperature, minGeneration, maxGeneration);
+        generationCarry += currentGeneration;
+
+        long whole = (long) Math.floor(generationCarry);
+        if (whole <= 0) {
+            return 0;
+        }
+
+        long space = capacity - storedEnergy;
+        long toAdd = Math.max(0, Math.min(whole, space));
+
+        if (toAdd > 0) {
+            generationCarry -= toAdd;
+        }
+
+        if (space <= 0) {
+            generationCarry = 0.0;
+        }
+
+        return toAdd;
+    }
+
+    long outputPower(
+            double temperature,
+            double temperatureFloor,
+            double minGeneration,
+            double maxGeneration) {
+        double ratio = Math.min(1.0, (temperature - temperatureFloor) / (targetTemperature - temperatureFloor));
+        double output = minGeneration + ratio * (maxGeneration - minGeneration);
+        return Math.round(output);
+    }
+
+    void reset() {
+        pidController.reset();
+        currentGeneration = defaultGeneration;
+        generationCarry = 0.0;
+    }
+
+    double currentGeneration() {
+        return currentGeneration;
+    }
+
+    double generationCarry() {
+        return generationCarry;
+    }
+
+    double pidIntegral() {
+        return pidController.getIntegral();
+    }
+
+    void restore(double currentGeneration, double generationCarry, double pidIntegral) {
+        this.currentGeneration = currentGeneration;
+        this.generationCarry = generationCarry;
+        pidController.setIntegral(pidIntegral);
+    }
+}

--- a/common/src/test/java/com/logistics/power/engine/block/entity/StirlingGenerationPlannerTest.java
+++ b/common/src/test/java/com/logistics/power/engine/block/entity/StirlingGenerationPlannerTest.java
@@ -1,0 +1,86 @@
+package com.logistics.power.engine.block.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+
+class StirlingGenerationPlannerTest {
+    private static final double TOLERANCE = 0.0001;
+
+    @Test
+    void outputPower_scalesBetweenConfiguredBoundsByTemperature() {
+        StirlingGenerationPlanner planner = planner();
+
+        assertThat(planner.outputPower(20, 20, 3, 10)).isEqualTo(3);
+        assertThat(planner.outputPower(85, 20, 3, 10)).isEqualTo(7);
+        assertThat(planner.outputPower(150, 20, 3, 10)).isEqualTo(10);
+    }
+
+    @Test
+    void outputPower_capsTemperatureRatioAtTarget() {
+        StirlingGenerationPlanner planner = planner();
+
+        assertThat(planner.outputPower(250, 20, 3, 10)).isEqualTo(10);
+    }
+
+    @Test
+    void generate_addsWholeEnergyAndKeepsFractionalCarry() {
+        StirlingGenerationPlanner planner = planner();
+
+        long first = planner.generate(150, 0, 10_000, 3.25, 3.25);
+        long second = planner.generate(150, first, 10_000, 3.25, 3.25);
+
+        assertThat(first).isEqualTo(3);
+        assertThat(second).isEqualTo(3);
+        assertThat(planner.currentGeneration()).isCloseTo(3.25, within(TOLERANCE));
+        assertThat(planner.generationCarry()).isCloseTo(0.5, within(TOLERANCE));
+    }
+
+    @Test
+    void generate_capsAddedEnergyToAvailableSpaceAndKeepsRemainder() {
+        StirlingGenerationPlanner planner = planner();
+
+        long generated = planner.generate(150, 8, 10, 3.25, 3.25);
+
+        assertThat(generated).isEqualTo(2);
+        assertThat(planner.generationCarry()).isCloseTo(1.25, within(TOLERANCE));
+    }
+
+    @Test
+    void generate_resetsCarryWhenBufferIsAlreadyFull() {
+        StirlingGenerationPlanner planner = planner();
+
+        long generated = planner.generate(150, 10, 10, 3.25, 3.25);
+
+        assertThat(generated).isZero();
+        assertThat(planner.generationCarry()).isZero();
+    }
+
+    @Test
+    void reset_restoresDefaultGenerationAndClearsState() {
+        StirlingGenerationPlanner planner = planner();
+        planner.generate(20, 0, 10_000, 3, 10);
+
+        planner.reset();
+
+        assertThat(planner.currentGeneration()).isCloseTo(3.0, within(TOLERANCE));
+        assertThat(planner.generationCarry()).isZero();
+        assertThat(planner.pidIntegral()).isZero();
+    }
+
+    @Test
+    void restore_rehydratesPersistentGenerationState() {
+        StirlingGenerationPlanner planner = planner();
+
+        planner.restore(6.5, 0.75, 12.25);
+
+        assertThat(planner.currentGeneration()).isCloseTo(6.5, within(TOLERANCE));
+        assertThat(planner.generationCarry()).isCloseTo(0.75, within(TOLERANCE));
+        assertThat(planner.pidIntegral()).isCloseTo(12.25, within(TOLERANCE));
+    }
+
+    private static StirlingGenerationPlanner planner() {
+        return new StirlingGenerationPlanner(0.2, 0.0002, 0.3, 150, 3);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts deterministic Stirling engine generation math into a small common helper.
- Adds focused unit coverage for PID-driven generation, fractional carry, capacity clamping, reset, and persistent state restore.
- Updates the testing guide coverage snapshot for the current Codecov-based workflow.

## Changes
- Keeps fuel lookup, inventory mutation, NBT keys, and block entity world behavior in .
- Leaves coverage gating to Codecov; no local ratchet baseline is changed.

## Notes
- This is an internal testability refactor with no intended player-visible behavior change.