### PR TITLE
perf(automation): reduce memory and load time for machine rendering

### DIFF
--- a/common/src/client/java/com/logistics/automation/render/LaserQuarryBlockEntityRenderer.java
+++ b/common/src/client/java/com/logistics/automation/render/LaserQuarryBlockEntityRenderer.java
@@ -1,6 +1,5 @@
 package com.logistics.automation.render;
 
-import com.logistics.LogisticsAutomationClientModels;
 import com.logistics.core.LogisticsConfig;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.automation.laserquarry.LaserQuarryGeometry;
@@ -8,10 +7,9 @@ import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
 import com.logistics.pipe.block.PipeBlock;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import com.logistics.core.lib.client.model.ClientModelRegistry;
+import com.logistics.core.lib.client.render.MachineModels;
 import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -20,9 +18,7 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.util.RandomSource;
 
-import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -37,10 +33,6 @@ import net.minecraft.world.phys.Vec3;
  */
 public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<LaserQuarryBlockEntity, LaserQuarryRenderState> {
     public LaserQuarryBlockEntityRenderer(BlockEntityRendererProvider.Context ctx) {}
-
-    private BlockStateModel getModel(ClientModelRegistry.ModelKey key) {
-        return ClientModelRegistry.get(key);
-    }
 
     @Override
     public LaserQuarryRenderState createRenderState() {
@@ -172,8 +164,8 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
             return;
         }
 
-        BlockStateModel armModel = getModel(LogisticsAutomationClientModels.ARM);
-        if (armModel == null) {
+        List<BlockStateModelPart> armParts = MachineModels.parts("laser_quarry_gantry_arm");
+        if (armParts.isEmpty()) {
             return;
         }
 
@@ -204,7 +196,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
         renderHorizontalBeam(
                 matrices,
                 queue,
-                armModel,
+                armParts,
                 renderLayer,
                 light,
                 state.frameStartX + 1 - quarryX,
@@ -217,7 +209,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
         renderHorizontalBeam(
                 matrices,
                 queue,
-                armModel,
+                armParts,
                 renderLayer,
                 light,
                 relArmX,
@@ -231,18 +223,16 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
         float verticalLength = verticalStartY - relArmY - 1;
         if (verticalLength > 0.1f) {
             renderVerticalBeam(
-                    matrices, queue, armModel, renderLayer, light, relArmX, verticalStartY, relArmZ, verticalLength);
+                    matrices, queue, armParts, renderLayer, light, relArmX, verticalStartY, relArmZ, verticalLength);
         }
 
         // Render drill head at the bottom of the vertical beam
-        BlockStateModel drillModel = getModel(LogisticsAutomationClientModels.DRILL);
-        if (drillModel != null) {
+        List<BlockStateModelPart> drillParts = MachineModels.parts("laser_quarry_drill");
+        if (!drillParts.isEmpty()) {
             matrices.pushPose();
             // Position drill at arm location, offset to center the model
             // Drill model is centered at X=0.5, Z=0.5, extends from Y=0.125 to Y=1
             matrices.translate(relArmX - 0.5, relArmY, relArmZ - 0.5);
-            List<BlockStateModelPart> drillParts = new ArrayList<>();
-            drillModel.collectParts(RandomSource.create(0), drillParts);
             queue.submitBlockModel(matrices, renderLayer, drillParts, new int[]{0xFFFFFF}, light, OverlayTexture.NO_OVERLAY, 0);
             matrices.popPose();
         }
@@ -258,7 +248,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
     private void renderHorizontalBeam(
             PoseStack matrices,
             SubmitNodeCollector queue,
-            BlockStateModel model,
+            List<BlockStateModelPart> modelParts,
             RenderType renderLayer,
             int lightmap,
             float startX,
@@ -266,8 +256,6 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
             float startZ,
             int length,
             boolean alongX) {
-        List<BlockStateModelPart> modelParts = new ArrayList<>();
-        model.collectParts(RandomSource.create(0), modelParts);
         for (int i = 0; i < length; i++) {
             matrices.pushPose();
 
@@ -304,7 +292,7 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
     private void renderVerticalBeam(
             PoseStack matrices,
             SubmitNodeCollector queue,
-            BlockStateModel model,
+            List<BlockStateModelPart> modelParts,
             RenderType renderLayer,
             int lightmap,
             float x,
@@ -313,9 +301,6 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
             float length) {
         int fullSegments = (int) length;
         float remainder = length - fullSegments;
-
-        List<BlockStateModelPart> modelParts = new ArrayList<>();
-        model.collectParts(RandomSource.create(0), modelParts);
 
         // Render partial segment at the TOP first (obscured by horizontal beams)
         if (remainder > 0.1f) {
@@ -368,8 +353,8 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
 
         // Green LED - instant on, gradual fade off over 12 ticks
         if (state.greenLedBrightness > 0) {
-            BlockStateModel greenLed = getModel(LogisticsAutomationClientModels.LED_GREEN);
-            if (greenLed != null) {
+            List<BlockStateModelPart> greenLedParts = MachineModels.parts("laser_quarry_led_green");
+            if (!greenLedParts.isEmpty()) {
                 matrices.pushPose();
                 matrices.translate(0.5, 0.5, 0.5);
                 matrices.mulPose(Axis.YP.rotationDegrees(rotation));
@@ -377,8 +362,6 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
                 // Brightness scales with fade (0-15)
                 int brightness = (int) (state.greenLedBrightness * 15);
                 int light = (brightness << 4) | (brightness << 20);
-                List<BlockStateModelPart> greenLedParts = new ArrayList<>();
-                greenLed.collectParts(RandomSource.create(0), greenLedParts);
                 queue.submitBlockModel(matrices, renderLayer, greenLedParts, new int[]{0xFFFFFF}, light, OverlayTexture.NO_OVERLAY, 0);
                 matrices.popPose();
             }
@@ -386,8 +369,8 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
 
         // Red LED - brightness proportional to energy level (0-15)
         if (state.energyLevel > 0) {
-            BlockStateModel redLed = getModel(LogisticsAutomationClientModels.LED_RED);
-            if (redLed != null) {
+            List<BlockStateModelPart> redLedParts = MachineModels.parts("laser_quarry_led_red");
+            if (!redLedParts.isEmpty()) {
                 matrices.pushPose();
                 matrices.translate(0.5, 0.5, 0.5);
                 matrices.mulPose(Axis.YP.rotationDegrees(rotation));
@@ -395,8 +378,6 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
                 // Brightness scaled by energy level (0-15)
                 int brightness = (int) (state.energyLevel * 15);
                 int light = (brightness << 4) | (brightness << 20);
-                List<BlockStateModelPart> redLedParts = new ArrayList<>();
-                redLed.collectParts(RandomSource.create(0), redLedParts);
                 queue.submitBlockModel(matrices, renderLayer, redLedParts, new int[]{0xFFFFFF}, light, OverlayTexture.NO_OVERLAY, 0);
                 matrices.popPose();
             }
@@ -405,8 +386,8 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
         // Display overlay - scrolling data screen (animated via .mcmeta)
         // Follows green LED: on when working, fades out when stopped
         if (state.greenLedBrightness > 0) {
-            BlockStateModel display = getModel(LogisticsAutomationClientModels.DISPLAY);
-            if (display != null) {
+            List<BlockStateModelPart> displayParts = MachineModels.parts("laser_quarry_display");
+            if (!displayParts.isEmpty()) {
                 matrices.pushPose();
                 matrices.translate(0.5, 0.5, 0.5);
                 matrices.mulPose(Axis.YP.rotationDegrees(rotation));
@@ -414,8 +395,6 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
                 // Scale brightness with fade (min 8 at full brightness, scales down to 0)
                 int brightness = Math.max(0, (int) (state.greenLedBrightness * 8));
                 int light = (brightness << 4) | (brightness << 20);
-                List<BlockStateModelPart> displayParts = new ArrayList<>();
-                display.collectParts(RandomSource.create(0), displayParts);
                 queue.submitBlockModel(matrices, renderLayer, displayParts, new int[]{0xFFFFFF}, light, OverlayTexture.NO_OVERLAY, 0);
                 matrices.popPose();
             }
@@ -427,8 +406,8 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
             return;
         }
 
-        BlockStateModel hatch = getModel(LogisticsAutomationClientModels.TOP_HATCH);
-        if (hatch == null) {
+        List<BlockStateModelPart> hatchParts = MachineModels.parts("laser_quarry_top_hatch");
+        if (hatchParts.isEmpty()) {
             return;
         }
 
@@ -436,24 +415,19 @@ public class LaserQuarryBlockEntityRenderer implements BlockEntityRenderer<Laser
         matrices.pushPose();
         // No rotation needed - top face is always up
         // Use light from above the quarry where the hatch is visible
-        List<BlockStateModelPart> hatchParts = new ArrayList<>();
-        hatch.collectParts(RandomSource.create(0), hatchParts);
         queue.submitBlockModel(matrices, renderLayer, hatchParts, new int[]{0xFFFFFF}, state.aboveLight, OverlayTexture.NO_OVERLAY, 0);
         matrices.popPose();
     }
 
     private void renderFramePreviewOutline(
             LaserQuarryRenderState state, PoseStack matrices, SubmitNodeCollector queue) {
-        BlockStateModel beamModel = getModel(LogisticsAutomationClientModels.CONSTRUCTION_BEAM);
-        if (beamModel == null) {
+        List<BlockStateModelPart> parts = MachineModels.parts("construction_beam");
+        if (parts.isEmpty()) {
             return;
         }
 
         RenderType renderLayer = RenderTypes.cutoutMovingBlock();
         int lightmap = LightCoordsUtil.FULL_BRIGHT;
-
-        List<BlockStateModelPart> parts = new ArrayList<>();
-        beamModel.collectParts(RandomSource.create(0), parts);
 
         float qx = state.quarryPos.getX();
         float qz = state.quarryPos.getZ();

--- a/common/src/client/java/com/logistics/automation/render/MarkerBlockEntityRenderer.java
+++ b/common/src/client/java/com/logistics/automation/render/MarkerBlockEntityRenderer.java
@@ -1,13 +1,11 @@
 package com.logistics.automation.render;
 
-import com.logistics.LogisticsAutomationClientModels;
 import com.logistics.automation.marker.MarkerBlockEntity;
 import com.logistics.automation.marker.MarkerManager;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import com.logistics.core.lib.client.model.ClientModelRegistry;
+import com.logistics.core.lib.client.render.MachineModels;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -16,9 +14,7 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.util.RandomSource;
 
-import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
@@ -147,41 +143,35 @@ public class MarkerBlockEntityRenderer implements BlockEntityRenderer<MarkerBloc
             return;
         }
 
-        BlockStateModel beamModel = getBeamModel();
-        if (beamModel == null) {
+        List<BlockStateModelPart> beamParts = MachineModels.parts("marker_beam");
+        if (beamParts.isEmpty()) {
             return;
         }
 
         RenderType renderLayer = RenderTypes.cutoutMovingBlock();
 
         if (state.beamNorth > 0) {
-            renderBeamInDirection(matrices, queue, beamModel, renderLayer, state.lightCoords, 180, state.beamNorth);
+            renderBeamInDirection(matrices, queue, beamParts, renderLayer, state.lightCoords, 180, state.beamNorth);
         }
         if (state.beamSouth > 0) {
-            renderBeamInDirection(matrices, queue, beamModel, renderLayer, state.lightCoords, 0, state.beamSouth);
+            renderBeamInDirection(matrices, queue, beamParts, renderLayer, state.lightCoords, 0, state.beamSouth);
         }
         if (state.beamEast > 0) {
-            renderBeamInDirection(matrices, queue, beamModel, renderLayer, state.lightCoords, 90, state.beamEast);
+            renderBeamInDirection(matrices, queue, beamParts, renderLayer, state.lightCoords, 90, state.beamEast);
         }
         if (state.beamWest > 0) {
-            renderBeamInDirection(matrices, queue, beamModel, renderLayer, state.lightCoords, -90, state.beamWest);
+            renderBeamInDirection(matrices, queue, beamParts, renderLayer, state.lightCoords, -90, state.beamWest);
         }
-    }
-
-    private BlockStateModel getBeamModel() {
-        return ClientModelRegistry.get(LogisticsAutomationClientModels.BEAM);
     }
 
     private void renderBeamInDirection(
             PoseStack matrices,
             SubmitNodeCollector queue,
-            BlockStateModel beamModel,
+            List<BlockStateModelPart> parts,
             RenderType renderLayer,
             int lightmap,
             float yRotation,
             int length) {
-        List<BlockStateModelPart> parts = new ArrayList<>();
-        beamModel.collectParts(RandomSource.create(0), parts);
         for (int i = 0; i < length; i++) {
             matrices.pushPose();
             matrices.translate(0.5, -0.0625, 0.5);

--- a/common/src/client/java/com/logistics/core/lib/client/render/BoxGeometry.java
+++ b/common/src/client/java/com/logistics/core/lib/client/render/BoxGeometry.java
@@ -1,0 +1,107 @@
+package com.logistics.core.lib.client.render;
+
+import java.util.List;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.Direction;
+
+/**
+ * Generic code generator for axis-aligned box models (single texture), replacing simple
+ * authored JSON block models. Each {@link Element} is a cuboid with a subset of faces; each
+ * {@link Face} carries its local UV rect (0..16) and texture rotation (0/90/180/270), lifted
+ * verbatim from the model JSON. Vanilla ignores {@code texture_size}, so UVs map to the sprite
+ * as {@code uv/16 * span} regardless of the texture's pixel dimensions.
+ *
+ * <p>Vertex winding and UV convention match the (visually verified) cable/pipe path. Geometry
+ * is emitted in the model's authored orientation; renderers apply any animation via the pose stack.
+ */
+public final class BoxGeometry {
+    private BoxGeometry() {}
+
+    /** A single cuboid face: direction, local UV rect in 0..16 (corners may be reversed to flip), and rotation. */
+    public record Face(Direction dir, float u0, float v0, float u1, float v1, int rotation) {}
+
+    /** A cuboid in 0..16 model space with an explicit list of faces (only the faces that exist are drawn). */
+    public record Element(float x0, float y0, float z0, float x1, float y1, float z1, List<Face> faces) {}
+
+    /** Emit all elements' faces into {@code sink}, textured from {@code sprite}. */
+    public static void emit(QuadSink sink, List<Element> elements, TextureAtlasSprite sprite) {
+        for (Element e : elements) {
+            for (Face f : e.faces()) {
+                emitFace(sink, f.dir(), e, f.u0(), f.v0(), f.u1(), f.v1(), f.rotation(), sprite);
+            }
+        }
+    }
+
+    private static void emitFace(QuadSink sink, Direction face, Element b,
+            float localU0, float localV0, float localU1, float localV1, int rotation,
+            TextureAtlasSprite sprite) {
+        float spriteU0 = sprite.getU0();
+        float spriteV0 = sprite.getV0();
+        float spriteUSpan = sprite.getU1() - spriteU0;
+        float spriteVSpan = sprite.getV1() - spriteV0;
+        float u0 = spriteU0 + spriteUSpan * (localU0 / 16f);
+        float u1 = spriteU0 + spriteUSpan * (localU1 / 16f);
+        float v0 = spriteV0 + spriteVSpan * (localV0 / 16f);
+        float v1 = spriteV0 + spriteVSpan * (localV1 / 16f);
+
+        float[][] uv = {{u0, v1}, {u1, v1}, {u1, v0}, {u0, v0}};
+        int shift = ((rotation / 90) % 4 + 4) % 4;
+        float[] a = uv[shift % 4];
+        float[] bb = uv[(1 + shift) % 4];
+        float[] c = uv[(2 + shift) % 4];
+        float[] d = uv[(3 + shift) % 4];
+
+        float[] p0 = vertex(face, 0, b);
+        float[] p1 = vertex(face, 1, b);
+        float[] p2 = vertex(face, 2, b);
+        float[] p3 = vertex(face, 3, b);
+        sink.emitQuad(face, null,
+                p3[0], p3[1], p3[2], a[0], a[1],
+                p2[0], p2[1], p2[2], bb[0], bb[1],
+                p1[0], p1[1], p1[2], c[0], c[1],
+                p0[0], p0[1], p0[2], d[0], d[1]);
+    }
+
+    private static float[] vertex(Direction face, int index, Element b) {
+        float x0 = b.x0() / 16f, y0 = b.y0() / 16f, z0 = b.z0() / 16f;
+        float x1 = b.x1() / 16f, y1 = b.y1() / 16f, z1 = b.z1() / 16f;
+        return switch (face) {
+            case DOWN -> switch (index) {
+                case 0 -> new float[] {x0, y0, z1};
+                case 1 -> new float[] {x1, y0, z1};
+                case 2 -> new float[] {x1, y0, z0};
+                default -> new float[] {x0, y0, z0};
+            };
+            case UP -> switch (index) {
+                case 0 -> new float[] {x0, y1, z0};
+                case 1 -> new float[] {x1, y1, z0};
+                case 2 -> new float[] {x1, y1, z1};
+                default -> new float[] {x0, y1, z1};
+            };
+            case NORTH -> switch (index) {
+                case 0 -> new float[] {x1, y1, z0};
+                case 1 -> new float[] {x0, y1, z0};
+                case 2 -> new float[] {x0, y0, z0};
+                default -> new float[] {x1, y0, z0};
+            };
+            case SOUTH -> switch (index) {
+                case 0 -> new float[] {x0, y1, z1};
+                case 1 -> new float[] {x1, y1, z1};
+                case 2 -> new float[] {x1, y0, z1};
+                default -> new float[] {x0, y0, z1};
+            };
+            case WEST -> switch (index) {
+                case 0 -> new float[] {x0, y1, z0};
+                case 1 -> new float[] {x0, y1, z1};
+                case 2 -> new float[] {x0, y0, z1};
+                default -> new float[] {x0, y0, z0};
+            };
+            case EAST -> switch (index) {
+                case 0 -> new float[] {x1, y1, z1};
+                case 1 -> new float[] {x1, y1, z0};
+                case 2 -> new float[] {x1, y0, z0};
+                default -> new float[] {x1, y0, z1};
+            };
+        };
+    }
+}

--- a/common/src/client/java/com/logistics/core/lib/client/render/MachineModels.java
+++ b/common/src/client/java/com/logistics/core/lib/client/render/MachineModels.java
@@ -1,0 +1,153 @@
+package com.logistics.core.lib.client.render;
+
+import com.logistics.core.lib.client.render.BoxGeometry.Element;
+import com.logistics.core.lib.client.render.BoxGeometry.Face;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.Direction;
+import net.minecraft.data.AtlasIds;
+import net.minecraft.resources.Identifier;
+
+/**
+ * Code-generated box geometry for the engine / laser-quarry / marker render parts that
+ * formerly loaded as standalone JSON models. Each entry is the model's texture (path under
+ * {@code block/}) plus its cuboid elements + per-face UVs, transcribed verbatim from the
+ * original model JSONs. Consumed by the block-entity renderers via {@link BoxGeometry}.
+ */
+public final class MachineModels {
+    private MachineModels() {}
+
+    /** A machine model: its texture base (under {@code block/}) and code-generated elements. */
+    public record Model(String textureBase, List<Element> elements) {}
+
+    private static final Map<String, Model> MODELS = Map.ofEntries(
+        Map.entry("redstone_engine_bellow", new Model("power/redstone_engine", List.of(
+            new Element(2f, 0f, 2f, 14f, 8f, 14f, List.of(
+                    new Face(Direction.NORTH, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.EAST, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.SOUTH, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.WEST, 0.5f, 12f, 3.5f, 14f, 0)))))),
+        Map.entry("redstone_engine_piston", new Model("power/redstone_engine", List.of(
+            new Element(0f, 0f, 0f, 16f, 4f, 16f, List.of(
+                    new Face(Direction.NORTH, 4f, 14f, 8f, 15f, 0),
+                    new Face(Direction.EAST, 0f, 14f, 4f, 15f, 0),
+                    new Face(Direction.SOUTH, 12f, 14f, 16f, 15f, 0),
+                    new Face(Direction.WEST, 8f, 14f, 12f, 15f, 0),
+                    new Face(Direction.UP, 8f, 14f, 4f, 10f, 0),
+                    new Face(Direction.DOWN, 12f, 10f, 8f, 14f, 0)))))),
+        Map.entry("stirling_engine_bellow", new Model("power/stirling_engine", List.of(
+            new Element(2f, 0f, 2f, 14f, 8f, 14f, List.of(
+                    new Face(Direction.NORTH, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.EAST, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.SOUTH, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.WEST, 0.5f, 12f, 3.5f, 14f, 0)))))),
+        Map.entry("stirling_engine_piston", new Model("power/stirling_engine", List.of(
+            new Element(0f, 0f, 0f, 16f, 4f, 16f, List.of(
+                    new Face(Direction.NORTH, 4f, 14f, 8f, 15f, 0),
+                    new Face(Direction.EAST, 0f, 14f, 4f, 15f, 0),
+                    new Face(Direction.SOUTH, 12f, 14f, 16f, 15f, 0),
+                    new Face(Direction.WEST, 8f, 14f, 12f, 15f, 0),
+                    new Face(Direction.UP, 8f, 14f, 4f, 10f, 0),
+                    new Face(Direction.DOWN, 12f, 10f, 8f, 14f, 0)))))),
+        Map.entry("creative_engine_bellow", new Model("power/creative_engine", List.of(
+            new Element(2f, 0f, 2f, 14f, 8f, 14f, List.of(
+                    new Face(Direction.NORTH, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.EAST, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.SOUTH, 0.5f, 12f, 3.5f, 14f, 0),
+                    new Face(Direction.WEST, 0.5f, 12f, 3.5f, 14f, 0)))))),
+        Map.entry("creative_engine_piston", new Model("power/creative_engine", List.of(
+            new Element(0f, 0f, 0f, 16f, 4f, 16f, List.of(
+                    new Face(Direction.NORTH, 4f, 14f, 8f, 15f, 0),
+                    new Face(Direction.EAST, 0f, 14f, 4f, 15f, 0),
+                    new Face(Direction.SOUTH, 12f, 14f, 16f, 15f, 0),
+                    new Face(Direction.WEST, 8f, 14f, 12f, 15f, 0),
+                    new Face(Direction.UP, 8f, 14f, 4f, 10f, 0),
+                    new Face(Direction.DOWN, 12f, 10f, 8f, 14f, 0)))))),
+        Map.entry("marker_beam", new Model("core/marker_beam", List.of(
+            new Element(7.1f, 8.1f, 0f, 8.9f, 9.9f, 16f, List.of(
+                    new Face(Direction.NORTH, 0f, 4f, 2f, 12f, 0),
+                    new Face(Direction.EAST, 0f, 0f, 16f, 8f, 0),
+                    new Face(Direction.SOUTH, 14f, 4f, 16f, 12f, 0),
+                    new Face(Direction.WEST, 0f, 8f, 16f, 16f, 0),
+                    new Face(Direction.UP, 16f, 16f, 0f, 8f, 90),
+                    new Face(Direction.DOWN, 16f, 16f, 0f, 8f, 90)))))),
+        Map.entry("construction_beam", new Model("core/construction_beam", List.of(
+            new Element(7.1f, 8.1f, 0f, 8.9f, 9.9f, 16f, List.of(
+                    new Face(Direction.NORTH, 0f, 4f, 2f, 12f, 0),
+                    new Face(Direction.EAST, 0f, 0f, 16f, 8f, 0),
+                    new Face(Direction.SOUTH, 14f, 4f, 16f, 12f, 0),
+                    new Face(Direction.WEST, 0f, 8f, 16f, 16f, 0),
+                    new Face(Direction.UP, 16f, 16f, 0f, 8f, 90),
+                    new Face(Direction.DOWN, 16f, 16f, 0f, 8f, 90)))))),
+        Map.entry("laser_quarry_gantry_arm", new Model("automation/quary_gantry_arm", List.of(
+            new Element(5f, 5f, 0f, 11f, 11f, 16f, List.of(
+                    new Face(Direction.NORTH, 0f, 1f, 1f, 2f, 0),
+                    new Face(Direction.EAST, 0f, 0f, 16f, 6f, 0),
+                    new Face(Direction.SOUTH, 0f, 1f, 1f, 2f, 0),
+                    new Face(Direction.WEST, 0f, 0f, 16f, 6f, 0),
+                    new Face(Direction.UP, 16f, 0f, 0f, 6f, 90),
+                    new Face(Direction.DOWN, 0f, 6f, 16f, 0f, 90))),
+            new Element(5.5f, 5.5f, 0.01f, 10.5f, 10.5f, 15.99f, List.of(
+                    new Face(Direction.NORTH, 0f, 6f, 5f, 11f, 0),
+                    new Face(Direction.EAST, 0f, 6f, 16f, 11f, 0),
+                    new Face(Direction.SOUTH, 11f, 6f, 16f, 11f, 0),
+                    new Face(Direction.WEST, 0f, 6f, 16f, 11f, 0),
+                    new Face(Direction.UP, 0f, 6f, 16f, 11f, 90),
+                    new Face(Direction.DOWN, 0f, 6f, 16f, 11f, 90)))))),
+        Map.entry("laser_quarry_drill", new Model("automation/quary_drill", List.of(
+            new Element(7f, 2f, 7f, 9f, 16f, 9f, List.of(
+                    new Face(Direction.NORTH, 4f, 2f, 6f, 16f, 0),
+                    new Face(Direction.EAST, 2f, 2f, 4f, 16f, 0),
+                    new Face(Direction.SOUTH, 4f, 2f, 6f, 16f, 0),
+                    new Face(Direction.WEST, 2f, 2f, 4f, 16f, 0),
+                    new Face(Direction.UP, 2f, 2f, 4f, 4f, 0),
+                    new Face(Direction.DOWN, 14f, 5f, 16f, 7f, 0)))))),
+        Map.entry("laser_quarry_led_green", new Model("automation/laser_quarry/led_green", List.of(
+            new Element(0f, 0f, -0.01f, 16f, 16f, -0.01f, List.of(
+                    new Face(Direction.NORTH, 0f, 0f, 16f, 16f, 0)))))),
+        Map.entry("laser_quarry_led_red", new Model("automation/laser_quarry/led_red", List.of(
+            new Element(0f, 0f, -0.01f, 16f, 16f, -0.01f, List.of(
+                    new Face(Direction.NORTH, 0f, 0f, 16f, 16f, 0)))))),
+        Map.entry("laser_quarry_display", new Model("automation/laser_quarry/display", List.of(
+            new Element(2f, 0f, -0.02f, 14f, 16f, -0.02f, List.of(
+                    new Face(Direction.NORTH, 2f, 0f, 14f, 16f, 0)))))),
+        Map.entry("laser_quarry_top_hatch", new Model("automation/laser_quarry/top_hatch", List.of(
+            new Element(0f, 16.01f, 0f, 16f, 16.01f, 16f, List.of(
+                    new Face(Direction.UP, 0f, 0f, 16f, 16f, 0))))))
+    );
+
+    public static Model get(String key) {
+        return MODELS.get(key);
+    }
+
+    private static final Map<String, List<BlockStateModelPart>> PARTS_CACHE = new HashMap<>();
+
+    /**
+     * Build (and cache) the code-generated parts for a machine model key, ready for
+     * {@code SubmitNodeCollector.submitBlockModel}. Geometry is static, so parts are cached by
+     * key (assumes no mid-session resource reload, matching the pipe/cable renderers). Returns
+     * an empty list for an unknown key.
+     */
+    public static List<BlockStateModelPart> parts(String key) {
+        List<BlockStateModelPart> cached = PARTS_CACHE.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        Model model = MODELS.get(key);
+        if (model == null) {
+            return List.of();
+        }
+        TextureAtlasSprite sprite = Minecraft.getInstance().getAtlasManager()
+                .getAtlasOrThrow(AtlasIds.BLOCKS)
+                .getSprite(Identifier.fromNamespaceAndPath("logistics", "block/" + model.textureBase()));
+        VanillaQuadBaker baker = new VanillaQuadBaker(sprite, -1, true, 0);
+        BoxGeometry.emit(baker::quad, model.elements(), sprite);
+        List<BlockStateModelPart> parts = baker.isEmpty() ? List.of() : List.of(baker.toPart());
+        PARTS_CACHE.put(key, parts);
+        return parts;
+    }
+}

--- a/fabric/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
+++ b/fabric/src/client/java/com/logistics/power/render/EngineBlockEntityRenderer.java
@@ -1,16 +1,14 @@
 package com.logistics.power.render;
 
-import com.logistics.LogisticsPowerClient;
+import com.logistics.core.lib.client.render.MachineModels;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.power.engine.block.entity.CreativeEngineBlockEntity;
 import com.logistics.power.engine.block.entity.RedstoneEngineBlockEntity;
 import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import com.logistics.core.lib.client.model.ClientModelRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -18,9 +16,7 @@ import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.util.RandomSource;
 
-import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -104,12 +100,12 @@ public class EngineBlockEntityRenderer implements BlockEntityRenderer<AbstractEn
             SubmitNodeCollector queue,
             CameraRenderState cameraState) {
 
-        // Get baked models
-        BlockStateModel pistonModel = getModel(getPistonKey(state.engineType));
-        BlockStateModel bellowModel = getModel(getBellowKey(state.engineType));
+        // Get code-generated parts
+        List<BlockStateModelPart> bellowParts = MachineModels.parts(getBellowKey(state.engineType));
+        List<BlockStateModelPart> pistonParts = MachineModels.parts(getPistonKey(state.engineType));
 
-        if (pistonModel == null || bellowModel == null) {
-            return; // Models not loaded yet
+        if (bellowParts.isEmpty() || pistonParts.isEmpty()) {
+            return; // Atlas/parts not ready yet
         }
 
         RenderType renderLayer = RenderTypes.cutoutMovingBlock();
@@ -124,35 +120,31 @@ public class EngineBlockEntityRenderer implements BlockEntityRenderer<AbstractEn
         matrices.translate(0, 4 / 16f, 0);
         float bellowScale = Math.max(pistonOffset / 0.5f, 0.01f);
         matrices.scale(1.0f, bellowScale, 1.0f);
-        List<BlockStateModelPart> bellowParts = new ArrayList<>();
-        bellowModel.collectParts(RandomSource.create(0), bellowParts);
         queue.submitBlockModel(matrices, renderLayer, bellowParts, new int[]{-1}, light, OverlayTexture.NO_OVERLAY, 0);
         matrices.popPose();
 
         // Render piston (translates with animation)
         matrices.pushPose();
         matrices.translate(0, 4 / 16f + pistonOffset, 0);
-        List<BlockStateModelPart> pistonParts = new ArrayList<>();
-        pistonModel.collectParts(RandomSource.create(0), pistonParts);
         queue.submitBlockModel(matrices, renderLayer, pistonParts, new int[]{-1}, light, OverlayTexture.NO_OVERLAY, 0);
         matrices.popPose();
 
         matrices.popPose();
     }
 
-    private ClientModelRegistry.ModelKey getBellowKey(EngineRenderState.EngineType type) {
+    private String getBellowKey(EngineRenderState.EngineType type) {
         return switch (type) {
-            case REDSTONE -> LogisticsPowerClient.MODEL.REDSTONE_BELLOW;
-            case STIRLING -> LogisticsPowerClient.MODEL.STIRLING_BELLOW;
-            case CREATIVE -> LogisticsPowerClient.MODEL.CREATIVE_BELLOW;
+            case REDSTONE -> "redstone_engine_bellow";
+            case STIRLING -> "stirling_engine_bellow";
+            case CREATIVE -> "creative_engine_bellow";
         };
     }
 
-    private ClientModelRegistry.ModelKey getPistonKey(EngineRenderState.EngineType type) {
+    private String getPistonKey(EngineRenderState.EngineType type) {
         return switch (type) {
-            case REDSTONE -> LogisticsPowerClient.MODEL.REDSTONE_PISTON;
-            case STIRLING -> LogisticsPowerClient.MODEL.STIRLING_PISTON;
-            case CREATIVE -> LogisticsPowerClient.MODEL.CREATIVE_PISTON;
+            case REDSTONE -> "redstone_engine_piston";
+            case STIRLING -> "stirling_engine_piston";
+            case CREATIVE -> "creative_engine_piston";
         };
     }
 
@@ -197,13 +189,6 @@ public class EngineBlockEntityRenderer implements BlockEntityRenderer<AbstractEn
         }
 
         cache.lastGameTick = currentTick;
-    }
-
-    /**
-     * Gets a baked model by model key.
-     */
-    private BlockStateModel getModel(ClientModelRegistry.ModelKey key) {
-        return ClientModelRegistry.get(key);
     }
 
     /**

--- a/neoforge/src/main/java/com/logistics/neoforge/client/render/NeoForgeEngineBlockEntityRenderer.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/render/NeoForgeEngineBlockEntityRenderer.java
@@ -1,18 +1,15 @@
 package com.logistics.neoforge.client.render;
 
-import com.logistics.LogisticsPower;
-import com.logistics.core.lib.client.model.ClientModelRegistry;
+import com.logistics.core.lib.client.render.MachineModels;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.power.engine.block.entity.CreativeEngineBlockEntity;
 import com.logistics.power.engine.block.entity.RedstoneEngineBlockEntity;
 import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -22,7 +19,6 @@ import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.Vec3;
 
@@ -31,19 +27,6 @@ public class NeoForgeEngineBlockEntityRenderer
     private static final java.util.Map<BlockPos, AnimationCache> ANIMATION_CACHE =
             new java.util.concurrent.ConcurrentHashMap<>();
     private static final float DEFAULT_PISTON_SPEED = 0.02f;
-
-    private static final ClientModelRegistry.ModelKey REDSTONE_BELLOW =
-            ClientModelRegistry.find(LogisticsPower.model("redstone_engine_bellow"));
-    private static final ClientModelRegistry.ModelKey REDSTONE_PISTON =
-            ClientModelRegistry.find(LogisticsPower.model("redstone_engine_piston"));
-    private static final ClientModelRegistry.ModelKey STIRLING_BELLOW =
-            ClientModelRegistry.find(LogisticsPower.model("stirling_engine_bellow"));
-    private static final ClientModelRegistry.ModelKey STIRLING_PISTON =
-            ClientModelRegistry.find(LogisticsPower.model("stirling_engine_piston"));
-    private static final ClientModelRegistry.ModelKey CREATIVE_BELLOW =
-            ClientModelRegistry.find(LogisticsPower.model("creative_engine_bellow"));
-    private static final ClientModelRegistry.ModelKey CREATIVE_PISTON =
-            ClientModelRegistry.find(LogisticsPower.model("creative_engine_piston"));
 
     private static final class AnimationCache {
         float progress = 0f;
@@ -100,10 +83,10 @@ public class NeoForgeEngineBlockEntityRenderer
             PoseStack matrices,
             SubmitNodeCollector queue,
             CameraRenderState cameraState) {
-        BlockStateModel pistonModel = getModel(getPistonKey(state.engineType));
-        BlockStateModel bellowModel = getModel(getBellowKey(state.engineType));
+        List<BlockStateModelPart> bellowParts = MachineModels.parts(getBellowKey(state.engineType));
+        List<BlockStateModelPart> pistonParts = MachineModels.parts(getPistonKey(state.engineType));
 
-        if (pistonModel == null || bellowModel == null) {
+        if (bellowParts.isEmpty() || pistonParts.isEmpty()) {
             return;
         }
 
@@ -118,34 +101,30 @@ public class NeoForgeEngineBlockEntityRenderer
         matrices.translate(0, 4 / 16f, 0);
         float bellowScale = Math.max(pistonOffset / 0.5f, 0.01f);
         matrices.scale(1.0f, bellowScale, 1.0f);
-        List<BlockStateModelPart> bellowParts = new ArrayList<>();
-        bellowModel.collectParts(RandomSource.create(0), bellowParts);
         queue.submitBlockModel(matrices, renderLayer, bellowParts, new int[]{-1}, light, OverlayTexture.NO_OVERLAY, 0);
         matrices.popPose();
 
         matrices.pushPose();
         matrices.translate(0, 4 / 16f + pistonOffset, 0);
-        List<BlockStateModelPart> pistonParts = new ArrayList<>();
-        pistonModel.collectParts(RandomSource.create(0), pistonParts);
         queue.submitBlockModel(matrices, renderLayer, pistonParts, new int[]{-1}, light, OverlayTexture.NO_OVERLAY, 0);
         matrices.popPose();
 
         matrices.popPose();
     }
 
-    private ClientModelRegistry.ModelKey getBellowKey(EngineRenderState.EngineType type) {
+    private String getBellowKey(EngineRenderState.EngineType type) {
         return switch (type) {
-            case REDSTONE -> REDSTONE_BELLOW;
-            case STIRLING -> STIRLING_BELLOW;
-            case CREATIVE -> CREATIVE_BELLOW;
+            case REDSTONE -> "redstone_engine_bellow";
+            case STIRLING -> "stirling_engine_bellow";
+            case CREATIVE -> "creative_engine_bellow";
         };
     }
 
-    private ClientModelRegistry.ModelKey getPistonKey(EngineRenderState.EngineType type) {
+    private String getPistonKey(EngineRenderState.EngineType type) {
         return switch (type) {
-            case REDSTONE -> REDSTONE_PISTON;
-            case STIRLING -> STIRLING_PISTON;
-            case CREATIVE -> CREATIVE_PISTON;
+            case REDSTONE -> "redstone_engine_piston";
+            case STIRLING -> "stirling_engine_piston";
+            case CREATIVE -> "creative_engine_piston";
         };
     }
 
@@ -183,10 +162,6 @@ public class NeoForgeEngineBlockEntityRenderer
         }
 
         cache.lastGameTick = currentTick;
-    }
-
-    private BlockStateModel getModel(ClientModelRegistry.ModelKey key) {
-        return ClientModelRegistry.get(key);
     }
 
     private void applyFacingRotation(PoseStack matrices, Direction facing) {


### PR DESCRIPTION
Stacked on #450 (pipe code-rendering).

## Summary

The engine (piston/bellow), laser-quarry (gantry arm, drill, LEDs, display, hatch), and marker beam render parts are now generated in code instead of loaded as standalone JSON models. In-world appearance is unchanged.

## Why

These ~14 models are the last consumers of Fabric's `fabric-model-loading-api` (which lags MC pre-releases and blocks the 26.2 port). Generating them in code is the groundwork for removing that dependency. They're all simple single-texture cuboids and pure block-entity render-parts (referenced by no items/blockstates).

## Changes

- Add shared `BoxGeometry` — a generic per-face-UV box emitter (handles partial face sets + face rotations), reusing the verified cable/pipe vertex/UV convention.
- Add `MachineModels` — the 14 box descriptors (texture + cuboid elements/UVs) generated verbatim from the model JSONs, plus a cached `parts(key)` helper.
- Rewire `EngineBlockEntityRenderer` (Fabric) + `NeoForgeEngineBlockEntityRenderer` + `LaserQuarryBlockEntityRenderer` + `MarkerBlockEntityRenderer` to build parts via `MachineModels.parts(...)` instead of `ClientModelRegistry`. All PoseStack animation/transforms are unchanged.

## Notes

- No player-visible change — engine animation, quarry arm/drill/LEDs/display/hatch, and marker beams verified identical in-game on Fabric.
- The model-loading scaffolding (`ClientModelRegistry`, `FabricModelLoader`, `NeoForgeModelLoader`, etc.) and the 14 JSONs are still present here (now unused); they're removed in the follow-up PR, which is what actually drops `fabric-model-loading-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)