### PR TITLE
fix(core): repair recipes and item colors broken on Minecraft 1.21.1

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/macerator/ender_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/ender_dust.json
@@ -1,6 +1,8 @@
 {
   "type": "logistics:macerator",
-  "ingredient": "minecraft:ender_pearl",
+  "ingredient": {
+    "item": "minecraft:ender_pearl"
+  },
   "result": {
     "id": "logistics:core/ender_dust",
     "count": 1

--- a/common/src/main/resources/data/logistics/recipe/power/copper_cable.json
+++ b/common/src/main/resources/data/logistics/recipe/power/copper_cable.json
@@ -2,8 +2,12 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["RRR", "CCC", "RRR"],
   "key": {
-    "C": "minecraft:copper_ingot",
-    "R": "logistics:power/rubber_chunk"
+    "C": {
+      "item": "minecraft:copper_ingot"
+    },
+    "R": {
+      "item": "logistics:power/rubber_chunk"
+    }
   },
   "result": {
     "count": 8,

--- a/common/src/main/resources/data/logistics/recipe/power/ender_cable.json
+++ b/common/src/main/resources/data/logistics/recipe/power/ender_cable.json
@@ -2,9 +2,15 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["RRR", "DGD", "RRR"],
   "key": {
-    "D": "logistics:core/ender_dust",
-    "G": "minecraft:gold_ingot",
-    "R": "logistics:power/rubber_chunk"
+    "D": {
+      "item": "logistics:core/ender_dust"
+    },
+    "G": {
+      "item": "minecraft:gold_ingot"
+    },
+    "R": {
+      "item": "logistics:power/rubber_chunk"
+    }
   },
   "result": {
     "count": 8,

--- a/common/src/main/resources/data/logistics/recipe/power/gold_cable.json
+++ b/common/src/main/resources/data/logistics/recipe/power/gold_cable.json
@@ -2,8 +2,12 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["RRR", "GGG", "RRR"],
   "key": {
-    "G": "minecraft:gold_ingot",
-    "R": "logistics:power/rubber_chunk"
+    "G": {
+      "item": "minecraft:gold_ingot"
+    },
+    "R": {
+      "item": "logistics:power/rubber_chunk"
+    }
   },
   "result": {
     "count": 8,

--- a/common/src/main/resources/data/logistics/recipe/power/rubber_chunk_from_rubber_mix.json
+++ b/common/src/main/resources/data/logistics/recipe/power/rubber_chunk_from_rubber_mix.json
@@ -1,6 +1,8 @@
 {
   "type": "minecraft:smelting",
-  "ingredient": "logistics:power/rubber_mix",
+  "ingredient": {
+    "item": "logistics:power/rubber_mix"
+  },
   "result": {
     "id": "logistics:power/rubber_chunk",
     "count": 2

--- a/common/src/main/resources/data/logistics/recipe/power/rubber_mix.json
+++ b/common/src/main/resources/data/logistics/recipe/power/rubber_mix.json
@@ -1,8 +1,12 @@
 {
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
-    "minecraft:slime_ball",
-    "logistics:core/coal_dust"
+    {
+      "item": "minecraft:slime_ball"
+    },
+    {
+      "item": "logistics:core/coal_dust"
+    }
   ],
   "result": {
     "id": "logistics:power/rubber_mix",

--- a/fabric/src/client/java/com/logistics/LogisticsPowerClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsPowerClient.java
@@ -2,6 +2,8 @@ package com.logistics;
 
 import com.logistics.core.bootstrap.ClientDomainBootstrap;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.core.lib.power.EngineHeatTint;
 import com.logistics.power.cable.CableTier;
 import com.logistics.power.render.EngineBlockEntityRenderer;
 import com.logistics.power.render.model.CableUnbakedRoot;
@@ -9,6 +11,7 @@ import com.logistics.power.screen.StirlingEngineScreen;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
+import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
@@ -70,6 +73,15 @@ public final class LogisticsPowerClient implements ClientDomainBootstrap {
 
         // Engine heat tinting is rendered in EngineBlockEntityRenderer (the heat core is drawn and
         // tinted per-frame from the live STAGE), so no BlockColors provider is needed here.
+
+        // The in-inventory engine item still tints its core (tintIndex 0) via the item model. On MC
+        // 1.21.1 the data-driven item "tints" array (1.21.4+) is unavailable, so register an item
+        // color in code. Items have no live heat state, so they always show the idle COLD blue.
+        ColorProviderRegistry.ITEM.register(
+                (stack, tintIndex) -> tintIndex == 0 ? EngineHeatTint.color(HeatStage.COLD) : -1,
+                LogisticsPower.BLOCK.REDSTONE_ENGINE,
+                LogisticsPower.BLOCK.STIRLING_ENGINE,
+                LogisticsPower.BLOCK.CREATIVE_ENGINE);
 
         // Register cleanup callback for engine animation cache
         AbstractEngineBlockEntity.setOnRemovedCallback(EngineBlockEntityRenderer::clearAnimationCache);

--- a/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
@@ -20,9 +20,12 @@ import com.logistics.pipe.screen.SinkScreen;
 import com.logistics.pipe.screen.SupplierScreen;
 import com.logistics.automation.render.LaserQuarryBlockEntityRenderer;
 import com.logistics.automation.render.MarkerBlockEntityRenderer;
+import com.logistics.core.lib.power.AbstractEngineBlockEntity.HeatStage;
+import com.logistics.core.lib.power.EngineHeatTint;
 import com.logistics.neoforge.NeoForgePacketRegistration;
 import com.logistics.neoforge.client.render.NeoForgeEngineBlockEntityRenderer;
 import com.logistics.neoforge.client.render.NeoForgeModelLoader;
+import com.logistics.pipe.item.MarkingFluidItem;
 import com.logistics.pipe.network.packet.SyncRequesterInventoryPacket;
 import com.logistics.pipe.render.PipeBlockEntityRenderer;
 import com.logistics.power.screen.StirlingEngineScreen;
@@ -30,6 +33,7 @@ import net.minecraft.client.Minecraft;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
 import net.neoforged.neoforge.client.event.RegisterMenuScreensEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 
@@ -41,6 +45,7 @@ public final class NeoForgeClientSetup {
         modBus.addListener(NeoForgeClientSetup::onClientSetup);
         modBus.addListener(NeoForgeClientSetup::registerScreens);
         modBus.addListener(NeoForgeClientSetup::registerRenderers);
+        modBus.addListener(NeoForgeClientSetup::registerItemColors);
         modBus.addListener(NeoForgeModelLoader::registerGeometryLoaders);
     }
 
@@ -94,6 +99,45 @@ public final class NeoForgeClientSetup {
                 LaserQuarryBlockEntityRenderer::new);
     }
 
+    /**
+     * Registers item tint handlers in code. On MC 1.21.1 the data-driven client item model
+     * "tints" array (1.21.4+) is unavailable, so the marking fluid overlay and the engine item
+     * core must be tinted through {@link RegisterColorHandlersEvent.Item} just like the Fabric
+     * client does via {@code ColorProviderRegistry.ITEM}.
+     */
+    private static void registerItemColors(RegisterColorHandlersEvent.Item event) {
+        // Marking fluid: leave layer0 (bottle) untinted, tint layer1 (overlay) with the dye color.
+        event.register((stack, tintIndex) -> {
+            if (tintIndex == 0) return -1;
+            if (stack.getItem() instanceof MarkingFluidItem fluid) {
+                return fluid.getColor().getFireworkColor() | 0xFF000000;
+            }
+            return -1;
+        },
+                LogisticsPipe.ITEM.WHITE_MARKING_FLUID,
+                LogisticsPipe.ITEM.ORANGE_MARKING_FLUID,
+                LogisticsPipe.ITEM.MAGENTA_MARKING_FLUID,
+                LogisticsPipe.ITEM.LIGHT_BLUE_MARKING_FLUID,
+                LogisticsPipe.ITEM.YELLOW_MARKING_FLUID,
+                LogisticsPipe.ITEM.LIME_MARKING_FLUID,
+                LogisticsPipe.ITEM.PINK_MARKING_FLUID,
+                LogisticsPipe.ITEM.GRAY_MARKING_FLUID,
+                LogisticsPipe.ITEM.LIGHT_GRAY_MARKING_FLUID,
+                LogisticsPipe.ITEM.CYAN_MARKING_FLUID,
+                LogisticsPipe.ITEM.PURPLE_MARKING_FLUID,
+                LogisticsPipe.ITEM.BLUE_MARKING_FLUID,
+                LogisticsPipe.ITEM.BROWN_MARKING_FLUID,
+                LogisticsPipe.ITEM.GREEN_MARKING_FLUID,
+                LogisticsPipe.ITEM.RED_MARKING_FLUID,
+                LogisticsPipe.ITEM.BLACK_MARKING_FLUID);
+
+        // Engine item: the in-inventory model tints its core (tintIndex 0). Items have no live heat
+        // state, so they always show the idle COLD blue (matches 26.x's static engine item tint).
+        event.register((stack, tintIndex) -> tintIndex == 0 ? EngineHeatTint.color(HeatStage.COLD) : -1,
+                LogisticsPower.BLOCK.REDSTONE_ENGINE,
+                LogisticsPower.BLOCK.STIRLING_ENGINE,
+                LogisticsPower.BLOCK.CREATIVE_ENGINE);
+    }
 
     private static void handleSyncRequesterInventory(SyncRequesterInventoryPacket packet) {
         var screen = Minecraft.getInstance().screen;

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/black_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/black_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:black_dye",
+    {
+      "item": "minecraft:black_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/black_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/black_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/blue_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/blue_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:blue_dye",
+    {
+      "item": "minecraft:blue_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/blue_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/blue_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/brown_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/brown_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:brown_dye",
+    {
+      "item": "minecraft:brown_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/brown_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/brown_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/cyan_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/cyan_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:cyan_dye",
+    {
+      "item": "minecraft:cyan_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/cyan_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/cyan_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/gray_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/gray_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/gray_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/gray_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:gray_dye",
+    {
+      "item": "minecraft:gray_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/green_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/green_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:green_dye",
+    {
+      "item": "minecraft:green_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/green_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/green_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/light_blue_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/light_blue_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:light_blue_dye",
+    {
+      "item": "minecraft:light_blue_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/light_blue_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/light_blue_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/light_gray_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/light_gray_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/light_gray_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/light_gray_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:light_gray_dye",
+    {
+      "item": "minecraft:light_gray_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/lime_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/lime_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/lime_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/lime_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:lime_dye",
+    {
+      "item": "minecraft:lime_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/magenta_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/magenta_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:magenta_dye",
+    {
+      "item": "minecraft:magenta_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/magenta_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/magenta_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/orange_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/orange_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:orange_dye",
+    {
+      "item": "minecraft:orange_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/orange_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/orange_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/pink_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/pink_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:pink_dye",
+    {
+      "item": "minecraft:pink_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/pink_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/pink_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/purple_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/purple_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:purple_dye",
+    {
+      "item": "minecraft:purple_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/purple_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/purple_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/red_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/red_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:red_dye",
+    {
+      "item": "minecraft:red_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/red_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/red_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/white_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/white_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:white_dye",
+    {
+      "item": "minecraft:white_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/white_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/white_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/yellow_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/yellow_marking_fluid.json
@@ -1,6 +1,8 @@
 {
   "ingredients": [
-    "minecraft:yellow_dye",
+    {
+      "item": "minecraft:yellow_dye"
+    },
     {
       "items": "minecraft:potion",
       "components": {

--- a/neoforge/src/main/resources/data/logistics/recipe/pipe/yellow_marking_fluid.json
+++ b/neoforge/src/main/resources/data/logistics/recipe/pipe/yellow_marking_fluid.json
@@ -10,7 +10,7 @@
           "potion": "minecraft:water"
         }
       },
-      "neoforge:ingredient_type": "neoforge:components",
+      "type": "neoforge:components",
       "strict": true
     }
   ],


### PR DESCRIPTION
## Summary

On Minecraft 1.21.1, several recipes silently failed to load (missing from the crafting table and JEI) and a few items rendered without their colors. Both stem from 26.x-era data formats that the 1.21.1 runtime doesn't understand. This restores them. Only `mc/1.21.1` is affected.

## Changes

**Recipes** (were failing to parse → vanished from crafting/JEI)
- Rubber Mix, Rubber Chunk, Copper/Gold/Ender Cable, Ender Dust: ingredients used the 1.21.2+ bare-string shorthand (`"minecraft:slime_ball"`); converted back to the `{ "item": ... }` object form that 1.21.1 requires.
- Marking Fluid (all 16 colors, NeoForge): the water-potion ingredient used the newer `neoforge:ingredient_type` key; switched to the `type` discriminator that NeoForge 21.1 expects.

**Colors**
- Marking Fluid bottles now tint correctly on NeoForge. The data-driven item `tints` array doesn't exist before 1.21.4, so the tint is now registered in code (mirroring the Fabric client).
- Engine items now show their idle blue in the inventory on both Fabric and NeoForge.

## Notes

- Scoped to `mc/1.21.1` only — `mc/1.21.11` and `mc/26.1` already work (their runtimes support the newer formats), so no backport is needed.
- Verified: full build green (Fabric + NeoForge), tests pass, `spotlessCheck` clean, and a dedicated server loads every datapack with zero recipe parse errors.
- Out of scope: the Battery block has no crafting recipe on any branch (1.21.1/1.21.11/26.1/26.2) — that's a separate, cross-version gap, not a 1.21.1 regression.