### PR TITLE
fix(neoforge): render cables and quarry frames correctly on NeoForge

### DIFF
--- a/common/src/main/resources/assets/logistics/models/block/automation/laser_quarry_frame_arm.json
+++ b/common/src/main/resources/assets/logistics/models/block/automation/laser_quarry_frame_arm.json
@@ -1,5 +1,6 @@
 {
   "parent": "logistics:block/pipe/pipe_arm",
+  "render_type": "minecraft:cutout",
   "elements": [
     {
       "name": "arm",

--- a/common/src/main/resources/assets/logistics/models/block/automation/laser_quarry_frame_core.json
+++ b/common/src/main/resources/assets/logistics/models/block/automation/laser_quarry_frame_core.json
@@ -1,5 +1,6 @@
 {
   "parent": "logistics:block/pipe/pipe_core",
+  "render_type": "minecraft:cutout",
   "elements": [
     {
       "name": "core",

--- a/neoforge/src/main/java/com/logistics/neoforge/client/render/NeoForgeCableBlockModelDefinition.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/render/NeoForgeCableBlockModelDefinition.java
@@ -2,8 +2,6 @@ package com.logistics.neoforge.client.render;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
-import com.logistics.power.cable.CableTier;
-import java.util.Locale;
 import java.util.function.Function;
 import net.minecraft.client.renderer.block.model.ItemOverrides;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -18,12 +16,13 @@ import net.neoforged.neoforge.client.model.geometry.IUnbakedGeometry;
 /**
  * NeoForge 21.1 custom geometry loader for power cables.
  *
- * <p>Implements {@link IGeometryLoader} to deserialize cable blockstate model JSON
- * and returns a {@link NeoForgeCableModel} as the baked model. Registered via
- * {@link net.neoforged.neoforge.client.event.ModelEvent.RegisterGeometryLoaders}.
+ * <p>Implements {@link IGeometryLoader} to deserialize cable model JSON and returns a
+ * {@link NeoForgeCableModel} as the baked model. The cable sprite is resolved from the model's
+ * {@code "cable"} texture variable through the baking context, so it is stitched into the block
+ * atlas like any normal model texture.
  *
- * <p>The loader ID is {@code logistics:cable_model}. Reference it from the cable
- * blockstate model JSON using {@code "loader": "logistics:cable_model"}.
+ * <p>The loader ID is {@code logistics:cable_model}. Reference it from the cable block model JSON
+ * using {@code "loader": "logistics:cable_model"}.
  */
 public final class NeoForgeCableBlockModelDefinition
         implements IGeometryLoader<NeoForgeCableBlockModelDefinition.CableGeometry> {
@@ -35,29 +34,12 @@ public final class NeoForgeCableBlockModelDefinition
 
     @Override
     public CableGeometry read(JsonObject jsonObject, JsonDeserializationContext context) {
-        String tierStr = jsonObject.has("tier")
-                ? jsonObject.get("tier").getAsString()
-                : "copper";
-        return new CableGeometry(tierFromId(tierStr));
+        return new CableGeometry();
     }
 
-    private static CableTier tierFromId(String id) {
-        for (CableTier tier : CableTier.values()) {
-            if (tier.id().equals(id) || tier.name().toLowerCase(Locale.ROOT).equals(id)) {
-                return tier;
-            }
-        }
-        throw new IllegalArgumentException("Unknown cable tier: " + id);
-    }
-
-    /** Unbaked geometry for a specific cable tier. */
-    public static final class CableGeometry
-            implements IUnbakedGeometry<CableGeometry> {
-        private final CableTier tier;
-
-        private CableGeometry(CableTier tier) {
-            this.tier = tier;
-        }
+    /** Unbaked geometry for a cable. The tier is encoded in the model's texture, not here. */
+    public static final class CableGeometry implements IUnbakedGeometry<CableGeometry> {
+        private CableGeometry() {}
 
         @Override
         public BakedModel bake(
@@ -66,7 +48,8 @@ public final class NeoForgeCableBlockModelDefinition
                 Function<Material, TextureAtlasSprite> spriteGetter,
                 ModelState modelState,
                 ItemOverrides overrides) {
-            return new NeoForgeCableModel(tier);
+            TextureAtlasSprite sprite = spriteGetter.apply(context.getMaterial("cable"));
+            return new NeoForgeCableModel(sprite);
         }
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/render/NeoForgeCableModel.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/render/NeoForgeCableModel.java
@@ -1,49 +1,48 @@
 package com.logistics.neoforge.client.render;
-import com.logistics.core.lib.resource.ResourceId;
 
 import com.logistics.power.cable.CableBlockEntity;
-import com.logistics.power.cable.CableTier;
 import com.logistics.power.render.model.CableGeometry;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemOverrides;
-import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.client.ChunkRenderTypeSet;
 import net.neoforged.neoforge.client.model.IDynamicBakedModel;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
 import net.neoforged.neoforge.client.model.pipeline.QuadBakingVertexConsumer;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class NeoForgeCableModel implements IDynamicBakedModel {
     /** Stores the cable connection bitmask from the block entity. */
     public static final ModelProperty<Integer> CONNECTION_MASK = new ModelProperty<>();
 
-    private final ResourceLocation textureId;
-    private volatile TextureAtlasSprite spriteCache;
+    /** Cables use transparent torch-style textures, so they always render on the cutout layer. */
+    private static final ChunkRenderTypeSet RENDER_TYPES = ChunkRenderTypeSet.of(RenderType.cutout());
 
-    public NeoForgeCableModel(CableTier tier) {
-        this.textureId = ResourceId.in("logistics", "block/power/" + tier.id()).toIdentifier();
+    private final TextureAtlasSprite sprite;
+
+    public NeoForgeCableModel(TextureAtlasSprite sprite) {
+        this.sprite = sprite;
     }
 
     @Override
     public TextureAtlasSprite getParticleIcon() {
-        return sprite();
+        return sprite;
     }
 
     @Override
     public TextureAtlasSprite getParticleIcon(ModelData data) {
-        return sprite();
+        return sprite;
     }
 
     @Override
@@ -72,6 +71,12 @@ public final class NeoForgeCableModel implements IDynamicBakedModel {
     }
 
     @Override
+    public @NotNull ChunkRenderTypeSet getRenderTypes(
+            @NotNull BlockState state, @NotNull RandomSource rand, @NotNull ModelData data) {
+        return RENDER_TYPES;
+    }
+
+    @Override
     public ModelData getModelData(
             BlockAndTintGetter level,
             BlockPos pos,
@@ -95,7 +100,6 @@ public final class NeoForgeCableModel implements IDynamicBakedModel {
             return List.of();
         }
 
-        TextureAtlasSprite sprite = sprite();
         CablePartBuilder builder = new CablePartBuilder(sprite);
         CableGeometry.emit(
                 builder,
@@ -103,17 +107,6 @@ public final class NeoForgeCableModel implements IDynamicBakedModel {
                 CableGeometry.TextureUvs.fromSprite(sprite),
                 direction -> true);
         return side == null ? builder.getUnculled() : builder.getCulled(side);
-    }
-
-    private TextureAtlasSprite sprite() {
-        TextureAtlasSprite sprite = spriteCache;
-        if (sprite == null) {
-            sprite = Minecraft.getInstance().getModelManager()
-                    .getAtlas(TextureAtlas.LOCATION_BLOCKS)
-                    .getSprite(textureId);
-            spriteCache = sprite;
-        }
-        return sprite;
     }
 
     private static final class CablePartBuilder implements CableGeometry.QuadSink {

--- a/neoforge/src/main/resources/assets/logistics/blockstates/power/copper_cable.json
+++ b/neoforge/src/main/resources/assets/logistics/blockstates/power/copper_cable.json
@@ -1,4 +1,5 @@
 {
-  "neoforge:definition_type": "logistics:power_cable",
-  "tier": "copper_cable"
+  "variants": {
+    "": { "model": "logistics:block/power/copper_cable_dynamic" }
+  }
 }

--- a/neoforge/src/main/resources/assets/logistics/blockstates/power/ender_cable.json
+++ b/neoforge/src/main/resources/assets/logistics/blockstates/power/ender_cable.json
@@ -1,4 +1,5 @@
 {
-  "neoforge:definition_type": "logistics:power_cable",
-  "tier": "ender_cable"
+  "variants": {
+    "": { "model": "logistics:block/power/ender_cable_dynamic" }
+  }
 }

--- a/neoforge/src/main/resources/assets/logistics/blockstates/power/gold_cable.json
+++ b/neoforge/src/main/resources/assets/logistics/blockstates/power/gold_cable.json
@@ -1,4 +1,5 @@
 {
-  "neoforge:definition_type": "logistics:power_cable",
-  "tier": "gold_cable"
+  "variants": {
+    "": { "model": "logistics:block/power/gold_cable_dynamic" }
+  }
 }

--- a/neoforge/src/main/resources/assets/logistics/models/block/power/copper_cable_dynamic.json
+++ b/neoforge/src/main/resources/assets/logistics/models/block/power/copper_cable_dynamic.json
@@ -1,0 +1,8 @@
+{
+  "loader": "logistics:cable_model",
+  "render_type": "minecraft:cutout",
+  "textures": {
+    "particle": "logistics:block/power/copper_cable",
+    "cable": "logistics:block/power/copper_cable"
+  }
+}

--- a/neoforge/src/main/resources/assets/logistics/models/block/power/ender_cable_dynamic.json
+++ b/neoforge/src/main/resources/assets/logistics/models/block/power/ender_cable_dynamic.json
@@ -1,0 +1,8 @@
+{
+  "loader": "logistics:cable_model",
+  "render_type": "minecraft:cutout",
+  "textures": {
+    "particle": "logistics:block/power/ender_cable",
+    "cable": "logistics:block/power/ender_cable"
+  }
+}

--- a/neoforge/src/main/resources/assets/logistics/models/block/power/gold_cable_dynamic.json
+++ b/neoforge/src/main/resources/assets/logistics/models/block/power/gold_cable_dynamic.json
@@ -1,0 +1,8 @@
+{
+  "loader": "logistics:cable_model",
+  "render_type": "minecraft:cutout",
+  "textures": {
+    "particle": "logistics:block/power/gold_cable",
+    "cable": "logistics:block/power/gold_cable"
+  }
+}


### PR DESCRIPTION
## Summary
On NeoForge (MC 1.21.1), power cables rendered as a broken magenta/black cube and laser quarry frames rendered as a solid orange block instead of a see-through grid. Both now render correctly.

## Changes
- **Cables:** rewired the NeoForge cable blockstates to standard `variants` pointing at dedicated dynamic cable models, so the custom cable geometry loader is actually used and the cable texture is stitched into the block atlas. Cables now show their proper texture and shape and render on the cutout layer.
- **Quarry frame:** the frame now renders on the cutout layer, so its transparent grid texture shows through instead of appearing as a solid orange block.

## Notes
- Fabric is unaffected — it already registers the cutout layer in code and ignores the model `render_type` field on 1.21.1, so the shared frame model change is harmless there.
- The same NeoForge frame issue exists on `mc/1.21.11` and can be ported separately.