### PR TITLE
ci(build): tune CodeRabbit review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,12 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   review_status: false
+  # Don't append the high-level summary to the PR description.
+  high_level_summary: false
+  auto_review:
+    # Skip release-please PRs (negative match); review everything else.
+    labels:
+      - "!autorelease: pending"
+    # Review PRs targeting any version branch, not just the default branch.
+    base_branches:
+      - "mc/.*"


### PR DESCRIPTION
## Summary

Tunes CodeRabbit's review behavior to cut noise and widen coverage across our version branches.

## Changes

- **No summary in the PR description.** Disables the high-level "Summary by CodeRabbit" block that was being appended to PR bodies (`high_level_summary: false`), so our own PR descriptions stay authoritative.
- **Skip release-please PRs.** Auto-review now ignores PRs carrying the `autorelease: pending` label (negative-match `labels` filter), since changelog/release PRs don't need review.
- **Review all version branches.** Auto-review now runs on PRs targeting any `mc/*` base branch (`base_branches: ["mc/.*"]`), not just the default branch — so PRs into `mc/1.21.1`, `mc/1.21.11`, `mc/26.2`, etc. get reviewed.
