### PR TITLE
chore(build): port to MC 26.2-pre-3 (Fabric-only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,23 @@
 version: 2
 updates:
+  # --- mc/26.2 ---
+  - package-ecosystem: "gradle"
+    directory: "/"
+    target-branch: "mc/26.2"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(update)"
+      prefix-development: "chore(update)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "mc/26.2"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(update)"
+
   # --- mc/26.1 ---
   - package-ecosystem: "gradle"
     directory: "/"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,18 +38,34 @@ dependencies {
     // Team Reborn Energy API (bundled into the Fabric jar via include in fabric/build.gradle)
     implementation("teamreborn:energy:${rootProject.fabric_energy_version}")
 
-    // JEI — compile only; players install separately at runtime
-    compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
+    // JEI — compile only; players install separately at runtime.
+    // Gated: no JEI artifact exists for some MC versions (e.g. 26.2 pre-releases).
+    if (rootProject.jei_enabled.toBoolean()) {
+        compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
+    }
 
     // Test infrastructure
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"
     testImplementation "net.fabricmc:fabric-loader-junit:${rootProject.fabric_loader_version}"
     testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"
+    // Fabric Loader 0.19.x pulls sponge-mixin 0.17.0 transitively here, which is missing
+    // IAdviceProvider that mixinextras needs — the Fabric test launcher then fails to start.
+    // Pin to the version Loom uses for the runnable subprojects so the headless env boots.
+    testImplementation "net.fabricmc:sponge-mixin:0.17.3+mixin.0.8.7"
 }
 
 sourceSets {
     test {
         java { srcDir 'src/test/java' }
+    }
+}
+
+// When JEI is disabled (no upstream artifact for this MC version), exclude the JEI
+// integration so the client source set compiles without the JEI API on the classpath.
+// The source stays in the tree, so re-enabling is just flipping jei_enabled.
+if (!rootProject.jei_enabled.toBoolean()) {
+    tasks.named('compileClientJava', JavaCompile) {
+        exclude '**/core/macerator/jei/**'
     }
 }
 

--- a/common/src/main/java/com/logistics/pipe/network/packet/PacketValidation.java
+++ b/common/src/main/java/com/logistics/pipe/network/packet/PacketValidation.java
@@ -12,8 +12,11 @@ final class PacketValidation {
     private PacketValidation() {}
 
     static boolean isPlayerInRange(ServerPlayer player, BlockPos pos, double maxDistance) {
-        // distanceToSqr avoids Math.sqrt(); squaring maxDistance gives the same comparison
-        return player.distanceToSqr(pos.getCenter()) <= maxDistance * maxDistance;
+        // distanceToSqr avoids Math.sqrt(); squaring maxDistance gives the same comparison.
+        // Use the block-center coordinates directly (matches the other distance checks in the
+        // codebase, e.g. AdvancedExtractorScreenHandler/RequesterModule).
+        return player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5)
+                <= maxDistance * maxDistance;
     }
 
     static boolean isPlayerOutOfRange(ServerPlayer player, BlockPos pos, double maxDistance) {

--- a/common/src/test/java/com/logistics/core/lib/block/BaseBlockEntityPersistenceTest.java
+++ b/common/src/test/java/com/logistics/core/lib/block/BaseBlockEntityPersistenceTest.java
@@ -8,12 +8,12 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraft.resources.Identifier;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.storage.TagValueInput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -69,7 +69,10 @@ class BaseBlockEntityPersistenceTest extends MinecraftTestEnvironment {
             // Use a real type/block pair to satisfy BlockEntity's validateBlockState check.
             // The type itself is irrelevant to our logic — we only test saveCustomOnly /
             // loadCustomOnly which call saveAdditional/loadAdditional directly.
-            super(BlockEntityType.CHEST, BlockPos.ZERO, Blocks.CHEST.defaultBlockState());
+            // BlockEntityType.CHEST was removed as a static constant in MC 26.2; look it up
+            // from the registry instead (the type is irrelevant to what this test exercises).
+            super(BuiltInRegistries.BLOCK_ENTITY_TYPE.getValue(Identifier.withDefaultNamespace("chest")),
+                    BlockPos.ZERO, Blocks.CHEST.defaultBlockState());
         }
 
         @Override

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -54,9 +54,12 @@ dependencies {
     include("teamreborn:energy:${rootProject.fabric_energy_version}")
     implementation("teamreborn:energy:${rootProject.fabric_energy_version}")
 
-    // JEI — compile against API only; players install separately at runtime
-    compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
-    runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
+    // JEI — compile against API only; players install separately at runtime.
+    // Gated: no JEI artifact exists for some MC versions (e.g. 26.2 pre-releases).
+    if (rootProject.jei_enabled.toBoolean()) {
+        compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
+        runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
+    }
 }
 
 processResources {
@@ -87,6 +90,15 @@ test {
 
 tasks.withType(JavaCompile).configureEach {
     it.options.release = rootProject.java_version.toInteger()
+}
+
+// The multiloader-loader convention adds common's client source dir to compileClientJava via
+// `source configurations.commonClientJava`, so the (shared) JEI integration compiles here too.
+// When JEI is disabled (no upstream artifact for this MC version), exclude it to match common.
+if (!rootProject.jei_enabled.toBoolean()) {
+    tasks.named('compileClientJava', JavaCompile) {
+        exclude '**/core/macerator/jei/**'
+    }
 }
 
 java {

--- a/fabric/src/client/java/com/logistics/LogisticsPipeClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsPipeClient.java
@@ -46,7 +46,7 @@ public final class LogisticsPipeClient implements ClientDomainBootstrap {
         ClientPlayNetworking.registerGlobalReceiver(SyncRequesterInventoryPacket.TYPE, (packet, context) -> {
             context.client().execute(() -> {
                 // Update the requester screen if it's open
-                if (Minecraft.getInstance().screen instanceof RequesterScreen requesterScreen) {
+                if (Minecraft.getInstance().gui.screen() instanceof RequesterScreen requesterScreen) {
                     requesterScreen.updateAvailableItems(packet.pipePos(), packet.items(), packet.amounts());
                 }
             });

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -16,8 +16,7 @@
   "description": "A modern logistics and pipe mod with authentic in-pipe item motion, mod interoperability, and request/autocrafting systems.",
   "entrypoints": {
     "client": ["com.logistics.LogisticsModClient"],
-    "main": ["com.logistics.fabric.LogisticsFabric"],
-    "jei_mod_plugin": ["com.logistics.core.macerator.jei.MaceratorJeiPlugin"]
+    "main": ["com.logistics.fabric.LogisticsFabric"]
   },
   "environment": "*",
   "icon": "assets/logistics/icon.png",

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,15 +10,17 @@ maven_group=com.logistics
 archives_base_name=logistics
 
 # Minecraft
-minecraft_version=26.1
+minecraft_version=26.2-pre-3
 # Half-open compatibility range as exactly "<min>,<next>" with no spaces; min is inclusive, next is exclusive.
-minecraft_compatibility_versions=26.1,26.2
+# Lower bound is the first pre-release so the mod loads on 26.2 pre-releases — Fabric semver
+# sorts "26.2-pre.3" BELOW "26.2", so a ">=26.2" bound would reject every pre-release.
+minecraft_compatibility_versions=26.2-pre.1,26.3
 java_version=25
 
 # Fabric
 # check these on https://fabricmc.net/develop
-fabric_loader_version=0.18.6
-fabric_version=0.145.2+26.1.1
+fabric_loader_version=0.19.3
+fabric_version=0.150.2+26.2
 loom_version=1.16-SNAPSHOT
 fabric_energy_version=5.0.0
 
@@ -30,6 +32,11 @@ neo_form_version=26.1-1
 moddev_version=2.0.141
 
 # Dependencies
+# JEI has no MC 26.2 artifact yet, so it is disabled on this branch (otherwise the
+# unresolvable jei-26.2-fabric dependency fails common+fabric before they compile).
+# Re-enable when JEI 26.2 ships: set jei_enabled=true, bump jei_version, and restore the
+# jei_mod_plugin entrypoint in fabric/src/main/resources/fabric.mod.json.
+jei_enabled=false
 jei_version=29.2.0.20
 
 # Test Dependencies

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,14 +1,14 @@
 {
   "packages": {
     ".": {
-      "package-name": "logistics-mc26.1",
-      "component": "mc26.1",
+      "package-name": "logistics-mc26.2",
+      "component": "mc26.2",
       "release-type": "simple",
       "include-component-in-tag": true,
       "pull-request-title-pattern": "chore(release): release ${version} for ${component}",
       "initial-version": "0.3.0",
       "bump-minor-pre-major": true,
-      "bootstrap-sha": "085d95cf5ff6314f0ba83a3733c60a6d36091963"
+      "bootstrap-sha": "db118cb0421da3f150365ce433640d2f13f0b0d7"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Forks the codebase onto the new **mc/26.2** branch as a **Fabric-only forward-port** for testing MC 26.2 pre-releases. Made possible by the just-completed render refactor (#449–#452), which dropped the two lagging Fabric API modules that blocked 26.2.

Targets **MC 26.2-pre-3** (Fabric Loader 0.19.3, Fabric API 0.150.2+26.2).

## Changes

- **Toolchain** bumped to MC 26.2-pre-3 / loader 0.19.3 / Fabric API 0.150.2+26.2. Compatibility range lower bound is `26.2-pre.1` so the mod actually loads on pre-releases (Fabric semver sorts `26.2-pre.3` *below* `26.2`).
- **JEI disabled** via a `jei_enabled=false` flag — there is no JEI build for MC 26.2 yet, so its (unresolvable) dependency would otherwise fail the build. The integration source is left in place and excluded from compilation; re-enable later by flipping the flag, bumping `jei_version`, and restoring the `jei_mod_plugin` entrypoint.
- **MC 26.2 API adaptations** (3 spots): current-screen access moved to `Minecraft.gui.screen()`; `BlockPos.getCenter()` replaced with the manual block-center coordinates used elsewhere; the removed `BlockEntityType.CHEST` test constant now looked up from the registry.
- **release-please** repointed to the `mc26.2` component, and **dependabot** given mc/26.2 entries.

## Notes

- **NeoForge is intentionally left untouched** — it can't build until NeoForge 26.2 + JEI 26.2 ship upstream, so `:neoforge:build` and its CI checks are **red on purpose**. This keeps the branch genuine and means NeoForge goes green on its own later with no config to revert. Branch protection for mc/26.2 should require only the **fabric/common** checks.
- **Validated:** `:common`/`:fabric` compile + lint + spotless + unit tests pass, the Fabric jar builds, and the mod loads on 26.2-pre-3 with **all 82 gametests passing**.