### PR TITLE
fix(automation): let quarry markers connect through solid blocks

### DIFF
--- a/common/src/main/java/com/logistics/automation/marker/MarkerManager.java
+++ b/common/src/main/java/com/logistics/automation/marker/MarkerManager.java
@@ -161,14 +161,9 @@ public final class MarkerManager {
             mutable.move(direction);
             BlockState state = world.getBlockState(mutable);
 
+            // Markers detect each other through intervening blocks; only the distance bounds the scan.
             if (state.getBlock() instanceof MarkerBlock) {
                 return mutable.immutable();
-            }
-
-            // Stop at non-air blocks that would obstruct the beam
-            // (but allow transparent blocks, fluids, etc.)
-            if (state.isSolidRender()) {
-                break;
             }
         }
 


### PR DESCRIPTION
## Summary

Quarry markers would only connect to each other if the straight line between them was completely clear. A single solid block on that line stopped the scan, so the region never formed.

In practice you place markers to outline an area that *contains* terrain — trees, hills, walls, existing builds — so the line between two corner markers is very often blocked. This made markers fail to connect in most real placements. Reported via Discord.

Fixes #578.

## Changes

- Marker-to-marker detection no longer requires a clear line of sight. The directional scan continues past intervening blocks and is bounded only by the max marker distance.

## Notes

- Logic lives in shared `common/` code, so this should be cherry-picked to mc/1.21.11 and mc/1.21.1 after merge.