### PR TITLE
refactor(energy): extract Redstone target gate

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,12 +72,12 @@ Current aggregate snapshot from `./gradlew testCoverage`:
 
 | Counter | Coverage |
 |---------|----------|
-| Instruction | 17.6% |
+| Instruction | 17.7% |
 | Branch | 15.4% |
 | Line | 17.7% |
-| Complexity | 16.8% |
-| Method | 22.5% |
-| Class | 34.1% |
+| Complexity | 16.9% |
+| Method | 22.6% |
+| Class | 34.5% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `power.cable`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
@@ -101,7 +101,7 @@ supported branches.
 - **Failure accounting regressions** — tracked delivery failure, partial delivery followed by failed remainder, retry accounting, and job state after dispatch loss
 - **Pipe network graph** — NetworkGraph, NetworkPathfinder
 - **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
-- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState, CreativeOutputLevels
+- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState, CreativeOutputLevels, RedstoneTargetGate
 - **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic, FluidTankComponent, ItemInventoryComponent
 - **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem
 

--- a/common/src/main/java/com/logistics/power/engine/block/entity/RedstoneEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/RedstoneEngineBlockEntity.java
@@ -2,7 +2,6 @@ package com.logistics.power.engine.block.entity;
 
 import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
-import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.core.lib.power.LowTierEnergySource;
 import com.logistics.power.engine.block.RedstoneEngineBlock;
 import com.logistics.LogisticsPower;
@@ -70,11 +69,7 @@ public class RedstoneEngineBlockEntity extends AbstractEngineBlockEntity impleme
         BlockPos targetPos = worldPosition.relative(outputDir);
         BlockEntity target = level.getBlockEntity(targetPos);
 
-        if (target instanceof AcceptsLowTierEnergy acceptor) {
-            return acceptor.acceptsLowTierEnergyFrom(outputDir.getOpposite());
-        }
-
-        return false; // Target doesn't accept low-tier energy
+        return RedstoneTargetGate.acceptsLowTierEnergy(target, outputDir);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/power/engine/block/entity/RedstoneTargetGate.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/RedstoneTargetGate.java
@@ -1,0 +1,16 @@
+package com.logistics.power.engine.block.entity;
+
+import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import net.minecraft.core.Direction;
+
+final class RedstoneTargetGate {
+    private RedstoneTargetGate() {}
+
+    static boolean acceptsLowTierEnergy(Object target, Direction outputDirection) {
+        if (!(target instanceof AcceptsLowTierEnergy acceptor)) {
+            return false;
+        }
+
+        return acceptor.acceptsLowTierEnergyFrom(outputDirection.getOpposite());
+    }
+}

--- a/common/src/test/java/com/logistics/power/engine/block/entity/RedstoneTargetGateTest.java
+++ b/common/src/test/java/com/logistics/power/engine/block/entity/RedstoneTargetGateTest.java
@@ -1,0 +1,61 @@
+package com.logistics.power.engine.block.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import net.minecraft.core.Direction;
+import org.junit.jupiter.api.Test;
+
+class RedstoneTargetGateTest {
+    @Test
+    void acceptsLowTierEnergy_rejectsNullTarget() {
+        assertThat(RedstoneTargetGate.acceptsLowTierEnergy(null, Direction.NORTH)).isFalse();
+    }
+
+    @Test
+    void acceptsLowTierEnergy_rejectsTargetWithoutLowTierContract() {
+        assertThat(RedstoneTargetGate.acceptsLowTierEnergy(new Object(), Direction.NORTH)).isFalse();
+    }
+
+    @Test
+    void acceptsLowTierEnergy_usesDefaultAcceptorContract() {
+        assertThat(RedstoneTargetGate.acceptsLowTierEnergy(new DefaultAcceptor(), Direction.NORTH)).isTrue();
+    }
+
+    @Test
+    void acceptsLowTierEnergy_passesOppositeOfEngineOutputDirectionToTarget() {
+        RecordingAcceptor acceptor = new RecordingAcceptor(Direction.SOUTH);
+
+        assertThat(RedstoneTargetGate.acceptsLowTierEnergy(acceptor, Direction.NORTH)).isTrue();
+        assertThat(acceptor.lastDirection()).isEqualTo(Direction.SOUTH);
+    }
+
+    @Test
+    void acceptsLowTierEnergy_rejectsWhenTargetRejectsInputSide() {
+        RecordingAcceptor acceptor = new RecordingAcceptor(Direction.UP);
+
+        assertThat(RedstoneTargetGate.acceptsLowTierEnergy(acceptor, Direction.NORTH)).isFalse();
+        assertThat(acceptor.lastDirection()).isEqualTo(Direction.SOUTH);
+    }
+
+    private static final class DefaultAcceptor implements AcceptsLowTierEnergy {}
+
+    private static final class RecordingAcceptor implements AcceptsLowTierEnergy {
+        private final Direction acceptedDirection;
+        private Direction lastDirection;
+
+        private RecordingAcceptor(Direction acceptedDirection) {
+            this.acceptedDirection = acceptedDirection;
+        }
+
+        @Override
+        public boolean acceptsLowTierEnergyFrom(Direction from) {
+            lastDirection = from;
+            return from == acceptedDirection;
+        }
+
+        private Direction lastDirection() {
+            return lastDirection;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts Redstone engine low-tier target acceptance into a small common helper.
- Adds focused unit coverage for null targets, non-acceptors, default acceptors, sided acceptors, and output-direction conversion.
- Updates the testing guide coverage snapshot for the current Codecov-based workflow.

## Changes
- Keeps Minecraft world lookup in RedstoneEngineBlockEntity.
- Leaves coverage gating to Codecov; no local ratchet baseline is changed.

## Notes
- This is an internal testability refactor with no intended player-visible behavior change.