### PR TITLE
chore(build): ignore NeoForge runs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ patches.lzma
 ats/
 /config.json
 
+# NeoForge
+/neoforge/runs/
+
 # MacOS
 .DS_Store
 


### PR DESCRIPTION
## Summary

`mc/1.21.1`'s `.gitignore` was missing the NeoForge run-directory rule that the other branches already carry (`/neoforge/runs/`). As a result, launching the NeoForge dev client (`./gradlew :neoforge:runClient`) left ~60 generated runtime files (test world saves, JEI/NeoForge config, cached dependency jars) showing as untracked.

## Changes

- Add a `# NeoForge` section to `.gitignore` ignoring `/neoforge/runs/`, matching `mc/26.1` / `mc/26.2` / `mc/1.21.11`.

## Notes

- No code or behavior change. Brings `mc/1.21.1` in line with the other branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)