### PR TITLE
ci(build): make Codecov coverage upload non-blocking

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -90,6 +90,9 @@ jobs:
         with:
           files: ${{ matrix.module }}/build/reports/jacoco/test/jacocoTestReport.xml
           flags: ${{ matrix.module }}
-          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
+          # Coverage is informational, not a correctness gate. Keep this non-blocking so a
+          # Codecov-side issue (e.g. the uploader's GPG key-import failing to verify the
+          # auto-updated CLI binary) can't fail an otherwise-green CI run.
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Stops a Codecov-side problem from blocking otherwise-green CI runs. The `Upload coverage to
Codecov` step has been failing on every run while **all tests pass**, turning the `test` jobs red.

## Why

The failure is in `codecov-action@v6.0.1`'s signature-verification step, not our tests and not a
Codecov outage (their status page is clean):

```
==> Downloading https://cli.codecov.io/latest/linux/codecov   (Version: v11.2.8)
gpg: no valid OpenPGP data found.          # public-key import returned nothing
gpg: Total number processed: 0
==> Verifying GPG signature integrity
gpg: using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Can't check signature: No public key
==> Could not verify signature. Exiting...
```

We pin the **action** to a SHA, but it still fetches two things live each run that we don't control:
the **`latest` CLI binary** (auto-rolled to v11.2.8) and **Codecov's public PGP key** (import now
returns 0 keys). So an external change broke a previously-green pipeline with no commit from us.
`codecov-action` is already at its newest release (v6.0.1), so there's no action bump that fixes it.

## Change

- `fail_ci_if_error: false` on the Codecov upload step.

Coverage still uploads when the action works; when its verification step breaks, CI stays green.
Coverage is informational, not a correctness gate, so it shouldn't gate merges on a third party's
tooling.

## Notes

- This is the second time Codecov tooling has interfered with CI; making the upload non-blocking is
  the durable posture.
- Affects CI only — no mod/runtime changes.
