### PR TITLE
refactor(energy): extract Creative engine output levels

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,12 +72,12 @@ Current aggregate snapshot from `./gradlew testCoverage`:
 
 | Counter | Coverage |
 |---------|----------|
-| Instruction | 17.5% |
-| Branch | 15.3% |
-| Line | 17.6% |
-| Complexity | 16.7% |
-| Method | 22.3% |
-| Class | 33.9% |
+| Instruction | 17.6% |
+| Branch | 15.4% |
+| Line | 17.7% |
+| Complexity | 16.8% |
+| Method | 22.5% |
+| Class | 34.1% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `power.cable`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
@@ -101,7 +101,7 @@ supported branches.
 - **Failure accounting regressions** — tracked delivery failure, partial delivery followed by failed remainder, retry accounting, and job state after dispatch loss
 - **Pipe network graph** — NetworkGraph, NetworkPathfinder
 - **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
-- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState
+- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState, CreativeOutputLevels
 - **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic, FluidTankComponent, ItemInventoryComponent
 - **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem
 

--- a/common/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -20,13 +20,13 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     // ==================== Constants ====================
 
     /** Output levels that double with each wrench click. */
-    public static final long[] OUTPUT_LEVELS = {20, 40, 80, 160, 320, 640, 1280};
+    public static final long[] OUTPUT_LEVELS = CreativeOutputLevels.DEFAULT_LEVELS.clone();
 
     private static final long MAX_ENERGY = 10_000L;
 
     // ==================== State ====================
 
-    private int outputLevelIndex = 0;
+    private final CreativeOutputLevels outputLevels = new CreativeOutputLevels();
 
     // ==================== Constructor & Ticker ====================
 
@@ -47,7 +47,7 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
 
     @Override
     protected long getOutputPower() {
-        return OUTPUT_LEVELS[outputLevelIndex];
+        return outputLevels.outputRate();
     }
 
     @Override
@@ -77,7 +77,7 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
 
     @Override
     public float getPistonSpeed() {
-        return 0.02F * (outputLevelIndex + 1);
+        return outputLevels.pistonSpeed();
     }
 
     // ==================== Lifecycle Hooks ====================
@@ -104,23 +104,23 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
      * @return the new output rate in RF/t
      */
     public long cycleOutputLevel() {
-        outputLevelIndex = (outputLevelIndex + 1) % OUTPUT_LEVELS.length;
+        long outputRate = outputLevels.cycle();
         markDirtyAndSync(); // Sync to clients so renderer can update piston speed
-        return OUTPUT_LEVELS[outputLevelIndex];
+        return outputRate;
     }
 
     /**
      * Gets the current output level index.
      */
     public int getOutputLevelIndex() {
-        return outputLevelIndex;
+        return outputLevels.index();
     }
 
     /**
      * Gets the current output rate in RF/t.
      */
     public long getOutputRate() {
-        return OUTPUT_LEVELS[outputLevelIndex];
+        return outputLevels.outputRate();
     }
 
     // ==================== NBT Serialization ====================
@@ -128,17 +128,13 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     @Override
     protected void saveLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
         super.saveLogisticsData(nbt, registries);
-        nbt.putInt("OutputLevelIndex", outputLevelIndex);
+        nbt.putInt("OutputLevelIndex", outputLevels.index());
     }
 
     @Override
     protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
         super.loadLogisticsData(nbt, registries);
-        outputLevelIndex = NbtCompat.getInt(nbt, "OutputLevelIndex", 0);
-        // Clamp to valid range
-        if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
-            outputLevelIndex = 0;
-        }
+        outputLevels.restore(NbtCompat.getInt(nbt, "OutputLevelIndex", 0));
     }
 
     @Override
@@ -147,11 +143,7 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
 
         // Load Creative-specific data from old "CreativeData" tag
         view.read("CreativeData", CompoundTag.CODEC).ifPresent(creativeData -> {
-            outputLevelIndex = NbtCompat.getInt(creativeData, "outputLevelIndex", 0);
-            // Clamp to valid range
-            if (outputLevelIndex < 0 || outputLevelIndex >= OUTPUT_LEVELS.length) {
-                outputLevelIndex = 0;
-            }
+            outputLevels.restore(NbtCompat.getInt(creativeData, "outputLevelIndex", 0));
         });
     }
 }

--- a/common/src/main/java/com/logistics/power/engine/block/entity/CreativeOutputLevels.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/CreativeOutputLevels.java
@@ -1,0 +1,40 @@
+package com.logistics.power.engine.block.entity;
+
+final class CreativeOutputLevels {
+    static final long[] DEFAULT_LEVELS = {20, 40, 80, 160, 320, 640, 1280};
+
+    private final long[] levels;
+    private int index;
+
+    CreativeOutputLevels() {
+        this(DEFAULT_LEVELS);
+    }
+
+    CreativeOutputLevels(long[] levels) {
+        if (levels.length == 0) {
+            throw new IllegalArgumentException("levels must not be empty");
+        }
+        this.levels = levels.clone();
+    }
+
+    long cycle() {
+        index = (index + 1) % levels.length;
+        return outputRate();
+    }
+
+    void restore(int index) {
+        this.index = index >= 0 && index < levels.length ? index : 0;
+    }
+
+    int index() {
+        return index;
+    }
+
+    long outputRate() {
+        return levels[index];
+    }
+
+    float pistonSpeed() {
+        return 0.02F * (index + 1);
+    }
+}

--- a/common/src/test/java/com/logistics/power/engine/block/entity/CreativeOutputLevelsTest.java
+++ b/common/src/test/java/com/logistics/power/engine/block/entity/CreativeOutputLevelsTest.java
@@ -1,0 +1,88 @@
+package com.logistics.power.engine.block.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class CreativeOutputLevelsTest {
+    @Test
+    void newState_startsAtFirstOutputLevel() {
+        CreativeOutputLevels levels = new CreativeOutputLevels();
+
+        assertThat(levels.index()).isZero();
+        assertThat(levels.outputRate()).isEqualTo(20);
+        assertThat(levels.pistonSpeed()).isEqualTo(0.02F);
+    }
+
+    @Test
+    void cycle_advancesToNextOutputLevel() {
+        CreativeOutputLevels levels = new CreativeOutputLevels();
+
+        long outputRate = levels.cycle();
+
+        assertThat(outputRate).isEqualTo(40);
+        assertThat(levels.index()).isEqualTo(1);
+        assertThat(levels.outputRate()).isEqualTo(40);
+        assertThat(levels.pistonSpeed()).isEqualTo(0.04F);
+    }
+
+    @Test
+    void cycle_wrapsBackToFirstOutputLevel() {
+        CreativeOutputLevels levels = new CreativeOutputLevels(new long[]{20, 40});
+
+        levels.cycle();
+        long outputRate = levels.cycle();
+
+        assertThat(outputRate).isEqualTo(20);
+        assertThat(levels.index()).isZero();
+    }
+
+    @Test
+    void restore_acceptsValidIndex() {
+        CreativeOutputLevels levels = new CreativeOutputLevels();
+
+        levels.restore(3);
+
+        assertThat(levels.index()).isEqualTo(3);
+        assertThat(levels.outputRate()).isEqualTo(160);
+        assertThat(levels.pistonSpeed()).isEqualTo(0.08F);
+    }
+
+    @Test
+    void restore_clampsNegativeIndexToFirstLevel() {
+        CreativeOutputLevels levels = new CreativeOutputLevels();
+
+        levels.restore(-1);
+
+        assertThat(levels.index()).isZero();
+        assertThat(levels.outputRate()).isEqualTo(20);
+    }
+
+    @Test
+    void restore_clampsOutOfRangeIndexToFirstLevel() {
+        CreativeOutputLevels levels = new CreativeOutputLevels();
+
+        levels.restore(CreativeOutputLevels.DEFAULT_LEVELS.length);
+
+        assertThat(levels.index()).isZero();
+        assertThat(levels.outputRate()).isEqualTo(20);
+    }
+
+    @Test
+    void constructor_rejectsEmptyLevels() {
+        assertThatThrownBy(() -> new CreativeOutputLevels(new long[]{}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("levels");
+    }
+
+    @Test
+    void constructor_defensivelyCopiesLevels() {
+        long[] configuredLevels = {20, 40};
+        CreativeOutputLevels levels = new CreativeOutputLevels(configuredLevels);
+
+        configuredLevels[0] = 999;
+
+        assertThat(levels.outputRate()).isEqualTo(20);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts deterministic Creative engine output-level behavior into a small common helper.
- Adds focused unit coverage for output rate cycling, wraparound, restore clamping, piston speed, and defensive level storage.
- Updates the testing guide coverage snapshot for the current Codecov-based workflow.

## Changes
- Keeps NBT keys, public block entity methods, and client sync behavior in the Creative engine block entity.
- Leaves coverage gating to Codecov; no local ratchet baseline is changed.

## Notes
- This is an internal testability refactor with no intended player-visible behavior change.