### PR TITLE
feat(core): grant ore XP when macerating metal and apatite ores

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/macerator/apatite_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/apatite_dust.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/apatite_dust",
     "count": 6
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 1.0
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/copper_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/copper_dust.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/copper_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 0.7
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_deepslate.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_deepslate.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/copper_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 0.7
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/gold_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/gold_dust.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/gold_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 1.0
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_deepslate.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_deepslate.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/gold_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 1.0
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_nether_ore.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_nether_ore.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/gold_dust",
     "count": 1
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 1.0
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/iron_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/iron_dust.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/iron_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 0.7
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_deepslate.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_deepslate.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/iron_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 0.7
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/tin_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/tin_dust.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/tin_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 0.7
 }

--- a/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_deepslate.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_deepslate.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/tin_dust",
     "count": 2
   },
-  "grindingtime": 200
+  "grindingtime": 200,
+  "experience": 0.7
 }


### PR DESCRIPTION
## Summary
Grinding a metal ore into dust in the Macerator granted **no XP**, and smelting dust into an ingot grants none either (intentional). So the ore-doubling route (`ore → dust → ingot`) netted **0 XP**, while smelting the ore directly (`ore → ingot`) granted the ore's smelting XP. The XP "locked in" the ore was silently lost whenever a player chose to double their yield.

Grinding is one-way, so awarding XP at the grind step can't be looped for infinite XP — the concern behind 0 XP on `dust → ingot` doesn't apply here.

Gem ores (diamond, redstone, lapis, coal, emerald, quartz) already award XP at the macerator step; only the metals — and apatite — were missing it.

## Changes
- Add `experience` to the metal **ore → dust** macerator recipes, matching the ore's smelting XP:
  - Tin, iron, copper (overworld + deepslate): **0.7**
  - Gold (overworld + deepslate + nether): **1.0**
- Add `experience: 1.0` to **apatite ore → dust**, matching apatite ore's average mining XP (`DropExperienceBlock` 0–2). Apatite has no smelting recipe, so silk-touching the ore to macerate it was the only way to obtain apatite dust while forfeiting the mining XP.

`*_from_ingot` / `*_from_block` macerator recipes and the `*_from_dust` smelting recipes stay at 0 XP — the metal has already been "claimed".

## Notes
- The Macerator already awards `recipe.experience()` on completion (fractional XP rounded probabilistically), so these are live values, not dead config.
- Recipe data lives in `common`, shared across all loaders.
- Fixes #547. Replicate across version branches via cherry-pick.