### PR TITLE
fix(automation): stop inactive markers rendering as a black cross

### DIFF
--- a/fabric/src/client/java/com/logistics/LogisticsAutomationClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsAutomationClient.java
@@ -23,7 +23,9 @@ public final class LogisticsAutomationClient implements ClientDomainBootstrap {
         LOGGER.info("Registering automation (client)");
         BlockEntityRendererRegistry.register(
                 LogisticsAutomation.ENTITY.MARKER_BLOCK_ENTITY, MarkerBlockEntityRenderer::new);
-        // Register quarry frame for cutout rendering (transparency support)
+        // Markers and the quarry frame use transparent torch-style textures and need the cutout layer;
+        // without it the inactive marker's transparent pixels render as a black cross.
+        BlockRenderLayerMap.putBlock(LogisticsAutomation.BLOCK.MARKER, ChunkSectionLayer.CUTOUT);
         BlockRenderLayerMap.putBlock(LogisticsAutomation.BLOCK.LASER_QUARRY_FRAME, ChunkSectionLayer.CUTOUT);
 
         BlockEntityRendererRegistry.register(


### PR DESCRIPTION
## Summary
An inactive (unlit) marker rendered as a black "cross" through the block instead of its transparent torch-style model. Active markers were unaffected. Fixes #481.

## Root cause
The inactive marker model is a torch template textured with `core/marker_off`, which has transparent pixels. That needs the **cutout** render layer, but the marker's cutout registration was dropped in the #356 client refactor. Without it the block falls back to the SOLID layer and the transparent pixels render black. The active marker's texture is opaque, so it looked fine.

## Changes
- Re-register the `MARKER` block on the cutout render layer, alongside the existing `LASER_QUARRY_FRAME` registration.

## Notes
- **Not a regression from the render-in-code work** — pre-existing since #356.
- **mc/26.1 is not affected**: there the chunk render layer is derived automatically from sprite transparency, so no registration is needed (and `BlockRenderLayerMap` no longer exposes this). See the note on #481.
- **Backport:** to be cherry-picked to mc/1.21.1 after merge (the 1.21.1 API differs — `INSTANCE.putBlock(block, RenderType.cutout())` — so it needs a small adaptation).
- No automated test: this is a Fabric client render-layer registration with no headless test surface; worth a quick in-game check on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)