### PR TITLE
fix(energy): make engines visibly change color with heat stage

### DIFF
--- a/common/src/client/java/com/logistics/power/render/EngineHeatTintSource.java
+++ b/common/src/client/java/com/logistics/power/render/EngineHeatTintSource.java
@@ -1,0 +1,31 @@
+package com.logistics.power.render;
+
+import com.logistics.core.lib.power.EngineHeatTint;
+import java.util.Set;
+import net.minecraft.client.color.block.BlockTintSource;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+
+/**
+ * Loader-agnostic block tint source that colors engine blocks by their heat stage.
+ *
+ * <p>Declaring {@link #relevantProperties()} is essential on 26.1: without it the renderer bakes a
+ * single tint for every heat stage and the color never changes in-world (see {@link EngineHeatTint}).
+ * Both the Fabric and NeoForge client setup register this same instance.
+ */
+public final class EngineHeatTintSource implements BlockTintSource {
+
+    public static final EngineHeatTintSource INSTANCE = new EngineHeatTintSource();
+
+    private EngineHeatTintSource() {}
+
+    @Override
+    public int color(BlockState state) {
+        return EngineHeatTint.color(state);
+    }
+
+    @Override
+    public Set<Property<?>> relevantProperties() {
+        return EngineHeatTint.RELEVANT_PROPERTIES;
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/power/EngineHeatTint.java
+++ b/common/src/main/java/com/logistics/core/lib/power/EngineHeatTint.java
@@ -1,0 +1,44 @@
+package com.logistics.core.lib.power;
+
+import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
+import java.util.Set;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+
+/**
+ * Heat-stage tint colors for engine blocks, shared by every loader's block tint source.
+ *
+ * <p>Kept loader-agnostic (no client imports) so it can be unit tested. The client-side
+ * {@code BlockTintSource} adapters delegate here for both the color and the set of relevant
+ * properties.
+ *
+ * <p><strong>Why {@link #RELEVANT_PROPERTIES} matters:</strong> in 26.1 a block's tint is baked
+ * once per "model group", and two block states share a group unless a property the tint source
+ * declares as relevant differs between them ({@code ModelGroupCollector} keys groups on
+ * {@code BlockColors.getColoringProperties}). The engine model is identical across heat stages, so
+ * unless {@link AbstractEngineBlockEntity#STAGE} is declared relevant, all stages collapse into one
+ * cached tint and the heat color never updates in-world.
+ */
+public final class EngineHeatTint {
+
+    private EngineHeatTint() {}
+
+    /** Block-state properties that affect the engine tint; must include STAGE (see class docs). */
+    public static final Set<Property<?>> RELEVANT_PROPERTIES = Set.of(AbstractEngineBlockEntity.STAGE);
+
+    /** Returns the ARGB tint for the given heat stage. */
+    public static int color(HeatStage stage) {
+        return switch (stage) {
+            case COLD -> 0xFF3366CC;
+            case COOL -> 0xFF33CC33;
+            case WARM -> 0xFFCCCC33;
+            case HOT -> 0xFFCC3333;
+            case OVERHEAT -> 0xFF191919;
+        };
+    }
+
+    /** Returns the ARGB tint for an engine block state, read from its {@code STAGE} property. */
+    public static int color(BlockState state) {
+        return color(state.getValue(AbstractEngineBlockEntity.STAGE));
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/power/EngineHeatTintTest.java
+++ b/common/src/test/java/com/logistics/core/lib/power/EngineHeatTintTest.java
@@ -1,0 +1,39 @@
+package com.logistics.core.lib.power;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.test.MinecraftTestEnvironment;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class EngineHeatTintTest extends MinecraftTestEnvironment {
+
+    /**
+     * In 26.1 block tint is baked per "model group", and the renderer only re-bakes a fresh tint when
+     * a block-state property that the tint source declares as relevant changes (see
+     * {@code ModelGroupCollector} / {@code BlockColors.getColoringProperties}). If the engine tint
+     * source does not declare {@link AbstractEngineBlockEntity#STAGE} as relevant, every heat stage
+     * collapses into one cached tint and the heat color never visibly changes in-world.
+     */
+    @Test
+    void relevantProperties_includeHeatStage() {
+        assertThat(EngineHeatTint.RELEVANT_PROPERTIES).contains(AbstractEngineBlockEntity.STAGE);
+    }
+
+    @Test
+    void color_isDistinctForEveryHeatStage() {
+        long distinctColors =
+                Arrays.stream(HeatStage.values()).mapToInt(EngineHeatTint::color).distinct().count();
+
+        assertThat(distinctColors).isEqualTo(HeatStage.values().length);
+    }
+
+    @Test
+    void color_isFullyOpaque() {
+        for (HeatStage stage : HeatStage.values()) {
+            int alpha = (EngineHeatTint.color(stage) >>> 24) & 0xFF;
+            assertThat(alpha).as("alpha for %s", stage).isEqualTo(0xFF);
+        }
+    }
+}

--- a/fabric/src/client/java/com/logistics/LogisticsPowerClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsPowerClient.java
@@ -4,6 +4,7 @@ import com.logistics.core.bootstrap.ClientDomainBootstrap;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.power.render.CableBlockEntityRenderer;
 import com.logistics.power.render.EngineBlockEntityRenderer;
+import com.logistics.power.render.EngineHeatTintSource;
 import com.logistics.power.screen.StirlingEngineScreen;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
@@ -43,8 +44,9 @@ public final class LogisticsPowerClient implements ClientDomainBootstrap {
     }
 
     /**
-     * Registers block color providers for engines to tint based on heat stage.
-     * Uses the STAGE block state property to determine color.
+     * Registers the block tint source that colors engines by heat stage. The source declares STAGE
+     * as a relevant property so 26.1 re-bakes the tint when the stage changes (see
+     * {@link EngineHeatTintSource}).
      *
      * <p>TODO: The non-overheating flash effect (HOT/WARM oscillation) is driven by block state
      * changes on the server tick, which causes chunk rebuilds at each half-stroke transition.
@@ -53,13 +55,7 @@ public final class LogisticsPowerClient implements ClientDomainBootstrap {
      */
     private void registerEngineBlockColors() {
         BlockColorRegistry.register(
-            List.of(state -> switch (state.getValue(AbstractEngineBlockEntity.STAGE)) {
-                case COLD -> 0xFF3366CC;
-                case COOL -> 0xFF33CC33;
-                case WARM -> 0xFFCCCC33;
-                case HOT -> 0xFFCC3333;
-                case OVERHEAT -> 0xFF191919;
-            }),
+            List.of(EngineHeatTintSource.INSTANCE),
             LogisticsPower.BLOCK.REDSTONE_ENGINE,
             LogisticsPower.BLOCK.STIRLING_ENGINE,
             LogisticsPower.BLOCK.CREATIVE_ENGINE);

--- a/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
@@ -20,10 +20,10 @@ import com.logistics.pipe.screen.SinkScreen;
 import com.logistics.pipe.screen.SupplierScreen;
 import com.logistics.automation.render.LaserQuarryBlockEntityRenderer;
 import com.logistics.automation.render.MarkerBlockEntityRenderer;
-import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.pipe.network.packet.SyncRequesterInventoryPacket;
 import com.logistics.pipe.render.PipeBlockEntityRenderer;
 import com.logistics.power.render.CableBlockEntityRenderer;
+import com.logistics.power.render.EngineHeatTintSource;
 import com.logistics.power.screen.StirlingEngineScreen;
 import com.logistics.neoforge.client.render.NeoForgeEngineBlockEntityRenderer;
 import java.util.List;
@@ -101,13 +101,7 @@ public final class NeoForgeClientSetup {
 
     private static void registerBlockColors(RegisterColorHandlersEvent.BlockTintSources event) {
         event.register(
-                List.of(state -> switch (state.getValue(AbstractEngineBlockEntity.STAGE)) {
-                    case COLD -> 0xFF3366CC;
-                    case COOL -> 0xFF33CC33;
-                    case WARM -> 0xFFCCCC33;
-                    case HOT -> 0xFFCC3333;
-                    case OVERHEAT -> 0xFF191919;
-                }),
+                List.of(EngineHeatTintSource.INSTANCE),
                 LogisticsPower.BLOCK.REDSTONE_ENGINE,
                 LogisticsPower.BLOCK.STIRLING_ENGINE,
                 LogisticsPower.BLOCK.CREATIVE_ENGINE);


### PR DESCRIPTION
## Summary
Engines (Redstone / Stirling / Creative) didn't visibly change color with their heat stage in-world — they stayed a single color from COLD to OVERHEAT. Fixes #479.

## Root cause
On 26.1 a block's tint is baked **once per model group**, and two block states only land in different groups (and get different tints) when a property the tint source declares as *relevant* differs between them (`ModelGroupCollector` keys groups on `BlockColors.getColoringProperties`). The engine tint was registered as a bare lambda whose `relevantProperties()` defaulted to empty, so all five heat stages collapsed into one cached tint — the color was computed once and never updated.

## Changes
- Add `EngineHeatTintSource` (shared client `BlockTintSource`) that declares `STAGE` as a relevant property, so the renderer re-bakes the tint when the stage changes.
- Extract the per-stage colors into a loader-agnostic `EngineHeatTint` helper so the logic is unit-testable.
- Fabric and NeoForge now register the same shared tint source instead of duplicate inline lambdas.

## Tests
- `EngineHeatTintTest` locks in the fix: the tint source must declare `STAGE` relevant, every stage maps to a distinct color, and all colors are fully opaque.

## Notes
This is 26.1-specific behavior (older versions evaluate block colors live each frame). The longer-term direction noted in the existing TODO — moving heat coloring into the block entity renderer for smooth per-frame coloring — is unchanged and still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)