### PR TITLE
feat(automation): show macerator and kiln progress in the Jade HUD

### DIFF
--- a/common/src/client/java/com/logistics/core/machine/MachineHudLines.java
+++ b/common/src/client/java/com/logistics/core/machine/MachineHudLines.java
@@ -1,0 +1,28 @@
+package com.logistics.core.machine;
+
+import com.logistics.core.lib.compat.NbtCompat;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Builds the machine HUD lines from the synced tag written by {@code MachineHudData}. Only a progress line
+ * while the machine is actively processing — item slots and energy are already shown by Jade's built-ins.
+ */
+public final class MachineHudLines {
+
+    private MachineHudLines() {}
+
+    public static List<Component> build(CompoundTag data) {
+        List<Component> lines = new ArrayList<>();
+        if (NbtCompat.getBoolean(data, MachineHudData.KEY_PROCESSING, false)) {
+            float progress = NbtCompat.getFloat(data, "progress", 0);
+            lines.add(Component.translatable("jade.logistics.machine.progress")
+                    .append(Component.literal(": "))
+                    .append(Component.literal(String.format("%.0f%%", progress * 100)).withStyle(ChatFormatting.GREEN)));
+        }
+        return lines;
+    }
+}

--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -2,6 +2,7 @@ package com.logistics.automation.kiln;
 
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.block.ProcessingMachine;
 import com.logistics.core.lib.block.behavior.MenuBehavior;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.block.capability.HasItemStorage;
@@ -51,7 +52,7 @@ import com.logistics.core.lib.energy.IEnergyStorage;
  * </ul>
  */
 public class KilnBlockEntity extends BaseBlockEntity
-    implements HasItemStorage, HasEnergyStorage, WorldlyContainer, MenuBehavior.HasMenu {
+    implements HasItemStorage, HasEnergyStorage, WorldlyContainer, MenuBehavior.HasMenu, ProcessingMachine {
 
     static final int INPUT_SLOT = 0;
     static final int OUTPUT_SLOT = 1;
@@ -236,6 +237,22 @@ public class KilnBlockEntity extends BaseBlockEntity
     @Override
     public boolean canTakeItemThroughFace(int slot, ItemStack stack, Direction direction) {
         return direction == Direction.DOWN && slot == OUTPUT_SLOT;
+    }
+
+    // ==================== ProcessingMachine ====================
+
+    @Override
+    public float processProgress() {
+        if (activeRecipe == null) {
+            return 0f;
+        }
+        int total = activeRecipe.value().cookingTime();
+        return total > 0 ? Math.min(1f, (float) processProgress / total) : 0f;
+    }
+
+    @Override
+    public boolean isProcessing() {
+        return activeRecipe != null;
     }
 
     // ==================== Container Delegation ====================

--- a/common/src/main/java/com/logistics/core/lib/block/ProcessingMachine.java
+++ b/common/src/main/java/com/logistics/core/lib/block/ProcessingMachine.java
@@ -1,0 +1,15 @@
+package com.logistics.core.lib.block;
+
+/**
+ * A machine that processes an input over time toward a recipe-defined duration (macerator, kiln, …).
+ * Lives in {@code core.lib} so HUD/integration code can read processing state uniformly without depending
+ * on a specific machine's domain.
+ */
+public interface ProcessingMachine {
+
+    /** Current processing progress as a 0..1 fraction; 0 when idle. */
+    float processProgress();
+
+    /** True while a recipe is being processed, even if currently stalled on power. */
+    boolean isProcessing();
+}

--- a/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/macerator/MaceratorBlockEntity.java
@@ -2,6 +2,7 @@ package com.logistics.core.macerator;
 
 import com.logistics.LogisticsCore;
 import com.logistics.core.lib.block.BaseBlockEntity;
+import com.logistics.core.lib.block.ProcessingMachine;
 import com.logistics.core.lib.block.behavior.MenuBehavior;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.block.capability.HasItemStorage;
@@ -52,7 +53,8 @@ import com.logistics.core.lib.energy.IEnergyStorage;
  * </ul>
  */
 public class MaceratorBlockEntity extends BaseBlockEntity
-    implements HasItemStorage, HasEnergyStorage, WorldlyContainer, MenuBehavior.HasMenu, EnergyDemandProvider {
+    implements HasItemStorage, HasEnergyStorage, WorldlyContainer, MenuBehavior.HasMenu, EnergyDemandProvider,
+        ProcessingMachine {
 
     static final int INPUT_SLOT = 0;
     static final int OUTPUT_SLOT = 1;
@@ -250,6 +252,22 @@ public class MaceratorBlockEntity extends BaseBlockEntity
         long storageRoom = Math.max(0, ENERGY_CAPACITY - energy.getAmount());
         long remainingInput = Math.max(0, MAX_ENERGY_INPUT - energyReceivedThisTick);
         return Math.min(remainingInput, storageRoom);
+    }
+
+    // ==================== ProcessingMachine ====================
+
+    @Override
+    public float processProgress() {
+        if (activeRecipe == null) {
+            return 0f;
+        }
+        int total = activeRecipe.value().grindingTime();
+        return total > 0 ? Math.min(1f, (float) processProgress / total) : 0f;
+    }
+
+    @Override
+    public boolean isProcessing() {
+        return activeRecipe != null;
     }
 
     // ==================== WorldlyContainer (Sided Inventory) ====================

--- a/common/src/main/java/com/logistics/core/machine/MachineHudData.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineHudData.java
@@ -1,0 +1,25 @@
+package com.logistics.core.machine;
+
+import com.logistics.core.lib.block.ProcessingMachine;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+/**
+ * Server-side capture of a processing machine's progress into the tag a look-at HUD (Jade) syncs to the
+ * client. Works off the {@link ProcessingMachine} contract, so it covers the macerator, kiln, and any
+ * future machine without depending on a specific domain. Read back by the client-side {@code MachineHudLines}.
+ */
+public final class MachineHudData {
+
+    /** NBT key whose presence marks that the tag carries machine processing state. */
+    public static final String KEY_PROCESSING = "processing";
+
+    private MachineHudData() {}
+
+    public static void write(CompoundTag data, BlockEntity blockEntity) {
+        if (blockEntity instanceof ProcessingMachine machine) {
+            data.putBoolean(KEY_PROCESSING, machine.isProcessing());
+            data.putFloat("progress", machine.processProgress());
+        }
+    }
+}

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -225,6 +225,7 @@
   "jade.logistics.quarry.phase.finished": "Finished",
   "jade.logistics.quarry.power_in": "Power In",
   "jade.logistics.quarry.arm_speed": "Arm Speed",
+  "jade.logistics.machine.progress": "Progress",
 
   "tag.item.c.ingots.tin": "Tin Ingots",
   "tag.item.c.ingots.bronze": "Bronze Ingots",

--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -1,8 +1,10 @@
 package com.logistics.compat.jade;
 
 import com.logistics.LogisticsMod;
+import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
+import com.logistics.core.macerator.MaceratorBlock;
 import com.logistics.power.block.CreativeSinkBlock;
 import com.logistics.power.cable.CableBlock;
 import snownee.jade.api.IWailaClientRegistration;
@@ -15,8 +17,9 @@ import snownee.jade.api.WailaPlugin;
  * {@code "jade"} entrypoint in fabric.mod.json — so it only initializes when Jade is actually installed.
  *
  * <p>Per-block content is added in stacked passes; see {@code EngineServerDataProvider} /
- * {@code EngineComponentProvider} for engines, {@code PowerInfra*Provider} for cables and the sink, and
- * {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser quarry.
+ * {@code EngineComponentProvider} for engines, {@code PowerInfra*Provider} for cables and the sink,
+ * {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser quarry, and
+ * {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -26,6 +29,8 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(EngineServerDataProvider.INSTANCE, AbstractEngineBlock.class);
         registration.registerBlockDataProvider(PowerInfraServerDataProvider.INSTANCE, CreativeSinkBlock.class);
         registration.registerBlockDataProvider(QuarryServerDataProvider.INSTANCE, LaserQuarryBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, MaceratorBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, KilnBlock.class);
     }
 
     @Override
@@ -34,5 +39,7 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CableBlock.class);
         registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CreativeSinkBlock.class);
         registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, MaceratorBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
     }
 }

--- a/fabric/src/client/java/com/logistics/compat/jade/MachineComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/MachineComponentProvider.java
@@ -1,0 +1,35 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.core.machine.MachineHudLines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the processing-machine Jade integration: renders the progress synced by
+ * {@link MachineServerDataProvider}. Formatting is shared in {@link MachineHudLines}.
+ */
+public final class MachineComponentProvider implements IBlockComponentProvider {
+    public static final MachineComponentProvider INSTANCE = new MachineComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("machine").toIdentifier();
+
+    private MachineComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        for (Component line : MachineHudLines.build(accessor.getServerData())) {
+            tooltip.add(line);
+        }
+    }
+}

--- a/fabric/src/client/java/com/logistics/compat/jade/MachineServerDataProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/MachineServerDataProvider.java
@@ -1,0 +1,31 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.core.machine.MachineHudData;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the processing-machine Jade integration (macerator, kiln): captures progress into the
+ * synced tag. The client half is {@link MachineComponentProvider}; logic is shared in {@link MachineHudData}.
+ */
+public final class MachineServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final MachineServerDataProvider INSTANCE = new MachineServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("machine").toIdentifier();
+
+    private MachineServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        MachineHudData.write(data, accessor.getBlockEntity());
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -1,8 +1,10 @@
 package com.logistics.neoforge.client.compat;
 
 import com.logistics.LogisticsMod;
+import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
+import com.logistics.core.macerator.MaceratorBlock;
 import com.logistics.power.block.CreativeSinkBlock;
 import com.logistics.power.cable.CableBlock;
 import snownee.jade.api.IWailaClientRegistration;
@@ -17,8 +19,8 @@ import snownee.jade.api.WailaPlugin;
  * <p>Client-only by nature (Jade is a client mod), hence the {@code com.logistics.neoforge.client} package
  * required by the NeoForge source-isolation rules. Per-block content is added in stacked passes; see
  * {@code EngineServerDataProvider} / {@code EngineComponentProvider} for engines, {@code PowerInfra*Provider}
- * for cables and the sink, and {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the
- * laser quarry.
+ * for cables and the sink, {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser
+ * quarry, and {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -28,6 +30,8 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(EngineServerDataProvider.INSTANCE, AbstractEngineBlock.class);
         registration.registerBlockDataProvider(PowerInfraServerDataProvider.INSTANCE, CreativeSinkBlock.class);
         registration.registerBlockDataProvider(QuarryServerDataProvider.INSTANCE, LaserQuarryBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, MaceratorBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, KilnBlock.class);
     }
 
     @Override
@@ -36,5 +40,7 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CableBlock.class);
         registration.registerBlockComponent(PowerInfraComponentProvider.INSTANCE, CreativeSinkBlock.class);
         registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, MaceratorBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineComponentProvider.java
@@ -1,0 +1,35 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.core.machine.MachineHudLines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Client half of the processing-machine Jade integration: renders the progress synced by
+ * {@link MachineServerDataProvider}. Formatting is shared in {@link MachineHudLines}.
+ */
+public final class MachineComponentProvider implements IBlockComponentProvider {
+    public static final MachineComponentProvider INSTANCE = new MachineComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("machine").toIdentifier();
+
+    private MachineComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        for (Component line : MachineHudLines.build(accessor.getServerData())) {
+            tooltip.add(line);
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineServerDataProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineServerDataProvider.java
@@ -1,0 +1,31 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.core.machine.MachineHudData;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+/**
+ * Server half of the processing-machine Jade integration (macerator, kiln): captures progress into the
+ * synced tag. The client half is {@link MachineComponentProvider}; logic is shared in {@link MachineHudData}.
+ */
+public final class MachineServerDataProvider implements IServerDataProvider<BlockAccessor> {
+    public static final MachineServerDataProvider INSTANCE = new MachineServerDataProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("machine").toIdentifier();
+
+    private MachineServerDataProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, BlockAccessor accessor) {
+        MachineHudData.write(data, accessor.getBlockEntity());
+    }
+}


### PR DESCRIPTION
## Summary
Adds processing progress to the Jade HUD for the macerator and kiln. Builds on the base Jade integration (#488, now merged).

## Changes
- Looking at a **Macerator** or **Kiln** that's working now shows a **Progress: NN%** line (alongside Jade's built-in item slots and energy bar). Idle machines show no extra line.
- Introduces a small `ProcessingMachine` interface in `core.lib` (`processProgress()` / `isProcessing()`) implemented by both machines, so the HUD reads progress uniformly and future machines get it for free.

## Notes
- Capture/format logic lives in common (`MachineHudData` / `MachineHudLines`); each loader has a thin server-data + component provider, matching the engine, power-infra, and quarry passes.
- Supersedes #491 (closed when its base branch was merged; recreated against `mc/26.1`).
