### PR TITLE
refactor(energy): extract Stirling fuel state

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -74,10 +74,10 @@ Current aggregate snapshot from `./gradlew testCoverage`:
 |---------|----------|
 | Instruction | 17.5% |
 | Branch | 15.3% |
-| Line | 17.5% |
-| Complexity | 16.6% |
-| Method | 22.1% |
-| Class | 33.8% |
+| Line | 17.6% |
+| Complexity | 16.7% |
+| Method | 22.3% |
+| Class | 33.9% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `power.cable`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
@@ -101,7 +101,7 @@ supported branches.
 - **Failure accounting regressions** — tracked delivery failure, partial delivery followed by failed remainder, retry accounting, and job state after dispatch loss
 - **Pipe network graph** — NetworkGraph, NetworkPathfinder
 - **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
-- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner
+- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState
 - **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic, FluidTankComponent, ItemInventoryComponent
 - **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem
 

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -81,10 +81,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
     // ==================== State ====================
 
-    // Fuel state
-    private int burnTime = 0;
-    private int fuelTime = 0;
-
+    private final StirlingFuelState fuelState = new StirlingFuelState();
     private final StirlingGenerationPlanner generationPlanner = new StirlingGenerationPlanner(
             PID_KP, PID_KI, PID_KD, TARGET_TEMPERATURE, DEFAULT_MIN_GENERATION);
 
@@ -96,8 +93,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         @Override
         public int get(int index) {
             return switch (index) {
-                case PROPERTY_BURN_TIME -> burnTime;
-                case PROPERTY_FUEL_TIME -> fuelTime;
+                case PROPERTY_BURN_TIME -> fuelState.burnTime();
+                case PROPERTY_FUEL_TIME -> fuelState.fuelTime();
                 case PROPERTY_HEAT -> (int) getTemperature();
                 case PROPERTY_ENERGY -> (int) (getEnergy() / 100);
                 case PROPERTY_GENERATION -> (int) (generationPlanner.currentGeneration() * 100);
@@ -108,8 +105,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         @Override
         public void set(int index, int value) {
             switch (index) {
-                case PROPERTY_BURN_TIME -> burnTime = value;
-                case PROPERTY_FUEL_TIME -> fuelTime = value;
+                case PROPERTY_BURN_TIME -> fuelState.restore(value, fuelState.fuelTime());
+                case PROPERTY_FUEL_TIME -> fuelState.restore(fuelState.burnTime(), value);
                 case PROPERTY_HEAT -> {} // Read-only on client, computed from energy level
                 case PROPERTY_ENERGY -> energyBuffer.setAmount(value * 100L);
                 case PROPERTY_GENERATION -> generationPlanner.restore(
@@ -197,7 +194,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         if (!world.isClientSide()) {
             BlockState currentState = world.getBlockState(pos);
             boolean wasLit = currentState.getValue(StirlingEngineBlock.LIT);
-            boolean isLit = entity.burnTime > 0;
+            boolean isLit = entity.fuelState.isBurning();
             if (isLit != wasLit) {
                 world.setBlock(pos, currentState.setValue(StirlingEngineBlock.LIT, isLit), Block.UPDATE_CLIENTS);
             }
@@ -240,17 +237,17 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     /** Stirling engine is running when powered, not overheated, AND has fuel burning. */
     @Override
     public boolean isRunning() {
-        return super.isRunning() && burnTime > 0;
+        return super.isRunning() && fuelState.isBurning();
     }
 
     @Override
     protected void produceEnergy() {
         if (!isRedstonePowered() || isOverheated()) {
-            extinguish();
+            fuelState.extinguish();
             return;
         }
 
-        if (burn() || refuel()) {
+        if (fuelState.burn() || refuel()) {
             generateWithCarry();
         }
     }
@@ -261,18 +258,6 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     }
 
     // ==================== Fuel & Generation ====================
-
-    private void extinguish() {
-        burnTime = 0;
-        fuelTime = 0;
-    }
-
-    private boolean burn() {
-        if (burnTime > 0) {
-            burnTime--;
-        }
-        return burnTime > 0;
-    }
 
     private boolean refuel() {
         if (level == null) {
@@ -285,8 +270,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
             return false;
         }
 
-        fuelTime = burnTicks;
-        burnTime = fuelTime;
+        fuelState.ignite(burnTicks);
 
         if (fuel.is(Items.LAVA_BUCKET)) {
             inventory.setItem(0, new ItemStack(Items.BUCKET));
@@ -313,11 +297,11 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
     // ==================== Public API ====================
 
     public int getBurnTime() {
-        return burnTime;
+        return fuelState.burnTime();
     }
 
     public int getFuelTime() {
-        return fuelTime;
+        return fuelState.fuelTime();
     }
 
     public double getCurrentGenerationRate() {
@@ -336,10 +320,14 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         builder.entry("Generation", String.format("%.2f RF/t", generationPlanner.currentGeneration()), ChatFormatting.GREEN);
 
         // Fuel burn time
-        if (fuelTime > 0) {
+        if (fuelState.fuelTime() > 0) {
             builder.entry(
                     "Fuel",
-                    String.format("%d / %d ticks (%.1f%%)", burnTime, fuelTime, (burnTime / (float) fuelTime) * 100),
+                    String.format(
+                            "%d / %d ticks (%.1f%%)",
+                            fuelState.burnTime(),
+                            fuelState.fuelTime(),
+                            (fuelState.burnTime() / (float) fuelState.fuelTime()) * 100),
                     ChatFormatting.YELLOW);
         } else {
             builder.entry("Fuel", "None", ChatFormatting.GRAY);
@@ -432,8 +420,8 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         super.saveLogisticsData(nbt, registries);
 
         // Save Stirling-specific data
-        nbt.putInt("BurnTimeRemaining", burnTime);
-        nbt.putInt("TotalFuelTime", fuelTime);
+        nbt.putInt("BurnTimeRemaining", fuelState.burnTime());
+        nbt.putInt("TotalFuelTime", fuelState.fuelTime());
         nbt.putDouble("CurrentGeneration", generationPlanner.currentGeneration());
         nbt.putDouble("GenerationCarryover", generationPlanner.generationCarry());
         nbt.putDouble("PIDIntegral", generationPlanner.pidIntegral());
@@ -447,8 +435,9 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
         super.loadLogisticsData(nbt, registries);
 
         // Load Stirling-specific data
-        burnTime = NbtCompat.getInt(nbt, "BurnTimeRemaining", 0);
-        fuelTime = NbtCompat.getInt(nbt, "TotalFuelTime", 0);
+        fuelState.restore(
+                NbtCompat.getInt(nbt, "BurnTimeRemaining", 0),
+                NbtCompat.getInt(nbt, "TotalFuelTime", 0));
         generationPlanner.restore(
                 NbtCompat.getDouble(nbt, "CurrentGeneration", DEFAULT_MIN_GENERATION),
                 NbtCompat.getDouble(nbt, "GenerationCarryover", 0.0),
@@ -473,8 +462,9 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
         // Load Stirling-specific data from old "StirlingData" tag
         view.read("StirlingData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(stirlingData -> {
-            burnTime = NbtCompat.getInt(stirlingData, "burnTime", 0);
-            fuelTime = NbtCompat.getInt(stirlingData, "fuelTime", 0);
+            fuelState.restore(
+                    NbtCompat.getInt(stirlingData, "burnTime", 0),
+                    NbtCompat.getInt(stirlingData, "fuelTime", 0));
             generationPlanner.restore(
                     NbtCompat.getDouble(stirlingData, "currentGeneration", DEFAULT_MIN_GENERATION),
                     NbtCompat.getDouble(stirlingData, "generationCarry", 0.0),

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingFuelState.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingFuelState.java
@@ -1,0 +1,40 @@
+package com.logistics.power.engine.block.entity;
+
+final class StirlingFuelState {
+    private int burnTime;
+    private int fuelTime;
+
+    boolean burn() {
+        if (burnTime > 0) {
+            burnTime--;
+        }
+        return isBurning();
+    }
+
+    void ignite(int burnTicks) {
+        fuelTime = Math.max(0, burnTicks);
+        burnTime = fuelTime;
+    }
+
+    void extinguish() {
+        burnTime = 0;
+        fuelTime = 0;
+    }
+
+    void restore(int burnTime, int fuelTime) {
+        this.burnTime = Math.max(0, burnTime);
+        this.fuelTime = Math.max(0, fuelTime);
+    }
+
+    boolean isBurning() {
+        return burnTime > 0;
+    }
+
+    int burnTime() {
+        return burnTime;
+    }
+
+    int fuelTime() {
+        return fuelTime;
+    }
+}

--- a/common/src/test/java/com/logistics/power/engine/block/entity/StirlingFuelStateTest.java
+++ b/common/src/test/java/com/logistics/power/engine/block/entity/StirlingFuelStateTest.java
@@ -1,0 +1,95 @@
+package com.logistics.power.engine.block.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StirlingFuelStateTest {
+    @Test
+    void newState_isNotBurningAndHasNoFuelTimers() {
+        StirlingFuelState state = new StirlingFuelState();
+
+        assertThat(state.isBurning()).isFalse();
+        assertThat(state.burnTime()).isZero();
+        assertThat(state.fuelTime()).isZero();
+    }
+
+    @Test
+    void ignite_setsBurnAndFuelTimers() {
+        StirlingFuelState state = new StirlingFuelState();
+
+        state.ignite(200);
+
+        assertThat(state.isBurning()).isTrue();
+        assertThat(state.burnTime()).isEqualTo(200);
+        assertThat(state.fuelTime()).isEqualTo(200);
+    }
+
+    @Test
+    void ignite_clampsNegativeBurnTicksToZero() {
+        StirlingFuelState state = new StirlingFuelState();
+
+        state.ignite(-10);
+
+        assertThat(state.isBurning()).isFalse();
+        assertThat(state.burnTime()).isZero();
+        assertThat(state.fuelTime()).isZero();
+    }
+
+    @Test
+    void burn_decrementsBurnTimeAndStaysBurningUntilZero() {
+        StirlingFuelState state = new StirlingFuelState();
+        state.ignite(2);
+
+        assertThat(state.burn()).isTrue();
+        assertThat(state.burnTime()).isEqualTo(1);
+        assertThat(state.fuelTime()).isEqualTo(2);
+
+        assertThat(state.burn()).isFalse();
+        assertThat(state.burnTime()).isZero();
+        assertThat(state.fuelTime()).isEqualTo(2);
+    }
+
+    @Test
+    void burn_onEmptyStateDoesNothing() {
+        StirlingFuelState state = new StirlingFuelState();
+
+        assertThat(state.burn()).isFalse();
+        assertThat(state.burnTime()).isZero();
+        assertThat(state.fuelTime()).isZero();
+    }
+
+    @Test
+    void extinguish_clearsBurnAndFuelTimers() {
+        StirlingFuelState state = new StirlingFuelState();
+        state.ignite(200);
+
+        state.extinguish();
+
+        assertThat(state.isBurning()).isFalse();
+        assertThat(state.burnTime()).isZero();
+        assertThat(state.fuelTime()).isZero();
+    }
+
+    @Test
+    void restore_rehydratesExistingTimers() {
+        StirlingFuelState state = new StirlingFuelState();
+
+        state.restore(40, 200);
+
+        assertThat(state.isBurning()).isTrue();
+        assertThat(state.burnTime()).isEqualTo(40);
+        assertThat(state.fuelTime()).isEqualTo(200);
+    }
+
+    @Test
+    void restore_clampsNegativeTimersToZero() {
+        StirlingFuelState state = new StirlingFuelState();
+
+        state.restore(-40, -200);
+
+        assertThat(state.isBurning()).isFalse();
+        assertThat(state.burnTime()).isZero();
+        assertThat(state.fuelTime()).isZero();
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts deterministic Stirling engine fuel timer behavior into a small common helper.
- Adds focused unit coverage for ignite, burn countdown, extinguish, restore, and negative timer clamping.
- Updates the testing guide coverage snapshot for the current Codecov-based workflow.

## Changes
- Keeps Minecraft fuel lookup and inventory mutation in the Stirling engine block entity.
- Preserves the existing NBT keys and GUI property indices for compatibility.
- Leaves coverage gating to Codecov; no local ratchet baseline is changed.

## Notes
- This is an internal testability refactor with no intended player-visible behavior change.