### PR TITLE
fix(automation): add missing macerator recipes for obsidian, netherite, and metal blocks

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/macerator/bronze_dust_from_bronze_block.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/bronze_dust_from_bronze_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "logistics:core/bronze_block",
+  "result": {
+    "id": "logistics:core/bronze_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/netherite_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/netherite_dust.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:ancient_debris",
+  "result": {
+    "id": "logistics:core/netherite_dust",
+    "count": 1
+  },
+  "grindingtime": 200
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/netherite_dust_from_scrap.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/netherite_dust_from_scrap.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:netherite_scrap",
+  "result": {
+    "id": "logistics:core/netherite_dust",
+    "count": 1
+  },
+  "grindingtime": 200
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/obsidian_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/obsidian_dust.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:obsidian",
+  "result": {
+    "id": "logistics:core/obsidian_dust",
+    "count": 1
+  },
+  "grindingtime": 200
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/obsidian_dust_from_crying_obsidian.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/obsidian_dust_from_crying_obsidian.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "minecraft:crying_obsidian",
+  "result": {
+    "id": "logistics:core/obsidian_dust",
+    "count": 1
+  },
+  "grindingtime": 200
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_raw_tin_block.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_raw_tin_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "logistics:core/raw_tin_block",
+  "result": {
+    "id": "logistics:core/tin_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_tin_block.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_tin_block.json
@@ -1,0 +1,9 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": "logistics:core/tin_block",
+  "result": {
+    "id": "logistics:core/tin_dust",
+    "count": 9
+  },
+  "grindingtime": 200
+}


### PR DESCRIPTION
## Summary
Fixes broken and incomplete macerator dust chains. Closes #548 (unobtainable obsidian/netherite dust) and #549 (missing tin/bronze block grinds).

## Changes
**Now obtainable (#548)** — these dusts were consumed by the Obsidian Core / Netherite Core (and valves) but had no producer, making those components uncraftable in survival:
- Obsidian Dust ← Obsidian, or Crying Obsidian
- Netherite Dust ← Ancient Debris, or Netherite Scrap

**Block grind parity (#549)** — match the iron/copper/gold block grinds (9 dust per block):
- Block of Tin → 9× Tin Dust
- Block of Raw Tin → 9× Tin Dust
- Block of Bronze → 9× Bronze Dust

## Notes
- Single-item sources yield 1 dust; storage blocks yield 9, consistent with existing recipes.
- Apatite Dust and Prismarine Dust remain produced-but-unused by design — left as-is.
- Recipe data is shared in `common`; replicate to mc/1.21.11 and mc/1.21.1 via cherry-pick.