### PR TITLE
ci(build): always publish snapshots without a game-version filter

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -73,13 +73,6 @@ jobs:
           MODRINTH_VERSION="${PRE_ID}+mc${MC_VERSION}.${LOADER_SHORT}"
           (( ${#MODRINTH_VERSION} > 32 )) && MODRINTH_VERSION="${MODRINTH_VERSION:0:32}"
 
-          # Snapshot / prerelease MC detection (supports 24w45a format)
-          if [[ "$MC_VERSION" =~ (snapshot|alpha|beta|-pre[0-9]+|-rc[0-9]+) ]] || [[ "$MC_VERSION" =~ ^[0-9]{2}w[0-9]{2}[a-z]$ ]]; then
-            GAME_VERSION_FILTER="none"
-          else
-            GAME_VERSION_FILTER="releases"
-          fi
-
           {
             echo "base_version=$BASE_VERSION"
             echo "pre_id=$PRE_ID"
@@ -88,7 +81,6 @@ jobs:
             echo "minecraft_version=$MC_VERSION"
             echo "loader=$LOADER"
             echo "gradle_task=$GRADLE_TASK"
-            echo "game_version_filter=$GAME_VERSION_FILTER"
             echo "base_branch=$BASE_BRANCH"
           } >> "$GITHUB_OUTPUT"
 
@@ -115,7 +107,10 @@ jobs:
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
-          game-version-filter: ${{ steps.version.outputs.game_version_filter }}
+          # Snapshots always publish with no game-version filter — they target whatever MC
+          # version (incl. pre-releases/snapshots) the branch builds against, so there is
+          # nothing to filter to "releases". (The old computed filter was release-strategy cruft.)
+          game-version-filter: none
           version-type: alpha
           version: ${{ steps.version.outputs.full_version }}
           name: "Logistics ${{ steps.version.outputs.pre_id }} for ${{ steps.version.outputs.loader }} ${{ steps.version.outputs.minecraft_version }}"


### PR DESCRIPTION
## Summary

The Snapshot publish workflow failed at the **upload** step on `mc/26.2`: the build succeeded but `mc-publish` couldn't attach a game version.

## Cause

`build-snapshot.yml` computed `game-version-filter` from an MC-version regex (`-pre[0-9]+`), which does **not** match the new pre-release format `26.2-pre-3` (a dash precedes the number: `-pre-3`). Detection fell through to `releases`, and there is no *released* 26.2 game version yet — so the filter matched nothing and the upload failed.

## Fix

Drop the legacy detection entirely and **hardcode `game-version-filter: none`** for snapshots. Snapshots target whatever MC version the branch builds against (stable, pre-release, or weekly snapshot), so there's never anything to filter to "releases" — the computed value was leftover release-strategy cruft.

## Notes

- Affects publishing only; no code change.
- The NeoForge leg still fails harmlessly (no 26.2 build) and does not block the Fabric upload.