### PR TITLE
ci(build): lower Codecov patch coverage threshold

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -64,7 +64,7 @@ On every PR each `test` matrix job uploads its module's JaCoCo report (tagged wi
 `common` / `fabric` / `neoforge` flag) and Codecov merges them, so the suite runs only
 once. Codecov posts a summary comment, flags uncovered changed lines inline, and
 publishes `project`/`patch` status checks. The thresholds live in `codecov.yml`
-(project: no drop beyond 0.5%; patch target 70%), so there is no hand-maintained
+(project: no drop beyond 0.5%; patch target 20%), so there is no hand-maintained
 baseline to bump. The local `testCoverage` task above still produces the aggregate
 HTML/XML for offline inspection.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,8 +13,8 @@ coverage:
         threshold: 0.5%
     patch:
       default:
-        # New / changed lines in a PR should be reasonably covered.
-        target: 70%
+        # Keep new / changed lines covered without blocking small Minecraft mod PRs.
+        target: 20%
 
 # Per-module uploads are tagged with a flag so Codecov can report coverage
 # per loader as well as merged together.


### PR DESCRIPTION
Summary
- Lowers the Codecov patch coverage target from 70% to 20%.

Changes
- Keeps project coverage on target: auto so overall coverage still trends upward.
- Makes patch coverage less likely to block Minecraft mod changes that are hard to unit test directly.

Notes
- Codecov notification and comment build counts are unchanged.