### PR TITLE
feat(pipes): show pipe contents in the Jade HUD

### DIFF
--- a/common/src/client/java/com/logistics/pipe/PipeHudLines.java
+++ b/common/src/client/java/com/logistics/pipe/PipeHudLines.java
@@ -32,12 +32,12 @@ public final class PipeHudLines {
             int shown = Math.min(items.size(), MAX_DETAIL_ITEMS);
             for (int i = 0; i < shown; i++) {
                 TravelingItem item = items.get(i);
-                String text = String.format(
-                        "%dx %s → %s",
-                        item.getStack().getCount(),
-                        item.getStack().getHoverName().getString(),
-                        item.getDirection().name());
-                lines.add(Component.literal(text).withStyle(ChatFormatting.AQUA));
+                // Append the hover name as a Component so colored/renamed items keep their styling.
+                Component line = Component.literal(item.getStack().getCount() + "x ")
+                        .append(item.getStack().getHoverName())
+                        .append(Component.literal(" → " + item.getDirection().name()))
+                        .withStyle(ChatFormatting.AQUA);
+                lines.add(line);
             }
             if (items.size() > shown) {
                 lines.add(Component.translatable("jade.logistics.pipe.more", items.size() - shown)

--- a/common/src/client/java/com/logistics/pipe/PipeHudLines.java
+++ b/common/src/client/java/com/logistics/pipe/PipeHudLines.java
@@ -1,0 +1,50 @@
+package com.logistics.pipe;
+
+import com.logistics.core.lib.pipe.TravelingItem;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Builds the pipe HUD lines from the traveling items the pipe is carrying (synced for rendering, so read
+ * client-side — no server data round-trip). The count shows always; the per-item breakdown shows when
+ * Jade's details key is held.
+ */
+public final class PipeHudLines {
+
+    /** Cap on per-item detail lines so a busy pipe can't blow up the tooltip. */
+    private static final int MAX_DETAIL_ITEMS = 5;
+
+    private PipeHudLines() {}
+
+    public static List<Component> build(List<TravelingItem> items, boolean showDetails) {
+        List<Component> lines = new ArrayList<>();
+        if (items.isEmpty()) {
+            return lines;
+        }
+
+        lines.add(Component.translatable("jade.logistics.pipe.items")
+                .append(Component.literal(": "))
+                .append(Component.literal(String.valueOf(items.size())).withStyle(ChatFormatting.WHITE)));
+
+        if (showDetails) {
+            int shown = Math.min(items.size(), MAX_DETAIL_ITEMS);
+            for (int i = 0; i < shown; i++) {
+                TravelingItem item = items.get(i);
+                String text = String.format(
+                        "%dx %s → %s",
+                        item.getStack().getCount(),
+                        item.getStack().getHoverName().getString(),
+                        item.getDirection().name());
+                lines.add(Component.literal(text).withStyle(ChatFormatting.AQUA));
+            }
+            if (items.size() > shown) {
+                lines.add(Component.translatable("jade.logistics.pipe.more", items.size() - shown)
+                        .withStyle(ChatFormatting.GRAY));
+            }
+        }
+
+        return lines;
+    }
+}

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -226,6 +226,8 @@
   "jade.logistics.quarry.power_in": "Power In",
   "jade.logistics.quarry.arm_speed": "Arm Speed",
   "jade.logistics.machine.progress": "Progress",
+  "jade.logistics.pipe.items": "Items",
+  "jade.logistics.pipe.more": "+%s more",
 
   "tag.item.c.ingots.tin": "Tin Ingots",
   "tag.item.c.ingots.bronze": "Bronze Ingots",

--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -5,6 +5,7 @@ import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.core.macerator.MaceratorBlock;
+import com.logistics.pipe.block.PipeBlock;
 import com.logistics.power.block.CreativeSinkBlock;
 import com.logistics.power.cable.CableBlock;
 import snownee.jade.api.IWailaClientRegistration;
@@ -18,8 +19,9 @@ import snownee.jade.api.WailaPlugin;
  *
  * <p>Per-block content is added in stacked passes; see {@code EngineServerDataProvider} /
  * {@code EngineComponentProvider} for engines, {@code PowerInfra*Provider} for cables and the sink,
- * {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser quarry, and
- * {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln.
+ * {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser quarry,
+ * {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln, and
+ * {@code PipeComponentProvider} for pipes.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -41,5 +43,6 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, MaceratorBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
+        registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
     }
 }

--- a/fabric/src/client/java/com/logistics/compat/jade/PipeComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/PipeComponentProvider.java
@@ -1,0 +1,39 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import com.logistics.pipe.PipeHudLines;
+import com.logistics.pipe.block.entity.PipeBlockEntity;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Jade integration for pipes: shows how many items are in transit and, on the details key, each item's
+ * destination and progress. Traveling items are synced for rendering, so this reads the client block
+ * entity directly — no server-data provider needed. Formatting is shared in {@link PipeHudLines}.
+ */
+public final class PipeComponentProvider implements IBlockComponentProvider {
+    public static final PipeComponentProvider INSTANCE = new PipeComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("pipe").toIdentifier();
+
+    private PipeComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        if (accessor.getBlockEntity() instanceof PipeBlockEntity pipe) {
+            for (Component line : PipeHudLines.build(pipe.getTravelingItems(), accessor.showDetails())) {
+                tooltip.add(line);
+            }
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -5,6 +5,7 @@ import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.core.macerator.MaceratorBlock;
+import com.logistics.pipe.block.PipeBlock;
 import com.logistics.power.block.CreativeSinkBlock;
 import com.logistics.power.cable.CableBlock;
 import snownee.jade.api.IWailaClientRegistration;
@@ -20,7 +21,8 @@ import snownee.jade.api.WailaPlugin;
  * required by the NeoForge source-isolation rules. Per-block content is added in stacked passes; see
  * {@code EngineServerDataProvider} / {@code EngineComponentProvider} for engines, {@code PowerInfra*Provider}
  * for cables and the sink, {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser
- * quarry, and {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln.
+ * quarry, {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln,
+ * and {@code PipeComponentProvider} for pipes.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -42,5 +44,6 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, MaceratorBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
+        registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/PipeComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/PipeComponentProvider.java
@@ -1,0 +1,39 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import com.logistics.pipe.PipeHudLines;
+import com.logistics.pipe.block.entity.PipeBlockEntity;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Jade integration for pipes: shows how many items are in transit and, on the details key, each item's
+ * destination and progress. Traveling items are synced for rendering, so this reads the client block
+ * entity directly — no server-data provider needed. Formatting is shared in {@link PipeHudLines}.
+ */
+public final class PipeComponentProvider implements IBlockComponentProvider {
+    public static final PipeComponentProvider INSTANCE = new PipeComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("pipe").toIdentifier();
+
+    private PipeComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        if (accessor.getBlockEntity() instanceof PipeBlockEntity pipe) {
+            for (Component line : PipeHudLines.build(pipe.getTravelingItems(), accessor.showDetails())) {
+                tooltip.add(line);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds in-transit pipe contents to the Jade HUD. Builds on the base Jade integration (#488, now merged).

## Changes
- Looking at a pipe carrying items shows **Items: N** at a glance.
- On Jade's "show details" key, each item in transit is listed as `2x Iron Ingot → NORTH` (capped at 5, then `+N more`).
- Empty pipes show no extra line.

## Notes
- Client-only: traveling items are already synced for the in-pipe animation, so this reads the client block entity directly — no server-data round-trip. Formatting lives in common (`PipeHudLines`).
- Module/filter/config readouts (provider/requester/chassis, etc.) are a follow-up stacked on this (#493).
- Supersedes #492 (closed when its base branch was merged; recreated against `mc/26.1`).
