### PR TITLE
feat(power): show power diagnostics in the Jade HUD

### DIFF
--- a/common/src/client/java/com/logistics/power/PowerInfraHudLines.java
+++ b/common/src/client/java/com/logistics/power/PowerInfraHudLines.java
@@ -1,0 +1,52 @@
+package com.logistics.power;
+
+import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.power.cable.CableTier;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Builds the power-infrastructure HUD lines. Cable throughput comes straight from the tier (client-side);
+ * the creative sink's lines come from the synced tag written by {@code PowerInfraHudData}. Pure formatting,
+ * shared across loaders; the per-loader Jade provider adds the returned lines to the tooltip.
+ */
+public final class PowerInfraHudLines {
+
+    private PowerInfraHudLines() {}
+
+    /** Cable: tier throughput. */
+    public static List<Component> cable(CableTier tier) {
+        List<Component> lines = new ArrayList<>();
+        lines.add(row(
+                "jade.logistics.cable.transfer",
+                String.format("%d RF/t", tier.transferRate()),
+                ChatFormatting.AQUA));
+        return lines;
+    }
+
+    /** Creative sink: configured drain rate and energy discarded last tick. */
+    public static List<Component> creativeSink(CompoundTag data) {
+        List<Component> lines = new ArrayList<>();
+        if (!PowerInfraHudData.TYPE_CREATIVE_SINK.equals(NbtCompat.getString(data, PowerInfraHudData.KEY_TYPE, ""))) {
+            return lines; // server data not present
+        }
+        lines.add(row(
+                "jade.logistics.creative_sink.drain",
+                String.format("%d RF/t", NbtCompat.getLong(data, "drainRate", 0)),
+                ChatFormatting.AQUA));
+        lines.add(row(
+                "jade.logistics.creative_sink.received",
+                String.format("%d RF/t", NbtCompat.getLong(data, "received", 0)),
+                ChatFormatting.GREEN));
+        return lines;
+    }
+
+    private static Component row(String labelKey, String value, ChatFormatting valueColor) {
+        return Component.translatable(labelKey)
+                .append(Component.literal(": "))
+                .append(Component.literal(value).withStyle(valueColor));
+    }
+}

--- a/common/src/client/java/com/logistics/power/engine/EngineHudLines.java
+++ b/common/src/client/java/com/logistics/power/engine/EngineHudLines.java
@@ -1,0 +1,97 @@
+package com.logistics.power.engine;
+
+import com.logistics.core.lib.compat.NbtCompat;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Builds the engine HUD lines from the synced diagnostics tag written by {@code EngineHudData}. Pure
+ * client-side formatting with no HUD-mod API, so it is shared across loaders; the per-loader Jade provider
+ * adds each returned line to the tooltip.
+ */
+public final class EngineHudLines {
+
+    private EngineHudLines() {}
+
+    /**
+     * Returns the engine readout lines, or an empty list when the tag carries no engine data. Stage and
+     * fuel are only included when {@code showDetails} is set (the player is holding Jade's details key).
+     */
+    public static List<Component> build(CompoundTag data, boolean showDetails) {
+        List<Component> lines = new ArrayList<>();
+        String stage = NbtCompat.getString(data, EngineHudData.KEY_STAGE, "");
+        if (stage.isEmpty()) {
+            return lines; // not an engine, or server data not present
+        }
+
+        boolean hasHeat = NbtCompat.getBoolean(data, "hasHeat", true);
+
+        if (hasHeat && showDetails) {
+            lines.add(row("jade.logistics.engine.stage", stage, stageColor(stage)));
+        }
+
+        if (hasHeat) {
+            double temp = NbtCompat.getDouble(data, "temp", 0);
+            double maxTemp = NbtCompat.getDouble(data, "maxTemp", 0);
+            // Current temperature always; the max only when expanded with the details key.
+            String tempText = showDetails
+                    ? String.format("%.0f°C (Max %.0f)", temp, maxTemp)
+                    : String.format("%.0f°C", temp);
+            // Colour by heat stage so the text matches the engine's visible heat tint.
+            lines.add(row("jade.logistics.engine.temperature", tempText, stageColor(stage)));
+        }
+
+        lines.add(row(
+                "jade.logistics.engine.output",
+                String.format("%d RF/t", NbtCompat.getLong(data, "output", 0)),
+                ChatFormatting.LIGHT_PURPLE));
+
+        boolean running = NbtCompat.getBoolean(data, "running", false);
+        lines.add(labelled("jade.logistics.engine.running")
+                .append(Component.translatable(running ? "jade.logistics.common.yes" : "jade.logistics.common.no")
+                        .withStyle(running ? ChatFormatting.GREEN : ChatFormatting.GRAY)));
+
+        if (showDetails && NbtCompat.getBoolean(data, "stirling", false)) {
+            int burnTime = NbtCompat.getInt(data, "burnTime", 0);
+            int fuelTime = NbtCompat.getInt(data, "fuelTime", 0);
+            if (fuelTime > 0) {
+                lines.add(row(
+                        "jade.logistics.engine.fuel",
+                        String.format("%d / %d ticks (%.1f%%)", burnTime, fuelTime, burnTime * 100.0f / fuelTime),
+                        ChatFormatting.YELLOW));
+            } else {
+                lines.add(labelled("jade.logistics.engine.fuel")
+                        .append(Component.translatable("jade.logistics.common.none").withStyle(ChatFormatting.GRAY)));
+            }
+        }
+
+        if (NbtCompat.getBoolean(data, "overheated", false)) {
+            lines.add(Component.translatable("jade.logistics.engine.overheated")
+                    .withStyle(ChatFormatting.RED, ChatFormatting.BOLD));
+        }
+
+        return lines;
+    }
+
+    private static Component row(String labelKey, String value, ChatFormatting valueColor) {
+        return labelled(labelKey).append(Component.literal(value).withStyle(valueColor));
+    }
+
+    private static net.minecraft.network.chat.MutableComponent labelled(String labelKey) {
+        return Component.translatable(labelKey).append(Component.literal(": "));
+    }
+
+    private static ChatFormatting stageColor(String stage) {
+        return switch (stage) {
+            case "COLD" -> ChatFormatting.BLUE;
+            case "COOL" -> ChatFormatting.GREEN;
+            case "WARM" -> ChatFormatting.YELLOW;
+            case "HOT" -> ChatFormatting.RED;
+            case "OVERHEAT" -> ChatFormatting.DARK_RED;
+            default -> ChatFormatting.WHITE;
+        };
+    }
+}

--- a/common/src/main/java/com/logistics/power/PowerInfraHudData.java
+++ b/common/src/main/java/com/logistics/power/PowerInfraHudData.java
@@ -1,0 +1,29 @@
+package com.logistics.power;
+
+import com.logistics.power.block.entity.CreativeSinkBlockEntity;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+/**
+ * Server-side capture of power-infrastructure diagnostics into the tag a look-at HUD (Jade) syncs to the
+ * client. Only the creative sink needs synced state (its drain rate and last-tick throughput); cables
+ * derive everything from their tier client-side, so they are not handled here. Read back by
+ * {@code PowerInfraHudLines}.
+ */
+public final class PowerInfraHudData {
+
+    /** NBT key naming which power-infra block the tag describes. */
+    public static final String KEY_TYPE = "type";
+
+    public static final String TYPE_CREATIVE_SINK = "creative_sink";
+
+    private PowerInfraHudData() {}
+
+    public static void write(CompoundTag data, BlockEntity blockEntity) {
+        if (blockEntity instanceof CreativeSinkBlockEntity sink) {
+            data.putString(KEY_TYPE, TYPE_CREATIVE_SINK);
+            data.putLong("drainRate", sink.getDrainRate());
+            data.putLong("received", sink.energyReceivedLastTick());
+        }
+    }
+}

--- a/common/src/main/java/com/logistics/power/engine/EngineHudData.java
+++ b/common/src/main/java/com/logistics/power/engine/EngineHudData.java
@@ -1,0 +1,40 @@
+package com.logistics.power.engine;
+
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.power.engine.block.entity.CreativeEngineBlockEntity;
+import com.logistics.power.engine.block.entity.StirlingEngineBlockEntity;
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Server-side capture of an engine's live diagnostics into the tag a look-at HUD (Jade) syncs to the
+ * client. Loader-agnostic and free of any HUD-mod API, so the logic lives once in common; the thin
+ * per-loader Jade provider just calls this from its server-data hook. Read back by the client-side
+ * {@code EngineHudLines}.
+ */
+public final class EngineHudData {
+
+    /** NBT key whose presence marks that the tag carries engine diagnostics. */
+    public static final String KEY_STAGE = "stage";
+
+    private EngineHudData() {}
+
+    public static void write(CompoundTag data, AbstractEngineBlockEntity engine) {
+        // Energy is intentionally omitted — Jade's built-in energy bar already shows the buffer. We only
+        // add what Jade doesn't surface on its own.
+        data.putString(KEY_STAGE, engine.getHeatStage().name());
+        // The Creative engine is the odd man out: its stage is hardwired to COLD and its temperature is
+        // meaningless, so the readout hides both for it.
+        data.putBoolean("hasHeat", !(engine instanceof CreativeEngineBlockEntity));
+        data.putDouble("temp", engine.getTemperature());
+        data.putDouble("maxTemp", engine.getMaxTemperature());
+        data.putLong("output", engine.getCurrentOutputPower());
+        data.putBoolean("running", engine.isRunning());
+        data.putBoolean("overheated", engine.isOverheated());
+
+        if (engine instanceof StirlingEngineBlockEntity stirling) {
+            data.putBoolean("stirling", true);
+            data.putInt("burnTime", stirling.getBurnTime());
+            data.putInt("fuelTime", stirling.getFuelTime());
+        }
+    }
+}

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -206,6 +206,16 @@
   "message.logistics.power.creative_sink.drain_rate": "Creative Sink: %s RF/t",
   "message.logistics.power.creative_engine.output": "Creative Engine: %s RF/t",
 
+  "jade.logistics.common.yes": "Yes",
+  "jade.logistics.common.no": "No",
+  "jade.logistics.common.none": "None",
+  "jade.logistics.engine.stage": "Stage",
+  "jade.logistics.engine.temperature": "Temperature",
+  "jade.logistics.engine.output": "Output",
+  "jade.logistics.engine.running": "Running",
+  "jade.logistics.engine.fuel": "Fuel",
+  "jade.logistics.engine.overheated": "Overheated!",
+
   "tag.item.c.ingots.tin": "Tin Ingots",
   "tag.item.c.ingots.bronze": "Bronze Ingots",
   "tag.item.c.nuggets.tin": "Tin Nuggets",

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -215,6 +215,9 @@
   "jade.logistics.engine.running": "Running",
   "jade.logistics.engine.fuel": "Fuel",
   "jade.logistics.engine.overheated": "Overheated!",
+  "jade.logistics.cable.transfer": "Transfer",
+  "jade.logistics.creative_sink.drain": "Drain Rate",
+  "jade.logistics.creative_sink.received": "Received",
 
   "tag.item.c.ingots.tin": "Tin Ingots",
   "tag.item.c.ingots.bronze": "Bronze Ingots",

--- a/fabric/src/client/java/com/logistics/compat/jade/EngineComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/EngineComponentProvider.java
@@ -1,0 +1,44 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.power.engine.EngineHudLines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the engine Jade integration: renders the diagnostics tag synced by
+ * {@link EngineServerDataProvider} as tooltip lines. Formatting is shared in {@link EngineHudLines}.
+ */
+public final class EngineComponentProvider implements IBlockComponentProvider {
+    public static final EngineComponentProvider INSTANCE = new EngineComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("engine").toIdentifier();
+
+    private EngineComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        // Run after Jade's built-in energy element (priority 1000) so we can strip it below.
+        return 2000;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        // The engine's internal buffer is an implementation detail — remove Jade's generic energy bar.
+        tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
+        for (Component line : EngineHudLines.build(accessor.getServerData(), accessor.showDetails())) {
+            tooltip.add(line);
+        }
+    }
+}

--- a/fabric/src/client/java/com/logistics/compat/jade/EngineServerDataProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/EngineServerDataProvider.java
@@ -1,0 +1,35 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.power.engine.EngineHudData;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the engine Jade integration: captures live engine diagnostics into the tag Jade syncs to
+ * the client. Jade requires the data and component providers to be separate classes (since MC 1.21.6); the
+ * client half is {@link EngineComponentProvider}. Capture logic is shared in {@link EngineHudData}.
+ */
+public final class EngineServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final EngineServerDataProvider INSTANCE = new EngineServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("engine").toIdentifier();
+
+    private EngineServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        if (accessor.getBlockEntity() instanceof AbstractEngineBlockEntity engine) {
+            EngineHudData.write(data, engine);
+        }
+    }
+}

--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -1,6 +1,7 @@
 package com.logistics.compat.jade;
 
 import com.logistics.LogisticsMod;
+import com.logistics.core.lib.power.AbstractEngineBlock;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
@@ -10,15 +11,19 @@ import snownee.jade.api.WailaPlugin;
  * Optional Jade HUD integration. Compiled against Jade's API only (clientCompileOnly) and loaded via the
  * {@code "jade"} entrypoint in fabric.mod.json — so it only initializes when Jade is actually installed.
  *
- * <p>Currently a no-op scaffold: it registers no providers yet. Per-block content (heat, fuel, quarry
- * status, pipe contents) is added in stacked passes on top of this foundation.
+ * <p>Per-block content is added in stacked passes; see {@link EngineServerDataProvider} and
+ * {@link EngineComponentProvider} for engines.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
 
     @Override
-    public void register(IWailaCommonRegistration registration) {}
+    public void register(IWailaCommonRegistration registration) {
+        registration.registerBlockDataProvider(EngineServerDataProvider.INSTANCE, AbstractEngineBlock.class);
+    }
 
     @Override
-    public void registerClient(IWailaClientRegistration registration) {}
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.registerBlockComponent(EngineComponentProvider.INSTANCE, AbstractEngineBlock.class);
+    }
 }

--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -2,6 +2,8 @@ package com.logistics.compat.jade;
 
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.power.AbstractEngineBlock;
+import com.logistics.power.block.CreativeSinkBlock;
+import com.logistics.power.cable.CableBlock;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
@@ -11,8 +13,8 @@ import snownee.jade.api.WailaPlugin;
  * Optional Jade HUD integration. Compiled against Jade's API only (clientCompileOnly) and loaded via the
  * {@code "jade"} entrypoint in fabric.mod.json — so it only initializes when Jade is actually installed.
  *
- * <p>Per-block content is added in stacked passes; see {@link EngineServerDataProvider} and
- * {@link EngineComponentProvider} for engines.
+ * <p>Per-block content is added in stacked passes; see {@code EngineServerDataProvider} /
+ * {@code EngineComponentProvider} for engines and {@code PowerInfra*Provider} for cables and the sink.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -20,10 +22,13 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
     @Override
     public void register(IWailaCommonRegistration registration) {
         registration.registerBlockDataProvider(EngineServerDataProvider.INSTANCE, AbstractEngineBlock.class);
+        registration.registerBlockDataProvider(PowerInfraServerDataProvider.INSTANCE, CreativeSinkBlock.class);
     }
 
     @Override
     public void registerClient(IWailaClientRegistration registration) {
         registration.registerBlockComponent(EngineComponentProvider.INSTANCE, AbstractEngineBlock.class);
+        registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CableBlock.class);
+        registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CreativeSinkBlock.class);
     }
 }

--- a/fabric/src/client/java/com/logistics/compat/jade/PowerInfraComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/PowerInfraComponentProvider.java
@@ -1,0 +1,55 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.power.PowerInfraHudLines;
+import com.logistics.power.block.CreativeSinkBlock;
+import com.logistics.power.cable.CableBlock;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import net.minecraft.world.level.block.Block;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the power-infrastructure Jade integration. Cables show their tier throughput; the creative
+ * sink shows its drain rate and last-tick throughput, with Jade's generic (unbounded) energy bar removed.
+ * Formatting is shared in {@link PowerInfraHudLines}.
+ */
+public final class PowerInfraComponentProvider implements IBlockComponentProvider {
+    public static final PowerInfraComponentProvider INSTANCE = new PowerInfraComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("power_infra").toIdentifier();
+
+    private PowerInfraComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        // Run after Jade's built-in energy element (priority 1000) so we can strip it for the sink.
+        return 2000;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        Block block = accessor.getBlockState().getBlock();
+        if (block instanceof CableBlock cable) {
+            for (Component line : PowerInfraHudLines.cable(cable.tier())) {
+                tooltip.add(line);
+            }
+        } else if (block instanceof CreativeSinkBlock) {
+            // The discard sink's buffer is effectively unbounded — remove Jade's generic energy bar.
+            tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
+            for (Component line : PowerInfraHudLines.creativeSink(accessor.getServerData())) {
+                tooltip.add(line);
+            }
+        }
+    }
+}

--- a/fabric/src/client/java/com/logistics/compat/jade/PowerInfraServerDataProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/PowerInfraServerDataProvider.java
@@ -1,0 +1,31 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.power.PowerInfraHudData;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the power-infrastructure Jade integration (currently the creative sink's drain/throughput).
+ * The client half is {@link PowerInfraComponentProvider}; capture logic is shared in {@link PowerInfraHudData}.
+ */
+public final class PowerInfraServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final PowerInfraServerDataProvider INSTANCE = new PowerInfraServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("power_infra").toIdentifier();
+
+    private PowerInfraServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        PowerInfraHudData.write(data, accessor.getBlockEntity());
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/EngineComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/EngineComponentProvider.java
@@ -1,0 +1,44 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.power.engine.EngineHudLines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the engine Jade integration: renders the diagnostics tag synced by
+ * {@link EngineServerDataProvider} as tooltip lines. Formatting is shared in {@link EngineHudLines}.
+ */
+public final class EngineComponentProvider implements IBlockComponentProvider {
+    public static final EngineComponentProvider INSTANCE = new EngineComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("engine").toIdentifier();
+
+    private EngineComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        // Run after Jade's built-in energy element (priority 1000) so we can strip it below.
+        return 2000;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        // The engine's internal buffer is an implementation detail — remove Jade's generic energy bar.
+        tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
+        for (Component line : EngineHudLines.build(accessor.getServerData(), accessor.showDetails())) {
+            tooltip.add(line);
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/EngineServerDataProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/EngineServerDataProvider.java
@@ -1,0 +1,35 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.power.engine.EngineHudData;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the engine Jade integration: captures live engine diagnostics into the tag Jade syncs to
+ * the client. Jade requires the data and component providers to be separate classes (since MC 1.21.6); the
+ * client half is {@link EngineComponentProvider}. Capture logic is shared in {@link EngineHudData}.
+ */
+public final class EngineServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final EngineServerDataProvider INSTANCE = new EngineServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("engine").toIdentifier();
+
+    private EngineServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        if (accessor.getBlockEntity() instanceof AbstractEngineBlockEntity engine) {
+            EngineHudData.write(data, engine);
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -1,6 +1,7 @@
 package com.logistics.neoforge.client.compat;
 
 import com.logistics.LogisticsMod;
+import com.logistics.core.lib.power.AbstractEngineBlock;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
@@ -11,16 +12,19 @@ import snownee.jade.api.WailaPlugin;
  * via the {@link WailaPlugin} annotation scan — so it only initializes when Jade is actually installed.
  *
  * <p>Client-only by nature (Jade is a client mod), hence the {@code com.logistics.neoforge.client} package
- * required by the NeoForge source-isolation rules. Currently a no-op scaffold: it registers no providers
- * yet. Per-block content (heat, fuel, quarry status, pipe contents) is added in stacked passes on top of
- * this foundation.
+ * required by the NeoForge source-isolation rules. Per-block content is added in stacked passes; see
+ * {@link EngineServerDataProvider} and {@link EngineComponentProvider} for engines.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
 
     @Override
-    public void register(IWailaCommonRegistration registration) {}
+    public void register(IWailaCommonRegistration registration) {
+        registration.registerBlockDataProvider(EngineServerDataProvider.INSTANCE, AbstractEngineBlock.class);
+    }
 
     @Override
-    public void registerClient(IWailaClientRegistration registration) {}
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.registerBlockComponent(EngineComponentProvider.INSTANCE, AbstractEngineBlock.class);
+    }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -2,6 +2,8 @@ package com.logistics.neoforge.client.compat;
 
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.power.AbstractEngineBlock;
+import com.logistics.power.block.CreativeSinkBlock;
+import com.logistics.power.cable.CableBlock;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
@@ -13,7 +15,8 @@ import snownee.jade.api.WailaPlugin;
  *
  * <p>Client-only by nature (Jade is a client mod), hence the {@code com.logistics.neoforge.client} package
  * required by the NeoForge source-isolation rules. Per-block content is added in stacked passes; see
- * {@link EngineServerDataProvider} and {@link EngineComponentProvider} for engines.
+ * {@code EngineServerDataProvider} / {@code EngineComponentProvider} for engines and
+ * {@code PowerInfra*Provider} for cables and the sink.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -21,10 +24,13 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
     @Override
     public void register(IWailaCommonRegistration registration) {
         registration.registerBlockDataProvider(EngineServerDataProvider.INSTANCE, AbstractEngineBlock.class);
+        registration.registerBlockDataProvider(PowerInfraServerDataProvider.INSTANCE, CreativeSinkBlock.class);
     }
 
     @Override
     public void registerClient(IWailaClientRegistration registration) {
         registration.registerBlockComponent(EngineComponentProvider.INSTANCE, AbstractEngineBlock.class);
+        registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CableBlock.class);
+        registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CreativeSinkBlock.class);
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/PowerInfraComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/PowerInfraComponentProvider.java
@@ -1,0 +1,55 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.power.PowerInfraHudLines;
+import com.logistics.power.block.CreativeSinkBlock;
+import com.logistics.power.cable.CableBlock;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import net.minecraft.world.level.block.Block;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the power-infrastructure Jade integration. Cables show their tier throughput; the creative
+ * sink shows its drain rate and last-tick throughput, with Jade's generic (unbounded) energy bar removed.
+ * Formatting is shared in {@link PowerInfraHudLines}.
+ */
+public final class PowerInfraComponentProvider implements IBlockComponentProvider {
+    public static final PowerInfraComponentProvider INSTANCE = new PowerInfraComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("power_infra").toIdentifier();
+
+    private PowerInfraComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        // Run after Jade's built-in energy element (priority 1000) so we can strip it for the sink.
+        return 2000;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        Block block = accessor.getBlockState().getBlock();
+        if (block instanceof CableBlock cable) {
+            for (Component line : PowerInfraHudLines.cable(cable.tier())) {
+                tooltip.add(line);
+            }
+        } else if (block instanceof CreativeSinkBlock) {
+            // The discard sink's buffer is effectively unbounded — remove Jade's generic energy bar.
+            tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
+            for (Component line : PowerInfraHudLines.creativeSink(accessor.getServerData())) {
+                tooltip.add(line);
+            }
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/PowerInfraServerDataProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/PowerInfraServerDataProvider.java
@@ -1,0 +1,31 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.power.PowerInfraHudData;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the power-infrastructure Jade integration (currently the creative sink's drain/throughput).
+ * The client half is {@link PowerInfraComponentProvider}; capture logic is shared in {@link PowerInfraHudData}.
+ */
+public final class PowerInfraServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final PowerInfraServerDataProvider INSTANCE = new PowerInfraServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("power_infra").toIdentifier();
+
+    private PowerInfraServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        PowerInfraHudData.write(data, accessor.getBlockEntity());
+    }
+}


### PR DESCRIPTION
## Summary
Adds power-block readouts to the Jade HUD — engines, cables, and the creative sink. Stacked on #488 (the base Jade integration) — review/merge that first.

## Engines (Redstone / Stirling / Creative)
- **Temperature**, **Output**, and **Running** state at a glance
- **Stage** and (Stirling) **fuel burn** when holding Jade's "show details" key
- An **Overheated!** warning when applicable
- Temperature text is colored to match the engine's heat tint (cold blue → hot red)
- The **Creative engine** omits temperature/stage — its stage is hardwired to cold, so those aren't meaningful
- Replaces Jade's generic energy bar on engines (the internal buffer isn't player-relevant)

## Cables
- **Transfer rate** by tier (copper 30 / gold 60 / ender 120 RF/t)

## Creative Sink
- **Drain Rate** and **Received** (last tick), with Jade's generic (unbounded) energy bar removed

## Notes
- Capture/format logic lives in common (`EngineHud*` / `PowerInfraHud*`); each loader has thin server-data + component providers.
- Batteries intentionally keep Jade's built-in energy bar; a net/input/output readout is deferred to a later feature (needs per-tick flow instrumentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)