### PR TITLE
fix(energy): transport energy through cables on NeoForge

### DIFF
--- a/fabric/src/main/java/com/logistics/fabric/energy/EnergyStorageAccess.java
+++ b/fabric/src/main/java/com/logistics/fabric/energy/EnergyStorageAccess.java
@@ -50,7 +50,7 @@ public final class EnergyStorageAccess {
      * opening any new transactions — safe to call from within TR close callbacks or from
      * the cable network's simulate-boolean path.
      */
-    private static final class SimulateBooleanAdapter implements EnergyStorage, IEnergyStorage {
+    static final class SimulateBooleanAdapter implements EnergyStorage, IEnergyStorage {
         private final IEnergyStorage delegate;
 
         SimulateBooleanAdapter(IEnergyStorage delegate) {

--- a/fabric/src/test/java/com/logistics/fabric/energy/FabricEnergyStorageTest.java
+++ b/fabric/src/test/java/com/logistics/fabric/energy/FabricEnergyStorageTest.java
@@ -1,5 +1,9 @@
 package com.logistics.fabric.energy;
 
+import com.logistics.core.lib.energy.IEnergyStorage;
+import java.util.ArrayList;
+import java.util.List;
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,6 +13,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Fabric energy storage adapters")
 class FabricEnergyStorageTest {
+
+    @Test
+    @DisplayName("SimulateBooleanAdapter forwards energy through a zero-capacity conduit (cable parity)")
+    void simulateBooleanAdapter_forwardsThroughZeroCapacityConduit() {
+        // Mirrors the Fabric engine-push path: target.insert(amount, tx); tx.commit().
+        // A cable reports capacity 0 but forwards inserts into its network, and the
+        // Fabric bridge delegates without a capacity gate — so this works on Fabric
+        // (unlike NeoForge before its fix).
+        FakeConduit conduit = new FakeConduit(80);
+        EnergyStorageAccess.SimulateBooleanAdapter adapter = new EnergyStorageAccess.SimulateBooleanAdapter(conduit);
+
+        FakeTransactionContext tx = new FakeTransactionContext();
+        long accepted = adapter.insert(200L, tx);
+
+        assertThat(accepted).isEqualTo(80);
+        assertThat(conduit.forwarded).isZero(); // not committed yet
+
+        tx.commit();
+        assertThat(conduit.forwarded).isEqualTo(80);
+    }
 
     @Test
     @DisplayName("FabricEnergyStorage should ignore non-positive transfer requests")
@@ -84,6 +108,91 @@ class FabricEnergyStorageTest {
         @Override
         public long getCapacity() {
             return capacity;
+        }
+    }
+
+    /**
+     * Models a cable: a bufferless conduit that reports zero capacity/amount but
+     * forwards inserted energy into its network (capped at {@code networkRoom}).
+     */
+    private static final class FakeConduit implements IEnergyStorage {
+        private final long networkRoom;
+        private long forwarded;
+
+        private FakeConduit(long networkRoom) {
+            this.networkRoom = networkRoom;
+        }
+
+        @Override
+        public long insert(long maxAmount, boolean simulate) {
+            if (maxAmount <= 0) return 0;
+            long accepted = Math.min(maxAmount, networkRoom);
+            if (!simulate) forwarded += accepted;
+            return accepted;
+        }
+
+        @Override
+        public long extract(long maxAmount, boolean simulate) {
+            return 0;
+        }
+
+        @Override
+        public long getAmount() {
+            return 0;
+        }
+
+        @Override
+        public long getCapacity() {
+            return 0;
+        }
+
+        @Override
+        public boolean canInsert() {
+            return true;
+        }
+
+        @Override
+        public boolean canExtract() {
+            return false;
+        }
+    }
+
+    /**
+     * Minimal {@link TransactionContext} that captures close callbacks so a unit
+     * test can drive Team Reborn's deferred-commit insert without bootstrapping the
+     * Fabric environment. {@link #commit()} fires the callbacks as a committed root.
+     */
+    private static final class FakeTransactionContext implements TransactionContext {
+        private final List<CloseCallback> callbacks = new ArrayList<>();
+
+        void commit() {
+            for (CloseCallback callback : callbacks) {
+                callback.onClose(this, Result.COMMITTED);
+            }
+            callbacks.clear();
+        }
+
+        @Override
+        public void addCloseCallback(CloseCallback callback) {
+            callbacks.add(callback);
+        }
+
+        @Override
+        public void addOuterCloseCallback(OuterCloseCallback callback) {}
+
+        @Override
+        public int nestingDepth() {
+            return 0;
+        }
+
+        @Override
+        public Transaction openNested() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Transaction getOpenTransaction(int nestingDepth) {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyStorage.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyStorage.java
@@ -115,8 +115,13 @@ public final class NeoForgeEnergyStorage implements IEnergyStorage {
         public int insert(int amount, net.neoforged.neoforge.transfer.transaction.TransactionContext transaction) {
             if (amount <= 0) return 0;
             updateSnapshots(transaction);
-            long effectiveFree = Math.max(0, getCapacityAsLong() - getAmountAsLong());
-            long inserted = Math.min(amount, effectiveFree);
+            // Ask the wrapped storage how much it can actually accept, accounting for
+            // what we've already staged this transaction. Delegating (instead of using
+            // capacity - amount) lets zero-capacity conduits such as cables, which
+            // forward energy into a network, accept inserts.
+            long alreadyStaged = Math.max(0, pendingDelta);
+            long totalInsertable = storage.insert(alreadyStaged + amount, true);
+            long inserted = Math.max(0, totalInsertable - alreadyStaged);
             if (inserted > 0) {
                 pendingDelta += inserted;
             }

--- a/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyStorage.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/energy/NeoForgeEnergyStorage.java
@@ -118,10 +118,14 @@ public final class NeoForgeEnergyStorage implements IEnergyStorage {
             // Ask the wrapped storage how much it can actually accept, accounting for
             // what we've already staged this transaction. Delegating (instead of using
             // capacity - amount) lets zero-capacity conduits such as cables, which
-            // forward energy into a network, accept inserts.
-            long alreadyStaged = Math.max(0, pendingDelta);
-            long totalInsertable = storage.insert(alreadyStaged + amount, true);
-            long inserted = Math.max(0, totalInsertable - alreadyStaged);
+            // forward energy into a network, accept inserts. Staged inserts (positive
+            // pendingDelta) occupy room already claimed this transaction; staged
+            // extractions (negative pendingDelta) free room that can be reused.
+            long stagedInserts = Math.max(0, pendingDelta);
+            long stagedExtractions = Math.max(0, -pendingDelta);
+            long committedInsertable = storage.insert(stagedInserts + amount, true);
+            long inserted = Math.max(0,
+                    Math.min(amount, committedInsertable - stagedInserts + stagedExtractions));
             if (inserted > 0) {
                 pendingDelta += inserted;
             }

--- a/neoforge/src/test/java/com/logistics/neoforge/energy/NeoForgeEnergyStorageTest.java
+++ b/neoforge/src/test/java/com/logistics/neoforge/energy/NeoForgeEnergyStorageTest.java
@@ -72,6 +72,23 @@ class NeoForgeEnergyStorageTest {
         }
 
         @Test
+        @DisplayName("insert forwards energy through a zero-capacity conduit (cable regression)")
+        void insert_forwardsThroughZeroCapacityConduit() {
+            // Cables report capacity 0 but forward inserts into their network.
+            // Before the fix, capacity-based gating (capacity - amount = 0) returned
+            // 0 here, so cables never transported energy on NeoForge.
+            FakeConduit conduit = new FakeConduit(80);
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(conduit);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                assertThat(handler.insert(200, tx)).isEqualTo(80);
+                tx.commit();
+            }
+
+            assertThat(conduit.forwarded).isEqualTo(80);
+        }
+
+        @Test
         @DisplayName("insert rollback does not mutate backing storage")
         void insert_rollback_doesNotMutate() {
             EnergyComponent backing = component(100);
@@ -222,6 +239,52 @@ class NeoForgeEnergyStorageTest {
             assertThat(wrapped.extract(-10, false)).isZero();
             assertThat(wrapped.extract(0, false)).isZero();
             assertThat(backing.getAmount()).isEqualTo(40);
+        }
+    }
+
+    /**
+     * Models a cable: a bufferless conduit that reports zero capacity/amount but
+     * forwards inserted energy into its network (capped at {@code networkRoom}).
+     */
+    private static final class FakeConduit implements IEnergyStorage {
+        private final long networkRoom;
+        private long forwarded;
+
+        private FakeConduit(long networkRoom) {
+            this.networkRoom = networkRoom;
+        }
+
+        @Override
+        public long insert(long maxAmount, boolean simulate) {
+            if (maxAmount <= 0) return 0;
+            long accepted = Math.min(maxAmount, networkRoom);
+            if (!simulate) forwarded += accepted;
+            return accepted;
+        }
+
+        @Override
+        public long extract(long maxAmount, boolean simulate) {
+            return 0;
+        }
+
+        @Override
+        public long getAmount() {
+            return 0;
+        }
+
+        @Override
+        public long getCapacity() {
+            return 0;
+        }
+
+        @Override
+        public boolean canInsert() {
+            return true;
+        }
+
+        @Override
+        public boolean canExtract() {
+            return false;
         }
     }
 }

--- a/neoforge/src/test/java/com/logistics/neoforge/energy/NeoForgeEnergyStorageTest.java
+++ b/neoforge/src/test/java/com/logistics/neoforge/energy/NeoForgeEnergyStorageTest.java
@@ -82,10 +82,30 @@ class NeoForgeEnergyStorageTest {
 
             try (Transaction tx = Transaction.openRoot()) {
                 assertThat(handler.insert(200, tx)).isEqualTo(80);
+                // Energy is only forwarded on commit, not during the staged insert.
+                assertThat(conduit.forwarded).isZero();
                 tx.commit();
             }
 
             assertThat(conduit.forwarded).isEqualTo(80);
+        }
+
+        @Test
+        @DisplayName("insert reuses room freed by a staged extraction within the same transaction")
+        void insert_reusesStagedExtractionRoom() {
+            EnergyComponent backing = component(100);
+            backing.insert(100, false); // full
+            EnergyHandler handler = NeoForgeEnergyStorage.asNeoForge(backing);
+
+            try (Transaction tx = Transaction.openRoot()) {
+                assertThat(handler.extract(30, tx)).isEqualTo(30);
+                // The staged extraction freed 30; an insert should reclaim that room
+                // even though the committed storage is still full.
+                assertThat(handler.insert(10, tx)).isEqualTo(10);
+                tx.commit();
+            }
+
+            assertThat(backing.getAmount()).isEqualTo(80); // 100 - 30 + 10
         }
 
         @Test
@@ -257,7 +277,8 @@ class NeoForgeEnergyStorageTest {
         @Override
         public long insert(long maxAmount, boolean simulate) {
             if (maxAmount <= 0) return 0;
-            long accepted = Math.min(maxAmount, networkRoom);
+            long remaining = Math.max(0, networkRoom - forwarded);
+            long accepted = Math.min(maxAmount, remaining);
             if (!simulate) forwarded += accepted;
             return accepted;
         }


### PR DESCRIPTION
## Summary

Cables transported no energy on NeoForge. A creative engine wired through copper cable to a Laser Quarry powers the quarry on Fabric, but did nothing on NeoForge. This fixes the NeoForge energy bridge so cables forward pushed energy into their network exactly like Fabric.

## Root cause

Cables are bufferless conduits: `CableEnergyStorage` reports `capacity == 0` and `amount == 0`, but `insert()` forwards energy into the cable network. The NeoForge bridge `CommonEnergyHandler.insert()` decided how much to accept from `capacity - amount` (always `0` for a conduit), so it never called the cable's `insert()` and no energy entered the network. Fabric's bridge delegates straight to the storage with no capacity gate, which is why it worked there. (Note the asymmetry: the sibling `extract()` already delegated to the wrapped storage.)

## Changes

- **energy:** `CommonEnergyHandler.insert()` now delegates to the wrapped storage to determine how much it accepts, while still respecting energy already staged within the current transaction so buffered machines stay correct.
- **test:** Add a NeoForge regression test (insert through a zero-capacity conduit) that failed before this fix, plus a Fabric parity test demonstrating the bug was loader-specific.

## Notes

- All existing NeoForge transaction tests (commit/rollback/pendingDelta) still pass.
- After merge, cherry-pick to other `mc/*` branches if they carry the same NeoForge bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)