### PR TITLE
chore(build): update to released MC 26.2 with official NeoForge beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,23 +10,20 @@ maven_group=com.logistics
 archives_base_name=logistics
 
 # Minecraft
-minecraft_version=26.2-rc-1
-minecraft_compatibility_versions=26.2-pre.4,26.3
+minecraft_version=26.2
+minecraft_compatibility_versions=26.2,26.3
 java_version=25
 
 # Fabric
 # check these on https://fabricmc.net/develop
 fabric_loader_version=0.19.3
-fabric_version=0.152.0+26.2
-loom_version=1.16-SNAPSHOT
+fabric_version=0.152.1+26.2
+loom_version=1.17-SNAPSHOT
 fabric_energy_version=5.0.0
 
 # NeoForge
-# No released NeoForge for MC 26.2 yet using the upstream port PR's CI build
-# (neoforged/NeoForge#3198 "Port to 26.2"), served from the prmaven repo added in
-# neoforge/build.gradle. This build targets MC 26.2-pre-4 (newest available; no pre-5 build yet).
-# Bump to the official artifact once a real 26.2 alpha ships. Released versions: https://projects.neoforged.net/neoforged/neoforge
-neoforge_version=26.2.0-alpha.0+pre-4.20260607.184824
+# First official NeoForge build for MC 26.2 (beta). Released versions: https://projects.neoforged.net/neoforged/neoforge
+neoforge_version=26.2.0.1-beta
 neoforge_loader_version_range=[4,)
 moddev_version=2.0.141
 
@@ -37,7 +34,9 @@ moddev_version=2.0.141
 # jei_mod_plugin entrypoint in fabric/src/main/resources/fabric.mod.json.
 jei_enabled=false
 jei_version=29.2.0.20
-jade_fabric_version=26.2.0+fabric
+jade_fabric_version=26.2.1+fabric
+# No Jade NeoForge build for MC 26.2 yet (latest is 26.1.1); compileOnly/runtimeOnly only,
+# never bundled, so this does not block the build. Bump when a 26.2 NeoForge Jade ships.
 jade_neoforge_version=26.1.1+neoforge
 
 # Test Dependencies

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -76,9 +76,13 @@ dependencies {
         runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-neoforge:${rootProject.jei_version}")
     }
 
-    // Jade HUD — compile against the API only; loaded in dev via runClient, never bundled
+    // Jade HUD — compile against the API only; never bundled.
     compileOnly("maven.modrinth:jade:${rootProject.jade_neoforge_version}")
-    runtimeOnly("maven.modrinth:jade:${rootProject.jade_neoforge_version}")
+    // No Jade NeoForge build for MC 26.2 yet — the 26.1.x jar is runtime-incompatible
+    // (NoClassDefFoundError MinMaxBounds$Ints, which moved in 26.2) and crashes runClient
+    // during mod construction. Keep it off the runtime classpath until a 26.2 build ships;
+    // restore runtimeOnly (and test the in-game HUD) then. The release jar is unaffected.
+    // runtimeOnly("maven.modrinth:jade:${rootProject.jade_neoforge_version}")
 
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -14,15 +14,6 @@ base {
 repositories {
     maven { url = "https://maven.terraformersmc.com/releases/" }
     maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
-    // No released NeoForge for MC 26.2 yet. Pull the artifact from the upstream port PR's
-    // CI maven (neoforged/NeoForge#3198, "Port to 26.2"). Scoped to the neoforge module only.
-    // This is an ephemeral, unmerged build — fine for dev/testing, NOT for a shippable release.
-    // Remove this repo and point neoforge_version at the official maven once a real 26.2 alpha ships.
-    maven {
-        name = "NeoForge PR #3198 (Port to 26.2)"
-        url = "https://prmaven.neoforged.net/NeoForge/pr3198"
-        content { includeModule("net.neoforged", "neoforge") }
-    }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"


### PR DESCRIPTION
## Summary

MC 26.2 has shipped as a final release, and the first official NeoForge 26.2 build (beta) plus an updated Fabric API are now available. This moves the branch off the pre-release/RC targets and the ephemeral NeoForge PR-maven onto real, released artifacts.

## Changes

- **Minecraft:** `26.2-rc-1` → `26.2` (final); compatibility floor raised `26.2-pre.4` → `26.2`
- **Fabric:** API `0.152.0` → `0.152.1+26.2`; Loom `1.16-SNAPSHOT` → `1.17-SNAPSHOT`
- **NeoForge:** now `26.2.0.1-beta` from the official maven; removed the temporary NeoForge PR #3198 prmaven repo
- **Jade (Fabric):** `26.2.0+fabric` → `26.2.1+fabric`

## Notes

- **JEI stays disabled** — no MC 26.2 JEI artifact exists yet (latest is 26.1.2). Re-enable when it ships.
- **Jade on NeoForge** is left pinned at `26.1.1+neoforge` — no 26.2 NeoForge Jade build yet. It's compileOnly/runtimeOnly and never bundled, so it doesn't affect the release.
- Both loaders build green; all 92 gametests pass; spotless clean.