### PR TITLE
refactor(energy): extract Creative sink drain state

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,12 +72,12 @@ Current aggregate snapshot from `./gradlew testCoverage`:
 
 | Counter | Coverage |
 |---------|----------|
-| Instruction | 17.7% |
-| Branch | 15.4% |
-| Line | 17.7% |
-| Complexity | 16.9% |
-| Method | 22.6% |
-| Class | 34.5% |
+| Instruction | 17.9% |
+| Branch | 15.6% |
+| Line | 18.0% |
+| Complexity | 17.1% |
+| Method | 22.9% |
+| Class | 34.6% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `power.cable`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
@@ -101,7 +101,7 @@ supported branches.
 - **Failure accounting regressions** — tracked delivery failure, partial delivery followed by failed remainder, retry accounting, and job state after dispatch loss
 - **Pipe network graph** — NetworkGraph, NetworkPathfinder
 - **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
-- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState, CreativeOutputLevels, RedstoneTargetGate
+- **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState, CreativeOutputLevels, RedstoneTargetGate, CreativeSinkDrainState
 - **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic, FluidTankComponent, ItemInventoryComponent
 - **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem
 

--- a/common/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -2,10 +2,11 @@ package com.logistics.power.block.entity;
 
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.block.BaseBlockEntity;
-import com.logistics.core.lib.block.capability.HasEnergyStorage;
-import com.logistics.core.lib.power.AcceptsLowTierEnergy;
-import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.block.behavior.ProbeResult;
+import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.energy.IEnergyStorage;
+import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.core.lib.power.EnergyDemandProvider;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -15,7 +16,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
-import com.logistics.core.lib.energy.IEnergyStorage;
 
 /**
  * Block entity for the Creative Sink.
@@ -28,24 +28,12 @@ import com.logistics.core.lib.energy.IEnergyStorage;
  */
 public class CreativeSinkBlockEntity extends BaseBlockEntity
     implements AcceptsLowTierEnergy, HasEnergyStorage, EnergyDemandProvider {
-    private static final long[] DRAIN_RATES = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 50, 100, Long.MAX_VALUE};
-    private int drainRateIndex = 4; // Default 5 RF/t
-    private long energyLastTick = 0;
-    private long energyThisTick = 0;
-
-    // Test-only counter - not persisted, resets on reload
-    // Used only for validating energy consumption in tests
-    long totalEnergyReceived = 0;
+    private final CreativeSinkDrainState drainState = new CreativeSinkDrainState();
 
     private final IEnergyStorage energyStorage = new IEnergyStorage() {
         @Override
         public long insert(long maxAmount, boolean simulate) {
-            long canAccept = Math.max(0, getDrainRate() - energyThisTick);
-            long toAccept = Math.min(maxAmount, canAccept);
-            if (toAccept > 0 && !simulate) {
-                energyThisTick += toAccept;
-            }
-            return toAccept;
+            return drainState.insert(maxAmount, simulate);
         }
 
         @Override
@@ -84,29 +72,16 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
     // ==================== Drain Rate & Stats ====================
 
     public static void tick(Level world, BlockPos pos, BlockState state, CreativeSinkBlockEntity entity) {
-        // Reset energy counter each tick - energy is discarded
-        entity.energyLastTick = entity.energyThisTick;
-
-        // Accumulate total energy with saturation to prevent overflow
-        // When at Long.MAX_VALUE drain rate, this could otherwise wrap around
-        if (entity.energyThisTick > 0 && Long.MAX_VALUE - entity.totalEnergyReceived <= entity.energyThisTick) {
-            entity.totalEnergyReceived = Long.MAX_VALUE;
-        } else {
-            entity.totalEnergyReceived += entity.energyThisTick;
-        }
-
-        entity.energyThisTick = 0;
+        entity.drainState.tick();
     }
 
     public long getDrainRate() {
-        return DRAIN_RATES[drainRateIndex];
+        return drainState.drainRate();
     }
 
     @Override
     public long networkDemandPerTick() {
-        long drainRate = getDrainRate();
-        if (drainRate == Long.MAX_VALUE) return Long.MAX_VALUE;
-        return Math.max(0, drainRate - energyThisTick);
+        return drainState.networkDemandPerTick();
     }
 
     /**
@@ -115,9 +90,9 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
      * @return the new drain rate
      */
     public long cycleDrainRate() {
-        drainRateIndex = (drainRateIndex + 1) % DRAIN_RATES.length;
+        long drainRate = drainState.cycle();
         markDirtyAndSync(); // Sync to clients for potential UI/tooltip updates
-        return DRAIN_RATES[drainRateIndex];
+        return drainRate;
     }
 
     /**
@@ -129,7 +104,7 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
      * This allows the sink to accept any amount of energy per tick.
      */
     public void setUnlimitedDrainRate() {
-        drainRateIndex = DRAIN_RATES.length - 1; // Last index is Long.MAX_VALUE
+        drainState.setUnlimited();
         markDirtyAndSync();
     }
 
@@ -139,7 +114,7 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
     public ProbeResult getProbeResult() {
         return ProbeResult.builder("Creative Sink Stats")
                 .entry("Drain Rate", String.format("%d RF/t", getDrainRate()), ChatFormatting.AQUA)
-                .entry("Energy Received", String.format("%d RF", energyLastTick), ChatFormatting.GREEN)
+                .entry("Energy Received", String.format("%d RF", drainState.energyLastTick()), ChatFormatting.GREEN)
                 .build();
     }
 
@@ -148,18 +123,14 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
     @Override
     protected void saveLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
         super.saveLogisticsData(nbt, registries);
-        nbt.putInt("DrainRateIndex", drainRateIndex);
+        nbt.putInt("DrainRateIndex", drainState.index());
         // Note: totalEnergyReceived not persisted - testing-only counter, resets on reload
     }
 
     @Override
     protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
         super.loadLogisticsData(nbt, registries);
-        drainRateIndex = NbtCompat.getInt(nbt, "DrainRateIndex", 4);
-        // Clamp to valid range
-        if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
-            drainRateIndex = 4; // Default to 5 RF/t
-        }
+        drainState.restore(NbtCompat.getInt(nbt, "DrainRateIndex", 4));
         // Note: totalEnergyReceived not loaded - testing-only counter, starts at 0
     }
 
@@ -168,11 +139,7 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
         super.loadLegacyData(view);
         view.read("CreativeSink", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
             // Load old key name (before BaseBlockEntity refactoring)
-            drainRateIndex = NbtCompat.getInt(data, "drainRateIndex", 4);
-            // Clamp to valid range
-            if (drainRateIndex < 0 || drainRateIndex >= DRAIN_RATES.length) {
-                drainRateIndex = 4; // Default to 5 RF/t
-            }
+            drainState.restore(NbtCompat.getInt(data, "drainRateIndex", 4));
         });
     }
 }

--- a/common/src/main/java/com/logistics/power/block/entity/CreativeSinkDrainState.java
+++ b/common/src/main/java/com/logistics/power/block/entity/CreativeSinkDrainState.java
@@ -1,0 +1,93 @@
+package com.logistics.power.block.entity;
+
+import java.util.Arrays;
+
+final class CreativeSinkDrainState {
+    static final long[] DEFAULT_DRAIN_RATES = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 50, 100, Long.MAX_VALUE};
+    private static final int DEFAULT_DRAIN_RATE_INDEX = 4;
+
+    private final long[] drainRates;
+    private int drainRateIndex = DEFAULT_DRAIN_RATE_INDEX;
+    private long energyLastTick;
+    private long energyThisTick;
+    private long totalEnergyReceived;
+
+    CreativeSinkDrainState() {
+        this(DEFAULT_DRAIN_RATES);
+    }
+
+    CreativeSinkDrainState(long[] drainRates) {
+        if (drainRates.length == 0) {
+            throw new IllegalArgumentException("drainRates must not be empty");
+        }
+
+        this.drainRates = Arrays.copyOf(drainRates, drainRates.length);
+        if (this.drainRates.length <= DEFAULT_DRAIN_RATE_INDEX) {
+            drainRateIndex = 0;
+        }
+    }
+
+    long insert(long maxAmount, boolean simulate) {
+        long toAccept = Math.min(maxAmount, networkDemandPerTick());
+        if (toAccept > 0 && !simulate) {
+            energyThisTick += toAccept;
+        }
+        return toAccept;
+    }
+
+    void tick() {
+        energyLastTick = energyThisTick;
+
+        if (energyThisTick > 0 && Long.MAX_VALUE - totalEnergyReceived <= energyThisTick) {
+            totalEnergyReceived = Long.MAX_VALUE;
+        } else {
+            totalEnergyReceived += energyThisTick;
+        }
+
+        energyThisTick = 0;
+    }
+
+    long drainRate() {
+        return drainRates[drainRateIndex];
+    }
+
+    long networkDemandPerTick() {
+        long drainRate = drainRate();
+        if (drainRate == Long.MAX_VALUE) return Long.MAX_VALUE;
+        return Math.max(0, drainRate - energyThisTick);
+    }
+
+    long cycle() {
+        drainRateIndex = (drainRateIndex + 1) % drainRates.length;
+        return drainRate();
+    }
+
+    void setUnlimited() {
+        drainRateIndex = drainRates.length - 1;
+    }
+
+    int index() {
+        return drainRateIndex;
+    }
+
+    void restore(int index) {
+        if (index < 0 || index >= drainRates.length) {
+            drainRateIndex = Math.min(DEFAULT_DRAIN_RATE_INDEX, drainRates.length - 1);
+            return;
+        }
+
+        drainRateIndex = index;
+    }
+
+    long energyLastTick() {
+        return energyLastTick;
+    }
+
+    long energyThisTick() {
+        return energyThisTick;
+    }
+
+    long totalEnergyReceived() {
+        return totalEnergyReceived;
+    }
+}

--- a/common/src/main/java/com/logistics/power/block/entity/CreativeSinkDrainState.java
+++ b/common/src/main/java/com/logistics/power/block/entity/CreativeSinkDrainState.java
@@ -30,9 +30,18 @@ final class CreativeSinkDrainState {
     long insert(long maxAmount, boolean simulate) {
         long toAccept = Math.min(maxAmount, networkDemandPerTick());
         if (toAccept > 0 && !simulate) {
-            energyThisTick += toAccept;
+            energyThisTick = saturatedTickEnergy(energyThisTick, toAccept, drainRate());
         }
         return toAccept;
+    }
+
+    private long saturatedTickEnergy(long current, long added, long drainRate) {
+        if (drainRate == Long.MAX_VALUE) {
+            if (Long.MAX_VALUE - current <= added) return Long.MAX_VALUE;
+            return current + added;
+        }
+
+        return Math.min(current + added, drainRate);
     }
 
     void tick() {

--- a/common/src/test/java/com/logistics/power/block/entity/CreativeSinkDrainStateTest.java
+++ b/common/src/test/java/com/logistics/power/block/entity/CreativeSinkDrainStateTest.java
@@ -40,6 +40,17 @@ class CreativeSinkDrainStateTest {
     }
 
     @Test
+    void insert_saturatesUnlimitedTickEnergyAtLongMaxValue() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState(new long[]{Long.MAX_VALUE});
+
+        assertThat(state.insert(Long.MAX_VALUE - 1, false)).isEqualTo(Long.MAX_VALUE - 1);
+        assertThat(state.insert(2, false)).isEqualTo(2);
+
+        assertThat(state.energyThisTick()).isEqualTo(Long.MAX_VALUE);
+        assertThat(state.networkDemandPerTick()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
     void tick_movesCurrentTickIntoLastTickAndTotalThenResetsDemand() {
         CreativeSinkDrainState state = new CreativeSinkDrainState();
         state.insert(4, false);

--- a/common/src/test/java/com/logistics/power/block/entity/CreativeSinkDrainStateTest.java
+++ b/common/src/test/java/com/logistics/power/block/entity/CreativeSinkDrainStateTest.java
@@ -1,0 +1,137 @@
+package com.logistics.power.block.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class CreativeSinkDrainStateTest {
+    @Test
+    void newState_usesDefaultDrainRate() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+
+        assertThat(state.index()).isEqualTo(4);
+        assertThat(state.drainRate()).isEqualTo(5);
+        assertThat(state.networkDemandPerTick()).isEqualTo(5);
+        assertThat(state.energyLastTick()).isZero();
+        assertThat(state.energyThisTick()).isZero();
+        assertThat(state.totalEnergyReceived()).isZero();
+    }
+
+    @Test
+    void insert_acceptsUpToRemainingDemandForCurrentTick() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+
+        assertThat(state.insert(3, false)).isEqualTo(3);
+        assertThat(state.insert(10, false)).isEqualTo(2);
+
+        assertThat(state.energyThisTick()).isEqualTo(5);
+        assertThat(state.networkDemandPerTick()).isZero();
+    }
+
+    @Test
+    void insert_simulationDoesNotConsumeDemand() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+
+        assertThat(state.insert(3, true)).isEqualTo(3);
+
+        assertThat(state.energyThisTick()).isZero();
+        assertThat(state.networkDemandPerTick()).isEqualTo(5);
+    }
+
+    @Test
+    void tick_movesCurrentTickIntoLastTickAndTotalThenResetsDemand() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+        state.insert(4, false);
+
+        state.tick();
+
+        assertThat(state.energyLastTick()).isEqualTo(4);
+        assertThat(state.energyThisTick()).isZero();
+        assertThat(state.totalEnergyReceived()).isEqualTo(4);
+        assertThat(state.networkDemandPerTick()).isEqualTo(5);
+    }
+
+    @Test
+    void tick_saturatesTotalEnergyAtLongMaxValue() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState(new long[]{Long.MAX_VALUE});
+        state.insert(Long.MAX_VALUE - 1, false);
+        state.tick();
+        state.insert(2, false);
+
+        state.tick();
+
+        assertThat(state.totalEnergyReceived()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    void cycle_advancesAndWrapsDrainRates() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState(new long[]{1, 2});
+
+        assertThat(state.cycle()).isEqualTo(2);
+        assertThat(state.index()).isEqualTo(1);
+
+        assertThat(state.cycle()).isEqualTo(1);
+        assertThat(state.index()).isZero();
+    }
+
+    @Test
+    void setUnlimited_selectsLastConfiguredDrainRate() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+
+        state.setUnlimited();
+
+        assertThat(state.index()).isEqualTo(CreativeSinkDrainState.DEFAULT_DRAIN_RATES.length - 1);
+        assertThat(state.drainRate()).isEqualTo(Long.MAX_VALUE);
+        assertThat(state.networkDemandPerTick()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    void restore_acceptsValidIndex() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+
+        state.restore(10);
+
+        assertThat(state.index()).isEqualTo(10);
+        assertThat(state.drainRate()).isEqualTo(15);
+    }
+
+    @Test
+    void restore_clampsNegativeIndexToDefault() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+        state.restore(10);
+
+        state.restore(-1);
+
+        assertThat(state.index()).isEqualTo(4);
+        assertThat(state.drainRate()).isEqualTo(5);
+    }
+
+    @Test
+    void restore_clampsOutOfRangeIndexToDefault() {
+        CreativeSinkDrainState state = new CreativeSinkDrainState();
+        state.restore(10);
+
+        state.restore(CreativeSinkDrainState.DEFAULT_DRAIN_RATES.length);
+
+        assertThat(state.index()).isEqualTo(4);
+        assertThat(state.drainRate()).isEqualTo(5);
+    }
+
+    @Test
+    void constructor_rejectsEmptyDrainRates() {
+        assertThatThrownBy(() -> new CreativeSinkDrainState(new long[]{}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("drainRates");
+    }
+
+    @Test
+    void constructor_defensivelyCopiesDrainRates() {
+        long[] drainRates = {5, 10};
+        CreativeSinkDrainState state = new CreativeSinkDrainState(drainRates);
+
+        drainRates[0] = 999;
+
+        assertThat(state.drainRate()).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts Creative Sink drain-rate, per-tick demand, and received-energy accounting into a small common helper.
- Adds focused unit coverage for demand limiting, simulation, tick reset accounting, overflow saturation, drain-rate cycling, unlimited mode, restore clamping, and defensive construction.
- Updates the testing guide coverage snapshot for the current Codecov-based workflow.

## Changes
- Keeps the block entity responsible for storage exposure, NBT keys, syncing, and probe output.
- Leaves coverage gating to Codecov; no local ratchet baseline is changed.

## Notes
- This is an internal testability refactor with no intended player-visible behavior change.