### PR TITLE
refactor(fluids): finalize fluid pump recipe

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/fluid/fluid_pump.json
+++ b/common/src/main/resources/data/logistics/recipe/fluid/fluid_pump.json
@@ -1,16 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " G ",
-    "VMV",
-    "IBI"
+    "IRI",
+    "IGI",
+    "TBT"
   ],
   "key": {
     "B": "minecraft:bucket",
     "G": "logistics:core/iron_gear",
     "I": "minecraft:iron_ingot",
-    "M": "logistics:core/machine_core",
-    "V": "logistics:core/iron_valve"
+    "R": "minecraft:redstone",
+    "T": "logistics:fluid/glass_tank"
   },
   "result": {
     "id": "logistics:fluid/fluid_pump",


### PR DESCRIPTION
## Summary

Replaces the placeholder fluid pump recipe (#537) with a final, BuildCraft-style recipe ahead of 0.7.3. Closes #539.

## Changes

- Fluid pump now crafts from iron, redstone, an iron gear, a bucket, and two glass tanks:

  ```
  I R I
  I G I
  T B T
  ```

  - `I` minecraft:iron_ingot
  - `R` minecraft:redstone
  - `G` logistics:core/iron_gear
  - `B` minecraft:bucket
  - `T` logistics:fluid/glass_tank

- Drops the crafted `machine_core` / `iron_valve` intermediates in favor of the two tanks, which read more thematically for a pump.

## Notes

- Needs backport to `mc/1.21.11` (identical) and `mc/1.21.1` (older `{"item": ...}` key form) to keep the recipe consistent across branches.
- Still worth a quick recipe-book / JEI check before the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the fluid pump crafting recipe with revised ingredient requirements and a reorganized crafting pattern layout. Players will now need to gather different components to craft the fluid pump. These recipe modifications adjust the crafting mechanics, material sourcing, and overall production process for this essential logistics component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->