### PR TITLE
fix(energy): fix crash when cables power machines from other mods

### DIFF
--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -4,14 +4,16 @@ import com.logistics.LogisticsMod;
 import com.logistics.LogisticsPower;
 import com.logistics.core.bootstrap.LogisticsCommonBootstrap;
 import com.logistics.core.lib.platform.CreativeTabRegistrar;
+import com.logistics.core.lib.energy.EnergyCapabilityLookup;
 import com.logistics.core.lib.energy.EnergyPushService;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.fabric.capability.FabricCapabilityRegistration;
 import com.logistics.fabric.energy.EnergyStorageAccess;
+import com.logistics.fabric.energy.FabricEnergyCapabilityLookup;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Items;
@@ -52,14 +54,13 @@ public final class LogisticsFabric implements ModInitializer {
     private void registerEnergyServices() {
         EnergyStorageAccess.register();
 
+        EnergyCapabilityLookup lookup = new FabricEnergyCapabilityLookup();
         EnergyPushService.set((level, targetPos, fromDirection, source, maxAmount) -> {
-            EnergyStorage target = EnergyStorage.SIDED.find(level, targetPos, fromDirection);
-            if (target == null) return 0L;
-            try (Transaction tx = Transaction.openOuter()) {
-                long inserted = target.insert(maxAmount, tx);
-                if (inserted > 0) tx.commit();
-                return inserted;
-            }
+            IEnergyStorage target = lookup.find(level, targetPos, fromDirection);
+            if (target == null || !target.canInsert()) return 0L;
+            // No outer transaction here: it would force the cable network's push to a
+            // third-party storage to nest openOuter() inside it, which Fabric forbids.
+            return target.insert(maxAmount, false);
         });
 
         AbstractEngineBlock.setEnergyPresenceChecker((world, pos, direction) -> {

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -10,14 +10,12 @@ import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.fabric.capability.FabricCapabilityRegistration;
 import com.logistics.fabric.energy.EnergyStorageAccess;
-import com.logistics.fabric.energy.FabricEnergyCapabilityLookup;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.resource.ResourcePackActivationType;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Items;
-import team.reborn.energy.api.EnergyStorage;
 
 public final class LogisticsFabric implements ModInitializer {
     private static final LogisticsCommonBootstrap COMMON_BOOTSTRAP = new LogisticsCommonBootstrap();
@@ -54,9 +52,8 @@ public final class LogisticsFabric implements ModInitializer {
     private void registerEnergyServices() {
         EnergyStorageAccess.register();
 
-        EnergyCapabilityLookup lookup = new FabricEnergyCapabilityLookup();
         EnergyPushService.set((level, targetPos, fromDirection, source, maxAmount) -> {
-            IEnergyStorage target = lookup.find(level, targetPos, fromDirection);
+            IEnergyStorage target = EnergyCapabilityLookup.INSTANCE.find(level, targetPos, fromDirection);
             if (target == null || !target.canInsert()) return 0L;
             // No outer transaction here: it would force the cable network's push to a
             // third-party storage to nest openOuter() inside it, which Fabric forbids.
@@ -64,8 +61,9 @@ public final class LogisticsFabric implements ModInitializer {
         });
 
         AbstractEngineBlock.setEnergyPresenceChecker((world, pos, direction) -> {
-            EnergyStorage target = EnergyStorage.SIDED.find(world, pos.relative(direction), direction.getOpposite());
-            return target != null && target.supportsInsertion();
+            IEnergyStorage target = EnergyCapabilityLookup.INSTANCE.find(
+                    world, pos.relative(direction), direction.getOpposite());
+            return target != null && target.canInsert();
         });
     }
 }


### PR DESCRIPTION
## Summary

Powering another mod's machine through Logistics cables and an engine or battery could crash the game on Fabric. Energy now flows into those machines safely.

Fixes #550.

## Changes

- Engine and battery energy output no longer wraps its push in its own transaction, which is what triggered the crash once a cable network handed energy off to a third-party machine.

## Notes

- Fabric-only. Direct engine-to-machine connections (no cable) were never affected.
- Verified in-game with a creative engine + cable into a Refined Storage controller; all game tests pass.