### PR TITLE
build(build): skip Spotless commit hook during cherry-pick and add pre-push check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,19 @@
 #!/bin/sh
 # Pre-commit hook to auto-format code with Spotless
 
+# Skip during sequencer operations (cherry-pick, rebase, merge, revert).
+# These prepare the commit message in the sequencer state; the stash below
+# wipes it, causing an empty-message abort. Such commits originate from
+# already-formatted commits, and the pre-push hook + CI verify formatting.
+if [ -f "$(git rev-parse --git-path CHERRY_PICK_HEAD)" ] || \
+   [ -f "$(git rev-parse --git-path MERGE_HEAD)" ] || \
+   [ -f "$(git rev-parse --git-path REVERT_HEAD)" ] || \
+   [ -d "$(git rev-parse --git-path rebase-merge)" ] || \
+   [ -d "$(git rev-parse --git-path rebase-apply)" ]; then
+    echo "Skipping Spotless (cherry-pick/rebase/merge/revert in progress)"
+    exit 0
+fi
+
 echo "Formatting code with Spotless..."
 
 # Exit early if no staged files

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Pre-push hook: verify formatting with Spotless as a safety net.
+#
+# Auto-formatting runs on commit, but the pre-commit hook intentionally skips
+# itself during cherry-pick/rebase/merge/revert (which also bypass CI in our
+# normal porting flow). This check should almost never fire; when it does, it
+# stops unformatted code from reaching a branch.
+
+echo "Checking formatting with Spotless..."
+
+if ! ./gradlew spotlessCheck --daemon --quiet; then
+    echo "✗ Spotless found unformatted code."
+    echo "  Run './gradlew spotlessApply', commit the result, then push again."
+    echo "  (To bypass in an emergency: git push --no-verify)"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

The Spotless pre-commit hook stashes the working tree before formatting, which wipes the pending commit message during sequencer operations (`cherry-pick`/`rebase`/`merge`/`revert` `--continue`) — producing an "Aborting commit due to empty commit message" failure mid-port. This guards the hook against that case and adds a lightweight pre-push safety net so unformatted code can't slip through when we cherry-pick (which skips both the commit hook and CI).

## Changes

- **pre-commit:** skip auto-formatting when a cherry-pick, rebase, merge, or revert is in progress. These commits originate from already-formatted commits, so there's nothing to format anyway.
- **pre-push (new):** run `spotlessCheck` and reject the push if anything is unformatted. Should almost never fire; it's the backstop for the cherry-pick path that bypasses CI.

## Notes

- Run `./gradlew installGitHooks` to pick up the new hooks (the pre-push hook is new).
- Bypass in an emergency with `git push --no-verify`.
- CI's `spotlessCheck` is unchanged and remains the authoritative gate.
