### PR TITLE
fix(ui): fix glass tank capacity overlay with held items

### DIFF
--- a/common/src/main/java/com/logistics/pipe/block/GlassTankBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/GlassTankBlock.java
@@ -112,6 +112,9 @@ public class GlassTankBlock extends BaseEntityBlock {
     @Override
     protected InteractionResult useWithoutItem(
             BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hit) {
+        if (!player.getMainHandItem().isEmpty()) {
+            return InteractionResult.PASS;
+        }
         if (!level.isClientSide() && level.getBlockEntity(pos) instanceof GlassTankBlockEntity tank) {
             player.sendOverlayMessage(describe(tank.column()));
         }

--- a/common/src/main/java/com/logistics/pipe/block/GlassTankBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/GlassTankBlock.java
@@ -13,7 +13,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -222,7 +221,7 @@ public class GlassTankBlock extends BaseEntityBlock {
         long perMb = Math.max(1, PlatformService.INSTANCE.fluidUnitsPerMillibucket());
         long amountMb = column.total() / perMb;
         long capacityMb = column.capacity() / perMb;
-        Component name = Component.translatable(BuiltInRegistries.FLUID.getKey(shared.getFluid()).toLanguageKey("fluid"));
+        Component name = shared.getFluid().defaultFluidState().createLegacyBlock().getBlock().getName();
         return Component.translatable("tooltip.logistics.fluid.tank_contents", name, amountMb, capacityMb);
     }
 

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -24,8 +24,6 @@
   "block.logistics.fluid.void_fluid_pipe": "Void Fluid Pipe",
   "block.logistics.fluid.bypass_fluid_pipe": "Bypass Fluid Pipe",
   "block.logistics.fluid.glass_tank": "Glass Tank",
-  "fluid.minecraft.water": "Water",
-  "fluid.minecraft.lava": "Lava",
   "tooltip.logistics.fluid.tank_capacity": "Holds %s buckets",
   "tooltip.logistics.fluid.tank_empty": "Empty",
   "tooltip.logistics.fluid.tank_contents": "%1$s: %2$s / %3$s mB",

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -24,6 +24,8 @@
   "block.logistics.fluid.void_fluid_pipe": "Void Fluid Pipe",
   "block.logistics.fluid.bypass_fluid_pipe": "Bypass Fluid Pipe",
   "block.logistics.fluid.glass_tank": "Glass Tank",
+  "fluid.minecraft.water": "Water",
+  "fluid.minecraft.lava": "Lava",
   "tooltip.logistics.fluid.tank_capacity": "Holds %s buckets",
   "tooltip.logistics.fluid.tank_empty": "Empty",
   "tooltip.logistics.fluid.tank_contents": "%1$s: %2$s / %3$s mB",


### PR DESCRIPTION
Summary
- Fixes glass tanks showing the contents/capacity overlay after right-clicking with unrelated held items.
- Keeps the contents/capacity readout available for genuine empty-hand interaction.
- Shows translated fluid names in the overlay by using the fluid block display name instead of mod-owned vanilla fluid translation keys.

Changes
- The empty-hand fallback now passes through when the player's main hand is not empty.
- Tank contents now display names like Water from the existing block translation.

Notes
- Closes #524.
- Verified with `./gradlew build`.
- Smoke-tested with `./gradlew :fabric:runClient` and `./gradlew :neoforge:runClient`.