### PR TITLE
refactor(automation): extract Kiln processing plan

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,12 +72,12 @@ Current aggregate snapshot from `./gradlew testCoverage`:
 
 | Counter | Coverage |
 |---------|----------|
-| Instruction | 17.9% |
-| Branch | 15.6% |
+| Instruction | 18.0% |
+| Branch | 15.8% |
 | Line | 18.0% |
-| Complexity | 17.1% |
-| Method | 22.9% |
-| Class | 34.6% |
+| Complexity | 17.3% |
+| Method | 23.0% |
+| Class | 34.9% |
 
 High-coverage pure-logic areas include `core.lib.resource`, `core.lib.filter`,
 `power.engine`, `power.cable`, `core.lib.energy`, `core.lib.network`, and `neoforge.energy`.
@@ -101,6 +101,7 @@ supported branches.
 - **Failure accounting regressions** — tracked delivery failure, partial delivery followed by failed remainder, retry accounting, and job state after dispatch loss
 - **Pipe network graph** — NetworkGraph, NetworkPathfinder
 - **Pipe runtime** — TravelingItem, TravelingItemPhysics, RoutePlan
+- **Automation** — GridScanner, FrameLayout, QuarryBounds, QuarryPhaseRunner, ActiveQuarryRegistry, QuarryBlockBreaker, KilnProcessingPlan
 - **Power** — CableTier, PIDController, EngineHeatModel, EngineCyclePlanner, StirlingGenerationPlanner, StirlingFuelState, CreativeOutputLevels, RedstoneTargetGate, CreativeSinkDrainState
 - **Core** — BaseBlockEntity, ResourceId, MaceratorRecipe, MaceratorBlockEntityLogic, FluidTankComponent, ItemInventoryComponent
 - **Serialization golden tests** — ItemFilterModule (backward compat), ProviderDispatchQueue, TravelingItem

--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -130,17 +130,23 @@ public class KilnBlockEntity extends BaseBlockEntity
 
         ItemStack result = activeRecipe.value().assemble(new SingleRecipeInput(input));
 
-        // Pause if not enough energy or output is full
-        if (energy.getAmount() < ENERGY_PER_TICK || !canAcceptOutput(result)) {
+        KilnProcessingPlan.Result plan = KilnProcessingPlan.advance(
+                processProgress,
+                activeRecipe.value().cookingTime(),
+                energy.getAmount(),
+                ENERGY_PER_TICK,
+                canAcceptOutput(result));
+
+        if (!plan.consumedEnergy()) {
             setLit(level, state, false);
             return false;
         }
 
         energy.consume(ENERGY_PER_TICK);
         setLit(level, state, true);
-        processProgress++;
+        processProgress = plan.progress();
 
-        if (processProgress >= activeRecipe.value().cookingTime()) {
+        if (plan.complete()) {
             completeProcessing(result);
         }
 
@@ -165,9 +171,7 @@ public class KilnBlockEntity extends BaseBlockEntity
 
     private boolean canAcceptOutput(ItemStack result) {
         ItemStack output = inventory.getItem(OUTPUT_SLOT);
-        if (output.isEmpty()) return true;
-        return ItemStack.isSameItemSameComponents(output, result)
-            && output.getCount() + result.getCount() <= output.getMaxStackSize();
+        return KilnProcessingPlan.acceptsOutput(output, result);
     }
 
     private void completeProcessing(ItemStack result) {

--- a/common/src/main/java/com/logistics/automation/kiln/KilnProcessingPlan.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnProcessingPlan.java
@@ -1,0 +1,24 @@
+package com.logistics.automation.kiln;
+
+import net.minecraft.world.item.ItemStack;
+
+final class KilnProcessingPlan {
+    private KilnProcessingPlan() {}
+
+    static Result advance(int progress, int cookingTime, long energyStored, int energyPerTick, boolean outputAccepted) {
+        if (energyStored < energyPerTick || !outputAccepted) {
+            return new Result(progress, false, false, false);
+        }
+
+        int nextProgress = progress + 1;
+        return new Result(nextProgress, true, true, nextProgress >= cookingTime);
+    }
+
+    static boolean acceptsOutput(ItemStack output, ItemStack result) {
+        if (output.isEmpty()) return true;
+        return ItemStack.isSameItemSameComponents(output, result)
+            && output.getCount() + result.getCount() <= output.getMaxStackSize();
+    }
+
+    record Result(int progress, boolean consumedEnergy, boolean lit, boolean complete) {}
+}

--- a/common/src/test/java/com/logistics/automation/kiln/KilnProcessingPlanTest.java
+++ b/common/src/test/java/com/logistics/automation/kiln/KilnProcessingPlanTest.java
@@ -1,0 +1,79 @@
+package com.logistics.automation.kiln;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.Test;
+
+class KilnProcessingPlanTest extends MinecraftTestEnvironment {
+    @Test
+    void advance_pausesWhenEnergyIsInsufficient() {
+        KilnProcessingPlan.Result result = KilnProcessingPlan.advance(3, 10, 0, 1, true);
+
+        assertThat(result.progress()).isEqualTo(3);
+        assertThat(result.consumedEnergy()).isFalse();
+        assertThat(result.lit()).isFalse();
+        assertThat(result.complete()).isFalse();
+    }
+
+    @Test
+    void advance_pausesWhenOutputCannotAcceptResult() {
+        KilnProcessingPlan.Result result = KilnProcessingPlan.advance(3, 10, 1, 1, false);
+
+        assertThat(result.progress()).isEqualTo(3);
+        assertThat(result.consumedEnergy()).isFalse();
+        assertThat(result.lit()).isFalse();
+        assertThat(result.complete()).isFalse();
+    }
+
+    @Test
+    void advance_consumesEnergyAndIncrementsProgress() {
+        KilnProcessingPlan.Result result = KilnProcessingPlan.advance(3, 10, 1, 1, true);
+
+        assertThat(result.progress()).isEqualTo(4);
+        assertThat(result.consumedEnergy()).isTrue();
+        assertThat(result.lit()).isTrue();
+        assertThat(result.complete()).isFalse();
+    }
+
+    @Test
+    void advance_completesWhenNextProgressReachesCookingTime() {
+        KilnProcessingPlan.Result result = KilnProcessingPlan.advance(9, 10, 1, 1, true);
+
+        assertThat(result.progress()).isEqualTo(10);
+        assertThat(result.consumedEnergy()).isTrue();
+        assertThat(result.lit()).isTrue();
+        assertThat(result.complete()).isTrue();
+    }
+
+    @Test
+    void acceptsOutput_acceptsEmptyOutputSlot() {
+        assertThat(KilnProcessingPlan.acceptsOutput(ItemStack.EMPTY, new ItemStack(Items.IRON_INGOT))).isTrue();
+    }
+
+    @Test
+    void acceptsOutput_acceptsMatchingStackWhenResultFits() {
+        ItemStack output = new ItemStack(Items.IRON_INGOT, 63);
+        ItemStack result = new ItemStack(Items.IRON_INGOT);
+
+        assertThat(KilnProcessingPlan.acceptsOutput(output, result)).isTrue();
+    }
+
+    @Test
+    void acceptsOutput_rejectsMatchingStackWhenResultWouldOverflow() {
+        ItemStack output = new ItemStack(Items.IRON_INGOT, 64);
+        ItemStack result = new ItemStack(Items.IRON_INGOT);
+
+        assertThat(KilnProcessingPlan.acceptsOutput(output, result)).isFalse();
+    }
+
+    @Test
+    void acceptsOutput_rejectsDifferentOutputStack() {
+        ItemStack output = new ItemStack(Items.GOLD_INGOT);
+        ItemStack result = new ItemStack(Items.IRON_INGOT);
+
+        assertThat(KilnProcessingPlan.acceptsOutput(output, result)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts Kiln progress gating and output acceptance into a small common helper.
- Adds focused unit coverage for energy pauses, output pauses, progress advancement, completion, and output stack fit rules.
- Updates the testing guide coverage snapshot for the current Codecov-based workflow.

## Changes
- Keeps recipe lookup, inventory mutation, energy storage, NBT, and block lit-state updates in KilnBlockEntity.
- Leaves coverage gating to Codecov; no local ratchet baseline is changed.

## Notes
- This is an internal testability refactor with no intended player-visible behavior change.