### PR TITLE
fix(pipes): apply config changes to modules installed in a chassis

### DIFF
--- a/common/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/AdvancedExtractorModule.java
@@ -136,9 +136,10 @@ public class AdvancedExtractorModule implements Module, TickingModule {
         if (ctx.world().isClientSide()) return InteractionResult.SUCCESS;
         if (!(player instanceof ServerPlayer serverPlayer)) return InteractionResult.PASS;
 
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, playerInventory, p) -> new AdvancedExtractorScreenHandler(
-                        syncId, playerInventory, ((PipeBlockEntity) ctx.blockEntity())),
+                        syncId, playerInventory, ((PipeBlockEntity) ctx.blockEntity()), moduleStateKey),
                 Component.translatable("screen.logistics.advanced_extractor")));
         return InteractionResult.SUCCESS;
     }

--- a/common/src/main/java/com/logistics/pipe/modules/CraftingModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/CraftingModule.java
@@ -1147,9 +1147,10 @@ public class CraftingModule implements Module, TickingModule, RoutingModule, Dis
         if (ctx.world().isClientSide()) return InteractionResult.SUCCESS;
         if (!(player instanceof ServerPlayer serverPlayer)) return InteractionResult.PASS;
 
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
-                (syncId, playerInventory, p) ->
-                        new CraftingScreenHandler(syncId, playerInventory, ((PipeBlockEntity) ctx.blockEntity())),
+                (syncId, playerInventory, p) -> new CraftingScreenHandler(
+                        syncId, playerInventory, ((PipeBlockEntity) ctx.blockEntity()), moduleStateKey),
                 Component.translatable("screen.logistics.crafting")));
 
         return InteractionResult.SUCCESS;

--- a/common/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
@@ -93,11 +93,12 @@ public class ItemFilterModule implements Module, RoutingModule {
 
         Level world = ctx.world();
         BlockPos pos = ctx.pos();
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new net.minecraft.world.SimpleMenuProvider(
                 (syncId, inventory, playerEntity) -> {
                     PipeBlockEntity pipeEntity =
                             world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null;
-                    return new ItemFilterScreenHandler(syncId, inventory, pipeEntity);
+                    return new ItemFilterScreenHandler(syncId, inventory, pipeEntity, moduleStateKey);
                 },
                 Component.translatable("screen.logistics.item_filter")));
         return InteractionResult.SUCCESS;

--- a/common/src/main/java/com/logistics/pipe/modules/ModSinkModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ModSinkModule.java
@@ -92,10 +92,12 @@ public class ModSinkModule implements Module, TickingModule, RoutingModule, Item
         if (!(player instanceof ServerPlayer serverPlayer)) return InteractionResult.PASS;
         Level world = ctx.world();
         BlockPos pos = ctx.pos();
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, inventory, p) -> new ModSinkScreenHandler(
                         syncId, inventory,
-                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null),
+                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null,
+                        moduleStateKey),
                 Component.translatable("screen.logistics.mod_sink")));
         return InteractionResult.SUCCESS;
     }

--- a/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
@@ -285,9 +285,11 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
 
         Level world = ctx.world();
         BlockPos pos = ctx.pos();
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, inv, p) -> new ProcessScreenHandler(syncId, inv,
-                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null),
+                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null,
+                        moduleStateKey),
                 Component.translatable("screen.logistics.process")));
         return InteractionResult.SUCCESS;
     }

--- a/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -415,9 +415,10 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
         if (ctx.world().isClientSide()) return InteractionResult.SUCCESS;
         if (!(player instanceof ServerPlayer serverPlayer)) return InteractionResult.PASS;
 
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, playerInventory, p) -> new ProviderScreenHandler(
-                        syncId, playerInventory, ((PipeBlockEntity) ctx.blockEntity())),
+                        syncId, playerInventory, ((PipeBlockEntity) ctx.blockEntity()), moduleStateKey),
                 Component.translatable("screen.logistics.provider")));
 
         return InteractionResult.SUCCESS;

--- a/common/src/main/java/com/logistics/pipe/modules/RequesterModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/RequesterModule.java
@@ -93,11 +93,13 @@ public class RequesterModule implements Module, TickingModule {
 
         Level world = ctx.world();
         BlockPos pos = ctx.pos();
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, inventory, p) -> new RequesterScreenHandler(
                         syncId,
                         inventory,
-                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null
+                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null,
+                        moduleStateKey
                 ),
                 Component.translatable("screen.logistics.requester")
         ));

--- a/common/src/main/java/com/logistics/pipe/modules/SatelliteModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/SatelliteModule.java
@@ -115,10 +115,12 @@ public class SatelliteModule implements Module, TickingModule, RoutingModule {
 
         Level world = ctx.world();
         var pos = ctx.pos();
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, inv, p) -> new SatelliteScreenHandler(
                         syncId, inv,
-                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null),
+                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null,
+                        moduleStateKey),
                 Component.translatable("screen.logistics.satellite")));
         return InteractionResult.SUCCESS;
     }

--- a/common/src/main/java/com/logistics/pipe/modules/SinkModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/SinkModule.java
@@ -117,11 +117,13 @@ public class SinkModule implements Module, TickingModule, RoutingModule, ItemAcc
 
         Level world = ctx.world();
         BlockPos pos = ctx.pos();
+        String moduleStateKey = ctx.moduleStateKey(this);
         serverPlayer.openMenu(new SimpleMenuProvider(
                 (syncId, inventory, p) -> new SinkScreenHandler(
                         syncId,
                         inventory,
-                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null
+                        world.getBlockEntity(pos) instanceof PipeBlockEntity entity ? entity : null,
+                        moduleStateKey
                 ),
                 Component.translatable("screen.logistics.sink.requested_items")
         ));

--- a/common/src/main/java/com/logistics/pipe/ui/AdvancedExtractorFilterInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/AdvancedExtractorFilterInventory.java
@@ -3,9 +3,7 @@ package com.logistics.pipe.ui;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.filter.FilterSlots;
 import com.logistics.core.lib.compat.NbtCompat;
-import com.logistics.pipe.Pipe;
 import com.logistics.core.lib.pipe.PipeContext;
-import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.AdvancedExtractorModule;
 import net.minecraft.core.NonNullList;
@@ -15,6 +13,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Inventory for the Advanced Extractor filter GUI.
@@ -26,9 +25,15 @@ public class AdvancedExtractorFilterInventory implements Container {
     private final NonNullList<ItemStack> stacks =
             NonNullList.withSize(FILTER_SLOT_COUNT, ItemStack.EMPTY);
     private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     public AdvancedExtractorFilterInventory(PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public AdvancedExtractorFilterInventory(PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
         if (pipeEntity != null) {
             loadFromModule();
         }
@@ -81,12 +86,14 @@ public class AdvancedExtractorFilterInventory implements Container {
 
         if (pipeEntity.getLevel() == null || pipeEntity.getLevel().isClientSide()) return;
 
-        PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-        Pipe pipe = block.getPipe();
-        AdvancedExtractorModule module = pipe.getModule(AdvancedExtractorModule.class, pipeEntity);
+        AdvancedExtractorModule module =
+                PipeModuleHelper.getModule(pipeEntity, AdvancedExtractorModule.class, targetModuleStateKey);
         if (module == null) return;
 
         PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
         FilterSlots filterItems = module.getFilterItems(ctx);
 
         for (int i = 0; i < filterItems.size(); i++) {

--- a/common/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -37,16 +37,22 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
     private final ContainerData data;
     private final AdvancedExtractorFilterInventory filterInventory;
     private final ContainerLevelAccess context;
+    @Nullable private final String targetModuleStateKey;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
     @Nullable private final ItemStack pinnedStack;
 
     public AdvancedExtractorScreenHandler(int syncId, Container playerInventory) {
-        this(syncId, playerInventory, null, new SimpleContainerData(1));
+        this(syncId, playerInventory, null, null, new SimpleContainerData(1));
     }
 
     public AdvancedExtractorScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
-        this(syncId, playerInventory, pipeEntity, new SimpleContainerData(1));
+        this(syncId, playerInventory, pipeEntity, null, new SimpleContainerData(1));
+    }
+
+    public AdvancedExtractorScreenHandler(
+            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
+        this(syncId, playerInventory, pipeEntity, targetModuleStateKey, new SimpleContainerData(1));
     }
 
     public AdvancedExtractorScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
@@ -54,6 +60,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
         this.data = new SimpleContainerData(1);
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
+        this.targetModuleStateKey = null;
         this.context = ContainerLevelAccess.NULL;
         ItemStack stack = player.getItemInHand(hand);
         this.pinnedStack = stack;
@@ -69,17 +76,22 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
     }
 
     private AdvancedExtractorScreenHandler(
-            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
+            int syncId,
+            Container playerInventory,
+            PipeBlockEntity pipeEntity,
+            @Nullable String targetModuleStateKey,
+            ContainerData data) {
         super(LogisticsPipe.SCREEN.ADVANCED_EXTRACTOR, syncId);
         this.data = data;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.pinnedStack = null;
-        this.filterInventory = new AdvancedExtractorFilterInventory(pipeEntity);
+        this.filterInventory = new AdvancedExtractorFilterInventory(pipeEntity, targetModuleStateKey);
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
-            PipeModuleHelper.withModule(pipeEntity, AdvancedExtractorModule.class, (ctx, module) ->
+            PipeModuleHelper.withModule(pipeEntity, AdvancedExtractorModule.class, targetModuleStateKey, (ctx, module) ->
                     data.set(0, module.isFilterInverted(ctx) ? 1 : 0));
         } else {
             this.context = ContainerLevelAccess.NULL;
@@ -148,7 +160,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                     });
                 } else {
                     filterInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
+                    PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, targetModuleStateKey, (ctx, module) ->
                             module.setFilterItem(ctx, slotIndex, ""));
                 }
                 broadcastChanges();
@@ -168,7 +180,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                 });
             } else {
                 filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
-                PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
+                PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, targetModuleStateKey, (ctx, module) ->
                         module.setFilterItem(ctx, slotIndex, itemId));
             }
             broadcastChanges();
@@ -187,7 +199,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                 if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> tag.putInt(AdvancedExtractorModule.FILTER_INVERTED, newInverted));
             } else {
-                PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
+                PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, targetModuleStateKey, (ctx, module) ->
                         module.setFilterInverted(ctx, newInverted == 1));
             }
             return true;
@@ -214,7 +226,7 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
             super.broadcastChanges();
             return;
         }
-        PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, (ctx, module) ->
+        PipeModuleHelper.withModule(context, AdvancedExtractorModule.class, targetModuleStateKey, (ctx, module) ->
                 data.set(0, module.isFilterInverted(ctx) ? 1 : 0));
         super.broadcastChanges();
     }

--- a/common/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/CraftingRecipeInventory.java
@@ -1,9 +1,7 @@
 package com.logistics.pipe.ui;
 
 import com.logistics.core.lib.resource.ResourceId;
-import com.logistics.pipe.Pipe;
 import com.logistics.core.lib.pipe.PipeContext;
-import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.CraftingModule;
 import net.minecraft.core.NonNullList;
@@ -13,6 +11,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Inventory for the Crafting Logistics Pipe GUI.
@@ -22,9 +21,15 @@ public class CraftingRecipeInventory implements Container {
     private static final int SLOT_COUNT = 10; // 9 ingredients + 1 result
     private final NonNullList<ItemStack> stacks = NonNullList.withSize(SLOT_COUNT, ItemStack.EMPTY);
     private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     public CraftingRecipeInventory(PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public CraftingRecipeInventory(PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
         if (pipeEntity != null) {
             loadFromModule();
         }
@@ -90,12 +95,13 @@ public class CraftingRecipeInventory implements Container {
         if (pipeEntity == null) return;
         if (pipeEntity.getLevel() == null || pipeEntity.getLevel().isClientSide()) return;
 
-        PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-        Pipe pipe = block.getPipe();
-        CraftingModule module = pipe.getModule(CraftingModule.class, pipeEntity);
+        CraftingModule module = PipeModuleHelper.getModule(pipeEntity, CraftingModule.class, targetModuleStateKey);
         if (module == null) return;
 
         PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
 
         // Load ingredient slots 0-8
         for (int slot = 0; slot < 9; slot++) {

--- a/common/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -39,22 +39,29 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
     private final CraftingRecipeInventory recipeInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final String targetModuleStateKey;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
     @Nullable private final ItemStack pinnedStack;
 
     public CraftingScreenHandler(int syncId, Container playerInventory) {
-        this(syncId, playerInventory, null, new SimpleContainerData(2));
+        this(syncId, playerInventory, null, null, new SimpleContainerData(2));
     }
 
     public CraftingScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
-        this(syncId, playerInventory, pipeEntity, new SimpleContainerData(2));
+        this(syncId, playerInventory, pipeEntity, null, new SimpleContainerData(2));
+    }
+
+    public CraftingScreenHandler(
+            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
+        this(syncId, playerInventory, pipeEntity, targetModuleStateKey, new SimpleContainerData(2));
     }
 
     /** Item-mode constructor: backs the screen with a module item in the player's hand. */
     public CraftingScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
         super(LogisticsPipe.SCREEN.CRAFTING, syncId);
         this.data = new SimpleContainerData(2);
+        this.targetModuleStateKey = null;
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
@@ -76,17 +83,22 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
     }
 
     private CraftingScreenHandler(
-            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
+            int syncId,
+            Container playerInventory,
+            PipeBlockEntity pipeEntity,
+            @Nullable String targetModuleStateKey,
+            ContainerData data) {
         super(LogisticsPipe.SCREEN.CRAFTING, syncId);
         this.data = data;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.pinnedStack = null;
-        this.recipeInventory = new CraftingRecipeInventory(pipeEntity);
+        this.recipeInventory = new CraftingRecipeInventory(pipeEntity, targetModuleStateKey);
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
-            PipeModuleHelper.withModule(pipeEntity, CraftingModule.class, (ctx, module) -> {
+            PipeModuleHelper.withModule(pipeEntity, CraftingModule.class, targetModuleStateKey, (ctx, module) -> {
                 data.set(DATA_CRAFT_STATE, module.isActive(ctx) ? 1 : 0);
                 data.set(DATA_BLOCKING, module.isBlocking(ctx) ? 1 : 0);
             });
@@ -188,7 +200,8 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             });
         } else {
             recipeInventory.setItem(RESULT_SLOT, ItemStack.EMPTY);
-            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, "", 1));
+            PipeModuleHelper.withModule(
+                    context, CraftingModule.class, targetModuleStateKey, (ctx, module) -> module.setResult(ctx, "", 1));
         }
     }
 
@@ -206,7 +219,11 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             });
         } else {
             recipeInventory.setItem(slot, ItemStack.EMPTY);
-            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, slot, "", 1));
+            PipeModuleHelper.withModule(
+                    context,
+                    CraftingModule.class,
+                    targetModuleStateKey,
+                    (ctx, module) -> module.setIngredient(ctx, slot, "", 1));
         }
     }
 
@@ -220,7 +237,11 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             });
         } else {
             recipeInventory.setItem(RESULT_SLOT, display);
-            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setResult(ctx, itemId, count));
+            PipeModuleHelper.withModule(
+                    context,
+                    CraftingModule.class,
+                    targetModuleStateKey,
+                    (ctx, module) -> module.setResult(ctx, itemId, count));
         }
     }
 
@@ -238,7 +259,11 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             });
         } else {
             recipeInventory.setItem(slot, display);
-            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.setIngredient(ctx, slot, itemId, count));
+            PipeModuleHelper.withModule(
+                    context,
+                    CraftingModule.class,
+                    targetModuleStateKey,
+                    (ctx, module) -> module.setIngredient(ctx, slot, itemId, count));
         }
     }
 
@@ -252,7 +277,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
                 if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(CraftingModule.BLOCKING, newBlocking));
             } else {
-                PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
+                PipeModuleHelper.withModule(context, CraftingModule.class, targetModuleStateKey, (ctx, module) -> {
                     module.setBlocking(ctx, newBlocking == 1);
                 });
             }
@@ -260,7 +285,11 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
         }
         if (id == 1 && itemConfigPlayer == null) {
             // Import recipe from adjacent autocrafter
-            PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> module.importFromAutocrafter(ctx));
+            PipeModuleHelper.withModule(
+                    context,
+                    CraftingModule.class,
+                    targetModuleStateKey,
+                    (ctx, module) -> module.importFromAutocrafter(ctx));
             recipeInventory.loadFromModule();
             broadcastChanges();
             return true;
@@ -284,7 +313,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             super.broadcastChanges();
             return;
         }
-        PipeModuleHelper.withModule(context, CraftingModule.class, (ctx, module) -> {
+        PipeModuleHelper.withModule(context, CraftingModule.class, targetModuleStateKey, (ctx, module) -> {
             data.set(DATA_CRAFT_STATE, module.isActive(ctx) ? 1 : 0);
             data.set(DATA_BLOCKING, module.isBlocking(ctx) ? 1 : 0);
         });

--- a/common/src/main/java/com/logistics/pipe/ui/FilterInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/FilterInventory.java
@@ -22,15 +22,22 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
 
 public class FilterInventory implements Container {
     private final NonNullList<ItemStack> stacks = NonNullList.withSize(
             ItemFilterModule.FILTER_ORDER.length * ItemFilterModule.FILTER_SLOTS_PER_SIDE, ItemStack.EMPTY);
     private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
     private final ItemFilterModule module;
 
     public FilterInventory(PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public FilterInventory(PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.module = getModuleFromPipe(pipeEntity);
 
         if (pipeEntity != null) {
@@ -43,10 +50,8 @@ public class FilterInventory implements Container {
             return new ItemFilterModule();
         }
 
-        com.logistics.pipe.block.PipeBlock block =
-                (com.logistics.pipe.block.PipeBlock) entity.getBlockState().getBlock();
-        com.logistics.pipe.Pipe pipe = block.getPipe();
-        ItemFilterModule pipeModule = pipe.getModule(ItemFilterModule.class, entity);
+        ItemFilterModule pipeModule =
+                PipeModuleHelper.getModule(entity, ItemFilterModule.class, targetModuleStateKey);
 
         return pipeModule != null ? pipeModule : new ItemFilterModule();
     }
@@ -127,6 +132,9 @@ public class FilterInventory implements Container {
     private void loadFromBlockEntity() {
         int slotIndex = 0;
         PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
         for (Direction direction : ItemFilterModule.FILTER_ORDER) {
             List<ItemStack> filterStacks = module.getFilterStacks(ctx, direction);
             for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
@@ -185,6 +193,9 @@ public class FilterInventory implements Container {
 
         int slotIndex = 0;
         PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
         for (Direction direction : ItemFilterModule.FILTER_ORDER) {
             List<ItemStack> slots = new ArrayList<>(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
             for (int i = 0; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {

--- a/common/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
@@ -34,6 +34,7 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
 
     private final FilterInventory filterInventory;
     private final ContainerLevelAccess context;
+    @Nullable private final String targetModuleStateKey;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
     @Nullable private final ItemStack originalStack;
@@ -41,6 +42,7 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
     public ItemFilterScreenHandler(int syncId, Container playerInventory) {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
         this.context = ContainerLevelAccess.NULL;
+        this.targetModuleStateKey = null;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.originalStack = null;
@@ -51,7 +53,13 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
     }
 
     public ItemFilterScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
+        this(syncId, playerInventory, pipeEntity, null);
+    }
+
+    public ItemFilterScreenHandler(
+            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
+        this.targetModuleStateKey = targetModuleStateKey;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.originalStack = null;
@@ -60,7 +68,7 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
         } else {
             this.context = ContainerLevelAccess.NULL;
         }
-        this.filterInventory = new FilterInventory(pipeEntity);
+        this.filterInventory = new FilterInventory(pipeEntity, targetModuleStateKey);
 
         addFilterSlots(filterInventory);
         addPlayerInventorySlots(playerInventory);
@@ -68,6 +76,7 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
 
     public ItemFilterScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
         super(LogisticsPipe.SCREEN.ITEM_FILTER, syncId);
+        this.targetModuleStateKey = null;
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
         this.originalStack = player.getItemInHand(hand);

--- a/common/src/main/java/com/logistics/pipe/ui/ModSinkInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ModSinkInventory.java
@@ -2,8 +2,7 @@ package com.logistics.pipe.ui;
 
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.compat.NbtCompat;
-import com.logistics.pipe.Pipe;
-import com.logistics.pipe.block.PipeBlock;
+import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.ModSinkModule;
 import net.minecraft.core.NonNullList;
@@ -14,6 +13,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Ghost inventory backing the mod filter display slots in the Mod-Based Item Sink GUI.
@@ -25,20 +25,30 @@ import net.minecraft.world.item.component.CustomData;
 public class ModSinkInventory implements Container {
     private final NonNullList<ItemStack> items =
             NonNullList.withSize(ModSinkModule.MAX_FILTERS, ItemStack.EMPTY);
+    @Nullable private final String targetModuleStateKey;
 
     public ModSinkInventory(@SuppressWarnings("unused") PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public ModSinkInventory(@SuppressWarnings("unused") PipeBlockEntity pipeEntity,
+            @Nullable String targetModuleStateKey) {
+        this.targetModuleStateKey = targetModuleStateKey;
         if (pipeEntity != null) {
             loadFilters(pipeEntity);
         }
     }
 
     private void loadFilters(PipeBlockEntity pipeEntity) {
-        PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-        Pipe pipe = block.getPipe();
-        ModSinkModule module = pipe.getModule(ModSinkModule.class, pipeEntity);
+        ModSinkModule module =
+                PipeModuleHelper.getModule(pipeEntity, ModSinkModule.class, targetModuleStateKey);
         if (module == null) return;
 
-        String[] filterIds = module.getFilterItemIds(pipeEntity.createContext());
+        PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
+        String[] filterIds = module.getFilterItemIds(ctx);
         for (int i = 0; i < filterIds.length; i++) {
             if (filterIds[i].isEmpty()) continue;
             ResourceId rid = ResourceId.tryParse(filterIds[i]);

--- a/common/src/main/java/com/logistics/pipe/ui/ModSinkScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ModSinkScreenHandler.java
@@ -48,6 +48,7 @@ public class ModSinkScreenHandler extends AbstractContainerMenu {
     private final SimpleContainer previewContainer = new SimpleContainer(1);
     private final ModSinkInventory modSinkInventory;
     private final ContainerLevelAccess context;
+    @Nullable private final String targetModuleStateKey;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
     @Nullable private final ItemStack originalModuleStack;
@@ -58,14 +59,20 @@ public class ModSinkScreenHandler extends AbstractContainerMenu {
 
     public ModSinkScreenHandler(int syncId, Container playerInventory,
             @Nullable PipeBlockEntity pipeEntity) {
+        this(syncId, playerInventory, pipeEntity, null);
+    }
+
+    public ModSinkScreenHandler(int syncId, Container playerInventory,
+            @Nullable PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         super(LogisticsPipe.SCREEN.MOD_SINK, syncId);
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.originalModuleStack = null;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.context = pipeEntity != null
                 ? ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos())
                 : ContainerLevelAccess.NULL;
-        this.modSinkInventory = new ModSinkInventory(pipeEntity);
+        this.modSinkInventory = new ModSinkInventory(pipeEntity, targetModuleStateKey);
         addModSinkSlots();
         addPlayerInventorySlots(playerInventory);
     }
@@ -80,6 +87,7 @@ public class ModSinkScreenHandler extends AbstractContainerMenu {
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
         this.originalModuleStack = stack;
+        this.targetModuleStateKey = null;
         this.context = ContainerLevelAccess.NULL;
         this.modSinkInventory = new ModSinkInventory(null);
         this.modSinkInventory.loadFromItem(stack);
@@ -162,7 +170,7 @@ public class ModSinkScreenHandler extends AbstractContainerMenu {
                         ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,
                                 tag -> tag.putString(ModSinkModule.MOD_IDS + "_" + slotIndex, itemId));
                     } else {
-                        PipeModuleHelper.withModule(context, ModSinkModule.class,
+                        PipeModuleHelper.withModule(context, ModSinkModule.class, targetModuleStateKey,
                                 (ctx, module) -> module.addModId(ctx, itemId));
                     }
                     break;
@@ -198,7 +206,7 @@ public class ModSinkScreenHandler extends AbstractContainerMenu {
                 });
             } else {
                 final int ri = removeIndex;
-                PipeModuleHelper.withModule(context, ModSinkModule.class,
+                PipeModuleHelper.withModule(context, ModSinkModule.class, targetModuleStateKey,
                         (ctx, module) -> module.removeModId(ctx, ri));
             }
             broadcastChanges();

--- a/common/src/main/java/com/logistics/pipe/ui/ProcessInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ProcessInventory.java
@@ -18,10 +18,16 @@ public class ProcessInventory extends SimpleContainer {
     public static final int TOTAL_SLOTS = INPUT_SLOTS + OUTPUT_SLOTS;
 
     @Nullable private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     public ProcessInventory(@Nullable PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public ProcessInventory(@Nullable PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         super(TOTAL_SLOTS);
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
         if (pipeEntity != null) {
             loadFromModule();
         }
@@ -30,7 +36,7 @@ public class ProcessInventory extends SimpleContainer {
     /** Refresh display slots from the module's current NBT state. */
     public void loadFromModule() {
         if (pipeEntity == null) return;
-        PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, (ctx, module) -> {
+        PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, targetModuleStateKey, (ctx, module) -> {
             for (int i = 0; i < INPUT_SLOTS; i++) {
                 setItem(i, resolveDisplayStack(module.getInputItem(ctx, i), module.getInputCount(ctx, i)));
             }

--- a/common/src/main/java/com/logistics/pipe/ui/ProcessScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ProcessScreenHandler.java
@@ -55,6 +55,7 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
     private final ContainerLevelAccess context;
     private final ContainerData data;
     @Nullable private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     public ProcessScreenHandler(int syncId, Container playerInventory) {
         this(syncId, playerInventory, null);
@@ -62,14 +63,20 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
 
     public ProcessScreenHandler(int syncId, Container playerInventory,
             @Nullable PipeBlockEntity pipeEntity) {
+        this(syncId, playerInventory, pipeEntity, null);
+    }
+
+    public ProcessScreenHandler(int syncId, Container playerInventory,
+            @Nullable PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         super(LogisticsPipe.SCREEN.PROCESS, syncId);
         this.pipeEntity = pipeEntity;
-        this.processInventory = new ProcessInventory(pipeEntity);
+        this.targetModuleStateKey = targetModuleStateKey;
+        this.processInventory = new ProcessInventory(pipeEntity, targetModuleStateKey);
         this.data = new SimpleContainerData(DATA_SIZE);
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
-            PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, (ctx, module) -> {
+            PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, targetModuleStateKey, (ctx, module) -> {
                 for (int i = 0; i < INPUT_SLOTS; i++) {
                     data.set(DATA_INPUT_COUNT_0 + i, module.getInputCount(ctx, i));
                 }
@@ -133,7 +140,7 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
 
         int nextId = available.get(idx);
         if (nextId != currentId) {
-            PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, (ctx, module) ->
+            PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, targetModuleStateKey, (ctx, module) ->
                     module.setInputSatelliteId(ctx, nextId));
         }
         broadcastChanges();
@@ -167,6 +174,7 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
                 context.execute((level, pos) -> PipeModuleHelper.withModule(
                         level.getBlockEntity(pos) instanceof PipeBlockEntity e ? e : null,
                         ProcessModule.class,
+                        targetModuleStateKey,
                         (ctx, module) -> {
                             if (isInput) module.setInput(ctx, moduleSlot, "", 1, "");
                             else module.setOutput(ctx, moduleSlot, "", 1);
@@ -183,6 +191,7 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
             context.execute((level, pos) -> PipeModuleHelper.withModule(
                     level.getBlockEntity(pos) instanceof PipeBlockEntity e ? e : null,
                     ProcessModule.class,
+                    targetModuleStateKey,
                     (ctx, module) -> {
                         if (isInput) {
                             String currentDest = module.getInputDest(ctx, moduleSlot);
@@ -205,6 +214,7 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
             PipeModuleHelper.withModule(
                     level.getBlockEntity(pos) instanceof PipeBlockEntity e ? e : null,
                     ProcessModule.class,
+                    targetModuleStateKey,
                     (ctx, module) -> {
                         for (int i = 0; i < INPUT_SLOTS; i++) {
                             data.set(DATA_INPUT_COUNT_0 + i, module.getInputCount(ctx, i));
@@ -233,7 +243,7 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
     private int getCurrentSatelliteIdFromModule() {
         if (pipeEntity == null) return 0;
         int[] result = {0};
-        PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, (ctx, module) ->
+        PipeModuleHelper.withModule(pipeEntity, ProcessModule.class, targetModuleStateKey, (ctx, module) ->
                 result[0] = module.getInputSatelliteId(ctx));
         return result[0];
     }

--- a/common/src/main/java/com/logistics/pipe/ui/ProviderFilterInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ProviderFilterInventory.java
@@ -3,9 +3,7 @@ package com.logistics.pipe.ui;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.filter.FilterSlots;
 import com.logistics.core.lib.compat.NbtCompat;
-import com.logistics.pipe.Pipe;
 import com.logistics.core.lib.pipe.PipeContext;
-import com.logistics.pipe.block.PipeBlock;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.ProviderModule;
 import net.minecraft.core.NonNullList;
@@ -15,6 +13,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Inventory for the Provider filter GUI.
@@ -24,9 +23,15 @@ public class ProviderFilterInventory implements Container {
     private final NonNullList<ItemStack> stacks =
             NonNullList.withSize(ProviderModule.MAX_FILTER_SLOTS, ItemStack.EMPTY);
     private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     public ProviderFilterInventory(PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public ProviderFilterInventory(PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
 
         if (pipeEntity != null) {
             loadFromModule();
@@ -100,15 +105,16 @@ public class ProviderFilterInventory implements Container {
             return;
         }
 
-        PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-        Pipe pipe = block.getPipe();
-        ProviderModule module = pipe.getModule(ProviderModule.class, pipeEntity);
+        ProviderModule module = PipeModuleHelper.getModule(pipeEntity, ProviderModule.class, targetModuleStateKey);
 
         if (module == null) {
             return;
         }
 
         PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
         FilterSlots filterItems = module.getFilterItems(ctx);
 
         for (int i = 0; i < Math.min(filterItems.size(), stacks.size()); i++) {

--- a/common/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
@@ -35,21 +35,28 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     private final ProviderFilterInventory filterInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final String targetModuleStateKey;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
     @Nullable private final ItemStack pinnedItemStack;
 
     public ProviderScreenHandler(int syncId, Container playerInventory) {
-        this(syncId, playerInventory, null, new SimpleContainerData(2));
+        this(syncId, playerInventory, null, null, new SimpleContainerData(2));
     }
 
     public ProviderScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
-        this(syncId, playerInventory, pipeEntity, new SimpleContainerData(2));
+        this(syncId, playerInventory, pipeEntity, null, new SimpleContainerData(2));
+    }
+
+    public ProviderScreenHandler(
+            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
+        this(syncId, playerInventory, pipeEntity, targetModuleStateKey, new SimpleContainerData(2));
     }
 
     public ProviderScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
         super(LogisticsPipe.SCREEN.PROVIDER, syncId);
         this.data = new SimpleContainerData(2);
+        this.targetModuleStateKey = null;
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
@@ -68,17 +75,23 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
         addDataSlots(data);
     }
 
-    private ProviderScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
+    private ProviderScreenHandler(
+            int syncId,
+            Container playerInventory,
+            PipeBlockEntity pipeEntity,
+            @Nullable String targetModuleStateKey,
+            ContainerData data) {
         super(LogisticsPipe.SCREEN.PROVIDER, syncId);
         this.data = data;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.pinnedItemStack = null;
-        this.filterInventory = new ProviderFilterInventory(pipeEntity);
+        this.filterInventory = new ProviderFilterInventory(pipeEntity, targetModuleStateKey);
 
         if (pipeEntity != null) {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
-            PipeModuleHelper.withModule(pipeEntity, ProviderModule.class, (ctx, module) -> {
+            PipeModuleHelper.withModule(pipeEntity, ProviderModule.class, targetModuleStateKey, (ctx, module) -> {
                 data.set(0, module.getModeOrdinal(ctx));
                 data.set(1, module.isFilterInverted(ctx) ? 1 : 0);
             });
@@ -170,7 +183,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
 
     private void handleClearSlotForModule(int slotIndex) {
         filterInventory.setItem(slotIndex, ItemStack.EMPTY);
-        PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, ""));
+        PipeModuleHelper.withModule(context, ProviderModule.class, targetModuleStateKey, (ctx, module) -> module.setFilterItem(ctx, slotIndex, ""));
     }
 
     private void handlePlaceItemForPlayer(int slotIndex, ItemStack cursor) {
@@ -188,7 +201,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     private void handlePlaceItemForModule(int slotIndex, ItemStack cursor) {
         String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
         filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
-        PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterItem(ctx, slotIndex, itemId));
+        PipeModuleHelper.withModule(context, ProviderModule.class, targetModuleStateKey, (ctx, module) -> module.setFilterItem(ctx, slotIndex, itemId));
     }
 
     @Override
@@ -200,7 +213,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
                 if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(ProviderModule.MODE, nextMode));
             } else {
-                PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setModeFromOrdinal(ctx, nextMode));
+                PipeModuleHelper.withModule(context, ProviderModule.class, targetModuleStateKey, (ctx, module) -> module.setModeFromOrdinal(ctx, nextMode));
             }
             return true;
         } else if (id == 1) {
@@ -210,7 +223,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
                 if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand,tag -> tag.putInt(ProviderModule.FILTER_INVERTED, newInverted));
             } else {
-                PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> module.setFilterInverted(ctx, newInverted == 1));
+                PipeModuleHelper.withModule(context, ProviderModule.class, targetModuleStateKey, (ctx, module) -> module.setFilterInverted(ctx, newInverted == 1));
             }
             return true;
         }
@@ -243,7 +256,7 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
             super.broadcastChanges();
             return;
         }
-        PipeModuleHelper.withModule(context, ProviderModule.class, (ctx, module) -> {
+        PipeModuleHelper.withModule(context, ProviderModule.class, targetModuleStateKey, (ctx, module) -> {
             data.set(0, module.getModeOrdinal(ctx));
             data.set(1, module.isFilterInverted(ctx) ? 1 : 0);
         });

--- a/common/src/main/java/com/logistics/pipe/ui/RequestInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/RequestInventory.java
@@ -7,6 +7,7 @@ import com.logistics.pipe.modules.RequesterModule;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,11 +22,17 @@ public class RequestInventory implements Container {
     private final NonNullList<ItemStack> stacks =
             NonNullList.withSize(RequesterModule.MAX_REQUEST_SLOTS, ItemStack.EMPTY);
     private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
     private List<ItemStack> cachedItems = new ArrayList<>();  // Client-side cached items from sync packet
     private List<Long> cachedAmounts = new ArrayList<>();  // Client-side cached full amounts
 
     public RequestInventory(PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public RequestInventory(PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
 
         if (pipeEntity != null) {
             loadFromNetwork();

--- a/common/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/RequesterScreenHandler.java
@@ -11,6 +11,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -26,6 +27,7 @@ public class RequesterScreenHandler extends AbstractContainerMenu {
 
     private final RequestInventory requestInventory;
     private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
     private BlockPos pipePos;
     private boolean initialSyncSent = false;
 
@@ -36,15 +38,22 @@ public class RequesterScreenHandler extends AbstractContainerMenu {
     public RequesterScreenHandler(int syncId, Container playerInventory) {
         super(LogisticsPipe.SCREEN.REQUESTER, syncId);
         this.pipeEntity = null;
+        this.targetModuleStateKey = null;
         this.pipePos = BlockPos.ZERO;
         this.requestInventory = new RequestInventory(null);
     }
 
     public RequesterScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
+        this(syncId, playerInventory, pipeEntity, null);
+    }
+
+    public RequesterScreenHandler(
+            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         super(LogisticsPipe.SCREEN.REQUESTER, syncId);
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.pipePos = pipeEntity.getBlockPos();
-        this.requestInventory = new RequestInventory(pipeEntity);
+        this.requestInventory = new RequestInventory(pipeEntity, targetModuleStateKey);
     }
 
     /**

--- a/common/src/main/java/com/logistics/pipe/ui/SatelliteScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/SatelliteScreenHandler.java
@@ -30,6 +30,7 @@ public class SatelliteScreenHandler extends AbstractContainerMenu {
 
     private final ContainerLevelAccess context;
     @Nullable private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     // Synced data: [0] = current satellite ID (0=unset), [1] = boolean flag (0/1) for whether
     // the current ID is taken by another satellite pipe (not a bitmask — MAX_ID exceeds 32 bits)
@@ -54,13 +55,19 @@ public class SatelliteScreenHandler extends AbstractContainerMenu {
     };
 
     public SatelliteScreenHandler(int syncId, Container playerInventory) {
-        this(syncId, playerInventory, null);
+        this(syncId, playerInventory, null, null);
     }
 
     public SatelliteScreenHandler(int syncId, Container playerInventory,
             @Nullable PipeBlockEntity pipeEntity) {
+        this(syncId, playerInventory, pipeEntity, null);
+    }
+
+    public SatelliteScreenHandler(int syncId, Container playerInventory,
+            @Nullable PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
         super(LogisticsPipe.SCREEN.SATELLITE, syncId);
         this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.context = pipeEntity != null
                 ? ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos())
                 : ContainerLevelAccess.NULL;
@@ -111,7 +118,7 @@ public class SatelliteScreenHandler extends AbstractContainerMenu {
 
         if (nextId > 0 && nextId != currentId) {
             int finalId = nextId;
-            PipeModuleHelper.withModule(pipeEntity, SatelliteModule.class, (ctx, module) ->
+            PipeModuleHelper.withModule(pipeEntity, SatelliteModule.class, targetModuleStateKey, (ctx, module) ->
                     module.setSatelliteId(ctx, finalId));
         }
         return true;
@@ -139,7 +146,7 @@ public class SatelliteScreenHandler extends AbstractContainerMenu {
     private int getCurrentIdFromModule() {
         if (pipeEntity == null) return 0;
         int[] result = {0};
-        PipeModuleHelper.withModule(pipeEntity, SatelliteModule.class, (ctx, module) ->
+        PipeModuleHelper.withModule(pipeEntity, SatelliteModule.class, targetModuleStateKey, (ctx, module) ->
                 result[0] = module.getSatelliteIdInt(ctx));
         return result[0];
     }
@@ -148,7 +155,7 @@ public class SatelliteScreenHandler extends AbstractContainerMenu {
     private Set<String> getNetworkTakenStrings() {
         if (pipeEntity == null) return Set.of();
         String[] ownId = {""};
-        PipeModuleHelper.withModule(pipeEntity, SatelliteModule.class, (ctx, module) ->
+        PipeModuleHelper.withModule(pipeEntity, SatelliteModule.class, targetModuleStateKey, (ctx, module) ->
                 ownId[0] = module.getSatelliteId(ctx));
         var network = NetworkRegistry.getNetwork(pipeEntity.getLevel(), pipeEntity.getBlockPos());
         if (network == null) return Set.of();

--- a/common/src/main/java/com/logistics/pipe/ui/SinkInventory.java
+++ b/common/src/main/java/com/logistics/pipe/ui/SinkInventory.java
@@ -3,8 +3,7 @@ package com.logistics.pipe.ui;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.lib.filter.FilterSlots;
 import com.logistics.core.lib.compat.NbtCompat;
-import com.logistics.pipe.Pipe;
-import com.logistics.pipe.block.PipeBlock;
+import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.SinkModule;
 import net.minecraft.core.NonNullList;
@@ -15,6 +14,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Inventory wrapper for the Sink GUI.
@@ -22,23 +22,34 @@ import net.minecraft.world.item.component.CustomData;
  */
 public class SinkInventory implements Container {
     private final NonNullList<ItemStack> items = NonNullList.withSize(SinkModule.MAX_FILTER_SLOTS, ItemStack.EMPTY);
+    private final PipeBlockEntity pipeEntity;
+    @Nullable private final String targetModuleStateKey;
 
     public SinkInventory(PipeBlockEntity pipeEntity) {
+        this(pipeEntity, null);
+    }
+
+    public SinkInventory(PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
+        this.pipeEntity = pipeEntity;
+        this.targetModuleStateKey = targetModuleStateKey;
+
         if (pipeEntity != null) {
             loadFilters(pipeEntity);
         }
     }
 
     private void loadFilters(PipeBlockEntity pipeEntity) {
-        PipeBlock block = (PipeBlock) pipeEntity.getBlockState().getBlock();
-        Pipe pipe = block.getPipe();
-        SinkModule module = pipe.getModule(SinkModule.class, pipeEntity);
+        SinkModule module = PipeModuleHelper.getModule(pipeEntity, SinkModule.class, targetModuleStateKey);
 
         if (module == null) {
             return;
         }
 
-        FilterSlots filters = module.getFilters(pipeEntity.createContext());
+        PipeContext ctx = pipeEntity.createContext();
+        if (targetModuleStateKey != null) {
+            ctx = ctx.withModuleStateKey(module, targetModuleStateKey);
+        }
+        FilterSlots filters = module.getFilters(ctx);
         for (int i = 0; i < filters.size(); i++) {
             String id = filters.get(i);
             if (id.isEmpty()) continue;

--- a/common/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -36,16 +36,22 @@ public class SinkScreenHandler extends AbstractContainerMenu {
     private final SinkInventory sinkInventory;
     private final ContainerLevelAccess context;
     private final ContainerData data;
+    @Nullable private final String targetModuleStateKey;
     @Nullable private final ServerPlayer itemConfigPlayer;
     @Nullable private final InteractionHand itemConfigHand;
     @Nullable private final ItemStack originalModuleStack;
 
     public SinkScreenHandler(int syncId, Container playerInventory) {
-        this(syncId, playerInventory, null, new SimpleContainerData(1));
+        this(syncId, playerInventory, null, null, new SimpleContainerData(1));
     }
 
     public SinkScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity) {
-        this(syncId, playerInventory, pipeEntity, new SimpleContainerData(1));
+        this(syncId, playerInventory, pipeEntity, null, new SimpleContainerData(1));
+    }
+
+    public SinkScreenHandler(
+            int syncId, Container playerInventory, PipeBlockEntity pipeEntity, @Nullable String targetModuleStateKey) {
+        this(syncId, playerInventory, pipeEntity, targetModuleStateKey, new SimpleContainerData(1));
     }
 
     public SinkScreenHandler(int syncId, Container playerInventory, ServerPlayer player, InteractionHand hand) {
@@ -55,6 +61,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             throw new IllegalArgumentException("Expected a ModuleItem in " + hand + " hand");
         }
         this.data = new SimpleContainerData(1);
+        this.targetModuleStateKey = null;
         this.itemConfigPlayer = player;
         this.itemConfigHand = hand;
         this.context = ContainerLevelAccess.NULL;
@@ -70,9 +77,15 @@ public class SinkScreenHandler extends AbstractContainerMenu {
         addDataSlots(data);
     }
 
-    private SinkScreenHandler(int syncId, Container playerInventory, PipeBlockEntity pipeEntity, ContainerData data) {
+    private SinkScreenHandler(
+            int syncId,
+            Container playerInventory,
+            PipeBlockEntity pipeEntity,
+            @Nullable String targetModuleStateKey,
+            ContainerData data) {
         super(LogisticsPipe.SCREEN.SINK, syncId);
         this.data = data;
+        this.targetModuleStateKey = targetModuleStateKey;
         this.itemConfigPlayer = null;
         this.itemConfigHand = null;
         this.originalModuleStack = null;
@@ -81,13 +94,13 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             this.context = ContainerLevelAccess.create(pipeEntity.getLevel(), pipeEntity.getBlockPos());
 
             // Load default route setting (server-side)
-            PipeModuleHelper.withModule(this.context, SinkModule.class, (ctx, module) -> {
+            PipeModuleHelper.withModule(this.context, SinkModule.class, targetModuleStateKey, (ctx, module) -> {
                 data.set(0, module.isDefaultRoute(ctx) ? 1 : 0);
             });
         } else {
             this.context = ContainerLevelAccess.NULL;
         }
-        this.sinkInventory = new SinkInventory(pipeEntity);
+        this.sinkInventory = new SinkInventory(pipeEntity, targetModuleStateKey);
 
         addFilterSlots(sinkInventory);
         addPlayerInventorySlots(playerInventory);
@@ -110,7 +123,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             return;
         }
         // Sync default route value from module to data slot
-        PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
+        PipeModuleHelper.withModule(context, SinkModule.class, targetModuleStateKey, (ctx, module) -> {
             data.set(0, module.isDefaultRoute(ctx) ? 1 : 0);
         });
         super.broadcastChanges();
@@ -181,7 +194,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                     });
                 } else {
                     sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
-                    PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
+                    PipeModuleHelper.withModule(context, SinkModule.class, targetModuleStateKey, (ctx, module) -> {
                         module.setFilter(ctx, slotIndex, "");
                     });
                 }
@@ -209,7 +222,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                 });
             } else {
                 sinkInventory.setItem(slotIndex, ghostItem);
-                PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
+                PipeModuleHelper.withModule(context, SinkModule.class, targetModuleStateKey, (ctx, module) -> {
                     module.setFilter(ctx, slotIndex, itemId);
                 });
             }
@@ -237,7 +250,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                 if (!isPinnedItemStillHeld()) return true;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> tag.putInt(SinkModule.DEFAULT_ROUTE, newValue ? 1 : 0));
             } else {
-                PipeModuleHelper.withModule(context, SinkModule.class, (ctx, module) -> {
+                PipeModuleHelper.withModule(context, SinkModule.class, targetModuleStateKey, (ctx, module) -> {
                     module.setDefaultRoute(ctx, newValue);
                 });
             }

--- a/common/src/test/java/com/logistics/pipe/modules/ChassisModuleConfigScopingTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/ChassisModuleConfigScopingTest.java
@@ -1,0 +1,213 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.core.lib.block.capability.PipeConnection;
+import com.logistics.core.lib.energy.EnergyComponent;
+import com.logistics.core.lib.network.ILogisticsNetwork;
+import com.logistics.core.lib.pipe.IPipeAccess;
+import com.logistics.core.lib.pipe.PipeContext;
+import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.pipe.ChassisPipe;
+import com.logistics.test.MinecraftTestEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for issue #494: reconfiguring a module while it is installed in a chassis
+ * pipe must write to the module's <em>scoped</em> state partition ({@code module.<uuid>.<statekey>}),
+ * not the class-default key.
+ *
+ * <p>The defect was that most module config screens opened from {@code onWrench} did not thread the
+ * scoped state key, so GUI edits landed on the class-default key while the module's own
+ * routing/HUD logic reads through the scoped key — leaving the change invisible (a stale Jade HUD,
+ * and potentially stale behavior).
+ *
+ * <p>The GUI wiring itself (screen handlers + companion inventories) needs a live {@code Level} and
+ * menu harness to drive end-to-end, which this unit-test layer does not provide. These tests instead
+ * lock the contract the fix depends on: once a module's scoped partition exists, config written
+ * through the scoped context is what the module reads back, and a write to the class-default key
+ * (the old, unthreaded path) does <em>not</em> leak into the scoped read. If this isolation ever
+ * regresses, the chassis re-config bug returns.
+ */
+@DisplayName("Chassis module config scoping (#494)")
+class ChassisModuleConfigScopingTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("Provider mode written via scoped context is isolated from a stale default-key write")
+    void provider_modeScopedIsolatedFromDefaultKey() {
+        ProviderModule module = new ProviderModule(8, 1);
+        Scope scope = scopeFor(module);
+
+        // Fixed GUI path: write through the scoped context. This also populates the scoped partition.
+        module.setModeFromOrdinal(scope.scoped(), ProviderModule.ProviderMode.RESERVE.ordinal());
+        // Old buggy path: write to the class-default key.
+        module.setModeFromOrdinal(scope.base(), ProviderModule.ProviderMode.SAMPLE.ordinal());
+
+        assertThat(module.getModeOrdinal(scope.scoped()))
+                .isEqualTo(ProviderModule.ProviderMode.RESERVE.ordinal());
+        // The stale default-key write is invisible to the scoped read.
+        assertThat(module.getModeOrdinal(scope.base()))
+                .isEqualTo(ProviderModule.ProviderMode.SAMPLE.ordinal());
+    }
+
+    @Test
+    @DisplayName("Provider filter-inverted flag is scoped")
+    void provider_filterInvertedScoped() {
+        ProviderModule module = new ProviderModule(8, 1);
+        Scope scope = scopeFor(module);
+
+        module.setFilterInverted(scope.scoped(), true);
+        module.setFilterInverted(scope.base(), false);
+
+        assertThat(module.isFilterInverted(scope.scoped())).isTrue();
+        assertThat(module.isFilterInverted(scope.base())).isFalse();
+    }
+
+    @Test
+    @DisplayName("Sink filter slot is scoped")
+    void sink_filterScoped() {
+        SinkModule module = new SinkModule(7);
+        Scope scope = scopeFor(module);
+
+        module.setFilter(scope.scoped(), 0, "minecraft:iron_ingot");
+        module.setFilter(scope.base(), 0, "minecraft:gold_ingot");
+
+        assertThat(module.getFilters(scope.scoped()).get(0)).isEqualTo("minecraft:iron_ingot");
+        assertThat(module.getFilters(scope.base()).get(0)).isEqualTo("minecraft:gold_ingot");
+    }
+
+    @Test
+    @DisplayName("AdvancedExtractor filter-inverted flag is scoped")
+    void advancedExtractor_filterInvertedScoped() {
+        AdvancedExtractorModule module = new AdvancedExtractorModule(8, 20);
+        Scope scope = scopeFor(module);
+
+        module.setFilterInverted(scope.scoped(), true);
+        module.setFilterInverted(scope.base(), false);
+
+        assertThat(module.isFilterInverted(scope.scoped())).isTrue();
+        assertThat(module.isFilterInverted(scope.base())).isFalse();
+    }
+
+    @Test
+    @DisplayName("Satellite id is scoped")
+    void satellite_idScoped() {
+        SatelliteModule module = new SatelliteModule();
+        Scope scope = scopeFor(module);
+
+        module.setSatelliteId(scope.scoped(), "scoped-sat");
+        module.setSatelliteId(scope.base(), "default-sat");
+
+        assertThat(module.getSatelliteId(scope.scoped())).isEqualTo("scoped-sat");
+        assertThat(module.getSatelliteId(scope.base())).isEqualTo("default-sat");
+    }
+
+    @Test
+    @DisplayName("ItemFilter per-direction filter slots are scoped")
+    void itemFilter_filterSlotsScoped() {
+        ItemFilterModule module = new ItemFilterModule();
+        Scope scope = scopeFor(module);
+
+        module.setFilterSlots(scope.scoped(), Direction.NORTH, List.of("minecraft:iron_ingot"));
+        module.setFilterSlots(scope.base(), Direction.NORTH, List.of("minecraft:gold_ingot"));
+
+        // getFilterSlots returns a fixed-size, blank-padded list; only the first entry is set.
+        assertThat(module.getFilterSlots(scope.scoped(), Direction.NORTH).get(0))
+                .isEqualTo("minecraft:iron_ingot");
+        assertThat(module.getFilterSlots(scope.base(), Direction.NORTH).get(0))
+                .isEqualTo("minecraft:gold_ingot");
+    }
+
+    // ==================== Helpers ====================
+
+    /** A base context (class-default key) plus a scoped context for the same module instance. */
+    private record Scope(PipeContext base, PipeContext scoped) {}
+
+    private static Scope scopeFor(com.logistics.core.lib.pipe.Module module) {
+        ItemStack stack = new ItemStack(Items.STICK);
+        StatefulFakePipe pipe = new StatefulFakePipe();
+        PipeContext base = new PipeContext(null, BlockPos.ZERO, null, pipe);
+        String stateKey = ChassisPipe.moduleStateKey(stack, module);
+        return new Scope(base, base.withModuleStateKey(module, stateKey));
+    }
+
+    /**
+     * In-memory {@link IPipeAccess} that distinguishes between "create" and "already exists"
+     * semantics. Implementing {@link #existingModuleState} faithfully is required: the scoped/legacy
+     * migration in {@link PipeContext#moduleState(com.logistics.core.lib.pipe.Module)} only backfills
+     * from the default key when the scoped partition does not yet exist.
+     */
+    private static class StatefulFakePipe implements IPipeAccess {
+        private final Map<String, CompoundTag> states = new HashMap<>();
+
+        @Override
+        public CompoundTag moduleState(String key) {
+            return states.computeIfAbsent(key, ignored -> new CompoundTag());
+        }
+
+        @Override
+        public @Nullable CompoundTag existingModuleState(String key) {
+            return states.get(key);
+        }
+
+        @Override
+        public void clearModuleState(String key) {
+            states.remove(key);
+        }
+
+        @Override
+        public @Nullable EnergyComponent getEnergy() {
+            return null;
+        }
+
+        @Override
+        public void markDirty() {}
+
+        @Override
+        public PipeConnection.Type getCachedConnectionType(Direction direction) {
+            return PipeConnection.Type.NONE;
+        }
+
+        @Override
+        public PipeConnection.Type getConnectionType(Level world, BlockPos pos, Direction direction) {
+            return PipeConnection.Type.NONE;
+        }
+
+        @Override
+        public boolean isNeighborPipe(Level world, BlockPos pos, Direction direction) {
+            return false;
+        }
+
+        @Override
+        public boolean isPowered() {
+            return false;
+        }
+
+        @Override
+        public @Nullable ILogisticsNetwork getNetwork() {
+            return null;
+        }
+
+        @Override
+        public List<TravelingItem> getTravelingItems() {
+            return List.of();
+        }
+
+        @Override
+        public boolean forceAddItem(TravelingItem item, Direction fromDirection) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reconfiguring a module **while it's installed in a chassis pipe** (changing a Provider's mode/filter, a Sink's filters, etc.) didn't take effect — the change was written to the wrong place and the module kept running its old config. Surfaced by the new Jade per-module HUD (#493), which showed stale config after an in-chassis edit.

Fixes #494.

## Cause

Each chassis slot stores its module's state under a **scoped** key (`module.<uuid>.<statekey>`) so multiple copies of the same module type don't collide. The `SupplierModule` config screen already threaded that scoped key correctly, but every other module's config screen wrote to the **class-default** key instead — so edits landed in a partition the module never reads back.

## Changes

- Thread the scoped module-state key from each module's `onWrench` through its screen handler and companion inventory, matching the existing `SupplierModule` pattern. Affected modules: **Provider, Sink, Requester, Item Filter, Mod Sink, Crafting, Advanced Extractor, Process, Satellite**.
- Held-item (wrench-in-hand) configuration is unchanged.

## Tests

- New `ChassisModuleConfigScopingTest` locks the scoped-vs-default state isolation per module.
- Full `:common` unit + game test suites and Spotless pass locally.

## Notes

- Requester's threading is structural only — its current GUI places one-shot network orders keyed by position and has no per-slot config to scope yet.
- Player-facing fix; to be cherry-picked to `mc/1.21.11` and `mc/1.21.1` after merge.