### PR TITLE
ci(build): make Codecov informational for common coverage

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -51,8 +51,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Each module uploads one Codecov report. When changing this list, update
-        # after_n_builds (notify and comment) in codecov.yml to match the count.
+        # Every module runs tests; only common uploads coverage because loader
+        # adapters are mostly integration glue around Minecraft APIs.
         module: [common, fabric, neoforge]
 
     steps:
@@ -85,7 +85,8 @@ jobs:
           name: test-reports-${{ matrix.module }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ matrix.module }}/build/reports/tests/test/
 
-      - name: Upload ${{ matrix.module }} coverage to Codecov
+      - name: Upload common coverage to Codecov
+        if: matrix.module == 'common'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ${{ matrix.module }}/build/reports/jacoco/test/jacocoTestReport.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,34 +1,33 @@
 codecov:
   notify:
-    # Each PR uploads three reports (common, fabric, neoforge matrix jobs).
-    # Wait for all of them before computing status so the merged total is used.
-    after_n_builds: 3
+    # CI still tests every module, but only common code uploads coverage.
+    after_n_builds: 1
+
+ignore:
+  - "fabric/**"
+  - "neoforge/**"
+  - "common/src/client/**"
 
 coverage:
   status:
     project:
       default:
-        # Compare against the parent commit's coverage; allow tiny rounding noise.
+        # Coverage is useful signal, but Minecraft world-bound code makes it a poor merge gate.
+        informational: true
         target: auto
         threshold: 0.5%
     patch:
       default:
-        # Keep new / changed lines covered without blocking small Minecraft mod PRs.
+        informational: true
         target: 20%
 
-# Per-module uploads are tagged with a flag so Codecov can report coverage
-# per loader as well as merged together.
 flag_management:
   default_rules:
     carryforward: true
   individual_flags:
     - name: common
-    - name: fabric
-    - name: neoforge
 
 comment:
   layout: "reach, diff, flags, files"
   require_changes: true
-  # Keep in sync with codecov.notify.after_n_builds and the test matrix size in
-  # .github/workflows/check-code.yml (one upload per module).
-  after_n_builds: 3
+  after_n_builds: 1


### PR DESCRIPTION
## Summary
- Makes Codecov report coverage without blocking PR merges.
- Narrows uploaded coverage to common code while keeping all module tests in CI.

## Changes
- Uploads Codecov coverage only from the common test job.
- Ignores loader-specific and shared client source paths in Codecov.
- Marks project and patch coverage statuses as informational.
- Updates Codecov build counting for a single uploaded report.

## Notes
- Verified with repo lint, YAML parsing, and common JaCoCo report generation.