### PR TITLE
ci(build): run Fabric game tests in CI

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -145,8 +145,7 @@ jobs:
         run: ./gradlew :${{ matrix.module }}:jacocoTestReport --console=plain
         # jacocoTestReport depends on the module's test task, so this runs the
         # tests once and emits the JaCoCo XML in the same step.
-        # Note: Game tests (./gradlew :fabric:runGameTest) are not run in CI due to resource
-        # constraints and long execution time. Run locally before merging if testing game mechanics.
+        # Note: Fabric game tests run separately in the `gametest` job below.
 
       - name: Upload test reports
         if: needs.changes.outputs.code_changed == 'true' && failure()
@@ -167,3 +166,46 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  gametest:
+    name: gametest (fabric)
+    # Fabric is the only module with a gametest source set; it boots a headless
+    # server, so it runs as its own job rather than in the unit-test matrix.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Skip game tests for non-code changes
+        if: needs.changes.outputs.code_changed != 'true'
+        run: echo "No code-affecting files changed; skipping Fabric game tests."
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: needs.changes.outputs.code_changed == 'true'
+        with:
+          persist-credentials: false
+          token: ${{ github.token }}
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        if: needs.changes.outputs.code_changed == 'true'
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Setup Gradle
+        if: needs.changes.outputs.code_changed == 'true'
+        uses: gradle/actions/setup-gradle@11d4d83c63a6ce61b32d8a9c4faddbdb04fe9917
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Run Fabric game tests
+        if: needs.changes.outputs.code_changed == 'true'
+        run: ./gradlew :fabric:runGameTest --console=plain
+
+      - name: Upload game test logs
+        if: needs.changes.outputs.code_changed == 'true' && failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: gametest-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: fabric/build/run/gameTest/logs/


### PR DESCRIPTION
## Summary

Adds a `gametest` job to the Check Code workflow so Fabric game tests gate PRs. Until now CI ran only the unit `test` task (`jacocoTestReport`); `:fabric:runGameTest` was excluded, so pump/pipe behavior — which is covered entirely by game tests — could merge with broken or missing tests (this is how #542 merged green with red game tests).

## Changes

- New `gametest (fabric)` job: runs `./gradlew :fabric:runGameTest`, gated on the same `changes` detection as `lint`/`test`, skipped on non-code changes and on draft PRs.
- Runs as its own job (no matrix) — Fabric is the only module with a gametest source set; it boots a headless server, so it's separated from the unit-test matrix and given a 30-minute timeout.
- Uploads `fabric/build/run/gameTest/logs/` as an artifact on failure.
- Removes the stale "game tests are not run in CI" note from the `test` job.

## Notes

- Depends on #543 (the game test fix). On its own branch this job will be **red until #543 lands**, because the base still has the broken assertions — i.e. the job is correctly catching the very breakage it's meant to prevent. Merge #543 first, then rebase/merge this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline to execute Fabric game tests as a dedicated workflow job, with automatic test log uploads on failure for improved debugging and test visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->