### PR TITLE
refactor(energy): add network energy sourcing and shared energy-push service

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/energy/EnergyPushService.java
+++ b/common/src/main/java/com/logistics/core/lib/energy/EnergyPushService.java
@@ -1,0 +1,46 @@
+package com.logistics.core.lib.energy;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Loader-agnostic service for pushing energy from a source buffer into an adjacent block.
+ *
+ * <p>Set once during loader-specific initialization (Fabric or NeoForge bootstrap) via
+ * {@link #set}. Used by energy producers (engines) and buffers (batteries) to send energy
+ * to neighboring blocks without importing platform-specific energy APIs.
+ */
+@FunctionalInterface
+public interface EnergyPushService {
+    /**
+     * Push up to {@code maxAmount} energy into the block at {@code targetPos}, approached from
+     * {@code fromDirection}.
+     *
+     * <p>Implementations must <em>not</em> mutate {@code source}; only return the amount
+     * transferred. The caller is the single authority that debits the source buffer
+     * (e.g. via {@link EnergyComponent#consume(long)}).
+     *
+     * @return the amount actually transferred (must be &ge; 0 and &le; maxAmount)
+     */
+    long push(Level level, BlockPos targetPos, Direction fromDirection, IEnergyStorage source, long maxAmount);
+
+    /** Registers the loader-specific implementation. Called once during bootstrap. */
+    static void set(EnergyPushService service) {
+        if (service == null) throw new IllegalArgumentException("EnergyPushService must not be null");
+        Holder.instance = service;
+    }
+
+    /** Returns the registered implementation, or {@code null} if none has been set yet. */
+    @Nullable
+    static EnergyPushService get() {
+        return Holder.instance;
+    }
+
+    final class Holder {
+        private static EnergyPushService instance;
+
+        private Holder() {}
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
+++ b/common/src/main/java/com/logistics/core/lib/network/ILogisticsNetwork.java
@@ -295,6 +295,35 @@ public interface ILogisticsNetwork {
      */
     default Set<String> getAvailableSatelliteIds() { return Set.of(); }
 
+    // ===== Energy Operations =====
+
+    /**
+     * Register a battery position as an energy source for this network.
+     * The battery's stored energy is drawn on by module operations via {@link #consumeEnergy}.
+     * Idempotent — registering the same position twice has no additional effect. The storage is
+     * resolved from the world on demand, so a removed/unloaded battery is simply skipped.
+     *
+     * @param pos world position of the battery block
+     */
+    default void registerEnergySource(BlockPos pos) {}
+
+    /**
+     * Unregister a battery position. Called when the battery is removed or the network splits.
+     *
+     * @param pos world position of the battery block
+     */
+    default void unregisterEnergySource(BlockPos pos) {}
+
+    /**
+     * Attempt to consume {@code amount} RF from the network's registered batteries.
+     * All-or-nothing: energy is only deducted if the full amount is available across all sources;
+     * otherwise nothing is consumed and {@code false} is returned.
+     *
+     * @param amount RF to consume (a non-positive amount is a no-op that returns {@code true})
+     * @return true if the full amount was consumed; false if insufficient energy was available
+     */
+    default boolean consumeEnergy(long amount) { return amount <= 0; }
+
     // ===== Routing Operations =====
 
     /**

--- a/common/src/main/java/com/logistics/core/lib/network/IWorldView.java
+++ b/common/src/main/java/com/logistics/core/lib/network/IWorldView.java
@@ -1,8 +1,10 @@
 package com.logistics.core.lib.network;
 
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.storage.IItemKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
@@ -56,4 +58,13 @@ public interface IWorldView {
      * @param message message to broadcast
      */
     void broadcastAlert(BlockPos pos, Component message);
+
+    /**
+     * Resolve the energy storage exposed by the block at {@code pos}, or {@code null} if there is
+     * none (or the chunk is unloaded). Used by the network to draw on registered battery sources.
+     */
+    @Nullable
+    default IEnergyStorage energyStorageAt(BlockPos pos) {
+        return null;
+    }
 }

--- a/common/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
@@ -115,6 +115,20 @@ public record PipeContext(
         }
     }
 
+    /**
+     * Attempt to consume {@code amount} RF from the logistics network's registered batteries.
+     * All-or-nothing — energy is only deducted if the full amount is available.
+     *
+     * <p>Returns {@code true} when no network is attached yet (a brief bootstrap window) so modules
+     * don't stall before the network forms. Once a network exists, a network with no powered battery
+     * returns {@code false}, gating module work until a battery supplies power.
+     */
+    public boolean consumeEnergy(long amount) {
+        ILogisticsNetwork net = network();
+        if (net == null) return true;
+        return net.consumeEnergy(amount);
+    }
+
     public CompoundTag getCompoundTag(Module module, String key) {
         return NbtCompat.getCompoundOrEmpty(moduleState(module), key);
     }

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.core.lib.power;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.energy.EnergyPushService;
 import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.block.behavior.ProbeResult;
@@ -92,32 +93,6 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
     protected CyclePhase cyclePhase = CyclePhase.IDLE;
     protected HeatStage heatStage = HeatStage.COLD;
     private boolean wasRunning = false;
-
-    /**
-     * Platform service for pushing energy from this engine to an adjacent block.
-     * Set once during loader-specific initialization (Fabric or NeoForge bootstrap).
-     */
-    @FunctionalInterface
-    public interface EnergyPushService {
-        /**
-         * Push up to {@code maxAmount} energy to the block at {@code targetPos},
-         * approached from {@code fromDirection}.
-         *
-         * <p>Implementations must <em>not</em> mutate {@code source}; only return the amount
-         * transferred. The caller ({@link AbstractEngineBlockEntity#sendEnergy()}) is the single
-         * authority that debits the source buffer via {@link EnergyComponent#consume(long)}.
-         *
-         * @return the amount actually transferred (must be &ge; 0 and &le; maxAmount)
-         */
-        long push(Level level, BlockPos targetPos, Direction fromDirection, IEnergyStorage source, long maxAmount);
-    }
-
-    private static EnergyPushService energyPushService;
-
-    public static void setEnergyPushService(EnergyPushService service) {
-        if (service == null) throw new IllegalArgumentException("EnergyPushService must not be null");
-        energyPushService = service;
-    }
 
     // Energy buffer — engines never accept energy (maxInsert=0); extraction is managed via sendEnergy()
     protected final EnergyComponent energyBuffer = new EnergyComponent(
@@ -339,14 +314,15 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
 
     /** Sends energy to the block this engine is facing via the loader-specific energy push service. */
     protected void sendEnergy() {
-        if (level == null || !isRedstonePowered() || energyPushService == null) return;
+        EnergyPushService pushService = EnergyPushService.get();
+        if (level == null || !isRedstonePowered() || pushService == null) return;
 
         Direction outputDir = getOutputDirection();
         BlockPos targetPos = getBlockPos().relative(outputDir);
         long maxSend = Math.min(getOutputPower(), energyBuffer.getAmount());
         if (maxSend <= 0) return;
 
-        long sent = energyPushService.push(level, targetPos, outputDir.getOpposite(), energyBuffer, maxSend);
+        long sent = pushService.push(level, targetPos, outputDir.getOpposite(), energyBuffer, maxSend);
         if (sent > 0) {
             energyBuffer.consume(Math.min(sent, energyBuffer.getAmount()));
             setChanged();

--- a/common/src/main/java/com/logistics/pipe/network/MinecraftWorldView.java
+++ b/common/src/main/java/com/logistics/pipe/network/MinecraftWorldView.java
@@ -1,6 +1,8 @@
 package com.logistics.pipe.network;
 
 import com.logistics.core.lib.block.capability.PipeConnection;
+import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.network.IWorldView;
 import com.logistics.pipe.Pipe;
 import com.logistics.core.lib.pipe.PipeContext;
@@ -104,6 +106,15 @@ public class MinecraftWorldView implements IWorldView {
                 p.sendSystemMessage(message);
             }
         });
+    }
+
+    @Override
+    @Nullable
+    public IEnergyStorage energyStorageAt(BlockPos pos) {
+        if (level.getBlockEntity(pos) instanceof HasEnergyStorage hasStorage) {
+            return hasStorage.energyStorage(null);
+        }
+        return null;
     }
 
     /**

--- a/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -11,10 +11,14 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import com.logistics.core.lib.energy.IEnergyStorage;
 
 /**
  * Represents a connected network of pipes.
@@ -32,6 +36,10 @@ public class PipeNetwork implements ILogisticsNetwork {
 
     // Satellite registry: logical ID → pipe position
     private final Map<String, BlockPos> satellites = new HashMap<>();
+
+    // Battery positions registered as energy sources. Insertion order = draw order.
+    // Storage is resolved from the world on demand so removed/unloaded batteries are skipped.
+    private final Set<BlockPos> energySources = new LinkedHashSet<>();
 
     /**
      * Constructor with dependency injection.
@@ -341,6 +349,44 @@ public class PipeNetwork implements ILogisticsNetwork {
         return jobCoordinator;
     }
 
+    // ===== Energy Operations =====
+
+    @Override
+    public void registerEnergySource(BlockPos pos) {
+        energySources.add(pos);
+    }
+
+    @Override
+    public void unregisterEnergySource(BlockPos pos) {
+        energySources.remove(pos);
+    }
+
+    @Override
+    public boolean consumeEnergy(long amount) {
+        if (amount <= 0) return true;
+        if (worldView == null || energySources.isEmpty()) return false;
+
+        // Phase 1: simulate across sources to verify the full amount is available.
+        long available = 0;
+        for (BlockPos pos : energySources) {
+            IEnergyStorage storage = worldView.energyStorageAt(pos);
+            if (storage == null) continue;
+            available += storage.extract(amount - available, true);
+            if (available >= amount) break;
+        }
+        if (available < amount) return false;
+
+        // Phase 2: commit in the same order. Nothing else mutates these buffers within the tick.
+        long remaining = amount;
+        for (BlockPos pos : energySources) {
+            if (remaining <= 0) break;
+            IEnergyStorage storage = worldView.energyStorageAt(pos);
+            if (storage == null) continue;
+            remaining -= storage.extract(remaining, false);
+        }
+        return remaining <= 0;
+    }
+
     /**
      * Merge another network into this one.
      */
@@ -349,6 +395,7 @@ public class PipeNetwork implements ILogisticsNetwork {
         controller.merge(other.controller);
         jobCoordinator.merge(other.jobCoordinator);
         sinkResolver.merge(other.sinkResolver);
+        energySources.addAll(other.energySources);
         other.satellites.forEach((satId, pos) -> {
             BlockPos existing = satellites.get(satId);
             if (existing != null && !existing.equals(pos)) {

--- a/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
+++ b/common/src/main/java/com/logistics/pipe/network/PipeNetwork.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -366,25 +367,30 @@ public class PipeNetwork implements ILogisticsNetwork {
         if (amount <= 0) return true;
         if (worldView == null || energySources.isEmpty()) return false;
 
-        // Phase 1: simulate across sources to verify the full amount is available.
-        long available = 0;
+        // Phase 1: build a fixed draw plan by simulating across sources in registration order.
+        Map<BlockPos, Long> plannedDraws = new LinkedHashMap<>();
+        long planned = 0;
         for (BlockPos pos : energySources) {
+            if (planned >= amount) break;
             IEnergyStorage storage = worldView.energyStorageAt(pos);
             if (storage == null) continue;
-            available += storage.extract(amount - available, true);
-            if (available >= amount) break;
+            long take = storage.extract(amount - planned, true);
+            if (take > 0) {
+                plannedDraws.put(pos, take);
+                planned += take;
+            }
         }
-        if (available < amount) return false;
+        if (planned < amount) return false;
 
-        // Phase 2: commit in the same order. Nothing else mutates these buffers within the tick.
-        long remaining = amount;
-        for (BlockPos pos : energySources) {
-            if (remaining <= 0) break;
-            IEnergyStorage storage = worldView.energyStorageAt(pos);
+        // Phase 2: commit exactly the planned amount from each recorded source. Within a single
+        // synchronous tick nothing else mutates these buffers, so each commit matches its plan.
+        long drawn = 0;
+        for (Map.Entry<BlockPos, Long> draw : plannedDraws.entrySet()) {
+            IEnergyStorage storage = worldView.energyStorageAt(draw.getKey());
             if (storage == null) continue;
-            remaining -= storage.extract(remaining, false);
+            drawn += storage.extract(draw.getValue(), false);
         }
-        return remaining <= 0;
+        return drawn >= amount;
     }
 
     /**

--- a/common/src/test/java/com/logistics/core/lib/energy/EnergyPushServiceTest.java
+++ b/common/src/test/java/com/logistics/core/lib/energy/EnergyPushServiceTest.java
@@ -1,0 +1,25 @@
+package com.logistics.core.lib.energy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Unit tests for the {@link EnergyPushService} holder. */
+class EnergyPushServiceTest {
+
+    @Test
+    void setAndGet_roundTripsAndPushes() {
+        EnergyPushService service = (level, target, dir, source, max) -> 7L;
+        EnergyPushService.set(service);
+
+        assertSame(service, EnergyPushService.get());
+        assertEquals(7L, EnergyPushService.get().push(null, null, null, null, 10));
+    }
+
+    @Test
+    void set_null_throws() {
+        assertThrows(IllegalArgumentException.class, () -> EnergyPushService.set(null));
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/pipe/PipeContextEnergyTest.java
+++ b/common/src/test/java/com/logistics/core/lib/pipe/PipeContextEnergyTest.java
@@ -1,0 +1,64 @@
+package com.logistics.core.lib.pipe;
+
+import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.energy.IEnergyStorage;
+import com.logistics.core.lib.network.IWorldView;
+import com.logistics.core.lib.network.NetworkGraph;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.pipe.network.PipeNetwork;
+import com.logistics.test.FakePipeAccess;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link PipeContext#consumeEnergy(long)}. */
+class PipeContextEnergyTest extends MinecraftTestEnvironment {
+
+    private static PipeContext context(FakePipeAccess access) {
+        return new PipeContext(null, BlockPos.ZERO, Blocks.STONE.defaultBlockState(), access);
+    }
+
+    @Test
+    void consumeEnergy_noNetwork_returnsTrue() {
+        // No network attached yet (bootstrap window) — modules must not stall.
+        assertTrue(context(new FakePipeAccess()).consumeEnergy(100));
+    }
+
+    @Test
+    void consumeEnergy_delegatesToNetwork() {
+        BlockPos batPos = new BlockPos(0, 0, 0);
+        EnergyComponent battery = new EnergyComponent(1000, 1000, 1000, () -> {});
+        battery.setAmount(100);
+        Map<BlockPos, IEnergyStorage> storages = new HashMap<>();
+        storages.put(batPos, battery);
+
+        IWorldView view = new IWorldView() {
+            @Override public boolean isPipe(BlockPos pos) { return false; }
+            @Override public List<BlockPos> getConnectedNeighbors(BlockPos pos) { return List.of(); }
+            @Override public boolean matchesSinkFilter(BlockPos pos, ItemStack stack) { return false; }
+            @Override public long dispatch(BlockPos p, BlockPos r, IItemKey i, long a, UUID d) { return 0; }
+            @Override public boolean isClientSide() { return false; }
+            @Override public void broadcastAlert(BlockPos pos, Component message) {}
+            @Override public IEnergyStorage energyStorageAt(BlockPos pos) { return storages.get(pos); }
+        };
+        PipeNetwork network = new PipeNetwork(UUID.randomUUID(), new NetworkGraph(), view);
+        network.registerEnergySource(batPos);
+
+        PipeContext ctx = context(new FakePipeAccess().setNetwork(network));
+        assertTrue(ctx.consumeEnergy(60), "battery has 100 RF, should cover 60");
+        assertFalse(ctx.consumeEnergy(60), "only 40 RF left, should gate");
+        assertEquals(40, battery.getAmount());
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/network/PipeNetworkEnergyTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/PipeNetworkEnergyTest.java
@@ -1,0 +1,188 @@
+package com.logistics.pipe.network;
+
+import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.energy.IEnergyStorage;
+import com.logistics.core.lib.network.IWorldView;
+import com.logistics.core.lib.network.NetworkGraph;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link PipeNetwork}'s energy sourcing — the all-or-nothing
+ * {@link com.logistics.core.lib.network.ILogisticsNetwork#consumeEnergy} contract and the
+ * pos-based source registration that re-resolves storage from the world on each call.
+ */
+class PipeNetworkEnergyTest extends MinecraftTestEnvironment {
+
+    private static final BlockPos BAT_A = new BlockPos(0, 0, 0);
+    private static final BlockPos BAT_B = new BlockPos(5, 0, 0);
+    private static final BlockPos BAT_C = new BlockPos(10, 0, 0);
+
+    // Stub world view resolves a registered battery position to its live storage (or null if gone).
+    private final Map<BlockPos, IEnergyStorage> storages = new HashMap<>();
+
+    private final IWorldView stubView = new IWorldView() {
+        @Override public boolean isPipe(BlockPos pos) { return false; }
+        @Override public List<BlockPos> getConnectedNeighbors(BlockPos pos) { return List.of(); }
+        @Override public boolean matchesSinkFilter(BlockPos pos, ItemStack stack) { return false; }
+        @Override public long dispatch(BlockPos p, BlockPos r, IItemKey i, long a, UUID d) { return 0; }
+        @Override public boolean isClientSide() { return false; }
+        @Override public void broadcastAlert(BlockPos pos, Component message) {}
+        @Override public IEnergyStorage energyStorageAt(BlockPos pos) { return storages.get(pos); }
+    };
+
+    private PipeNetwork network;
+
+    private static EnergyComponent battery(long amount) {
+        EnergyComponent e = new EnergyComponent(1_000_000, 1_000_000, 1_000_000, () -> {});
+        e.setAmount(amount);
+        return e;
+    }
+
+    @BeforeEach
+    void setUp() {
+        storages.clear();
+        network = new PipeNetwork(UUID.randomUUID(), new NetworkGraph(), stubView);
+    }
+
+    @Test
+    void consumeEnergy_noSources_returnsFalse() {
+        assertFalse(network.consumeEnergy(10));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void consumeEnergy_noWorldView_returnsFalse() {
+        // Legacy constructor leaves worldView null — sources can't be resolved, so consumption fails.
+        PipeNetwork legacy = new PipeNetwork(UUID.randomUUID());
+        legacy.registerEnergySource(BAT_A);
+        assertFalse(legacy.consumeEnergy(10));
+    }
+
+    @Test
+    void consumeEnergy_nonPositive_isNoOpTrue() {
+        assertTrue(network.consumeEnergy(0));
+        assertTrue(network.consumeEnergy(-5));
+    }
+
+    @Test
+    void consumeEnergy_sufficient_drawsAndReturnsTrue() {
+        EnergyComponent a = battery(100);
+        storages.put(BAT_A, a);
+        network.registerEnergySource(BAT_A);
+
+        assertTrue(network.consumeEnergy(60));
+        assertEquals(40, a.getAmount());
+    }
+
+    @Test
+    void consumeEnergy_insufficient_drawsNothing() {
+        EnergyComponent a = battery(50);
+        storages.put(BAT_A, a);
+        network.registerEnergySource(BAT_A);
+
+        assertFalse(network.consumeEnergy(60));
+        assertEquals(50, a.getAmount(), "all-or-nothing: nothing consumed when insufficient");
+    }
+
+    @Test
+    void consumeEnergy_multipleSources_drawsInRegistrationOrder() {
+        EnergyComponent a = battery(40);
+        EnergyComponent b = battery(40);
+        storages.put(BAT_A, a);
+        storages.put(BAT_B, b);
+        network.registerEnergySource(BAT_A);
+        network.registerEnergySource(BAT_B);
+
+        assertTrue(network.consumeEnergy(60));
+        assertEquals(0, a.getAmount(), "first registered source drained first");
+        assertEquals(20, b.getAmount(), "remainder taken from second source");
+    }
+
+    @Test
+    void consumeEnergy_stopsOncePlanSatisfied_leavingLaterSourcesUntouched() {
+        EnergyComponent a = battery(40);
+        EnergyComponent b = battery(40);
+        EnergyComponent c = battery(40);
+        storages.put(BAT_A, a);
+        storages.put(BAT_B, b);
+        storages.put(BAT_C, c);
+        network.registerEnergySource(BAT_A);
+        network.registerEnergySource(BAT_B);
+        network.registerEnergySource(BAT_C);
+
+        assertTrue(network.consumeEnergy(60));
+        assertEquals(0, a.getAmount());
+        assertEquals(20, b.getAmount());
+        assertEquals(40, c.getAmount(), "planning stops once the amount is met; third source untouched");
+    }
+
+    @Test
+    void consumeEnergy_skipsEmptySource() {
+        EnergyComponent empty = battery(0);
+        EnergyComponent full = battery(100);
+        storages.put(BAT_A, empty);
+        storages.put(BAT_B, full);
+        network.registerEnergySource(BAT_A);
+        network.registerEnergySource(BAT_B);
+
+        assertTrue(network.consumeEnergy(70));
+        assertEquals(0, empty.getAmount(), "empty source contributes nothing");
+        assertEquals(30, full.getAmount());
+    }
+
+    @Test
+    void consumeEnergy_skipsUnresolvedSource() {
+        // A registered position whose battery was removed/unloaded resolves to null and is skipped.
+        network.registerEnergySource(BAT_A);
+        EnergyComponent b = battery(100);
+        storages.put(BAT_B, b);
+        network.registerEnergySource(BAT_B);
+
+        assertTrue(network.consumeEnergy(70));
+        assertEquals(30, b.getAmount());
+    }
+
+    @Test
+    void unregisterEnergySource_removesIt() {
+        EnergyComponent a = battery(100);
+        storages.put(BAT_A, a);
+        network.registerEnergySource(BAT_A);
+        network.unregisterEnergySource(BAT_A);
+
+        assertFalse(network.consumeEnergy(10));
+        assertEquals(100, a.getAmount());
+    }
+
+    @Test
+    void merge_unionsEnergySources() {
+        EnergyComponent a = battery(50);
+        EnergyComponent b = battery(50);
+        storages.put(BAT_A, a);
+        storages.put(BAT_B, b);
+        network.registerEnergySource(BAT_A);
+
+        PipeNetwork other = new PipeNetwork(UUID.randomUUID(), new NetworkGraph(), stubView);
+        other.registerEnergySource(BAT_B);
+
+        network.merge(other);
+
+        assertTrue(network.consumeEnergy(80), "merged network draws from both batteries");
+        assertEquals(0, a.getAmount());
+        assertEquals(20, b.getAmount());
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -4,8 +4,8 @@ import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPower;
 import com.logistics.core.bootstrap.LogisticsCommonBootstrap;
 import com.logistics.core.lib.platform.CreativeTabRegistrar;
+import com.logistics.core.lib.energy.EnergyPushService;
 import com.logistics.core.lib.power.AbstractEngineBlock;
-import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.fabric.capability.FabricCapabilityRegistration;
 import com.logistics.fabric.energy.EnergyStorageAccess;
 import net.fabricmc.api.ModInitializer;
@@ -52,7 +52,7 @@ public final class LogisticsFabric implements ModInitializer {
     private void registerEnergyServices() {
         EnergyStorageAccess.register();
 
-        AbstractEngineBlockEntity.setEnergyPushService((level, targetPos, fromDirection, source, maxAmount) -> {
+        EnergyPushService.set((level, targetPos, fromDirection, source, maxAmount) -> {
             EnergyStorage target = EnergyStorage.SIDED.find(level, targetPos, fromDirection);
             if (target == null) return 0L;
             try (Transaction tx = Transaction.openOuter()) {

--- a/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
@@ -3,8 +3,8 @@ package com.logistics.neoforge;
 import com.logistics.core.bootstrap.LogisticsCommonBootstrap;
 import com.logistics.core.lib.platform.CreativeTabRegistrar;
 import com.logistics.core.lib.platform.ResourceReloadRegistrar;
+import com.logistics.core.lib.energy.EnergyPushService;
 import com.logistics.core.lib.power.AbstractEngineBlock;
-import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.neoforge.energy.NeoForgeEnergyStorage;
 import com.logistics.neoforge.client.NeoForgeClientSetup;
 import com.logistics.neoforge.platform.NeoForgeCreativeTabRegistrar;
@@ -59,7 +59,7 @@ public final class LogisticsNeoForge {
     }
 
     private void registerEnergyServices() {
-        AbstractEngineBlockEntity.setEnergyPushService((level, targetPos, fromDirection, source, maxAmount) -> {
+        EnergyPushService.set((level, targetPos, fromDirection, source, maxAmount) -> {
             var target = level.getCapability(Capabilities.Energy.BLOCK, targetPos, fromDirection);
             if (target == null) {
                 return 0L;


### PR DESCRIPTION
## Summary

Foundation for the upcoming **power use in logistics pipes** feature. Adds the plumbing for a
logistics network to draw energy from registered battery sources, with no player-visible change
on its own. The Battery block and per-module energy costs land in the stacked follow-up.

## Changes

- **`ILogisticsNetwork`** gains `registerEnergySource(pos)` / `unregisterEnergySource(pos)` /
  `consumeEnergy(amount)` (default no-ops, so existing implementors/tests are unaffected).
- **`PipeNetwork`** tracks registered battery positions and implements `consumeEnergy` as an
  all-or-nothing two-phase simulate/commit over the loader-agnostic `IEnergyStorage` API — no
  Fabric/Team-Reborn types in `common`. Sources are stored by `BlockPos` and re-resolved from the
  world each call (via a new `IWorldView.energyStorageAt`), so removed/unloaded batteries are
  skipped and network split/merge needs no special handling.
- **`PipeContext.consumeEnergy`** delegates to the network (returns `true` during the brief
  pre-network bootstrap window).
- **`EnergyPushService`** extracted from `AbstractEngineBlockEntity` into a shared
  `core.lib.energy` service so both engines and (next PR) batteries push energy through one
  loader-registered implementation. Engine behavior is unchanged.

## Notes

- New unit tests cover the all-or-nothing contract, multi-source draw order, and stale-source skip.
- No loader imports leak into `common`; both loaders build; all game tests pass.
- Stacked: the Battery block + module energy costs build on this branch.
