### PR TITLE
fix(neoforge): fix startup crash when JEI is on the classpath

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ fabric_energy_version=5.0.0
 
 # NeoForge
 # check versions at https://projects.neoforged.net/neoforged/neoforge
-neoforge_version=26.1.0.5-beta
+neoforge_version=26.1.0.8-beta
 neoforge_loader_version_range=[4,)
 neo_form_version=26.1-1
 moddev_version=2.0.141


### PR DESCRIPTION
## Summary

Bumps NeoForge from `26.1.0.5-beta` to `26.1.0.8-beta` — the minimum version JEI requires — so the mod loads on NeoForge when JEI is present.

## Why

JEI `29.2.0.20` (the NeoForge build) requires **neoforge ≥ 26.1.0.8-beta** *and* **Minecraft 26.1**. The old pin (`26.1.0.5-beta`) is below JEI's floor, so NeoForge aborts at mod-load:

```
Mod jei requires neoforge 26.1.0.8-beta or above — Currently, neoforge is 26.1.0.5-beta
```

`26.1.0.8-beta` is the **earliest** NeoForge that satisfies JEI's floor, and it's still on the `26.1.0.x` line so Minecraft stays at **26.1** (keeping JEI's `minecraft 26.1` constraint satisfied and NeoForge aligned with the Fabric side). Using the floor — rather than a newer release — keeps the mod's *declared minimum* as low as possible.

## Changes

- `gradle.properties`: `neoforge_version` `26.1.0.5-beta` → `26.1.0.8-beta`.

## Impact

`neoforge_version` is both what the dev/CI environment runs against **and** the mod's declared minimum (`neoforge.mods.toml` → `versionRange="[${neoforge_version},)"`).

- **Dev / CI — always affected.** The build pulls JEI in via `runtimeOnly`, so JEI is always on the classpath in `:neoforge:runClient` (no manual install involved). On `26.1.0.5-beta` that meant launch failed every time. This is the concrete thing the bump fixes.
- **Shipped mod — narrow.** JEI is `compileOnly`/`runtimeOnly` and only *suggested* (Fabric) / not declared (NeoForge) — it is **not bundled** in the jar and **not** a hard dependency. So a shipped install would only hit JEI's check by adding JEI on a NeoForge in the `26.1.0.5`–`26.1.0.7-beta` window; anything `≥ 26.1.0.8-beta` already satisfied it.

So: primarily a dev-environment/declared-minimum correction, not a widespread player-facing crash.

## Notes

- Verified: `:neoforge:build` green and `:neoforge:runClient` reaches the game on `26.1.0.8-beta` (previously failed at mod-load).
- One-line, standalone fix off `mc/26.1` — not part of the in-flight code-rendering PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)