### PR TITLE
feat(automation): show laser quarry status in the Jade HUD

### DIFF
--- a/common/src/client/java/com/logistics/automation/laserquarry/QuarryHudLines.java
+++ b/common/src/client/java/com/logistics/automation/laserquarry/QuarryHudLines.java
@@ -1,0 +1,60 @@
+package com.logistics.automation.laserquarry;
+
+import com.logistics.core.lib.compat.NbtCompat;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Builds the laser-quarry HUD lines from the synced status tag written by {@code QuarryHudData}. Phase and
+ * any no-power warning show always; power-in and arm speed are detail lines gated behind Jade's details key.
+ */
+public final class QuarryHudLines {
+
+    private QuarryHudLines() {}
+
+    public static List<Component> build(CompoundTag data, boolean showDetails) {
+        List<Component> lines = new ArrayList<>();
+        String phase = NbtCompat.getString(data, QuarryHudData.KEY_PHASE, "");
+        if (phase.isEmpty()) {
+            return lines; // not a quarry, or server data not present
+        }
+        boolean finished = NbtCompat.getBoolean(data, "finished", false);
+
+        String phaseKey = finished ? "jade.logistics.quarry.phase.finished" : phaseKey(phase);
+        lines.add(Component.translatable("jade.logistics.quarry.phase")
+                .append(Component.literal(": "))
+                .append(Component.translatable(phaseKey).withStyle(ChatFormatting.AQUA)));
+
+        if (!finished && showDetails) {
+            lines.add(row(
+                    "jade.logistics.quarry.power_in",
+                    String.format("%,d RF/t", NbtCompat.getLong(data, "powerIn", 0)),
+                    ChatFormatting.GREEN));
+            if ("MINING".equals(phase)) {
+                lines.add(row(
+                        "jade.logistics.quarry.arm_speed",
+                        String.format("%.2f blocks/tick", NbtCompat.getFloat(data, "armSpeed", 0)),
+                        ChatFormatting.LIGHT_PURPLE));
+            }
+        }
+
+        return lines;
+    }
+
+    private static String phaseKey(String phase) {
+        return switch (phase) {
+            case "CLEARING" -> "jade.logistics.quarry.phase.clearing";
+            case "BUILDING_FRAME" -> "jade.logistics.quarry.phase.building_frame";
+            default -> "jade.logistics.quarry.phase.mining";
+        };
+    }
+
+    private static Component row(String labelKey, String value, ChatFormatting valueColor) {
+        return Component.translatable(labelKey)
+                .append(Component.literal(": "))
+                .append(Component.literal(value).withStyle(valueColor));
+    }
+}

--- a/common/src/main/java/com/logistics/automation/laserquarry/QuarryHudData.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/QuarryHudData.java
@@ -1,0 +1,23 @@
+package com.logistics.automation.laserquarry;
+
+import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Server-side capture of a laser quarry's status into the tag a look-at HUD (Jade) syncs to the client.
+ * Loader-agnostic and free of any HUD-mod API; read back by the client-side {@code QuarryHudLines}.
+ */
+public final class QuarryHudData {
+
+    /** NBT key whose presence marks that the tag carries quarry status. */
+    public static final String KEY_PHASE = "phase";
+
+    private QuarryHudData() {}
+
+    public static void write(CompoundTag data, LaserQuarryBlockEntity quarry) {
+        data.putString(KEY_PHASE, quarry.getCurrentPhase().name());
+        data.putBoolean("finished", quarry.isFinished());
+        data.putLong("powerIn", quarry.getEnergyReceivedLastTick());
+        data.putFloat("armSpeed", quarry.getSyncedArmSpeed());
+    }
+}

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -206,6 +206,14 @@
   "message.logistics.power.creative_sink.drain_rate": "Creative Sink: %s RF/t",
   "message.logistics.power.creative_engine.output": "Creative Engine: %s RF/t",
 
+  "jade.logistics.quarry.phase": "Phase",
+  "jade.logistics.quarry.phase.clearing": "Clearing",
+  "jade.logistics.quarry.phase.building_frame": "Building Frame",
+  "jade.logistics.quarry.phase.mining": "Mining",
+  "jade.logistics.quarry.phase.finished": "Finished",
+  "jade.logistics.quarry.power_in": "Power In",
+  "jade.logistics.quarry.arm_speed": "Arm Speed",
+
   "tag.item.c.ingots.tin": "Tin Ingots",
   "tag.item.c.ingots.bronze": "Bronze Ingots",
   "tag.item.c.nuggets.tin": "Tin Nuggets",

--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -1,6 +1,7 @@
 package com.logistics.compat.jade;
 
 import com.logistics.LogisticsMod;
+import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
@@ -10,15 +11,19 @@ import snownee.jade.api.WailaPlugin;
  * Optional Jade HUD integration. Compiled against Jade's API only (clientCompileOnly) and loaded via the
  * {@code "jade"} entrypoint in fabric.mod.json — so it only initializes when Jade is actually installed.
  *
- * <p>Currently a no-op scaffold: it registers no providers yet. Per-block content (heat, fuel, quarry
- * status, pipe contents) is added in stacked passes on top of this foundation.
+ * <p>Per-block content is added in stacked passes; see {@code QuarryServerDataProvider} /
+ * {@code QuarryComponentProvider} for the laser quarry.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
 
     @Override
-    public void register(IWailaCommonRegistration registration) {}
+    public void register(IWailaCommonRegistration registration) {
+        registration.registerBlockDataProvider(QuarryServerDataProvider.INSTANCE, LaserQuarryBlock.class);
+    }
 
     @Override
-    public void registerClient(IWailaClientRegistration registration) {}
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
+    }
 }

--- a/fabric/src/client/java/com/logistics/compat/jade/QuarryComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/QuarryComponentProvider.java
@@ -1,0 +1,35 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.automation.laserquarry.QuarryHudLines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the laser-quarry Jade integration: renders the status tag synced by
+ * {@link QuarryServerDataProvider}. Formatting is shared in {@link QuarryHudLines}.
+ */
+public final class QuarryComponentProvider implements IBlockComponentProvider {
+    public static final QuarryComponentProvider INSTANCE = new QuarryComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("quarry").toIdentifier();
+
+    private QuarryComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        for (Component line : QuarryHudLines.build(accessor.getServerData(), accessor.showDetails())) {
+            tooltip.add(line);
+        }
+    }
+}

--- a/fabric/src/client/java/com/logistics/compat/jade/QuarryServerDataProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/QuarryServerDataProvider.java
@@ -1,0 +1,34 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.automation.laserquarry.QuarryHudData;
+import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the laser-quarry Jade integration: captures quarry status into the synced tag. The client
+ * half is {@link QuarryComponentProvider}; capture logic is shared in {@link QuarryHudData}.
+ */
+public final class QuarryServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final QuarryServerDataProvider INSTANCE = new QuarryServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("quarry").toIdentifier();
+
+    private QuarryServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        if (accessor.getBlockEntity() instanceof LaserQuarryBlockEntity quarry) {
+            QuarryHudData.write(data, quarry);
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -1,6 +1,7 @@
 package com.logistics.neoforge.client.compat;
 
 import com.logistics.LogisticsMod;
+import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaCommonRegistration;
 import snownee.jade.api.IWailaPlugin;
@@ -11,16 +12,19 @@ import snownee.jade.api.WailaPlugin;
  * via the {@link WailaPlugin} annotation scan — so it only initializes when Jade is actually installed.
  *
  * <p>Client-only by nature (Jade is a client mod), hence the {@code com.logistics.neoforge.client} package
- * required by the NeoForge source-isolation rules. Currently a no-op scaffold: it registers no providers
- * yet. Per-block content (heat, fuel, quarry status, pipe contents) is added in stacked passes on top of
- * this foundation.
+ * required by the NeoForge source-isolation rules. Per-block content is added in stacked passes; see
+ * {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser quarry.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
 
     @Override
-    public void register(IWailaCommonRegistration registration) {}
+    public void register(IWailaCommonRegistration registration) {
+        registration.registerBlockDataProvider(QuarryServerDataProvider.INSTANCE, LaserQuarryBlock.class);
+    }
 
     @Override
-    public void registerClient(IWailaClientRegistration registration) {}
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
+    }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/QuarryComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/QuarryComponentProvider.java
@@ -1,0 +1,35 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.automation.laserquarry.QuarryHudLines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the laser-quarry Jade integration: renders the status tag synced by
+ * {@link QuarryServerDataProvider}. Formatting is shared in {@link QuarryHudLines}.
+ */
+public final class QuarryComponentProvider implements IBlockComponentProvider {
+    public static final QuarryComponentProvider INSTANCE = new QuarryComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("quarry").toIdentifier();
+
+    private QuarryComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        for (Component line : QuarryHudLines.build(accessor.getServerData(), accessor.showDetails())) {
+            tooltip.add(line);
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/QuarryServerDataProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/QuarryServerDataProvider.java
@@ -1,0 +1,34 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.automation.laserquarry.QuarryHudData;
+import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the laser-quarry Jade integration: captures quarry status into the synced tag. The client
+ * half is {@link QuarryComponentProvider}; capture logic is shared in {@link QuarryHudData}.
+ */
+public final class QuarryServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final QuarryServerDataProvider INSTANCE = new QuarryServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("quarry").toIdentifier();
+
+    private QuarryServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        if (accessor.getBlockEntity() instanceof LaserQuarryBlockEntity quarry) {
+            QuarryHudData.write(data, quarry);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds laser quarry status to the Jade HUD. Stacked on #488 (the base Jade integration) — review/merge that first.

## Changes
Looking at a Laser Quarry with Jade installed now shows:
- **Phase** — Clearing → Building Frame → Mining → Finished (always)
- **Power In** (RF/t) and, during mining, **Arm Speed** (blocks/tick) — when holding Jade's "show details" key

The quarry keeps Jade's built-in energy bar (it has a real buffer, unlike the engines' internal ones).

## Notes
- Capture/format logic lives in common (`QuarryHudData` / `QuarryHudLines`); each loader has a thin server-data + component provider, matching the engine and power-infra passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)