### PR TITLE
feat(automation): add configurable laser quarry chunk loading

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -10,6 +10,9 @@ import com.logistics.core.bootstrap.DomainBootstrap;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.automation.marker.MarkerBlock;
 import com.logistics.automation.marker.MarkerBlockEntity;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.server.level.TicketType;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
@@ -45,10 +48,12 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         MENU.register();
         CREATIVE.register();
         ALIAS.register();
+        TICKET_TYPE.register();
     }
 
     public static final class BLOCK {
-        private BLOCK() {}
+        private BLOCK() {
+        }
 
         public static Block MARKER;
         public static Block LASER_QUARRY;
@@ -57,19 +62,20 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
 
         static void register() {
             MARKER = INSTANCE.registerBlockWithItem("marker",
-                props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
+                    props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
             LASER_QUARRY = INSTANCE.registerBlockWithItem("laser_quarry",
-                props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
+                    props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
             LASER_QUARRY_FRAME = INSTANCE.registerBlock("laser_quarry_frame",
-                props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
+                    props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
             KILN = INSTANCE.registerBlockWithItem("kiln",
-                props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
-                    .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
+                    props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
+                            .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
         }
     }
 
     public static final class ENTITY {
-        private ENTITY() {}
+        private ENTITY() {
+        }
 
         public static BlockEntityType<MarkerBlockEntity> MARKER_BLOCK_ENTITY;
         public static BlockEntityType<LaserQuarryBlockEntity> LASER_QUARRY_BLOCK_ENTITY;
@@ -78,14 +84,15 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         static void register() {
             MARKER_BLOCK_ENTITY = INSTANCE.registerBlockEntity("marker", MarkerBlockEntity::new, LogisticsAutomation.BLOCK.MARKER);
             LASER_QUARRY_BLOCK_ENTITY =
-                INSTANCE.registerBlockEntity("laser_quarry", LaserQuarryBlockEntity::new, BLOCK.LASER_QUARRY);
+                    INSTANCE.registerBlockEntity("laser_quarry", LaserQuarryBlockEntity::new, BLOCK.LASER_QUARRY);
             KILN_BLOCK_ENTITY =
-                INSTANCE.registerBlockEntity("kiln", KilnBlockEntity::new, BLOCK.KILN);
+                    INSTANCE.registerBlockEntity("kiln", KilnBlockEntity::new, BLOCK.KILN);
         }
     }
 
     public static final class MENU {
-        private MENU() {}
+        private MENU() {
+        }
 
         public static MenuType<KilnScreenHandler> KILN;
 
@@ -95,7 +102,8 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     public static final class CREATIVE {
-        private CREATIVE() {}
+        private CREATIVE() {
+        }
 
         static void register() {
             LogisticsCore.CREATIVE.TAB.add(BLOCK.MARKER);
@@ -105,7 +113,8 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     public static final class ALIAS {
-        private ALIAS() {}
+        private ALIAS() {
+        }
 
         static void register() {
             // v0.2 => v0.3
@@ -135,6 +144,27 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
             // automation domain => core domain (quartz_crystal moved)
             INSTANCE.registerBlockAlias("automation/quartz_crystal", LogisticsCore.BLOCK.QUARTZ_CRYSTAL);
             INSTANCE.registerItemAlias("automation/quartz_crystal", LogisticsCore.BLOCK.QUARTZ_CRYSTAL.asItem());
+        }
+    }
+
+    public static final class TICKET_TYPE {
+
+        public static TicketType QUARRY;
+        public static TicketType QUARRY_BOUNDARY;
+
+
+        static void register() {
+            QUARRY = Registry.register(
+                    BuiltInRegistries.TICKET_TYPE,
+                    "logistics:quarry",
+                    new TicketType(20L, TicketType.FLAG_PERSIST | TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
+            );
+
+            QUARRY_BOUNDARY = Registry.register(
+                    BuiltInRegistries.TICKET_TYPE,
+                    "logistics:quarry_boundary",
+                    new TicketType(20L, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
+            );
         }
     }
 }

--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -152,7 +152,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
             QUARRY = Registry.register(
                     BuiltInRegistries.TICKET_TYPE,
                     "logistics:quarry",
-                    new TicketType(2props0L, TicketType.FLAG_PERSIST | TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
+                    new TicketType(20L, TicketType.FLAG_PERSIST | TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
             );
 
             QUARRY_BOUNDARY = Registry.register(

--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -61,14 +61,14 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
 
         static void register() {
             MARKER = INSTANCE.registerBlockWithItem("marker",
-        props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
+            props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
             LASER_QUARRY = INSTANCE.registerBlockWithItem("laser_quarry",
-        props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
+            props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
             LASER_QUARRY_FRAME = INSTANCE.registerBlock("laser_quarry_frame",
-        props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
+            props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
             KILN = INSTANCE.registerBlockWithItem("kiln",
-        props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
-            .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
+            props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
+                .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
         }
     }
 
@@ -82,9 +82,9 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         static void register() {
             MARKER_BLOCK_ENTITY = INSTANCE.registerBlockEntity("marker", MarkerBlockEntity::new, LogisticsAutomation.BLOCK.MARKER);
             LASER_QUARRY_BLOCK_ENTITY =
-                    INSTANCE.registerBlockEntity("laser_quarry", LaserQuarryBlockEntity::new, BLOCK.LASER_QUARRY);
+                INSTANCE.registerBlockEntity("laser_quarry", LaserQuarryBlockEntity::new, BLOCK.LASER_QUARRY);
             KILN_BLOCK_ENTITY =
-                    INSTANCE.registerBlockEntity("kiln", KilnBlockEntity::new, BLOCK.KILN);
+                INSTANCE.registerBlockEntity("kiln", KilnBlockEntity::new, BLOCK.KILN);
         }
     }
 
@@ -152,7 +152,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
             QUARRY = Registry.register(
                     BuiltInRegistries.TICKET_TYPE,
                     "logistics:quarry",
-                    new TicketType(20L, TicketType.FLAG_PERSIST | TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
+                    new TicketType(2props0L, TicketType.FLAG_PERSIST | TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
             );
 
             QUARRY_BOUNDARY = Registry.register(

--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -61,14 +61,14 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
 
         static void register() {
             MARKER = INSTANCE.registerBlockWithItem("marker",
-            props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
+                props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
             LASER_QUARRY = INSTANCE.registerBlockWithItem("laser_quarry",
-            props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
+                props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
             LASER_QUARRY_FRAME = INSTANCE.registerBlock("laser_quarry_frame",
-            props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
+                props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
             KILN = INSTANCE.registerBlockWithItem("kiln",
-            props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
-                .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
+                props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
+                    .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
         }
     }
 

--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -52,8 +52,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     public static final class BLOCK {
-        private BLOCK() {
-        }
+        private BLOCK() {}
 
         public static Block MARKER;
         public static Block LASER_QUARRY;
@@ -62,20 +61,19 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
 
         static void register() {
             MARKER = INSTANCE.registerBlockWithItem("marker",
-                    props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
+        props -> new MarkerBlock(props.strength(0.0f).sound(SoundType.WOOD).noCollision()));
             LASER_QUARRY = INSTANCE.registerBlockWithItem("laser_quarry",
-                    props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
+        props -> new LaserQuarryBlock(props.strength(5.0f).sound(SoundType.STONE)));
             LASER_QUARRY_FRAME = INSTANCE.registerBlock("laser_quarry_frame",
-                    props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
+        props -> new LaserQuarryFrameBlock(props.strength(-1.0f, 3600000.0f).noOcclusion().noLootTable().randomTicks()));
             KILN = INSTANCE.registerBlockWithItem("kiln",
-                    props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
-                            .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
+        props -> new KilnBlock(props.strength(3.5f).sound(SoundType.METAL).requiresCorrectToolForDrops()
+            .lightLevel(state -> state.getValue(KilnBlock.LIT) ? 13 : 0)));
         }
     }
 
     public static final class ENTITY {
-        private ENTITY() {
-        }
+        private ENTITY() {}
 
         public static BlockEntityType<MarkerBlockEntity> MARKER_BLOCK_ENTITY;
         public static BlockEntityType<LaserQuarryBlockEntity> LASER_QUARRY_BLOCK_ENTITY;
@@ -91,8 +89,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     public static final class MENU {
-        private MENU() {
-        }
+        private MENU() {}
 
         public static MenuType<KilnScreenHandler> KILN;
 
@@ -102,8 +99,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     public static final class CREATIVE {
-        private CREATIVE() {
-        }
+        private CREATIVE() {}
 
         static void register() {
             LogisticsCore.CREATIVE.TAB.add(BLOCK.MARKER);
@@ -113,8 +109,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     public static final class ALIAS {
-        private ALIAS() {
-        }
+        private ALIAS() {}
 
         static void register() {
             // v0.2 => v0.3
@@ -148,10 +143,10 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
     }
 
     public static final class TICKET_TYPE {
+        private TICKET_TYPE() {}
 
         public static TicketType QUARRY;
         public static TicketType QUARRY_BOUNDARY;
-
 
         static void register() {
             QUARRY = Registry.register(

--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -151,13 +151,13 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         static void register() {
             QUARRY = Registry.register(
                     BuiltInRegistries.TICKET_TYPE,
-                    "logistics:quarry",
+                    LogisticsMod.modId("quarry").toIdentifier(),
                     new TicketType(20L, TicketType.FLAG_PERSIST | TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
             );
 
             QUARRY_BOUNDARY = Registry.register(
                     BuiltInRegistries.TICKET_TYPE,
-                    "logistics:quarry_boundary",
+                    LogisticsMod.modId("quarry_boundary").toIdentifier(),
                     new TicketType(20L, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE)
             );
         }

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -77,9 +77,7 @@ public final class QuarryPhaseRunner {
         this.currentTarget = null;
     }
 
-    /**
-     * Marker callback: bounds changed, restart the full clear -> frame -> mine sequence.
-     */
+    /** Marker callback: bounds changed, restart the full clear -> frame -> mine sequence. */
     public void onCustomBoundsSet() {
         phase = Phase.CLEARING;
         frameBuildIndex = 0;
@@ -90,9 +88,7 @@ public final class QuarryPhaseRunner {
         resetBreakProgress();
     }
 
-    /**
-     * True if the quarry has been placed but hasn't started any clearing yet.
-     */
+    /** True if the quarry has been placed but hasn't started any clearing yet. */
     public boolean isFreshlyPlaced() {
         return phase == Phase.CLEARING && miningX == 0 && miningY == 0 && miningZ == 0 && breakProgress == 0;
     }
@@ -495,9 +491,7 @@ public final class QuarryPhaseRunner {
         }
     }
 
-    /**
-     * Load from the legacy {@code MiningState} compound.
-     */
+    /** Load from the legacy {@code MiningState} compound. */
     public void loadLegacy(CompoundTag miningStateTag) {
         miningX = NbtCompat.getInt(miningStateTag, "X", 0);
         miningY = NbtCompat.getInt(miningStateTag, "Y", 0);

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -104,8 +104,7 @@ public final class QuarryPhaseRunner {
             case CLEARING -> tickClearing(be, world, pos, state);
             case BUILDING_FRAME -> tickBuildingFrame(be, world, state);
             case MINING -> tickMining(be, world, state);
-            default -> {
-            }
+            default -> {}
         }
     }
 

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -1,5 +1,6 @@
 package com.logistics.automation.laserquarry.entity;
 
+import com.logistics.LogisticsAutomation;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity.ArmState;
 import com.logistics.automation.laserquarry.entity.LaserQuarryBlockEntity.Phase;
@@ -7,9 +8,13 @@ import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.compat.NbtCompat;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.*;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Owns the laser quarry's per-phase execution state — {@code Phase} dispatch,
@@ -72,7 +77,9 @@ public final class QuarryPhaseRunner {
         this.currentTarget = null;
     }
 
-    /** Marker callback: bounds changed, restart the full clear -> frame -> mine sequence. */
+    /**
+     * Marker callback: bounds changed, restart the full clear -> frame -> mine sequence.
+     */
     public void onCustomBoundsSet() {
         phase = Phase.CLEARING;
         frameBuildIndex = 0;
@@ -83,7 +90,9 @@ public final class QuarryPhaseRunner {
         resetBreakProgress();
     }
 
-    /** True if the quarry has been placed but hasn't started any clearing yet. */
+    /**
+     * True if the quarry has been placed but hasn't started any clearing yet.
+     */
     public boolean isFreshlyPlaced() {
         return phase == Phase.CLEARING && miningX == 0 && miningY == 0 && miningZ == 0 && breakProgress == 0;
     }
@@ -91,12 +100,61 @@ public final class QuarryPhaseRunner {
     // ==================== Tick dispatch ====================
 
     public void tick(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
+        switch (LogisticsConfig.get().quarry.chunkLoading) {
+            case NONE -> {
+            }
+            case BOUNDARY_ONLY -> loadBoundaryOnly(be, world, pos, state);
+            case FULL -> loadFull(be, world, pos, state);
+        }
+
         switch (phase) {
             case CLEARING -> tickClearing(be, world, pos, state);
             case BUILDING_FRAME -> tickBuildingFrame(be, world, state);
             case MINING -> tickMining(be, world, state);
-            default -> {}
+            default -> {
+            }
         }
+    }
+
+    private void loadBoundaryOnly(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
+        ServerChunkCache chunkCache = world.getChunkSource();
+        QuarryFrameRect frame = QuarryFrameRect.resolve(
+                LaserQuarryBlock.getMiningDirection(state),
+                pos,
+                be.getBounds(),
+                LogisticsConfig.get().quarry.area
+        );
+
+        Set<ChunkPos> chunks = new HashSet<>();
+        for (int x = frame.startX(); x < frame.endX(); x++) {
+            for (int z = frame.startZ(); z < frame.endZ(); z++) {
+                BlockPos offsetPost = new BlockPos(x, frame.bottomY(), z);
+                chunks.add(ChunkPos.containing(offsetPost));
+            }
+        }
+
+        for (ChunkPos chunk : chunks) {
+            System.out.printf("%d %d %n", chunk.x(), chunk.z());
+            Ticket ticket = new Ticket(
+                    LogisticsAutomation.TICKET_TYPE.QUARRY_BOUNDARY,
+                    ChunkLevel.byStatus(FullChunkStatus.BLOCK_TICKING)
+            );
+
+            chunkCache.addTicket(ticket, chunk);
+        }
+    }
+
+    private void loadFull(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
+        this.loadBoundaryOnly(be, world, pos, state);
+
+        Ticket ticket = new Ticket(
+                LogisticsAutomation.TICKET_TYPE.QUARRY,
+                ChunkLevel.byStatus(FullChunkStatus.BLOCK_TICKING)
+        );
+        ChunkPos chunk = ChunkPos.containing(pos);
+
+        ServerChunkCache chunkCache = world.getChunkSource();
+        chunkCache.addTicket(ticket, chunk);
     }
 
     private void tickClearing(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
@@ -442,7 +500,9 @@ public final class QuarryPhaseRunner {
         }
     }
 
-    /** Load from the legacy {@code MiningState} compound. */
+    /**
+     * Load from the legacy {@code MiningState} compound.
+     */
     public void loadLegacy(CompoundTag miningStateTag) {
         miningX = NbtCompat.getInt(miningStateTag, "X", 0);
         miningY = NbtCompat.getInt(miningStateTag, "Y", 0);

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -100,11 +100,8 @@ public final class QuarryPhaseRunner {
     // ==================== Tick dispatch ====================
 
     public void tick(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
-        switch (LogisticsConfig.get().quarry.chunkLoading) {
-            case NONE -> {
-            }
-            case BOUNDARY_ONLY -> loadBoundaryOnly(be, world, pos, state);
-            case FULL -> loadFull(be, world, pos, state);
+        if (LogisticsConfig.get().quarry.loadChunks) {
+            loadChunks(be, world, pos, state);
         }
 
         switch (phase) {
@@ -116,7 +113,7 @@ public final class QuarryPhaseRunner {
         }
     }
 
-    private void loadBoundaryOnly(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
+    private void loadChunks(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
         ServerChunkCache chunkCache = world.getChunkSource();
         QuarryFrameRect frame = QuarryFrameRect.resolve(
                 LaserQuarryBlock.getMiningDirection(state),
@@ -146,18 +143,12 @@ public final class QuarryPhaseRunner {
 
             chunkCache.addTicket(ticket, chunk);
         }
-    }
-
-    private void loadFull(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {
-        this.loadBoundaryOnly(be, world, pos, state);
 
         Ticket ticket = new Ticket(
                 LogisticsAutomation.TICKET_TYPE.QUARRY,
                 ChunkLevel.byStatus(FullChunkStatus.BLOCK_TICKING)
         );
         ChunkPos chunk = ChunkPos.containing(pos);
-
-        ServerChunkCache chunkCache = world.getChunkSource();
         chunkCache.addTicket(ticket, chunk);
     }
 

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -124,17 +124,21 @@ public final class QuarryPhaseRunner {
                 be.getBounds(),
                 LogisticsConfig.get().quarry.area
         );
+        if (frame == null) {
+            throw new IllegalStateException("Query has null frame");
+        }
 
         Set<ChunkPos> chunks = new HashSet<>();
-        for (int x = frame.startX(); x < frame.endX(); x++) {
-            for (int z = frame.startZ(); z < frame.endZ(); z++) {
-                BlockPos offsetPost = new BlockPos(x, frame.bottomY(), z);
-                chunks.add(ChunkPos.containing(offsetPost));
+        ChunkPos start = ChunkPos.containing(new BlockPos(frame.startX(), 0, frame.startZ()));
+        ChunkPos end = ChunkPos.containing(new BlockPos(frame.endX(), 0, frame.endZ()));
+
+        for (int x = start.x(); x <= end.x(); x++) {
+            for (int z = start.z(); z <= end.z(); z++) {
+                chunks.add(new ChunkPos(x, z));
             }
         }
 
         for (ChunkPos chunk : chunks) {
-            System.out.printf("%d %d %n", chunk.x(), chunk.z());
             Ticket ticket = new Ticket(
                     LogisticsAutomation.TICKET_TYPE.QUARRY_BOUNDARY,
                     ChunkLevel.byStatus(FullChunkStatus.BLOCK_TICKING)

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -8,13 +8,14 @@ import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.compat.NbtCompat;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.*;
+import net.minecraft.server.level.ChunkLevel;
+import net.minecraft.server.level.FullChunkStatus;
+import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.Ticket;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Owns the laser quarry's per-phase execution state — {@code Phase} dispatch,
@@ -117,34 +118,21 @@ public final class QuarryPhaseRunner {
                 LogisticsConfig.get().quarry.area
         );
         if (frame == null) {
-            throw new IllegalStateException("Query has null frame");
+            throw new IllegalStateException("Quarry has null frame");
         }
 
-        Set<ChunkPos> chunks = new HashSet<>();
+        int ticketLevel = ChunkLevel.byStatus(FullChunkStatus.BLOCK_TICKING);
         ChunkPos start = ChunkPos.containing(new BlockPos(frame.startX(), 0, frame.startZ()));
         ChunkPos end = ChunkPos.containing(new BlockPos(frame.endX(), 0, frame.endZ()));
 
         for (int x = start.x(); x <= end.x(); x++) {
             for (int z = start.z(); z <= end.z(); z++) {
-                chunks.add(new ChunkPos(x, z));
+                chunkCache.addTicket(
+                        new Ticket(LogisticsAutomation.TICKET_TYPE.QUARRY_BOUNDARY, ticketLevel), new ChunkPos(x, z));
             }
         }
 
-        for (ChunkPos chunk : chunks) {
-            Ticket ticket = new Ticket(
-                    LogisticsAutomation.TICKET_TYPE.QUARRY_BOUNDARY,
-                    ChunkLevel.byStatus(FullChunkStatus.BLOCK_TICKING)
-            );
-
-            chunkCache.addTicket(ticket, chunk);
-        }
-
-        Ticket ticket = new Ticket(
-                LogisticsAutomation.TICKET_TYPE.QUARRY,
-                ChunkLevel.byStatus(FullChunkStatus.BLOCK_TICKING)
-        );
-        ChunkPos chunk = ChunkPos.containing(pos);
-        chunkCache.addTicket(ticket, chunk);
+        chunkCache.addTicket(new Ticket(LogisticsAutomation.TICKET_TYPE.QUARRY, ticketLevel), ChunkPos.containing(pos));
     }
 
     private void tickClearing(LaserQuarryBlockEntity be, ServerLevel world, BlockPos pos, BlockState state) {

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -49,6 +49,18 @@ public final class LogisticsConfig {
         public long armEnergy = 20L;
         public float rainPenalty = 0.7f;
         public int scanRate = 256;
+        public ChunkLoadingMode chunkLoading = ChunkLoadingMode.BOUNDARY_ONLY;
+
+        public enum ChunkLoadingMode {
+            // No chunks are loaded
+            NONE,
+
+            // Only chunks within the quarry boundary are loaded as TODO chunks
+            BOUNDARY_ONLY,
+
+            // The chunk the quarry is located in is fully loaded, and the boundary chunks are loaded as TODO chunks
+            FULL;
+        };
 
         // Derived values — computed from the fields above.
         public double energyPerBlockMultiplier() { return nonNegativeFiniteOrZero(energyPerBlock * energyMultiplier * 2); }
@@ -141,6 +153,11 @@ public final class LogisticsConfig {
                 v -> INSTANCE.quarry.scanRate = v.intValue(),
                 Long::parseLong,
                 v -> requireRange(v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
+        reg(map, "quarry_chunk_loading", "Quarry chunk loading.",
+                () -> INSTANCE.quarry.chunkLoading,
+                mode -> INSTANCE.quarry.chunkLoading = mode,
+                QuarryConfig.ChunkLoadingMode::valueOf,
+                _ -> {});
 
         // Pipe
         reg(map, "pipe_max_speed", "Item speed ceiling (blocks/tick)",

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -142,7 +142,7 @@ public final class LogisticsConfig {
                 v -> INSTANCE.quarry.scanRate = v.intValue(),
                 Long::parseLong,
                 v -> requireRange(v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
-        reg(map, "quarry_load_chunks", "Should the quarry chunk-load itself",
+        reg(map, "quarry_load_chunks", "Keep the quarry and its work area chunk-loaded while running",
                 () -> INSTANCE.quarry.loadChunks,
                 mode -> INSTANCE.quarry.loadChunks = mode,
                 LogisticsConfig::parseBooleanStrict,

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -49,18 +49,7 @@ public final class LogisticsConfig {
         public long armEnergy = 20L;
         public float rainPenalty = 0.7f;
         public int scanRate = 256;
-        public ChunkLoadingMode chunkLoading = ChunkLoadingMode.BOUNDARY_ONLY;
-
-        public enum ChunkLoadingMode {
-            // No chunks are loaded
-            NONE,
-
-            // Only chunks within the quarry boundary are loaded as TODO chunks
-            BOUNDARY_ONLY,
-
-            // The chunk the quarry is located in is fully loaded, and the boundary chunks are loaded as TODO chunks
-            FULL;
-        };
+        public boolean loadChunks = false;
 
         // Derived values — computed from the fields above.
         public double energyPerBlockMultiplier() { return nonNegativeFiniteOrZero(energyPerBlock * energyMultiplier * 2); }
@@ -153,17 +142,11 @@ public final class LogisticsConfig {
                 v -> INSTANCE.quarry.scanRate = v.intValue(),
                 Long::parseLong,
                 v -> requireRange(v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
-        reg(map, "quarry_chunk_loading", "Quarry chunk loading. Must be one of NONE, BOUNDARY_ONLY, FULL",
-                () -> INSTANCE.quarry.chunkLoading,
-                mode -> INSTANCE.quarry.chunkLoading = mode,
-                string -> {
-                    try {
-                        return QuarryConfig.ChunkLoadingMode.valueOf(string);
-                    } catch (IllegalArgumentException e) {
-                        return null;
-                    }
-                },
-                mode -> requireCondition(mode != null, "must be one of NONE, BOUNDARY_ONLY, FULL"));
+        reg(map, "quarry_load_chunks", "Should the quarry chunk-load itself",
+                () -> INSTANCE.quarry.loadChunks,
+                mode -> INSTANCE.quarry.loadChunks = mode,
+                LogisticsConfig::parseBooleanStrict,
+                v -> {});
 
         // Pipe
         reg(map, "pipe_max_speed", "Item speed ceiling (blocks/tick)",
@@ -382,8 +365,6 @@ public final class LogisticsConfig {
         sanitizeInt("quarry_scan_rate", () -> (long) config.quarry.scanRate, v -> config.quarry.scanRate = v.intValue(),
                 () -> (long) defaults.quarry.scanRate, v -> requireRange(
                         v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
-        sanitizeValue("quarry_chunk_loading", () -> config.quarry.chunkLoading, m -> config.quarry.chunkLoading = m,
-                () -> defaults.quarry.chunkLoading, mode -> requireCondition(mode != null, "must be one of NONE, BOUNDARY_ONLY, FULL"));
 
         sanitizeFloat("pipe_min_speed", () -> (double) config.pipe.minSpeed,
                 v -> config.pipe.minSpeed = v.floatValue(), () -> (double) defaults.pipe.minSpeed,

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -153,11 +153,17 @@ public final class LogisticsConfig {
                 v -> INSTANCE.quarry.scanRate = v.intValue(),
                 Long::parseLong,
                 v -> requireRange(v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
-        reg(map, "quarry_chunk_loading", "Quarry chunk loading.",
+        reg(map, "quarry_chunk_loading", "Quarry chunk loading. Must be one of NONE, BOUNDARY_ONLY, FULL",
                 () -> INSTANCE.quarry.chunkLoading,
                 mode -> INSTANCE.quarry.chunkLoading = mode,
-                QuarryConfig.ChunkLoadingMode::valueOf,
-                _ -> {});
+                string -> {
+                    try {
+                        return QuarryConfig.ChunkLoadingMode.valueOf(string);
+                    } catch (IllegalArgumentException e) {
+                        return null;
+                    }
+                },
+                mode -> requireCondition(mode != null, "must be one of NONE, BOUNDARY_ONLY, FULL"));
 
         // Pipe
         reg(map, "pipe_max_speed", "Item speed ceiling (blocks/tick)",
@@ -376,6 +382,8 @@ public final class LogisticsConfig {
         sanitizeInt("quarry_scan_rate", () -> (long) config.quarry.scanRate, v -> config.quarry.scanRate = v.intValue(),
                 () -> (long) defaults.quarry.scanRate, v -> requireRange(
                         v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
+        sanitizeValue("quarry_chunk_loading", () -> config.quarry.chunkLoading, m -> config.quarry.chunkLoading = m,
+                () -> defaults.quarry.chunkLoading, mode -> requireCondition(mode != null, "must be one of NONE, BOUNDARY_ONLY, FULL"));
 
         sanitizeFloat("pipe_min_speed", () -> (double) config.pipe.minSpeed,
                 v -> config.pipe.minSpeed = v.floatValue(), () -> (double) defaults.pipe.minSpeed,


### PR DESCRIPTION
## Summary

The laser quarry can now keep its work area chunk-loaded while it runs, so it keeps mining even when no players are nearby. It's opt-in and off by default, so existing worlds are unaffected.

## Changes

- **New `quarry_load_chunks` setting (default: off).** When enabled, a running quarry keeps its own chunk and the chunks across its mining area loaded, allowing it to continue working while you're away.
- Toggle it in-game with `/logistics config set quarry_load_chunks true` (use `false` to turn it back off).

## Notes

- **Opt-in — no change for existing worlds.** The setting defaults to `false`; quarries behave exactly as before unless you enable it.
- **Self-releasing.** Chunk loading is tied to the quarry actually running. When it stops, finishes, or is broken, the forced chunks expire on their own within about a second — removing a quarry never leaves chunks stuck loaded.
- **Performance.** Keeping chunks loaded carries an ongoing server cost that scales with the quarry's footprint, so enable it only where you want always-on quarries.
