### PR TITLE
docs(core): incorporate #476 review and align design docs to the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,22 +25,23 @@ This phase focuses on the core automation loop:
 
 Work currently active, planned, or near-term.
 
-| Area                 | Status  | Notes                                            |
-|----------------------|---------|--------------------------------------------------|
-| Fluid foundation     | Active  | Fluid pipes, tanks, pumps, and machine I/O       |
-| Core machines        | Planned | Macerator improvements, Alloy Smelter, Sawmill   |
-| Power progression    | Planned | Combustion engine and fuel chain                 |
-| Material progression | Planned | Bronze, alloys, and machine crafting progression |
-| Loader parity        | Ongoing | Keep Fabric and NeoForge aligned                 |
+| Area                 | Status  | Notes                                               |
+|----------------------|---------|-----------------------------------------------------|
+| Fluid foundation     | Active  | Fluid pipes, tanks, pumps, and machine I/O          |
+| Core machines        | Planned | Macerator improvements, Alloy Smelter, Sawmill      |
+| Power progression    | Planned | Combustion engine, fuel chain, and tiered batteries |
+| Material progression | Planned | Bronze, alloys, and machine crafting progression    |
+| Loader parity        | Ongoing | Keep Fabric and NeoForge aligned                    |
 
 ## Next
 
 Likely after the current automation core is stable.
 
-| Area               | Status    | Notes                                                        |
-|--------------------|-----------|--------------------------------------------------------------|
-| Crafting logistics | Exploring | A Logistics crafting table or related crafting-request system may become the next major logistics-network expansion |
-| Firewall Pipe      | Exploring | Needs design validation around routing behavior and network boundaries |
+| Area                      | Status    | Notes                                                                                                               |
+|---------------------------|-----------|---------------------------------------------------------------------------------------------------------------------|
+| Crafting logistics        | Planned   | A Logistics crafting table or related crafting-request system may become the next major logistics-network expansion |
+| Firewall Pipe             | Exploring | Needs design validation around routing behavior and network boundaries                                              |
+| Pipe based power delivery | Exploring | Sending power through logistics pipes to allow one connection to provide items and power to machines.               |
 
 ## Later
 
@@ -48,12 +49,11 @@ Important to the long-term vision, but not part of the immediate core milestone.
 
 *These are in no specific order.*
 
-| Area                      | Status        | Notes                                                        |
-|---------------------------|---------------|--------------------------------------------------------------|
-| Facades / pipe hiding     | Planned later | Cosmetic integration for hiding pipes cleanly in builds      |
-| Forestry-style farms      | Planned later | Multifarm-inspired automation, modernized for current Minecraft |
-| Rail transport            | Planned later | Tracks, carts, routing, and train logistics                  |
-| Pipe based power delivery | Planned later | Sending power through logistics pipes to allow one connection to provide items and power to machines.  |
+| Area                  | Status        | Notes                                                                                                                 |
+|-----------------------|---------------|-----------------------------------------------------------------------------------------------------------------------|
+| Facades / pipe hiding | Planned later | Cosmetic integration for hiding pipes cleanly in builds                                                               |
+| Forestry-style farms  | Planned later | Single-block farms plus the processing/biofuel chain, modernized for current Minecraft (not the multiblock multifarm) |
+| Rail transport        | Planned later | Tracks, carts, routing, and train logistics                                                                           |
 
 ## Exploring / RFC
 
@@ -61,19 +61,21 @@ These ideas are under discussion and may change significantly.
 
 - Programmable pipe gates / pipe signaling
 - Machine upgrades
+- Remote Orderer (handheld network access; really wants an Ender Chest-style companion to shine)
 - Railcraft-style multiblock steam boilers/engines
-- Optional split of Logistics domains into independent mods (core, pipes, automation, forestry, rails)
+- Optional split of Logistics domains into independent mods (core, automation, forestry, transport)
 
 ## Not Currently Planned
 
 These are intentionally not part of the current direction.
 
 - Full BuildCraft builder/filler clone
-- Full classic Forestry bee genetics or butterflies
+- Obsidian / vacuum pickup pipe (vanilla hoppers fill this role now)
+- Full classic Forestry bee, tree or butterfly genetics
 - Full Thermal Expansion item/fluid/storage replacement
 - Railcraft style multiblock fluid tanks
 - Forestry style multiblock farms
-- Deep magic-style teleport logistics
+- Deep magic-style teleport logistics (tesseracts)
 - Exact one-to-one ports of legacy mods
 - Chunk loading
 

--- a/design/README.md
+++ b/design/README.md
@@ -24,7 +24,7 @@ We split the work across three tools, each doing the job it's best at:
 | [`principles.md`](principles.md) | The decision framework (**Port / Modernize / Skip**), modernization rules, balance philosophy, and the shared decision-table template. |
 | [`architecture.md`](architecture.md) | Current domains and the **provisional** module/jar split. |
 | [`progression-tiers.md`](progression-tiers.md) | The **canonical tier ladder** (Copper→Echo Shard), unlock-point phases, and the per-line "pick a subset in order" convention every tiered line follows. |
-| [`roadmap.md`](roadmap.md) | The phased plan (Phase 0–3), what's done, and how it maps to Project #4. |
+| [`delivery-plan.md`](delivery-plan.md) | The detailed phased build plan (Phase 0–3), what's done, and how it maps to Project #4 — the contributor-facing companion to the root user-facing [`ROADMAP.md`](../ROADMAP.md). |
 | [`mods/`](mods/) | One feature breakdown per source mod: BuildCraft, Logistics Pipes, Thermal Expansion, Forestry, Railcraft. |
 | [`features/`](features/) | **Feature briefs** — settled roadmap rows expanded into start-ready specs (problem, requirements, design sketch grounded in the code, open questions). One file per feature. |
 | [`rfcs/`](rfcs/) | **RFCs** — the contested, unsettled design calls (TBD rows): the question, options with trade-offs, a leaning, and how we'll decide. Authored here, then taken to a Discussion. |

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -20,7 +20,7 @@ Domains don't import each other; they talk through `core.lib` (`PlatformService`
 
 The aim is to let players install **only what they want** — not a monolith. Recreating five mods' worth of content in one giant jar would undercut the "install the parts you want" flexibility that defined classic tech packs.
 
-Proposed provisional split, roughly along the source-mod lines:
+Finalized split, roughly along the source-mod lines:
 
 ```text
 logistics-core        # shared library: core.lib abstractions, energy/item/fluid APIs,

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -1,6 +1,6 @@
 # Architecture: Domains & Module Split
 
-> **Status: provisional.** This is a target to steer toward and revisit, not a committed boundary. The hard question — *where exactly do the seams go so each module stands alone?* — is still open.
+> **Status: shape decided, seams provisional.** The module *count and lines* are settled — **four modules: `core` / `automation` / `forestry` / `transport`** (Jun 2026). What's still open is the precise seam placement (*where exactly does each module end so it stands alone?*) and the timing — packaging only becomes real once Forestry and Transport exist.
 
 ## Today: domains in one jar
 
@@ -31,14 +31,17 @@ logistics-automation  # BuildCraft + Logistics Pipes + Thermal Expansion:
                       #   pipes & the logistics network, engines & cables, RF machines
                       #   (macerator, kiln, quarry). The current "main" content.
 
-logistics-forestry    # Forestry: bees, trees, farms, electron tubes, the worktable.
+logistics-forestry    # Forestry (industrial side): farms, processing, electron tubes, the worktable.
+                      #   Genetics (bees/trees/butterflies) is out of scope.
 
 logistics-transport   # Railcraft: rails, advanced carts, tanks, signals, bulk processing.
 ```
 
-### Open question: split `logistics-automation` further?
+### Decided: four modules, not finer
 
-`logistics-automation` is the biggest bucket and arguably three mods in a trench coat. A finer split could be:
+**The direction is the four-module split above — `core` + `automation` + `forestry` + `transport`** (maintainer + contributor call, Jun 2026). We will *not* carve `logistics-automation` further into `pipes` / `power` / `machines`.
+
+A finer split was considered:
 
 ```text
 logistics-pipes    # transport + logistics network (the "glue")
@@ -46,11 +49,11 @@ logistics-power    # engines, cables, battery, energy distribution
 logistics-machines # RF machines: macerator, kiln, quarry, future Thermal-style machines
 ```
 
-**Trade-off:**
-- *Finer split* → maximum player choice (pipes without machines, etc.), but more inter-module API surface to keep stable, and harder to "find the edges" so each stands alone (e.g. pipes are far more useful *with* power once operations cost energy — see the power-gated pipe work).
-- *Coarser split* (single `logistics-automation`) → simpler edges, fewer cross-module contracts, but less granular choice.
+It was rejected (for now) because:
+- The extra granularity buys little real player choice — pipes are far more useful *with* power once operations cost energy (see the power-gated pipe work), so the pieces don't cleanly stand alone.
+- It adds inter-module API surface to keep stable for no current payoff.
 
-**Provisional recommendation:** ship the coarse split first (`core` + `automation` + `forestry` + `transport`), and only carve `automation` apart if/when the internal `core.lib` seams prove clean enough that pipes/power/machines genuinely stand alone. Decide via Discussion before committing.
+This isn't urgent either way: **packaging only becomes a real question once Forestry and Transport actually exist**, so the four-module shape stays the working target and `automation` is treated as one bucket until evidence says otherwise. If the internal `core.lib` seams later prove clean enough that pipes/power/machines genuinely stand alone, revisit via Discussion.
 
 ## Principles for keeping modules separable
 

--- a/design/delivery-plan.md
+++ b/design/delivery-plan.md
@@ -1,4 +1,6 @@
-# Roadmap
+# Delivery Plan
+
+> The **detailed, contributor-facing** phased build plan. For the short, high-level, user-facing direction, see the root [`ROADMAP.md`](../ROADMAP.md) — that's the canonical public roadmap; this file is its in-depth companion.
 
 The phased plan from day zero to "complete." Phases are sequenced to **build on existing strength first**: the BuildCraft / Logistics Pipes / Thermal Expansion automation core is largely in place, so we round it out before opening the Forestry and Railcraft frontiers.
 
@@ -8,26 +10,27 @@ This file is the human-readable mirror of **GitHub Project #4 "Logistics Roadmap
 
 ## Phase overview
 
-| Phase | Theme | Source mods | State |
-|---|---|---|---|
-| **0 — Foundation** | Materials, tools, energy, the pipe network | Logistics Pipes, base of BuildCraft/TE | ✅ Largely done |
-| **1 — Automation core** | Round out engines, ore processing, RF machines, quarry, gates/automation | BuildCraft + Thermal Expansion | 🚧 In progress |
-| **2 — Forestry** | Biological automation: bees, trees, farms, electronics | Forestry | — Not started |
-| **3 — Transport** | Rails, advanced carts, tanks, signals, bulk processing | Railcraft | — Not started |
+| Phase                   | Theme                                                                                                  | Source mods                            | State          |
+|-------------------------|--------------------------------------------------------------------------------------------------------|----------------------------------------|----------------|
+| **0 — Foundation**      | Materials, tools, energy, the pipe network                                                             | Logistics Pipes, base of BuildCraft/TE | ✅ Largely done |
+| **1 — Automation core** | Round out engines, ore processing, RF machines, and the quarry                                         | BuildCraft + Thermal Expansion         | 🚧 In progress |
+| **2 — Forestry**        | Industrial Forestry: farms, processing, power, electronics *(no genetics — no bees/trees/butterflies)* | Forestry                               | — Not started  |
+| **3 — Transport**       | Rails, advanced carts, tanks, signals, bulk processing                                                 | Railcraft                              | — Not started  |
 
 ---
 
 ## Versioning & 1.0
 
-**1.0 is a stability promise, not the finish line.** It does *not* mean all five mods are done — that's the long-term vision. 1.0 means a coherent, self-contained slice is complete and we'll stand behind it.
+**1.0 is a stability promise, not the finish line.** It does *not* mean all four mods are done — that's the long-term vision. 1.0 means a coherent, self-contained slice is complete and we'll stand behind it.
 
 **1.0 = the Automation core (Phase 1) complete and stable, on both loaders.** That's BuildCraft + Logistics Pipes + Thermal Expansion — a complete, recognizable mod on its own. Forestry (`logistics-forestry`) and Railcraft (`logistics-transport`) are **post-1.0** modules that ship as later 1.x minors.
 
 ### Definition of done for 1.0
 
-1. **Phase 1 feature-complete** — the BC/TE gaps filled (fluids foundation, combustion-tier engine, alloy smelter, sawmill, macerator secondary outputs, machine upgrades). Logistics Pipes is already done.
+1. **Phase 1 feature-complete** — the BC/TE gaps filled (fluids foundation, combustion-tier engine, alloy smelter, sawmill, macerator secondary outputs). Logistics Pipes is already done. *(Machine upgrades is **exploratory**, not part of the 1.0 bar — see [ROADMAP.md](../ROADMAP.md) Exploring/RFC.)*
 2. **Loader parity** — NeoForge shipped, not "in progress." Fabric + NeoForge both at the bar.
 3. **Format stability** — block/BE NBT, data components, and config settled; **no save-breaking changes expected**. This is the real meaning of 1.0.
+   - **Content availability** is part of this promise: a 1.0 world must stay fully playable through later phases — no post-1.0 material may become *unobtainable* on an existing save. New materials are sourced without new worldgen ore where possible; any genuinely-new ore commits to retrogen, not pre-seeding. See [RFC 0004](rfcs/0004-worldgen-stability.md).
 4. **Polish** — JEI/recipe coverage, a balance pass, current docs, no known crashes.
 
 ### Released in lockstep
@@ -74,26 +77,30 @@ This file is the human-readable mirror of **GitHub Project #4 "Logistics Roadmap
 - Macerator secondary/byproduct outputs (chance-based)
 - Alloy Smelter (Bronze/Invar/Electrum + the alloy material set)
 - Sawmill (logs → planks + sawdust)
-- Machine upgrades / augments (speed / efficiency / secondary / auto-output)
 - Magma Crucible + Fluid Transposer *(needs fluids)*
 
+*Exploratory (not committed for 1.0 — [ROADMAP.md](../ROADMAP.md) Exploring/RFC):*
+- Machine upgrades / augments (speed / efficiency / secondary / auto-output) — see [`features/0106-machine-upgrades.md`](features/0106-machine-upgrades.md)
+
 **Pipes & logistics QoL**
-- Pipe operation power gating *(in progress)*
-- Remote Orderer (handheld network access)
-- Obsidian vacuum pipe (world item pickup)
+- Pipe operation power gating *(done — #464/#465/#469)*
 - Firewall pipe (network segmentation)
 - Fluid logistics: liquid provider/supplier/request *(needs fluids)*
+
+*Reclassified (not committed for 1.0 — [ROADMAP.md](../ROADMAP.md)):*
+- Remote Orderer (handheld network access) — **exploratory**; leaned on an Ender Chest-style companion mod. See [`features/0109-remote-orderer.md`](features/0109-remote-orderer.md).
+- Obsidian vacuum pipe (world item pickup) — **not planned**; vanilla hoppers cover this. See [`features/0108-obsidian-vacuum-pipe.md`](features/0108-obsidian-vacuum-pipe.md).
 
 **Fuels** *(couples to Combustion Engine + Forestry biofuel)*
 - Decide oil/biofuel sourcing; build the fuel chain
 
 **Programmable behavior — explicitly post-1.0 (deferred)**
 - The unified gates + circuits system (BuildCraft **gates** · TE programmable **augments** · Forestry **circuits** → one "programmable behavior" layer) is **not a 1.0 item.** Deferred until Forestry actually needs it — i.e. circuit boards to program Forestry blocks (Phase 2) — or later. See [RFC 0001](rfcs/0001-programmable-behavior.md).
-- *Distinct from the Phase-1 **machine upgrades** (speed/efficiency/auto-output modifiers) in the Definition of Done above — that's a modifier system, not the programmable-logic layer, and is unaffected by this deferral.*
+- *Distinct from **machine upgrades** (speed/efficiency/auto-output modifiers) — that's a modifier system, not the programmable-logic layer. It's separately **exploratory** (not committed for 1.0; see [ROADMAP.md](../ROADMAP.md) Exploring/RFC) and is unaffected by this deferral either way.*
 
 ## Phase 2 — Forestry —
 
-*Biological automation and endgame variety. Derived from [`mods/forestry.md`](mods/forestry.md). Apatite (fertilizer) and the logic-chip/core/valve "electronics" are already seeded.*
+*Industrial Forestry — farms, processing, power, and electronics. Derived from [`mods/forestry.md`](mods/forestry.md). Apatite (fertilizer) and the logic-chip/core/valve "electronics" are already seeded. The genetics/biology axis (bees, tree-breeding, butterflies) is **out of scope** — see [RFC 0002](rfcs/0002-forestry-bees.md).*
 
 **Farms** *(headline)*
 - Single-block farms (the older Forestry design, **not** the later multiblock multifarm) + farm-type selection/upgrades
@@ -106,15 +113,15 @@ This file is the human-readable mirror of **GitHub Project #4 "Logistics Roadmap
 - Bottler *(needs fluids)*
 - Peat / biofuel engines unified into the engine line
 
-**Trees**
-- Arboriculture (saplings/pollen, grafter); products aligned to vanilla woods + resin
+**Trees** *(wood via farms only — no breeding)*
+- Farms harvest vanilla trees for wood + resin; **no arboriculture/breeding genetics** (out of scope — [RFC 0002](rfcs/0002-forestry-bees.md))
 
 **Electronics**
 - Thermionic Fabricator (modernized, ideally unified with the Carpenter) → electron tubes (map to existing cores/valves/logic chips)
-- Circuit boards + soldering → ties into the Phase 1 programmable-behavior RFC
+- Circuit boards + soldering → ties into the (post-1.0) programmable-behavior RFC, and is the natural trigger to revisit it
 
-**Bees** *(deferred / uncertain — may be skipped for v1)*
-- Vanilla flower-breeding diverges sharply from Forestry's princess/drone/queen; needs a design pass (Discussion) before scheduling
+**Bees / genetics** *(out of scope — separate-mod territory)*
+- Bees, tree-breeding, and butterflies are not built here; the genetics axis diverges from vanilla and would dominate the module — see [RFC 0002](rfcs/0002-forestry-bees.md)
 
 ## Phase 3 — Transport —
 
@@ -136,7 +143,7 @@ This file is the human-readable mirror of **GitHub Project #4 "Logistics Roadmap
 **Steam & steel chain**
 - Coke Oven (coke + creosote) — reconsider multiblock
 - Blast Furnace → **Steel** (single-block preferred); creosote → treated wood
-- Steam power (boiler/turbine) — *TBD, couples to engine line*
+- Steam power (boiler/turbine) — *TBD; leaning toward a **Create compat layer** over a homegrown boiler (see [RFC 0003](rfcs/0003-railcraft-multiblocks.md)); electric locomotives/tracks are out of scope*
 - Bulk fluid Tanks — *TBD (valid multiblock exception?)*
 
 > **Cross-cutting dependencies:** the **Fluids foundation** (Phase 1) unblocks fluid logistics, several TE machines, biofuel bottling (Phase 2), and tank carts/tanks (Phase 3). The **programmable-behavior RFC** spans Phases 1–2. Schedule both early within their phases.
@@ -147,13 +154,13 @@ This file is the human-readable mirror of **GitHub Project #4 "Logistics Roadmap
 
 When a breakdown section settles, decompose it into Project #4:
 
-| Doc concept | Project #4 representation |
-|---|---|
-| **Phase** (0–3) | **Milestone** (e.g. "Phase 1 — Automation core") |
-| **Mod-area / epic** (e.g. "Engines & power") | **Epic issue** (parent issue) |
-| **Feature row** in a `mods/*.md` table | **Sub-issue** under the epic (uses the board's *Parent issue* / *Sub-issues progress* fields) |
-| **Decision** (Port/Modernize/Skip) | Label: `port` / `modernize` / `wontport` *(to be created)* + existing scope labels |
-| **Status** (✅/🚧/—/❌) | Board **Status** field; ❌ rows are not filed |
+| Doc concept                                  | Project #4 representation                                                                     |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------|
+| **Phase** (0–3)                              | **Milestone** (e.g. "Phase 1 — Automation core")                                              |
+| **Mod-area / epic** (e.g. "Engines & power") | **Epic issue** (parent issue)                                                                 |
+| **Feature row** in a `mods/*.md` table       | **Sub-issue** under the epic (uses the board's *Parent issue* / *Sub-issues progress* fields) |
+| **Decision** (Port/Modernize/Skip)           | Label: `port` / `modernize` / `wontport` *(to be created)* + existing scope labels            |
+| **Status** (✅/🚧/—/❌)                        | Board **Status** field; ❌ rows are not filed                                                  |
 
 **Decomposition rules:**
 - Reconcile with issues already on the board (e.g. *"Forestry-Inspired Farming & Electronics Roadmap"*, *"BuildCraft compatibility shim"*) — extend/link them, don't duplicate.

--- a/design/delivery-plan.md
+++ b/design/delivery-plan.md
@@ -14,7 +14,7 @@ This file is the human-readable mirror of **GitHub Project #4 "Logistics Roadmap
 |-------------------------|--------------------------------------------------------------------------------------------------------|----------------------------------------|----------------|
 | **0 — Foundation**      | Materials, tools, energy, the pipe network                                                             | Logistics Pipes, base of BuildCraft/TE | ✅ Largely done |
 | **1 — Automation core** | Round out engines, ore processing, RF machines, and the quarry                                         | BuildCraft + Thermal Expansion         | 🚧 In progress |
-| **2 — Forestry**        | Industrial Forestry: farms, processing, power, electronics *(no genetics — no bees/trees/butterflies)* | Forestry                               | — Not started  |
+| **2 — Forestry**        | Industrial Forestry: farms, processing, power, electronics *(tree harvesting only; no genetics/breeding)* | Forestry                               | — Not started  |
 | **3 — Transport**       | Rails, advanced carts, tanks, signals, bulk processing                                                 | Railcraft                              | — Not started  |
 
 ---

--- a/design/features/0101-fluids-foundation.md
+++ b/design/features/0101-fluids-foundation.md
@@ -134,7 +134,7 @@ All start-blocking questions are settled — this brief is ready to build:
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → 🔑 Fluids foundation
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → 🔑 Fluids foundation
 - Breakdowns: [`../mods/buildcraft.md`](../mods/buildcraft.md) (Fluid pipes, Pump, Oil/Refinery), [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) (Magma Crucible, Fluid Transposer)
 - Code precedent (item side, mirror it): `core/lib/storage/IItemStorage`, `core/lib/block/capability/HasItemStorage`, `core/lib/storage/ItemStorageLookup`, `fabric/.../capability/ItemStorageAccess`, `neoforge/.../NeoForgeCapabilityRegistration`
 - Already-built fluid layer: `core/lib/fluids/*`, `core/lib/block/capability/HasFluidStorage`, `fabric/.../fluids/*`, `neoforge/.../fluids/*`

--- a/design/features/0102-macerator-secondary-outputs.md
+++ b/design/features/0102-macerator-secondary-outputs.md
@@ -76,7 +76,7 @@ All mechanism-level questions are settled — the byproduct *content* is the onl
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → macerator outputs
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → macerator outputs
 - Breakdown: [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) → "secondary/byproduct outputs" row
 - **TE sourcing note:** Thermal Expansion has **no public source repo** — Pulverizer behavior (dedicated secondary slot, per-op chance, ~5–25% range) is reconstructed from knowledge + the TE wiki. Treat exact chances as *approximate* and tune in playtesting; do not cite source line numbers.
 - Code: `core/macerator/{MaceratorRecipeWrapper,MaceratorRecipeSerializer,MaceratorProcessingPlan,MaceratorRecipeDisplay}.java`, `core/macerator/jei/MaceratorRecipeCategory.java`, recipes in `data/logistics/recipe/macerator/`

--- a/design/features/0103-hand-grinder.md
+++ b/design/features/0103-hand-grinder.md
@@ -75,7 +75,7 @@ common/src/main/java/com/logistics/core/handgrinder/
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 (early-game processing on-ramp)
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 (early-game processing on-ramp)
 - Pairs with: [`0102-macerator-secondary-outputs.md`](0102-macerator-secondary-outputs.md) (shared recipes; powered upgrade with byproducts), [`0105-alloy-smelter.md`](0105-alloy-smelter.md) (the no-power Bronze path this enables)
 - Tier placement: [`../progression-tiers.md`](../progression-tiers.md) (bottom-of-ladder manual tool)
 - Code precedent: vanilla `ComposterBlock` (block-state progress + right-click), `LecternBlock` (BE holds an item); `core/macerator/{MaceratorRecipeWrapper,MaceratorRecipeSerializer}` (reused recipes); registration in `LogisticsCore.java`

--- a/design/features/0104-sawmill.md
+++ b/design/features/0104-sawmill.md
@@ -78,7 +78,7 @@ All start-blocking questions are settled:
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → Sawmill
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → Sawmill
 - Breakdown: [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) → Sawmill row (notes existing Wood Pulp/Flour dusts)
 - **TE sourcing note:** TE has **no public source** — yields are wiki/knowledge-based, approximate; tune in playtest. Existing items confirmed in `LogisticsCore.java`: `WOOD_PULP` (`logistics:core/wood_pulp`), `FLOUR`.
 - Code pattern: `automation/kiln/*`, `core/macerator/*`; registration in `LogisticsAutomation.java`

--- a/design/features/0105-alloy-smelter.md
+++ b/design/features/0105-alloy-smelter.md
@@ -101,7 +101,7 @@ common/src/main/java/com/logistics/automation/alloysmelter/
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → Alloy Smelter; materials rows in [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md)
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → Alloy Smelter; materials rows in [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md)
 - Code pattern: `automation/kiln/*` and `core/macerator/*` (block, BE, recipe, serializer, processing plan, screen, JEI); registration in `LogisticsAutomation.java`; new metal items in `LogisticsCore.java` (next to `TIN_*`/`BRONZE_*`)
 - Shared mechanism: [`0102-macerator-secondary-outputs.md`](0102-macerator-secondary-outputs.md) `ChanceResult` (generalized here to the shared output inventory)
 - **TE sourcing note:** TE has **no public source** — slag/byproduct behavior and ratios are wiki/knowledge-based, approximate; tune in playtest. Existing metal items confirmed in `LogisticsCore.java`: `TIN_*`, `BRONZE_*`, `*_DUST`, `*_GEAR`, `COPPER/BRONZE_VALVE`, `COPPER/BRONZE_CORE` (Nickel/Invar/Slag do **not** exist yet).

--- a/design/features/0106-machine-upgrades.md
+++ b/design/features/0106-machine-upgrades.md
@@ -1,8 +1,8 @@
 # Machine Upgrades / Augments
 
-> **Status:** 🚧 Planned · **Phase:** 1 — Automation core · **Module:** `logistics-automation` (cross-machine; `core.lib` contract)
+> **Status:** 🔍 Exploring — **not committed for 1.0** ([`ROADMAP.md`](../../ROADMAP.md) lists machine upgrades under *Exploring / RFC*). This brief captures *how* we'd build it if/when it's accepted; it is not yet scheduled. · **Module:** `logistics-automation` (cross-machine; `core.lib` contract)
 > **Source:** [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) (Augments) · **Depends on:** the machine pattern (Macerator/Kiln); pairs with [`0102-macerator-secondary-outputs.md`](0102-macerator-secondary-outputs.md) (secondary augment)
-> **Maps to (roadmap):** Phase 1 — machine upgrades
+> **Maps to (roadmap):** [`ROADMAP.md`](../../ROADMAP.md) → Exploring / RFC → machine upgrades
 
 A unified, slot-in modifier system applied across all RF machines (Macerator, Kiln, Sawmill, Alloy Smelter): speed, efficiency, secondary-yield, and auto-output augments. The cross-cutting "make machines feel like a system, not isolated blocks" feature. There is no upgrade system today — this defines one.
 
@@ -43,7 +43,7 @@ Define the contract in `core.lib`, apply it in each machine's processing plan.
 
 ## Scope & non-goals
 
-- **In:** the `core.lib` upgrade contract, four augment types, GUI slots, adoption across the four Phase-1 machines.
+- **In (if accepted):** the `core.lib` upgrade contract, four augment types, GUI slots, adoption across the four core machines (Macerator/Kiln/Sawmill/Alloy Smelter).
 - **Out:** machine **tiers / frames** (Basic→Resonant crafted machine bodies — separate, see TE breakdown "Machine frames / tiers"); per-side augment config; augments that change *what* a machine does (only how fast/cheap/auto); fluid-machine augments (until those machines exist).
 - **Out:** engine augments — engines aren't processing machines; revisit separately if wanted.
 
@@ -63,7 +63,7 @@ Define the contract in `core.lib`, apply it in each machine's processing plan.
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → machine upgrades
+- Roadmap: [`ROADMAP.md`](../../ROADMAP.md) → Exploring / RFC → machine upgrades (and [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → exploratory)
 - Breakdown: [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) → "Augments" and "Machine frames / tiers" rows
 - Code: the four machines' `*ProcessingPlan` + `*ScreenHandler`; `core/lib/items/ItemInventoryComponent`; `core/lib/storage/ItemStorageLookup` (auto-output); data-component precedent in `pipe/data/PipeDataComponents`
 - Related: [`0102-macerator-secondary-outputs.md`](0102-macerator-secondary-outputs.md), [`0107-tiered-batteries.md`](0107-tiered-batteries.md)

--- a/design/features/0107-tiered-batteries.md
+++ b/design/features/0107-tiered-batteries.md
@@ -84,7 +84,7 @@ common/src/main/java/com/logistics/power/block/
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → Battery (tiers); [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) → "Energy Cells" row
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → Battery (tiers); [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) → "Energy Cells" row
 - Code: `core/lib/power/AbstractBatteryBlockEntity` (tier-ready constructor), `power/block/{BatteryBlock,BatteryBlockItem}`, `power/block/entity/BatteryBlockEntity`; tier precedent `power/cable/{CableTier,CableBlock,CableBlockEntity,CableNetwork}` (current rates 30/60/120 RF/t, lossless, bufferless); data-component precedent `pipe/data/PipeDataComponents`; registration in `LogisticsPower.java`
 - TE Fluxduct reference (wiki — TE has no public source): [Team CoFH — Fluxducts](https://teamcofh.com/docs/1.12/thermal-dynamics/fluxducts/) (Leadstone 200 / Hardened 800 / Redstone 8,000 / Resonant 32,000 RF/t; [Cryo-Stabilized](https://teamcofh.com/docs/1.12/thermal-dynamics/cryo-stabilized-fluxduct/) = unlimited)
 - Related: [`0105-alloy-smelter.md`](0105-alloy-smelter.md) (materials gate), [`0106-machine-upgrades.md`](0106-machine-upgrades.md) (creates the demand for bigger storage)

--- a/design/features/0108-obsidian-vacuum-pipe.md
+++ b/design/features/0108-obsidian-vacuum-pipe.md
@@ -1,8 +1,8 @@
 # Obsidian Vacuum Pipe
 
-> **Status:** 🚧 Planned · **Phase:** 1 — Automation core · **Module:** `logistics-automation` (`pipe` domain)
+> **Status:** ❌ Not planned — vanilla **hoppers** fill this role in modern Minecraft ([`ROADMAP.md`](../../ROADMAP.md) → Not Currently Planned). This brief is retained as a record of the design only. · **Module:** `logistics-automation` (`pipe` domain)
 > **Source:** [`../mods/buildcraft.md`](../mods/buildcraft.md) (Obsidian pipe — world pickup) · **Depends on:** nothing
-> **Maps to (roadmap):** Phase 1 — pipes (Obsidian vacuum pipe)
+> **Maps to (roadmap):** [`ROADMAP.md`](../../ROADMAP.md) → Not Currently Planned
 
 A pipe that vacuums up dropped item entities from the world around it and injects them into the pipe network. A faithful, low-risk Port — the pipe/module system already has everything needed; this is a new module + pipe registration.
 
@@ -59,5 +59,5 @@ The closest precedent is the **Void pipe** (`VoidModule`) for "special routing p
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → pipes; [`../mods/buildcraft.md`](../mods/buildcraft.md) → Obsidian pipe row
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → pipes; [`../mods/buildcraft.md`](../mods/buildcraft.md) → Obsidian pipe row
 - Code: `pipe/modules/VoidModule` (special pipe precedent), `core/lib/pipe/{Module,TickingModule,RoutingModule,TravelingItem}`, `pipe/block/entity/PipeBlockEntity#dropItem` (reverse of the operation), `automation/laserquarry/.../QuarryBlockBreaker` (entity-scan idiom), `pipe/PipeTypes`, `LogisticsPipe.java`

--- a/design/features/0108-obsidian-vacuum-pipe.md
+++ b/design/features/0108-obsidian-vacuum-pipe.md
@@ -59,5 +59,5 @@ The closest precedent is the **Void pipe** (`VoidModule`) for "special routing p
 
 ## References
 
-- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → pipes; [`../mods/buildcraft.md`](../mods/buildcraft.md) → Obsidian pipe row
+- Roadmap: [`../../ROADMAP.md`](../../ROADMAP.md) → Not Currently Planned; [`../mods/buildcraft.md`](../mods/buildcraft.md) → Obsidian pipe row
 - Code: `pipe/modules/VoidModule` (special pipe precedent), `core/lib/pipe/{Module,TickingModule,RoutingModule,TravelingItem}`, `pipe/block/entity/PipeBlockEntity#dropItem` (reverse of the operation), `automation/laserquarry/.../QuarryBlockBreaker` (entity-scan idiom), `pipe/PipeTypes`, `LogisticsPipe.java`

--- a/design/features/0109-remote-orderer.md
+++ b/design/features/0109-remote-orderer.md
@@ -62,5 +62,5 @@ common/src/main/java/com/logistics/pipe/item/RemoteOrdererItem.java
 
 ## References
 
-- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → logistics QoL; [`../mods/logistics-pipes.md`](../mods/logistics-pipes.md) → Remote Orderer row
+- Roadmap: [`../../ROADMAP.md`](../../ROADMAP.md) → Exploring/RFC; [`../mods/logistics-pipes.md`](../mods/logistics-pipes.md) → Remote Orderer row
 - Code: `pipe/ui/RequesterScreenHandler` (reuse), `pipe/modules/RequesterModule#onWrench` (openMenu idiom), `pipe/item/ModuleItem#use` (handheld→screen), `pipe/network/NetworkRegistry` (resolve network by pos), `core/lib/network/{ILogisticsNetwork,Order}`, `pipe/data/PipeDataComponents` (data-component binding), `LogisticsPipe.java`

--- a/design/features/0109-remote-orderer.md
+++ b/design/features/0109-remote-orderer.md
@@ -1,8 +1,8 @@
 # Remote Orderer
 
-> **Status:** 🚧 Planned · **Phase:** 1 — Automation core · **Module:** `logistics-automation` (`pipe` domain)
+> **Status:** 🔍 Exploring — **not committed** ([`ROADMAP.md`](../../ROADMAP.md) → Exploring/RFC). Its payoff leaned on an Ender Chest-style companion mod to be broadly useful; revisit if that need is met. This brief captures *how* we'd build it if accepted. · **Module:** `logistics-automation` (`pipe` domain)
 > **Source:** [`../mods/logistics-pipes.md`](../mods/logistics-pipes.md) (Remote Orderer) · **Depends on:** nothing
-> **Maps to (roadmap):** Phase 1 — logistics QoL
+> **Maps to (roadmap):** [`ROADMAP.md`](../../ROADMAP.md) → Exploring/RFC
 
 A handheld item that opens the network request UI from anywhere in range — order items from your logistics network without standing at a Requester pipe. A high-value QoL Modernize: the request UI and order flow already exist; this is a new item that reaches them.
 
@@ -62,5 +62,5 @@ common/src/main/java/com/logistics/pipe/item/RemoteOrdererItem.java
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → logistics QoL; [`../mods/logistics-pipes.md`](../mods/logistics-pipes.md) → Remote Orderer row
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → logistics QoL; [`../mods/logistics-pipes.md`](../mods/logistics-pipes.md) → Remote Orderer row
 - Code: `pipe/ui/RequesterScreenHandler` (reuse), `pipe/modules/RequesterModule#onWrench` (openMenu idiom), `pipe/item/ModuleItem#use` (handheld→screen), `pipe/network/NetworkRegistry` (resolve network by pos), `core/lib/network/{ILogisticsNetwork,Order}`, `pipe/data/PipeDataComponents` (data-component binding), `LogisticsPipe.java`

--- a/design/features/0110-firewall-pipe.md
+++ b/design/features/0110-firewall-pipe.md
@@ -62,5 +62,5 @@ The explore surfaced **two viable approaches** — this is the key decision to m
 
 ## References
 
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 1 → logistics advanced; [`../mods/logistics-pipes.md`](../mods/logistics-pipes.md) → Firewall pipe row
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → logistics advanced; [`../mods/logistics-pipes.md`](../mods/logistics-pipes.md) → Firewall pipe row
 - Code: `core/lib/pipe/{Module,RoutingModule}`, `pipe/modules/*` (e.g. `NetworkRouterModule`, `VoidModule`), `pipe/network/{NetworkRegistry,PipeNetwork,NetworkController}`, `core/lib/network/{INetworkGraph,NetworkGraph,NetworkPathfinder,ILogisticsNetwork}`, `pipe/ui/RequesterScreenHandler` (config-UI pattern), `pipe/PipeTypes`, `LogisticsPipe.java`

--- a/design/features/README.md
+++ b/design/features/README.md
@@ -1,8 +1,8 @@
 # Feature Briefs
 
-This folder expands settled [`roadmap.md`](../roadmap.md) rows into **feature briefs** — one file per feature, detailed enough to *start the work*. Each brief is grounded in the actual codebase: it names the real classes and patterns a feature plugs into, so an implementer isn't starting from a blank page.
+This folder expands settled [`delivery-plan.md`](../delivery-plan.md) rows into **feature briefs** — one file per feature, detailed enough to *start the work*. Each brief is grounded in the actual codebase: it names the real classes and patterns a feature plugs into, so an implementer isn't starting from a blank page.
 
-Briefs sit **between** the durable "why" (the [`mods/`](../mods/) breakdowns, [`vision.md`](../vision.md), [`principles.md`](../principles.md)) and the live work tracking (GitHub Project #4). The breakdown says *what we decided and why*; the brief says *what to build and how to start*; the Project issue tracks *the work*. When a brief settles, decompose it onto the board (see the roadmap's [Mapping to the board](../roadmap.md#mapping-to-the-board)).
+Briefs sit **between** the durable "why" (the [`mods/`](../mods/) breakdowns, [`vision.md`](../vision.md), [`principles.md`](../principles.md)) and the live work tracking (GitHub Project #4). The breakdown says *what we decided and why*; the brief says *what to build and how to start*; the Project issue tracks *the work*. When a brief settles, decompose it onto the board (see the roadmap's [Mapping to the board](../delivery-plan.md#mapping-to-the-board)).
 
 > These are **starting points, not specs set in stone**. Every brief carries an "Open questions" section — the decisions still owed before or during implementation. Resolve the blocking ones (often via a Discussion or a short spike) before scheduling.
 
@@ -25,10 +25,10 @@ The first batch covers the **[Fluids foundation](0101-fluids-foundation.md)** (t
 | 0103 | [Hand Grinder](0103-hand-grinder.md) | Machines (no-power on-ramp) | Modernize | Macerator recipes |
 | 0104 | [Sawmill](0104-sawmill.md) | Machines | Port | `ChanceResult` (0102) |
 | 0105 | [Alloy Smelter](0105-alloy-smelter.md) | Machines + materials | Port/Modernize | `ChanceResult` (0102), Hand Grinder (0103) |
-| 0106 | [Machine Upgrades / Augments](0106-machine-upgrades.md) | Machines (cross-cutting) | Modernize | the machines (0102 / 0104 / 0105) |
+| 0106 | [Machine Upgrades / Augments](0106-machine-upgrades.md) 🔍 *exploratory — not committed for 1.0* | Machines (cross-cutting) | Modernize | the machines (0102 / 0104 / 0105) |
 | 0107 | [Tiered Batteries](0107-tiered-batteries.md) | Power | Modernize | — (extends Battery) |
-| 0108 | [Obsidian Vacuum Pipe](0108-obsidian-vacuum-pipe.md) | Pipes | Port | — |
-| 0109 | [Remote Orderer](0109-remote-orderer.md) | Logistics QoL | Modernize | — |
+| 0108 | [Obsidian Vacuum Pipe](0108-obsidian-vacuum-pipe.md) ❌ *not planned — hoppers cover it* | Pipes | Skip | — |
+| 0109 | [Remote Orderer](0109-remote-orderer.md) 🔍 *exploratory — not committed* | Logistics QoL | Modernize | — |
 | 0110 | [Firewall Pipe](0110-firewall-pipe.md) | Logistics advanced | Port | — |
 
 ### Reading the order
@@ -36,8 +36,8 @@ The first batch covers the **[Fluids foundation](0101-fluids-foundation.md)** (t
 The step numbers encode dependencies, but several briefs are independent and can run in parallel:
 
 - **Start first — `0101` Fluids:** the keystone. Begin with its design spike (parallel fluid pipe vs. network-integrated) since it unblocks the entire deferred batch.
-- **Machine / dust chain — `0102` → `0103` → `0104` / `0105` → `0106`:** build [Macerator Secondary Outputs](0102-macerator-secondary-outputs.md) first (the shared `ChanceResult` mechanism); then the [Hand Grinder](0103-hand-grinder.md) (the no-power ore→dust on-ramp, prerequisite for the Alloy Smelter's no-power Bronze path). [Sawmill](0104-sawmill.md) and [Alloy Smelter](0105-alloy-smelter.md) reuse `ChanceResult` (Alloy also needs the Hand Grinder); then layer [Machine Upgrades](0106-machine-upgrades.md) across them.
-- **Independent (any time) — `0107`/`0108`/`0109`:** [Tiered Batteries](0107-tiered-batteries.md), [Obsidian Vacuum Pipe](0108-obsidian-vacuum-pipe.md), [Remote Orderer](0109-remote-orderer.md) have no in-batch dependencies.
+- **Machine / dust chain — `0102` → `0103` → `0104` / `0105` → `0106`:** build [Macerator Secondary Outputs](0102-macerator-secondary-outputs.md) first (the shared `ChanceResult` mechanism); then the [Hand Grinder](0103-hand-grinder.md) (the no-power ore→dust on-ramp, prerequisite for the Alloy Smelter's no-power Bronze path). [Sawmill](0104-sawmill.md) and [Alloy Smelter](0105-alloy-smelter.md) reuse `ChanceResult` (Alloy also needs the Hand Grinder). [Machine Upgrades](0106-machine-upgrades.md) could later layer across them, but it's **exploratory** (per [`ROADMAP.md`](../../ROADMAP.md) Exploring/RFC), not part of the committed batch.
+- **Independent (any time) — `0107`:** [Tiered Batteries](0107-tiered-batteries.md) has no in-batch dependencies. ([Obsidian Vacuum Pipe](0108-obsidian-vacuum-pipe.md) is now **not planned** — hoppers cover it; [Remote Orderer](0109-remote-orderer.md) is **exploratory**, not committed — see [`ROADMAP.md`](../../ROADMAP.md).)
 - **Spike before scheduling — `0101` and `0110`:** the [Fluids](0101-fluids-foundation.md) pipe approach and the [Firewall Pipe](0110-firewall-pipe.md) (routing-gate vs. graph-segmentation, which touches stable network code) each need a short spike to settle the approach.
 
 ### Deferred to a later batch (Phase 1, fluid-blocked or needs a Discussion)
@@ -45,7 +45,7 @@ The step numbers encode dependencies, but several briefs are independent and can
 Not written yet — they wait on the keystone or on an open decision, and will take `0111+` steps:
 
 - **Needs fluids first:** Combustion-tier engine, Magmatic/dynamo tier, Magma Crucible, Fluid Transposer, fluid logistics (provider/supplier/request), Pump (built as the Fluids-foundation validation slice), the oil/biofuel fuel chain.
-- **Deferred post-1.0 (RFC, not a feature brief):** the programmable-automation / gates+circuits system (BuildCraft gates + TE programmable augments + Forestry circuits) — **not a 1.0 item**; revisit when Forestry needs circuit boards (Phase 2) or later. See [`../rfcs/0001-programmable-behavior.md`](../rfcs/0001-programmable-behavior.md). *(Distinct from the Phase-1 machine-modifier upgrades, [0106](0106-machine-upgrades.md).)*
+- **Deferred post-1.0 (RFC, not a feature brief):** the programmable-automation / gates+circuits system (BuildCraft gates + TE programmable augments + Forestry circuits) — **not a 1.0 item**; revisit when Forestry needs circuit boards (Phase 2) or later. See [`../rfcs/0001-programmable-behavior.md`](../rfcs/0001-programmable-behavior.md). *(Distinct from the machine-modifier upgrades, [0106](0106-machine-upgrades.md) — themselves exploratory, not committed for 1.0.)*
 - **Already done:** pipe operation power gating (✅, #464/#465/#469).
 
 ## Brief template

--- a/design/mods/buildcraft.md
+++ b/design/mods/buildcraft.md
@@ -14,7 +14,7 @@ See [`../principles.md`](../principles.md) for the table legend. Pipe transport 
 |---|---|---|---|---|---|
 | Item transport pipes (wood/cobble/stone/iron/gold/diamond/obsidian/etc.) | Move/sort/extract items by material | Modernize | Covered by the Logistics transport + smart pipe set with vanilla-material identity | ✅ Done | `pipe` / transport + smart pipes |
 | Diamond pipe (sorting) | Per-side item sorting | Port | Item Filter Pipe | ✅ Done | `pipe` / Item Filter Pipe |
-| Obsidian pipe (world pickup) | Suck up dropped items/entities | Port | Worth adding — vacuum behavior; balance range | — | Phase 1 — pipes |
+| Obsidian pipe (world pickup) | Suck up dropped items/entities | Skip | Vanilla **hoppers** fill this role in modern Minecraft — not worth a dedicated pipe ([ROADMAP](../../ROADMAP.md) → Not Currently Planned) | ❌ | — |
 | Cobblestone/lapis/quartz flavor pipes | Routing-speed/color variants | Modernize | Covered/absorbed by current material tiers + marking fluid | ✅ Done | `pipe` / pipes + marking |
 | Kinesis (power) pipes | Transport engine power (MJ) | Modernize | Replaced by RF **cables** (copper/gold/ender) | ✅ Done | `power` / cables |
 | Fluid (waterproof) pipes | Transport liquids | Port | Needs a fluid-transport layer (platform fluid API) | — | Phase 1 — fluids |
@@ -37,7 +37,7 @@ See [`../principles.md`](../principles.md) for the table legend. Pipe transport 
 | Landmarks / markers | Define work areas | Modernize | Marker blocks (solo + connected bounds) | ✅ Done | `automation` / Marker |
 | Pump | Pump fluids from world into pipes/tanks | Port | Needs the fluid layer; classic oil/water/lava pumping | — | Phase 1 — fluids |
 | Oil & Refinery & Fuel | Oil lakes → refine to fuel for combustion engines | Port | Bring it over as-is: oil world-gen → Refinery → fuel. Couples to the Combustion Engine; Forestry biofuel is a *parallel* fuel, not a replacement | — | Phase 1 — fuels |
-| Filler | Auto-fill/clear areas with patterns | Skip | Construction automation; tedious, overlaps Create/Schematica niche | ❌ | — |
+| Filler | Auto-fill/clear areas with patterns | Skip | Handy, but **terrain/construction automation isn't this mod's job** — it belongs in its own dedicated mod (and modern Create/Schematica-likes already cover the niche). A simplified clear/flatten Filler was floated in review; the call is to keep it out of Logistics' scope | ❌ | — |
 | Builder / Architect / Blueprints / Library | Save & auto-build structures | Skip | Heavy; modern Schematica-likes cover this; out of scope | ❌ | — |
 
 ## Gates, wiring & automation logic

--- a/design/mods/forestry.md
+++ b/design/mods/forestry.md
@@ -1,6 +1,6 @@
 # Forestry
 
-*The "endgame variety" layer. For our purposes the **farms** are the headline — followed closely by the **processing machines and the power** that feed them — then trees and electronics. **Bees are deferred** (the vanilla breeding model diverges sharply from Forestry's; see below) and butterflies are skipped. Groundwork is already seeded: apatite for fertilizer, and the logic-chip/core/valve components resemble electron-tube electronics. This is Phase 2.*
+*The "endgame variety" layer. For our purposes the **farms** are the headline — followed closely by the **processing machines and the power** that feed them — then electronics. **The entire genetics/biology axis is out of scope** for this mod: no bees, no tree-breeding (arboriculture), no butterflies (maintainer + contributor call, Jun 2026 — see [RFC 0002](../rfcs/0002-forestry-bees.md)). Forestry's fit here is its *industrial* side. Groundwork is already seeded: apatite for fertilizer, and the logic-chip/core/valve components resemble electron-tube electronics. This is Phase 2.*
 
 **Source era:** 1.7.10–1.12.2 (Forestry).
 **Logistics module:** `logistics-forestry` (new).
@@ -31,12 +31,14 @@ See [`../principles.md`](../principles.md) for the table legend. Forestry is lar
 | Engines (peat / biogas / biofuel / electrical) | Forestry's own engine line | Modernize | **Unify with the engine line**: peat-fired + biofuel engine tiers rather than a parallel system. This is "the power that went with the farms" | — | `power` / engines |
 | Moistener | Make mycelium/mossy blocks | Modernize | Minor; low priority | — | — |
 
-## Trees (arboriculture)
+## Trees (arboriculture) — out of scope
+
+> **Tree breeding/arboriculture is genetics, and genetics is out of scope for Logistics** (Jun 2026 — see [RFC 0002](../rfcs/0002-forestry-bees.md)). Logistics farms can already *grow and harvest* vanilla trees for wood; what we skip is the **breeding/species-discovery** layer (saplings/pollen genetics, grafter, treealyzer, specialty bred woods). If breeding is ever wanted, it's a separate, dedicated mod's job.
 
 | Feature | What it did | Decision | Modern take / balance notes | Status | Maps to |
 |---|---|---|---|---|---|
-| Arboriculture | Breed tree species; saplings/pollen; grafter; treealyzer | Port | Yields wood variety + fruit; could start with a simpler species set before deep genetics | — | Phase 2 — trees |
-| Tree products (fruit/wood/sapling) | Specialty woods, fruits, latex | Modernize | Align with vanilla wood types + **resin** (not "sap") | — | Phase 2 — trees |
+| Arboriculture (tree breeding/genetics) | Breed tree species; saplings/pollen; grafter; treealyzer | Skip | Genetics axis — out of scope for this mod; belongs in a dedicated genetics mod | ❌ | — |
+| Tree products (fruit/wood/sapling) | Specialty woods, fruits, latex | Modernize | No *bred* specialty woods; cover wood/resin via the **farms** harvesting vanilla trees (resin, not "sap") rather than an arboriculture system | — | Phase 2 — farms |
 
 ## Electronics (electron tubes & circuits)
 
@@ -46,17 +48,17 @@ See [`../principles.md`](../principles.md) for the table legend. Forestry is lar
 | Electron tubes (copper/tin/bronze/iron/gold/diamond/blaze/apatite/lapis/ender/etc.) | Typed components for circuit programming | Modernize | **Already seeded**: Logistics has *logic chips*, *cores* (13), and *valves* (13) that mirror this tube set | 🚧 Planned | `core` / cores, valves, logic chips |
 | Circuit boards + Soldering | Program machine/farm behavior via tube layouts | TBD | **Unify** circuits with TE-style augments + BC gates into one "programmable behavior" system across the mod | — | Phase 1/2 — electronics (RFC) |
 
-## Bees (apiculture) — deferred
+## Bees (apiculture) — out of scope
 
-> **Bees are not a Phase 2 headline and may be skipped entirely for v1.** Modern vanilla already breeds bees by feeding them flowers — a model that diverges sharply from Forestry's princess/drone/queen lifecycle and Mendelian genetics. Reconciling the two (extend vanilla? full parallel system? skip?) needs a deliberate design pass before any of this is scheduled — flag for an Ideas Discussion.
+> **Bees are out of scope for Logistics** (decided Jun 2026 — see [RFC 0002](../rfcs/0002-forestry-bees.md)). Modern vanilla already breeds bees by feeding them flowers — a model that diverges sharply from Forestry's princess/drone/queen lifecycle and Mendelian genetics — and the whole genetics axis (bees/trees/butterflies) is deliberately not this mod's job. The rows below are retained as the rationale for that call; they are **not** on the roadmap.
 
 | Feature | What it did | Decision | Modern take / balance notes | Status | Maps to |
 |---|---|---|---|---|---|
-| Apiary | Single-block bee housing; bees produce combs | Modernize | **Vanilla already has the beehive/bee nest** — extend its behavior rather than add a parallel block | — | — |
-| Bee lifecycle (princess/drone/queen) | Breed queens; offspring; decay | TBD | Fundamentally different from vanilla flower-breeding; the crux of whether bees happen at all | — | — |
-| Bee genetics / mutations | Mendelian traits + species discovery | TBD | Depends on the lifecycle decision; if pursued, simplify the trait matrix | — | — |
-| Bee products + Centrifuge | Combs → centrifuge → honey/wax/jelly | TBD | Coupled to bees; deferred with them | — | — |
-| Frames / Alveary / bee tools | Output modifiers; advanced multiblock; analysis | TBD | Deferred; Alveary would also fight the multiblock stance | — | — |
+| Apiary | Single-block bee housing; bees produce combs | Skip | Vanilla already has the beehive/bee nest; genetics axis is out of scope | ❌ | — |
+| Bee lifecycle (princess/drone/queen) | Breed queens; offspring; decay | Skip | Fundamentally different from vanilla flower-breeding; genetics — out of scope (separate-mod territory) | ❌ | — |
+| Bee genetics / mutations | Mendelian traits + species discovery | Skip | The genetics axis we're explicitly not building | ❌ | — |
+| Bee products + Centrifuge | Combs → centrifuge → honey/wax/jelly | Skip | Coupled to bees; out with them (source any needed products another way) | ❌ | — |
+| Frames / Alveary / bee tools | Output modifiers; advanced multiblock; analysis | Skip | Out with bees; Alveary would also fight the multiblock stance | ❌ | — |
 
 ## Out of scope
 
@@ -68,4 +70,4 @@ See [`../principles.md`](../principles.md) for the table legend. Forestry is lar
 | Mail / Letters / Trade Stations | In-game postal + auto-trade | Skip | Niche; out of scope | ❌ | — |
 
 > TODO: confirm the exact electron-tube → circuit-board recipe model, and whether to merge it with TE augments + BuildCraft gates into a single "programmable behavior" subsystem (likely an Ideas Discussion — it spans three source mods). See [RFC 0001 — Programmable Behavior](../rfcs/0001-programmable-behavior.md).
-> TODO: settle the bees question (extend vanilla / parallel system / skip for v1) before any Phase 2 bee work is scheduled. See [RFC 0002 — Forestry Bees](../rfcs/0002-forestry-bees.md).
+> Decided (Jun 2026): the genetics axis — bees, tree-breeding, butterflies — is **out of scope** for Logistics; it would be a separate, dedicated mod. See [RFC 0002 — Forestry Genetics](../rfcs/0002-forestry-bees.md).

--- a/design/mods/logistics-pipes.md
+++ b/design/mods/logistics-pipes.md
@@ -50,7 +50,7 @@ See [`../principles.md`](../principles.md) for the table legend.
 
 | Feature | What it did | Decision | Modern take / balance notes | Status | Maps to |
 |---|---|---|---|---|---|
-| Remote Orderer | Handheld GUI to request from the network anywhere in range | Modernize | A handheld access item (probe-like) opening the request UI; balance the range/cost | 🚧 Planned | Phase 1 — logistics QoL |
+| Remote Orderer | Handheld GUI to request from the network anywhere in range | Modernize | A handheld access item (probe-like) opening the request UI; balance the range/cost. **Exploratory** — leaned on an Ender Chest-style companion to be broadly useful ([ROADMAP](../../ROADMAP.md) → Exploring/RFC) | — | Exploring — logistics QoL |
 | Power gating for operations | LP operations needed power (Power Junction / supplier) | Port | Done — pipe operations consume RF, with network energy sourcing + a shared energy-push service; pipes render green/red by power state (#464, #465, #469) | ✅ Done | `power` / pipe power gate |
 | Fluid logistics | Liquid supplier/provider/request over the network | Modernize | Depends on fluid pipes (see [`buildcraft.md`](buildcraft.md) / [`thermal-expansion.md`](thermal-expansion.md)) | — | Phase 1 — fluids |
 | Firewall pipe | Isolate/segment a sub-network | Port | Network segmentation block; useful for large bases | — | Phase 1 — logistics advanced |

--- a/design/mods/railcraft.md
+++ b/design/mods/railcraft.md
@@ -45,8 +45,8 @@ See [`../principles.md`](../principles.md) for the table legend. Railcraft is *e
 |---|---|---|---|---|---|
 | Coke Oven | Multiblock: coal → coke + creosote oil | Modernize | Coke + creosote feed steel + fuel/treated-wood. **Reconsider the multiblock** — prefer single block or tileable (scale optional) | — | Phase 3 — steam chain |
 | Blast Furnace | Multiblock: iron + coke → steel | Modernize | Steel is the module's key material; **single-block machine** preferred over the 34-block structure | — | Phase 3 — steel |
-| Steam Boiler (solid/liquid, HP/LP) | Multiblock: fuel + water → steam | TBD | Steam as a power tier, but the big multiblock fights the no-multiblock stance. **Leaning: lean on Create for steam via a compat layer** rather than build our own boiler; else single-block tier or cut. See [RFC 0003](../rfcs/0003-railcraft-multiblocks.md) | — | Phase 3 — steam power |
-| Steam Turbine / steam engines | Steam → RF/work | Modernize | Unify with the engine line (steam-tier engine) | — | `power` / engines |
+| Steam Boiler (solid/liquid, HP/LP) | Multiblock: fuel + water → steam | Modernize | Prefer **Create steam compat** over building a Logistics boiler; fallback is a simplified Logistics steam path if compat is not enough. See [RFC 0003](../rfcs/0003-railcraft-multiblocks.md) | — | Phase 3 — steam power |
+| Steam Turbine / steam engines | Steam → RF/work | Modernize | Unify with the engine line through Create steam compat first; fallback is a simplified steam-tier engine | — | `power` / engines |
 | Iron / Steel Tank | Multiblock bulk fluid storage | Modernize | The classic "Iron Tanks" role. *Scale is the feature* — a valid multiblock exception, or tileable tank blocks | — | Phase 3 — tanks (fluids) |
 | Rock Crusher | Multiblock ore processing | Skip | Covered by the Macerator | ❌ | [`thermal-expansion.md`](thermal-expansion.md) |
 | Rolling Machine | Cart/rail crafting | Modernize | Fold rail crafting into normal/vanilla-Crafter recipes | — | — |
@@ -63,5 +63,5 @@ See [`../principles.md`](../principles.md) for the table legend. Railcraft is *e
 | Engraving / emblems / firestone / misc | Cosmetic & niche extras | Skip | Out of scope | ❌ | — |
 
 > TODO: the multiblock calls (coke oven, blast furnace, boiler, tank) are the biggest design tension in this module vs. the no-multiblock stance — decide per-block (single vs. tileable vs. true multiblock) via a Discussion before scheduling. See [RFC 0003 — Railcraft Multiblocks & Steam](../rfcs/0003-railcraft-multiblocks.md).
-> TODO: confirm scope of the steam power chain — whether steam is a real `power` tier (boiler→turbine→RF), a **Create compat layer** (the current maintainer leaning), or simplified away; it couples to the engine-line unification in [`buildcraft.md`](buildcraft.md) / [`thermal-expansion.md`](thermal-expansion.md). See [RFC 0003 — Railcraft Multiblocks & Steam](../rfcs/0003-railcraft-multiblocks.md).
+> TODO: confirm the exact Create compatibility seam for steam power, with a simplified Logistics steam path only as fallback; it couples to the engine-line unification in [`buildcraft.md`](buildcraft.md) / [`thermal-expansion.md`](thermal-expansion.md). See [RFC 0003 — Railcraft Multiblocks & Steam](../rfcs/0003-railcraft-multiblocks.md).
 > Decided (Jun 2026): **electric locomotives/tracks are out of scope** — Railcraft transport is steam-only for v1.

--- a/design/mods/railcraft.md
+++ b/design/mods/railcraft.md
@@ -18,13 +18,13 @@ See [`../principles.md`](../principles.md) for the table legend. Railcraft is *e
 | Detector tracks | Emit redstone on cart conditions | Port | Automation glue | — | Phase 3 — tracks |
 | Control tracks (boarding/holding/locking/one-way/buffer/launcher) | Fine cart control + fun (launcher) | Modernize | Consolidate the dozen+ control tracks into a smaller, configurable set | — | Phase 3 — tracks |
 | Routing track + ticket | Route carts by destination | Port | Pairs naturally with the logistics theme | — | Phase 3 — routing |
-| Electric track | Power electric locomotives | TBD | Only if electric locomotives are in scope | — | Phase 3 — tracks |
+| Electric track | Power electric locomotives | Skip | Out of scope for now — a long way out if ever (maintainer + contributor call, Jun 2026). Revisit only if electric locomotives are ever pursued | ❌ | — |
 
 ## Minecarts
 
 | Feature | What it did | Decision | Modern take / balance notes | Status | Maps to |
 |---|---|---|---|---|---|
-| Locomotive (steam / electric / creative) | Self-powered engine that pulls carts | Port | The headline: automated trains. Start with steam | — | Phase 3 — locomotives |
+| Locomotive (steam / electric / creative) | Self-powered engine that pulls carts | Port | The headline: automated trains. Start with steam; **electric is out of scope** (see Tracks → Electric track) | — | Phase 3 — locomotives |
 | Tank cart | Mobile fluid transport | Port | Depends on the fluid layer | — | Phase 3 — carts |
 | Chest / work carts (energy/anchor) | Mobile inventory + utility carts | Port | Mobile storage transport; pairs with loaders | — | Phase 3 — carts |
 | Loaders / unloaders (item & fluid) | Auto-load/unload carts at stations | Port | Connects rails to the pipe/fluid networks | — | Phase 3 — loaders |
@@ -45,7 +45,7 @@ See [`../principles.md`](../principles.md) for the table legend. Railcraft is *e
 |---|---|---|---|---|---|
 | Coke Oven | Multiblock: coal → coke + creosote oil | Modernize | Coke + creosote feed steel + fuel/treated-wood. **Reconsider the multiblock** — prefer single block or tileable (scale optional) | — | Phase 3 — steam chain |
 | Blast Furnace | Multiblock: iron + coke → steel | Modernize | Steel is the module's key material; **single-block machine** preferred over the 34-block structure | — | Phase 3 — steel |
-| Steam Boiler (solid/liquid, HP/LP) | Multiblock: fuel + water → steam | Modernize | Steam as a power tier; big multiblock — reconsider scale-vs-tedium; couples to `power` | — | Phase 3 — steam power |
+| Steam Boiler (solid/liquid, HP/LP) | Multiblock: fuel + water → steam | TBD | Steam as a power tier, but the big multiblock fights the no-multiblock stance. **Leaning: lean on Create for steam via a compat layer** rather than build our own boiler; else single-block tier or cut. See [RFC 0003](../rfcs/0003-railcraft-multiblocks.md) | — | Phase 3 — steam power |
 | Steam Turbine / steam engines | Steam → RF/work | Modernize | Unify with the engine line (steam-tier engine) | — | `power` / engines |
 | Iron / Steel Tank | Multiblock bulk fluid storage | Modernize | The classic "Iron Tanks" role. *Scale is the feature* — a valid multiblock exception, or tileable tank blocks | — | Phase 3 — tanks (fluids) |
 | Rock Crusher | Multiblock ore processing | Skip | Covered by the Macerator | ❌ | [`thermal-expansion.md`](thermal-expansion.md) |
@@ -63,5 +63,5 @@ See [`../principles.md`](../principles.md) for the table legend. Railcraft is *e
 | Engraving / emblems / firestone / misc | Cosmetic & niche extras | Skip | Out of scope | ❌ | — |
 
 > TODO: the multiblock calls (coke oven, blast furnace, boiler, tank) are the biggest design tension in this module vs. the no-multiblock stance — decide per-block (single vs. tileable vs. true multiblock) via a Discussion before scheduling. See [RFC 0003 — Railcraft Multiblocks & Steam](../rfcs/0003-railcraft-multiblocks.md).
-> TODO: confirm scope of the steam power chain — whether steam is a real `power` tier (boiler→turbine→RF) or simplified away; it couples to the engine-line unification in [`buildcraft.md`](buildcraft.md) / [`thermal-expansion.md`](thermal-expansion.md). See [RFC 0003 — Railcraft Multiblocks & Steam](../rfcs/0003-railcraft-multiblocks.md).
-> TODO: confirm whether electric locomotives/tracks are in scope or steam-only for v1.
+> TODO: confirm scope of the steam power chain — whether steam is a real `power` tier (boiler→turbine→RF), a **Create compat layer** (the current maintainer leaning), or simplified away; it couples to the engine-line unification in [`buildcraft.md`](buildcraft.md) / [`thermal-expansion.md`](thermal-expansion.md). See [RFC 0003 — Railcraft Multiblocks & Steam](../rfcs/0003-railcraft-multiblocks.md).
+> Decided (Jun 2026): **electric locomotives/tracks are out of scope** — Railcraft transport is steam-only for v1.

--- a/design/mods/thermal-expansion.md
+++ b/design/mods/thermal-expansion.md
@@ -28,7 +28,7 @@ See [`../principles.md`](../principles.md) for the table legend.
 
 | Feature | What it did | Decision | Modern take / balance notes | Status | Maps to |
 |---|---|---|---|---|---|
-| Augments (speed / efficiency / secondary / auto-output) | Slot-in machine modifiers | Modernize | Strong system worth adopting as a unified **machine upgrade** mechanic across Macerator/Kiln/etc. | 🚧 Planned | Phase 1 — machine upgrades |
+| Augments (speed / efficiency / secondary / auto-output) | Slot-in machine modifiers | Modernize | Strong system worth adopting as a unified **machine upgrade** mechanic across Macerator/Kiln/etc. **Exploratory — not committed for 1.0** ([ROADMAP](../../ROADMAP.md) Exploring/RFC) | — | Exploring — machine upgrades |
 | Machine frames / tiers (Basic→Resonant) | Crafted tiers gating machine power | Modernize | Map onto vanilla metal ladder; keep tier count modest | — | Phase 1 — machine tiers |
 
 ## Power generation & storage (Dynamos / Energy Cells)

--- a/design/progression-tiers.md
+++ b/design/progression-tiers.md
@@ -61,7 +61,7 @@ Each line picks its subset in canonical order. *(Illustrative subsets — refine
 | Line | Flavor | Canonical subset |
 |---|---|---|
 | **Cables** | conductivity | Copper · Gold · **Amethyst** · Ender |
-| **Gears** | mechanical | Wood · Stone · Copper · Iron · Bronze · Gold · Diamond · Netherite *(drop Tin)* |
+| **Gears** | mechanical | Wood · Stone · Copper · Iron · Bronze · Gold · Diamond · Netherite *(Tin is not a tier — see note)* |
 | **Batteries** ([0107](features/0107-tiered-batteries.md)) | storage | Copper · Gold · Ender |
 | **Cores / Valves** | electronics | Copper · Bronze · Gold · Amethyst |
 | **Machine frames** (future) | structural | Iron · Bronze · Diamond · Netherite |
@@ -72,7 +72,7 @@ Each line picks its subset in canonical order. *(Illustrative subsets — refine
 Per the maintainer call, **existing lines conform too** (not just new work). These are implementation tasks for later PRs on the `mc/*` branches — this doc records the decision; the code changes are separate:
 
 - **Cables** — add an **Amethyst** tier → `Copper 30 / Gold 60 / Amethyst 120 / Ender 240` RF/t (keeps the ×2 ladder; Amethyst takes the old Ender rate and Ender rises for late-game headroom — see [`features/0107-tiered-batteries.md`](features/0107-tiered-batteries.md)). Numbers tunable against the RF curve. Touches `power/cable/CableTier` + an `amethyst_cable` block/model/recipe.
-- **Gears** — remove `tin_gear`; reorder to canonical Wood · Stone · Copper · Iron · Bronze · Gold · Diamond · Netherite. *Migration:* `tin_gear` removal is breaking for existing worlds — acceptable pre-1.0, or remap `tin_gear → bronze_gear` via a data-fixer/recipe.
+- **Gears** — the canonical ladder is Wood · Stone · Copper · Iron · Bronze · Gold · Diamond · Netherite; **Tin is not a tier.** The already-shipped `tin_gear` is **grandfathered legacy** — we are *not* doing a breaking removal/migration (maintainer + contributor call, Jun 2026: tin's only role is enabling Bronze, and a removal isn't worth the world-break). It simply stays as-is and the gear line gains no new tin content; treat tin everywhere else as a Bronze feedstock, not a rank.
 - **Cores / Valves** — currently Copper · Bronze; extend toward Copper · Bronze · Gold · Amethyst as the electronics system grows (couples to the deferred programmable-behavior work — [`rfcs/0001-programmable-behavior.md`](rfcs/0001-programmable-behavior.md)). No forced change now.
 
 ## References

--- a/design/rfcs/0001-programmable-behavior.md
+++ b/design/rfcs/0001-programmable-behavior.md
@@ -1,7 +1,7 @@
 # RFC 0001: Programmable Behavior (Gates + Circuits)
 
 > **Status:** 🟡 Open — **deferred post-1.0** (maintainer call, Jun 2026): explicitly **not a 1.0 item**; revisit when Forestry needs circuit boards (Phase 2) or later · **Scope:** Phase 2+ · **Decides:** maintainer + community signal
-> **Affects:** [`../mods/buildcraft.md`](../mods/buildcraft.md) (Gates, Pipe wiring, Autarchic gate), [`../mods/forestry.md`](../mods/forestry.md) (Circuit boards + Soldering), [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) (programmable augments) · **Blocks:** scheduling the BC gate rows and Forestry circuit-board rows — **not** the machines/farms, and **not** the Phase-1 machine-modifier upgrades ([`../features/0106-machine-upgrades.md`](../features/0106-machine-upgrades.md))
+> **Affects:** [`../mods/buildcraft.md`](../mods/buildcraft.md) (Gates, Pipe wiring, Autarchic gate), [`../mods/forestry.md`](../mods/forestry.md) (Circuit boards + Soldering), [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) (programmable augments) · **Blocks:** scheduling the BC gate rows and Forestry circuit-board rows — **not** the machines/farms, and **not** the (separate, exploratory) machine-modifier upgrades ([`../features/0106-machine-upgrades.md`](../features/0106-machine-upgrades.md))
 
 The biggest open design call spanning the source mods. Three of them each shipped a "make this block do something conditional" system; the roadmap floats unifying them. This RFC frames the decision.
 
@@ -13,7 +13,7 @@ Three lineages of "program a block's behavior":
 - **Forestry circuit boards + soldering** — program machine/farm behavior by arranging **electron tubes** on a board. *Logic / configuration.*
 - **Thermal Expansion augments** — slot-in machine **modifiers** (speed/efficiency/secondary/auto-output). *Modifiers, not logic.*
 
-**Important distinction this RFC draws:** the *modifier* axis (TE augments) is already being handled as [machine upgrades](../features/0106-machine-upgrades.md) (`0106`). That is **not** what's contested here. This RFC is specifically about **programmable logic** — gates and circuits — i.e. "when condition X holds, do action Y." The augment work may *share an item vocabulary* (Logistics already has logic chips, cores, and valves that mirror Forestry's electron tubes), but the logic system is a separate, much larger design question.
+**Important distinction this RFC draws:** the *modifier* axis (TE augments) is tracked separately as the (exploratory) [machine upgrades](../features/0106-machine-upgrades.md) brief (`0106`) — a different question from this one, and itself not a committed 1.0 item. That is **not** what's contested here. This RFC is specifically about **programmable logic** — gates and circuits — i.e. "when condition X holds, do action Y." The augment work may *share an item vocabulary* (Logistics already has logic chips, cores, and valves that mirror Forestry's electron tubes), but the logic system is a separate, much larger design question.
 
 The tension with [`../principles.md`](../principles.md): programmable logic is high-value for power users but risks violating **"learnable without a wiki"** and is a large, cross-cutting design + implementation effort. Modern Minecraft also already has redstone + comparators, which cover a lot of the simple cases gates once did.
 
@@ -29,7 +29,7 @@ One logic layer pluggable into pipes, machines, and farms: read state (inventory
 - **Cons:** very large design + UX + implementation effort; highest "needs-a-wiki" risk; spans three mods' worth of expectations; easy to over-scope.
 
 ### Option B — Vanilla-leaning, targeted hooks *(leaning for v1)*
-No general programming system. Lean on vanilla redstone/comparators, and add only **narrow, per-feature** config: e.g. a pipe/machine that emits redstone on a condition, an extractor that respects a redstone signal, farm enable/disable. Reuse the existing module config UIs.
+No general programming system. Lean on vanilla redstone/comparators, and add only **narrow, per-feature** config that covers the cases people actually reach for. Concretely: an **inverted wooden (extraction) pipe**, **redstone-controlled extraction/routing**, a pipe/machine that emits redstone on a condition, farm enable/disable. Reuse the existing module config UIs.
 - **Pros:** low complexity; ships incrementally; stays "learnable"; doesn't gate 1.0.
 - **Cons:** less power-user depth; "gates" as a distinct feature effectively becomes "skip / use redstone"; no single programmable layer.
 
@@ -40,7 +40,9 @@ Ship machines/farms with fixed behavior + basic redstone hooks; defer all gates/
 
 ## Recommendation / leaning
 
-**B for now; A is explicitly post-1.0 — deferred until Forestry needs it (decided, Jun 2026).** Rationale: 1.0 = the Phase 1 automation core complete ([`../roadmap.md`](../roadmap.md)); a general programming system is *not* required for that and would be a major scope risk. The maintainer has confirmed the unified system is **not a 1.0 item** — the natural trigger to revisit it is Forestry **circuit boards** (programming Forestry blocks, Phase 2), or later. Until then, targeted redstone hooks (B) cover the common cases; C is the fallback if even those aren't wanted. When revisited, let community demand (poll) weigh A's complexity.
+**B for now; A is explicitly post-1.0 — deferred until Forestry needs it (decided, Jun 2026).** Rationale: 1.0 = the Phase 1 automation core complete ([`../delivery-plan.md`](../delivery-plan.md)); a general programming system is *not* required for that and would be a major scope risk. The maintainer has confirmed the unified system is **not a 1.0 item** — the natural trigger to revisit it is Forestry **circuit boards** (programming Forestry blocks, Phase 2), or later. Until then, targeted redstone hooks (B) cover the common cases; C is the fallback if even those aren't wanted. When revisited, let community demand (poll) weigh A's complexity.
+
+*Review concurrence (Jun 2026):* a contributor independently landed on the same call — Option B for v1 (purpose-built solutions like an inverted wooden pipe and redstone-controlled extraction/routing), with C as the acceptable fallback, agreeing that a unified gates/circuits layer is too much scope for something not needed at 1.0.
 
 ## Sub-questions still open
 
@@ -56,7 +58,7 @@ Ideas/Polls **Discussion** (it spans three mods and is taste-heavy). Weigh again
 
 ## References
 
-- Roadmap RFC note: [`../roadmap.md`](../roadmap.md) → Phase 1 → "RFC (cross-cutting)"
+- Roadmap RFC note: [`../delivery-plan.md`](../delivery-plan.md) → Phase 1 → "RFC (cross-cutting)"
 - Breakdowns: [`../mods/buildcraft.md`](../mods/buildcraft.md) (Gates/wiring rows + TODO), [`../mods/forestry.md`](../mods/forestry.md) (Circuit boards row + TODO), [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) (Augments)
 - Related feature brief (the modifier axis, *not* this RFC): [`../features/0106-machine-upgrades.md`](../features/0106-machine-upgrades.md)
 - Already-seeded components: `core` cores / valves / logic chips

--- a/design/rfcs/0002-forestry-bees.md
+++ b/design/rfcs/0002-forestry-bees.md
@@ -47,9 +47,9 @@ If breeding-style genetics is ever pursued, it should be its **own dedicated mod
 - The **Alveary** (advanced multiblock) is a Skip regardless of A/B/C — confirm and record.
 - Does anything else in Forestry depend on bee products (e.g. Carpenter recipes using honey/wax)? If so, source those another way under A.
 
-## How we'll decide
+## Historical note
 
-Ideas/**Polls** Discussion — bees are nostalgia-heavy, so reaction/vote demand is the right signal. Decide **before** any Phase 2 bee scheduling. Outcome flips the `forestry.md` Bees rows from TBD to Modernize/Skip and, if B, seeds a feature brief.
+This was originally expected to need an Ideas/**Polls** Discussion because bees are nostalgia-heavy. The June 2026 maintainer + contributor call closed it earlier: genetics is out of scope for Logistics, and any future genetics work should live in a separate dedicated mod.
 
 ## References
 

--- a/design/rfcs/0002-forestry-bees.md
+++ b/design/rfcs/0002-forestry-bees.md
@@ -1,9 +1,9 @@
-# RFC 0002: Forestry Bees — Whether and How
+# RFC 0002: Forestry Genetics (Bees, Trees, Butterflies) — Whether and How
 
-> **Status:** 🟡 Open — needs an Ideas/Polls Discussion before any Phase 2 bee work · **Scope:** Phase 2 (Forestry) · **Decides:** maintainer + community demand signal
-> **Affects:** [`../mods/forestry.md`](../mods/forestry.md) § Bees (all TBD rows) · **Blocks:** scheduling any apiculture work — **not** farms, trees, processing, or electronics
+> **Status:** 🟢 Decided — **genetics is out of scope for Logistics** (maintainer + contributor call, Jun 2026). No bees, no tree-breeding, no butterflies for v1; revisit only as a *separate, dedicated mod* if demand ever warrants. · **Scope:** Phase 2 (Forestry) · **Decided by:** maintainer, with contributor concurrence
+> **Affects:** [`../mods/forestry.md`](../mods/forestry.md) § Bees + § Trees (arboriculture/breeding rows) · **Blocks:** nothing in the Logistics roadmap — Forestry ships on farms, processing, power, and electronics **without** any genetics system
 
-Bees are the most nostalgia-loaded and most *divergent* part of Forestry. This RFC settles whether they happen at all for v1, and on what model — before any of it is scheduled.
+Bees are the most nostalgia-loaded and most *divergent* part of Forestry — and the same is true of tree breeding and butterflies. This RFC originally asked whether *bees* happen for v1; the call has since broadened: **the whole genetics/biology axis (bees, trees, butterflies) is out of scope for this mod.** What follows is preserved as the reasoning behind that decision.
 
 ## Context
 
@@ -21,7 +21,7 @@ The problem: **modern vanilla already has bees**, bred by feeding flowers. That 
 
 ### Option A — Skip bees for v1 *(leaning)*
 Ship `logistics-forestry` without apiculture. Revisit post-1.0 if demand is there.
-- **Pros:** removes the hardest, most divergent, most wiki-prone subsystem from the critical path; lets Forestry ship on its actual headline (farms/trees/processing); matches the breakdown's stated lean.
+- **Pros:** removes the hardest, most divergent, most wiki-prone subsystem from the critical path; lets Forestry ship on its actual headline (farms/processing/electronics); matches the breakdown's stated lean.
 - **Cons:** "Forestry without bees" disappoints the nostalgia crowd for whom bees *were* Forestry.
 
 ### Option B — Extend vanilla bees *(the modernized path if pursued)*
@@ -34,9 +34,11 @@ Reimplement princess/drone/queen + Mendelian mutations + species discovery as a 
 - **Pros:** the most faithful recreation; the deepest endgame.
 - **Cons:** very high complexity; fights vanilla bees (two parallel bee systems); maximally wiki-dependent; the Alveary pulls in a multiblock. Highest risk against the principles.
 
-## Recommendation / leaning
+## Decision (Jun 2026)
 
-**A for v1**, with **B as the eventual modernized path** if bees are pursued post-1.0. **C is unlikely** — it conflicts with multiple principles (modernize-to-vanilla, learnable-without-wiki, multiblock stance) and duplicates a system vanilla now owns. But this is taste- and demand-driven, so it should go to a poll rather than be defaulted.
+**Option A — skip, and broaden it: genetics is not Logistics' job.** The maintainer call (with contributor concurrence) is that **none of the genetics/biology systems — bees, tree-breeding/arboriculture, butterflies — belong in this mod.** Forestry's strongest fit within Logistics is the *industrial* side: farms, automation, processing chains, and infrastructure. The genetics side is extremely complex, highly design-dependent, and historically wiki-dependent; it would dominate the Forestry module and fight several principles (modernize-to-vanilla, learnable-without-wiki, multiblock stance).
+
+If breeding-style genetics is ever pursued, it should be its **own dedicated mod** (ours or someone else's), not bolted onto Logistics. Option B (extend vanilla bees for the recognizable *products*) and Option C (full parallel genetics) are kept below only as the shape such a separate effort might take — they are **not** on the Logistics roadmap.
 
 ## Sub-questions still open
 
@@ -51,6 +53,6 @@ Ideas/**Polls** Discussion — bees are nostalgia-heavy, so reaction/vote demand
 
 ## References
 
-- Breakdown: [`../mods/forestry.md`](../mods/forestry.md) § Bees (deferred) + the bees TODO
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 2 → "Bees (deferred / uncertain)"
+- Breakdown: [`../mods/forestry.md`](../mods/forestry.md) § Bees + § Trees (both out of scope)
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 2 → "Bees / genetics (out of scope)"
 - Principles in tension: [`../principles.md`](../principles.md) (modernize-to-vanilla, learnable-without-wiki, multiblock stance)

--- a/design/rfcs/0003-railcraft-multiblocks.md
+++ b/design/rfcs/0003-railcraft-multiblocks.md
@@ -23,14 +23,15 @@ This is **Phase 3 / post-1.0**, so it does *not* gate 1.0 — but it defines the
 |---|---|---|---|
 | **Coke Oven** | Multiblock | **Single block** (or tileable) | Produces coke + creosote; scale isn't the point — hold the no-multiblock line. |
 | **Blast Furnace → Steel** | 34-block multiblock | **Single-block machine** | Breakdown already prefers this; steel is the module's key material and shouldn't need a schematic. Pairs with the Alloy Smelter pattern. |
-| **Steam Boiler** | Up to 36-block multiblock | **Single-block engine-line tier *or* cut** | Tied to the steam-power decision below. If steam stays, a single-block boiler tier; if not, drop it. |
+| **Steam Boiler** | Up to 36-block multiblock | **Create compat, single-block tier, *or* cut** | Tied to the steam-power decision below. Leaning: lean on **Create** for steam rather than build our own boiler; otherwise a single-block boiler tier, or drop it. |
 | **Bulk Tank** | Multiblock | **Tileable tank blocks** (auto-merge into one logical tank) | The one genuine "scale is the feature" case — but tileable, not a rigid schematic. The valid exception. |
 
-**Steam-power scope:** two sub-options —
+**Steam-power scope:** three sub-options —
 - **(i) Steam is a real tier** — boiler → turbine → RF, unified into the engine line (consistent with the "unify everything into one engine line" thread in [`../mods/buildcraft.md`](../mods/buildcraft.md)/[`../mods/thermal-expansion.md`](../mods/thermal-expansion.md)).
 - **(ii) Simplified** — ship coke/creosote/steel and treated-wood tracks **without** a steam power tier; carts run on the existing RF/engine power.
+- **(iii) Create compat instead of our own steam** *(maintainer leaning, Jun 2026)* — don't reimplement a steam/boiler subsystem at all. **Create already nails steam**, and its multiblocks read intuitively. Instead, build a thin **compatibility layer**: accept Create steam/rotational power to drive a Logistics engine (or convert Create rotation → the Logistics reciprocal), so players who run Create get the satisfying steam progression there while Logistics avoids the multiblock + steam-design burden. Steam becomes an *optional, integration-gated* tier rather than core content.
 
-**Leaning:** hold single-block for Coke Oven + Blast Furnace; allow **tileable** Bulk Tanks as the lone scale-is-the-feature exception; treat steam as **(ii) simplified for the transport module's v1**, revisiting a steam engine tier only if it earns its place.
+**Leaning:** hold single-block for Coke Oven + Blast Furnace; allow **tileable** Bulk Tanks as the lone scale-is-the-feature exception. For steam power, the maintainer leans toward **(iii) a Create compat layer** over a homegrown boiler — keeping Logistics out of the multiblock/steam-balance trench while still letting steam-loving players reach it through Create; **(ii) simplified** is the fallback if no compat is built. Reconsider a first-party steam tier (i) only if it clearly earns its place.
 
 ## Sub-questions still open
 
@@ -47,5 +48,5 @@ Discussion, weighing **tedium vs. the satisfaction of scale** per block, against
 
 - Breakdown: [`../mods/railcraft.md`](../mods/railcraft.md) § Steam/steel/bulk + the multiblock & steam-power TODOs
 - Principles: [`../principles.md`](../principles.md) § The multiblock stance
-- Roadmap: [`../roadmap.md`](../roadmap.md) → Phase 3 → Steam & steel chain (notes the TBDs)
+- Roadmap: [`../delivery-plan.md`](../delivery-plan.md) → Phase 3 → Steam & steel chain (notes the TBDs)
 - Related: engine-line unification thread in [`../mods/buildcraft.md`](../mods/buildcraft.md) / [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md); Steel pairs with [`../features/0105-alloy-smelter.md`](../features/0105-alloy-smelter.md)

--- a/design/rfcs/0004-worldgen-stability.md
+++ b/design/rfcs/0004-worldgen-stability.md
@@ -40,11 +40,10 @@ Design each new material to be obtainable from already-available inputs: **vanil
 
 ## Recommendation / leaning
 
-**C is the default; B is the fallback; A is a narrow exception.**
+**C is the default; B is the fallback.**
 
 1. **Source without worldgen (C) by default.** Every new material should derive from vanilla ores, alloying, byproducts, processing, or structure/loot. This is already the documented sourcing stance — make it an explicit rule.
 2. **If a material genuinely must be a fresh worldgen ore, commit to version-tracked retrogen (B)** for it, on both loaders — don't pre-seed.
-3. **Pre-seed (A) only** for an ore whose need *and* distribution are already certain and settled — a deliberate, case-by-case call, never the default.
 
 And: **fold content availability into the 1.0 stability promise.** "No save-breaking changes" should also mean "a 1.0 world stays fully playable through later phases — no material becomes unobtainable on an existing save." (Added to the delivery-plan Definition of Done.)
 

--- a/design/rfcs/0004-worldgen-stability.md
+++ b/design/rfcs/0004-worldgen-stability.md
@@ -1,0 +1,67 @@
+# RFC 0004: Post-1.0 Material Sourcing & Worldgen Stability
+
+> **Status:** 🟡 Open — needs a Discussion to ratify the policy · **Scope:** cross-cutting (set in Phase 1; governs every material added in Phases 2–3 and beyond) · **Decides:** maintainer
+> **Affects:** [`../progression-tiers.md`](../progression-tiers.md) (feedstock/alloy sourcing), [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) (Base metals · Alloys · High-tier alloys rows), any new-material rows in [`../mods/forestry.md`](../mods/forestry.md) / [`../mods/railcraft.md`](../mods/railcraft.md), and the [`../delivery-plan.md`](../delivery-plan.md) 1.0 Definition of Done · **Blocks:** nothing immediately — it's a standing policy for *how* post-1.0 materials may be introduced
+
+The 1.0 promise is save stability. New materials arrive in **post-1.0** phases (Forestry, Railcraft). If any of those materials depends on **new worldgen ore**, a player's existing 1.0 world won't contain it — a content-availability gap that quietly breaks progression on long-running saves. This RFC sets the policy that keeps that promise.
+
+## Context
+
+Ore placement runs at **chunk generation**. A mod that adds an ore later only affects **newly generated chunks**; already-generated chunks never receive it unless a **retrogen** pass re-applies placement (gated by a per-chunk "features version" flag). So a new ore introduced in (say) Phase 2 is invisible to everything a 1.0 player has already explored — not a crash, but a real gating failure.
+
+This matters less than it sounds, because the design already minimizes bespoke ores:
+
+- The canonical ladder in [`../progression-tiers.md`](../progression-tiers.md) is almost entirely **vanilla** (Copper · Iron · Gold · Diamond · Amethyst · Netherite · Ender · Echo Shard).
+- The non-vanilla materials are **alloys** (Bronze, Invar) or **byproducts** — e.g. macerator-byproduct nickel feeds Invar. Neither needs its own ore.
+- Tin is the main legacy worldgen ore; high-tier alloys (signalum/lumium/enderium) are explicitly TBD and may never land.
+
+So the worldgen-ore surface is already small by design. The question is what to do when a future material *does* want a fresh ore.
+
+## The decision to make
+
+**When a post-1.0 material needs a raw resource, how do we guarantee it's obtainable in worlds created at 1.0 — without stranding existing saves or seeding speculative dead content?**
+
+## Options
+
+### Option A — Pre-seed worldgen before 1.0
+Register every anticipated ore feature now (unused), so all worlds from 1.0 onward contain it everywhere.
+- **Pros:** simplest technically (just register features); no retrogen; every world has the ore from day one.
+- **Cons:** commits to specific ores / biomes / distributions **before Phases 2–3 are designed** — and scope has been churning (genetics out, electric rails out, steam → Create compat). Dead ores clutter worlds and confuse players. If a distribution is later changed, existing worlds keep the old one — the gap reappears. Brittle against design churn.
+
+### Option B — Commit to retrogen later
+Build a version-tracked retro-injector that places new ores into already-generated chunks when a feature ships.
+- **Pros:** add only what we actually use, when we use it; no speculative content; existing worlds get the ore.
+- **Cons:** retrogen is historically fragile — double-placement, load-time performance, mod-compat edge cases — and must be built and maintained on **both** Fabric and NeoForge.
+
+### Option C — Source new materials *without* new worldgen ore *(leaning — the default)*
+Design each new material to be obtainable from already-available inputs: **vanilla ore + alloying + machine byproduct + processing + structure loot / trade**. A material with no chunk-gen dependency behaves identically in old and new worlds.
+- **Pros:** dissolves the problem entirely for most materials; fits the mod's alloying/byproduct identity; zero save risk; no fragile infra; already where [`../progression-tiers.md`](../progression-tiers.md) points.
+- **Cons:** not every conceivable material can be sourced this way; constrains material design (must tie to an existing input); a few genuinely-mined resources may still need a real ore.
+
+## Recommendation / leaning
+
+**C is the default; B is the fallback; A is a narrow exception.**
+
+1. **Source without worldgen (C) by default.** Every new material should derive from vanilla ores, alloying, byproducts, processing, or structure/loot. This is already the documented sourcing stance — make it an explicit rule.
+2. **If a material genuinely must be a fresh worldgen ore, commit to version-tracked retrogen (B)** for it, on both loaders — don't pre-seed.
+3. **Pre-seed (A) only** for an ore whose need *and* distribution are already certain and settled — a deliberate, case-by-case call, never the default.
+
+And: **fold content availability into the 1.0 stability promise.** "No save-breaking changes" should also mean "a 1.0 world stays fully playable through later phases — no material becomes unobtainable on an existing save." (Added to the delivery-plan Definition of Done.)
+
+## Sub-questions still open
+
+- Do we want a **single reusable retrogen utility** in `core.lib` (loader-adapted) ready *before* the first post-1.0 ore, so option B is cheap when needed — or build it lazily on first need?
+- Is **structure/loot or trade** an acceptable primary source for a "mined-feeling" material, or does that break the classic-tech feel for some resources?
+- For tin (the existing legacy ore): is its current distribution considered settled, or in scope for a future change (which would itself be a soft availability change on old worlds)?
+- Where exactly does the policy live long-term — here as the RFC, mirrored as a one-line **principle** in [`../principles.md`](../principles.md)?
+
+## How we'll decide
+
+A short **Ideas Discussion** — this is an infrastructure/policy call, not a taste-heavy one, so it mainly needs maintainer ratification against the save-stability promise and the "minimize bespoke content" principle. Once ratified, flip this RFC to 🟢 Decided, and apply the rule when scheduling any post-1.0 material row in the `mods/` breakdowns.
+
+## References
+
+- Progression ladder & sourcing: [`../progression-tiers.md`](../progression-tiers.md) (vanilla-anchored ladder; Tin/Nickel as feedstock; nickel as macerator byproduct)
+- Material rows that this governs: [`../mods/thermal-expansion.md`](../mods/thermal-expansion.md) (Base metals · Alloys · High-tier alloys)
+- The stability promise: [`../delivery-plan.md`](../delivery-plan.md) → Versioning & 1.0 → Definition of done
+- Principle in tension: [`../principles.md`](../principles.md) (modernize-to-vanilla; minimize bespoke content)

--- a/design/rfcs/README.md
+++ b/design/rfcs/README.md
@@ -19,11 +19,16 @@ RFCs are numbered sequentially (`NNNN-`), independent of the phase/step build or
 | # | RFC | Scope | The question | Leaning |
 |---|---|---|---|---|
 | 0001 | [Programmable Behavior](0001-programmable-behavior.md) | Phase 2+ (post-1.0) | Unified gates+circuits logic system, vanilla-leaning hooks, or skip for v1? | **Deferred post-1.0** (maintainer): not a 1.0 item; revisit when Forestry needs circuit boards |
-| 0002 | [Forestry Genetics](0002-forestry-bees.md) | Phase 2 (Forestry) | Do bees/trees/butterflies (genetics) happen at all? | ✅ **Decided: out of scope** — genetics belongs in a separate, dedicated mod |
 | 0003 | [Railcraft Multiblocks & Steam](0003-railcraft-multiblocks.md) | Phase 3 (Transport) | Single-block / tileable / multiblock per signature block; is steam a power tier? | Single-block machines; tileable bulk tanks; **steam via a Create compat layer** (else simplified) |
-| 0004 | [Material Sourcing & Worldgen Stability](0004-worldgen-stability.md) | Cross-cutting (post-1.0 materials) | How do we keep post-1.0 materials obtainable on existing 1.0 worlds without dead pre-seeded ore? | Source without new worldgen ore by default; retrogen as fallback; pre-seed only when certain |
+| 0004 | [Material Sourcing & Worldgen Stability](0004-worldgen-stability.md) | Cross-cutting (post-1.0 materials) | How do we keep post-1.0 materials obtainable on existing 1.0 worlds without dead pre-seeded ore? | Source without new worldgen ore by default; retrogen as fallback |
 
 > The **leaning** column is a starting position to argue against, not a decision. Each RFC carries the full options + trade-offs.
+
+## Decided RFCs
+
+| # | RFC | Scope | Decision |
+|---|---|---|---|
+| 0002 | [Forestry Genetics](0002-forestry-bees.md) | Phase 2 (Forestry) | Genetics is out of scope for Logistics; bees, tree breeding, and butterflies belong in a separate dedicated mod |
 
 ## RFC template
 

--- a/design/rfcs/README.md
+++ b/design/rfcs/README.md
@@ -19,8 +19,9 @@ RFCs are numbered sequentially (`NNNN-`), independent of the phase/step build or
 | # | RFC | Scope | The question | Leaning |
 |---|---|---|---|---|
 | 0001 | [Programmable Behavior](0001-programmable-behavior.md) | Phase 2+ (post-1.0) | Unified gates+circuits logic system, vanilla-leaning hooks, or skip for v1? | **Deferred post-1.0** (maintainer): not a 1.0 item; revisit when Forestry needs circuit boards |
-| 0002 | [Forestry Bees](0002-forestry-bees.md) | Phase 2 (Forestry) | Ship bees at all — and extend vanilla or build parallel genetics? | Skip for v1; extend-vanilla if pursued later |
-| 0003 | [Railcraft Multiblocks & Steam](0003-railcraft-multiblocks.md) | Phase 3 (Transport) | Single-block / tileable / multiblock per signature block; is steam a power tier? | Single-block machines; tileable bulk tanks; steam simplified for v1 |
+| 0002 | [Forestry Genetics](0002-forestry-bees.md) | Phase 2 (Forestry) | Do bees/trees/butterflies (genetics) happen at all? | ✅ **Decided: out of scope** — genetics belongs in a separate, dedicated mod |
+| 0003 | [Railcraft Multiblocks & Steam](0003-railcraft-multiblocks.md) | Phase 3 (Transport) | Single-block / tileable / multiblock per signature block; is steam a power tier? | Single-block machines; tileable bulk tanks; **steam via a Create compat layer** (else simplified) |
+| 0004 | [Material Sourcing & Worldgen Stability](0004-worldgen-stability.md) | Cross-cutting (post-1.0 materials) | How do we keep post-1.0 materials obtainable on existing 1.0 worlds without dead pre-seeded ore? | Source without new worldgen ore by default; retrogen as fallback; pre-seed only when certain |
 
 > The **leaning** column is a starting position to argue against, not a decision. Each RFC carries the full options + trade-offs.
 

--- a/design/vision.md
+++ b/design/vision.md
@@ -4,7 +4,7 @@
 
 Recreate the gameplay of a **classic 1.7.10-era tech modpack** in a modern Minecraft client — with a single coherent mod (or small family of mods) that *feels* classic rather than bolting old content onto new versions.
 
-Think of it as a **parallel to Create, but classic**: where Create leans into kinetic contraptions and a bespoke aesthetic, Logistics leans into the BuildCraft/Thermal/Forestry lineage — pipes you can see items move through, engines that overheat, RF machines, ore doubling, bees and trees, and rails that tie a base together.
+Think of it as a **parallel to Create, but classic**: where Create leans into kinetic contraptions and a bespoke aesthetic, Logistics leans into the BuildCraft/Thermal/Forestry lineage — pipes you can see items move through, engines that overheat, RF machines, ore doubling, automated farms, and rails that tie a base together.
 
 > *Personal note: this grew out of a 1.7.10 pack I used to run. The target is the genre that pack represented, not any one pack's exact contents.*
 
@@ -17,7 +17,7 @@ That era's tech identity came from a handful of mods, **all now abandoned**. The
 | **BuildCraft** | Pipes, engines, the quarry, gates/automation | Largely covered (pipes, engines, laser quarry) |
 | **Logistics Pipes** | Request/provider/supplier network logistics — *the* glue that tied a base together | **Done** (3-tier pipe network, chassis + modules) |
 | **Thermal Expansion** | RF machines, ore processing (pulverizer/dusts), energy cells, fluid handling | Partially covered (macerator, kiln, dusts, cables) |
-| **Forestry** | Bees, trees, butterflies, farms/multifarms, electron tubes, the worktable | Not started |
+| **Forestry** | Bees, trees, butterflies, farms/multifarms, electron tubes, the worktable | Not started — **industrial side only** (farms, processing, electronics); genetics (bees/trees/butterflies) is out of scope |
 | **Railcraft** | Rails, advanced minecarts, tanks, signals, coke ovens, boilers | Not started |
 
 See each breakdown in [`mods/`](mods/).
@@ -53,7 +53,7 @@ A player can install Logistics (or its module family) on a modern client and pla
 1. Early mechanical pipes + redstone/stirling engines.
 2. Ore processing and RF machines (the Thermal layer).
 3. Logistics-network automation tying storage and crafting together.
-4. Forestry-style biological automation (bees/trees/farms) for endgame variety.
+4. Forestry-style farming and processing automation (farms, biofuel, electronics) for endgame variety.
 5. Railcraft-style transport and bulk processing for inter-base logistics.
 
 …all while letting players install **only the parts they want** (see [`architecture.md`](architecture.md)).

--- a/design/vision.md
+++ b/design/vision.md
@@ -27,7 +27,7 @@ See each breakdown in [`mods/`](mods/).
 Packs of this style also leaned on storage and quality-of-life mods. Most have living modern equivalents and are **not** Logistics' job:
 
 - **Storage** — Iron Chests, Iron Tanks, Storage Drawers all exist in modern form; **Ender Storage** is abandoned but has modern replacements. Out of scope (Logistics provides the *pipes*, not the *boxes*).
-- **World/flair** — Biomes O' Plenty, Binnie's Mods (extends Forestry). Out of scope, though Forestry-style genetics may overlap.
+- **World/flair** — Biomes O' Plenty, Binnie's Mods (extends Forestry). Out of scope; Logistics may share the same farming/processing context, but Forestry-style genetics itself is not in scope.
 - **Magic** — Soul Shards. Out of scope.
 - **Tools/QoL** — NEI, Waila, Schematica, Chisel, Carpenter's Blocks. Out of scope (modern equivalents exist; we integrate with JEI/Jade where it helps).
 


### PR DESCRIPTION
## Summary

Follow-up to #476. Incorporates the post-merge review discussion (maintainer + contributor) into the `design/` docs, reconciles them against the user-facing `ROADMAP.md`, and resolves the two-files-named-roadmap confusion.

**`ROADMAP.md` stays the canonical, high-level, user-facing doc.** The `design/` set is the detailed contributor companion and was aligned *to* it.

## Changes

**Review decisions captured (from #476 discussion)**
- **Genetics is out of scope** — no bees, no tree-breeding, no butterflies; a separate dedicated mod's job (RFC 0002 reframed → decided; `forestry.md`, `vision.md`).
- **Module split** settled at four: `core` / `automation` / `forestry` / `transport` (not five) — `architecture.md` + ROADMAP.
- **Steam** leans on a **Create compat layer** rather than a homegrown Railcraft boiler (RFC 0003).
- **Electric rails** → skip; **Filler** → stays out (its own mod's job).
- **Programmable gates/circuits** → deferred post-1.0; revisited when Forestry needs circuit boards.
- **Machine upgrades** and **Remote Orderer** reclassified as **exploratory**; **obsidian vacuum pipe** → **not planned** (vanilla hoppers cover it).
- `tin_gear` grandfathered (no breaking removal); tin stays a Bronze feedstock.

**Roadmap alignment**
- Single-block farms (not multifarm); 4-part module split; surfaced missing design content (tiered batteries, Forestry biofuel chain) and pruned what's reclassified.

**Housekeeping**
- Renamed `design/roadmap.md` → **`design/delivery-plan.md`** (the detailed build plan) so it no longer collides conceptually with the root `ROADMAP.md`; all 16 references updated.
- **New RFC 0004 — Material Sourcing & Worldgen Stability**: post-1.0 materials must stay obtainable on existing 1.0 worlds. Default to sourcing without new worldgen ore; retrogen as fallback; pre-seed only when certain. Added a matching *content availability* clause to the 1.0 Definition of Done.

## Notes

- Documentation only — no code or API changes.
- A few open questions are flagged in-doc for later Discussions (eager vs. lazy retrogen utility; mirroring the worldgen policy as a `principles.md` line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)