### PR TITLE
perf(core): streamline world loading by dropping legacy save migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,18 @@ Merge vX.Y+1.0 release-please PR → ships → cherry-pick
 
 **Use the Hotfix Workflow (above) only when:** v0.6.0 is already out AND new features have already merged, making a v0.5.x backport necessary.
 
+## Backward Compatibility Policy
+
+To bound technical debt while in pre-release, backward-compatibility support reaches back **one major only**. During pre-release the "major" is the **second version digit** (e.g. `0.7.x`); each major keeps compatibility bridges for the **previous major** (`0.6.x`) but nothing older.
+
+This applies to **two** kinds of bridge:
+- **Registry ID aliases** — old block/item/block-entity/menu/data-component IDs mapped to current ones. Registered in the `ALIAS` static classes of `LogisticsCore` / `LogisticsAutomation` / `LogisticsPipe` via `registerItemAlias` / `registerBlockAlias` / `registerBlockEntityAlias` / `PlatformService.registerAlias`.
+- **NBT save migrations** — old saved-state formats read on load. Implemented as `loadLegacyData` overrides on block entities (the live format is read by `loadLogisticsData`).
+
+**Rule of thumb:** keep a bridge only if its old form was the **live (written) form in some release of the previous major**. Drop anything whose old form was already gone by the previous major's first release. When a new major opens, prune the bridges that now fall outside the window.
+
+**Consequence for players:** worlds must be loaded in the **latest release of each major in sequence** before skipping ahead (e.g. pre-`0.6` → latest `0.6.x` → `0.7+`). Skipping a major may silently drop blocks/items or saved machine state. Note this in release notes whenever bridges are pruned.
+
 ## Architecture
 
 This is a multiloader Minecraft mod organized into **independent domains** following **SOLID principles** to maximize maintainability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,18 @@ Merge vX.Y+1.0 release-please PR → ships → cherry-pick
 
 **Use the Hotfix Workflow (above) only when:** v0.6.0 is already out AND new features have already merged, making a v0.5.x backport necessary.
 
+## Backward Compatibility Policy
+
+To bound technical debt while in pre-release, backward-compatibility support reaches back **one major only**. During pre-release the "major" is the **second version digit** (e.g. `0.7.x`); each major keeps compatibility bridges for the **previous major** (`0.6.x`) but nothing older.
+
+This applies to **two** kinds of bridge:
+- **Registry ID aliases** — old block/item/block-entity/menu/data-component IDs mapped to current ones. Registered in the `ALIAS` static classes of `LogisticsCore` / `LogisticsAutomation` / `LogisticsPipe` via `registerItemAlias` / `registerBlockAlias` / `registerBlockEntityAlias` / `PlatformService.registerAlias`.
+- **NBT save migrations** — old saved-state formats read on load. Implemented as `loadLegacyData` overrides on block entities (the live format is read by `loadLogisticsData`).
+
+**Rule of thumb:** keep a bridge only if its old form was the **live (written) form in some release of the previous major**. Drop anything whose old form was already gone by the previous major's first release. When a new major opens, prune the bridges that now fall outside the window.
+
+**Consequence for players:** worlds must be loaded in the **latest release of each major in sequence** before skipping ahead (e.g. pre-`0.6` → latest `0.6.x` → `0.7+`). Skipping a major may silently drop blocks/items or saved machine state. Note this in release notes whenever bridges are pruned.
+
 ## Architecture
 
 This is a multiloader Minecraft mod organized into **independent domains** following **SOLID principles** to maximize maintainability.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 **Logistics is in active development.** Core pipe transport works, but expect rough edges, missing features, and the occasional bug. Report issues on [GitHub](https://github.com/indemnity83/logistics/issues) if something breaks, or [join the Discord](https://discord.gg/94DP3CVNVt) for help and discussion.
 
+**Updating worlds:** while in pre-release, save compatibility reaches back one major version (the second version digit). Load your world in the **latest release of each major in turn** before jumping ahead — e.g. a `0.5.x` world should pass through the latest `0.6.x` before `0.7+`. Skipping a major may drop renamed blocks/items or saved machine state.
+
 
 ## About
 

--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -112,33 +112,7 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         private ALIAS() {}
 
         static void register() {
-            // v0.2 => v0.3
-            INSTANCE.registerBlockAlias("marker", BLOCK.MARKER);
-            INSTANCE.registerBlockEntityAlias("marker", ENTITY.MARKER_BLOCK_ENTITY);
-            INSTANCE.registerItemAlias("marker", BLOCK.MARKER.asItem());
-            // core domain => automation domain (marker moved)
-            INSTANCE.registerBlockAlias("core/marker", BLOCK.MARKER);
-            INSTANCE.registerBlockEntityAlias("core/marker", ENTITY.MARKER_BLOCK_ENTITY);
-            INSTANCE.registerItemAlias("core/marker", BLOCK.MARKER.asItem());
-            INSTANCE.registerBlockAlias("quarry", BLOCK.LASER_QUARRY);
-            INSTANCE.registerItemAlias("quarry", BLOCK.LASER_QUARRY.asItem());
-            INSTANCE.registerBlockAlias("quarry_frame", BLOCK.LASER_QUARRY_FRAME);
-            INSTANCE.registerBlockEntityAlias("quarry", ENTITY.LASER_QUARRY_BLOCK_ENTITY);
-
-            // v0.2 => v0.3 (quarry renamed to laser_quarry)
-            INSTANCE.registerBlockAlias("automation/quarry", BLOCK.LASER_QUARRY);
-            INSTANCE.registerItemAlias("automation/quarry", BLOCK.LASER_QUARRY.asItem());
-            INSTANCE.registerBlockAlias("automation/quarry_frame", BLOCK.LASER_QUARRY_FRAME);
-            INSTANCE.registerBlockEntityAlias("automation/quarry", ENTITY.LASER_QUARRY_BLOCK_ENTITY);
-
-            // core domain => automation domain (kiln moved)
-            INSTANCE.registerBlockAlias("core/kiln", BLOCK.KILN);
-            INSTANCE.registerBlockEntityAlias("core/kiln", ENTITY.KILN_BLOCK_ENTITY);
-            INSTANCE.registerItemAlias("core/kiln", BLOCK.KILN.asItem());
-
-            // automation domain => core domain (quartz_crystal moved)
-            INSTANCE.registerBlockAlias("automation/quartz_crystal", LogisticsCore.BLOCK.QUARTZ_CRYSTAL);
-            INSTANCE.registerItemAlias("automation/quartz_crystal", LogisticsCore.BLOCK.QUARTZ_CRYSTAL.asItem());
+            // Aliases bridging IDs renamed in the previous major go here; none in window.
         }
     }
 

--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -450,15 +450,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         private ALIAS() {}
 
         static void register() {
-            // v0.2 => v0.3
-            INSTANCE.registerItemAlias("wrench", ITEM.WRENCH);
-            INSTANCE.registerItemAlias("wooden_gear", ITEM.WOODEN_GEAR);
-            INSTANCE.registerItemAlias("stone_gear", ITEM.STONE_GEAR);
-            INSTANCE.registerItemAlias("copper_gear", ITEM.COPPER_GEAR);
-            INSTANCE.registerItemAlias("iron_gear", ITEM.IRON_GEAR);
-            INSTANCE.registerItemAlias("gold_gear", ITEM.GOLD_GEAR);
-            INSTANCE.registerItemAlias("diamond_gear", ITEM.DIAMOND_GEAR);
-            INSTANCE.registerItemAlias("netherite_gear", ITEM.NETHERITE_GEAR);
+            // Aliases bridging IDs renamed in the previous major go here; none in window.
         }
     }
 }

--- a/common/src/main/java/com/logistics/LogisticsPipe.java
+++ b/common/src/main/java/com/logistics/LogisticsPipe.java
@@ -2,7 +2,6 @@ package com.logistics;
 
 import com.logistics.api.LogisticsApi;
 import com.logistics.core.bootstrap.DomainBootstrap;
-import com.logistics.core.lib.platform.PlatformService;
 import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.pipe.modules.*;
 import com.logistics.pipe.Pipe;
@@ -460,26 +459,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
         private ALIAS() {}
 
         static void register() {
-            // v0.2 => v0.3
-            INSTANCE.registerBlockEntityAlias("pipe", ENTITY.PIPE_BLOCK_ENTITY);
-
-            for (Map.Entry<DyeColor, Item> entry : ITEM.MARKING_FLUIDS_BY_COLOR.entrySet()) {
-                INSTANCE.registerItemAlias("marking_fluid_" + entry.getKey().getName(), entry.getValue());
-            }
-
-            // v0.4.0 => v0.4.1 (marking_fluid_<color> => <color>_marking_fluid)
-            for (Map.Entry<DyeColor, Item> entry : ITEM.MARKING_FLUIDS_BY_COLOR.entrySet()) {
-                INSTANCE.registerItemAlias("pipe/marking_fluid_" + entry.getKey().getName(), entry.getValue());
-            }
-
-            PlatformService.INSTANCE.registerAlias(
-                    BuiltInRegistries.MENU,
-                    LogisticsMod.modId("item_filter"),
-                    SCREEN.ITEM_FILTER);
-            PlatformService.INSTANCE.registerAlias(
-                    BuiltInRegistries.DATA_COMPONENT_TYPE,
-                    LogisticsMod.modId("weathering_state"),
-                    DATA.WEATHERING_STATE);
+            // Aliases bridging IDs renamed in the previous major go here; none in window.
         }
     }
 

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/ArmController.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/ArmController.java
@@ -202,24 +202,4 @@ public final class ArmController {
         expectedTravelTicks = NbtCompat.getInt(tag, "ArmExpectedTravelTicks", 0);
         syncedSpeed = NbtCompat.getFloat(tag, "ArmSyncedSpeed", 0.0f);
     }
-
-    /**
-     * Load from the legacy {@code MiningState} compound, which used different keys
-     * for the settling and travel-tick fields than the current top-level format.
-     */
-    public void loadLegacy(CompoundTag miningStateTag) {
-        String armStateName = NbtCompat.getString(miningStateTag, "ArmState", "MOVING");
-        try {
-            state = ArmState.valueOf(armStateName);
-        } catch (IllegalArgumentException e) {
-            state = ArmState.MOVING;
-        }
-        x = NbtCompat.getFloat(miningStateTag, "ArmX", 0f);
-        y = NbtCompat.getFloat(miningStateTag, "ArmY", 0f);
-        z = NbtCompat.getFloat(miningStateTag, "ArmZ", 0f);
-        initialized = NbtCompat.getBoolean(miningStateTag, "ArmInitialized", false);
-        settlingTicksRemaining = NbtCompat.getInt(miningStateTag, "SettlingTicks", 0);
-        expectedTravelTicks = NbtCompat.getInt(miningStateTag, "ExpectedTravelTicks", 0);
-        syncedSpeed = NbtCompat.getFloat(miningStateTag, "SyncedArmSpeed", 0.0f);
-    }
 }

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -6,7 +6,6 @@ import com.logistics.core.LogisticsConfig;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.block.capability.PipeConnection;
-import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.EnergyDemandProvider;
@@ -249,37 +248,11 @@ public class LaserQuarryBlockEntity extends BaseBlockEntity
     protected void loadLogisticsData(CompoundTag nbt, HolderLookup.Provider registries) {
         super.loadLogisticsData(nbt, registries);
 
-        if (nbt.contains("Energy")) {
-            energy.readNbt(nbt, "Energy");
-        } else {
-            energy.setAmount(NbtCompat.getLong(nbt, "StoredEnergy", 0L));
-        }
+        energy.readNbt(nbt, "Energy");
 
         phaseRunner.load(nbt);
         armController.load(nbt);
         bounds.load(nbt);
-    }
-
-    @Override
-    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
-        super.loadLegacyData(view);
-
-        bounds.clear();
-
-        view.read("Energy", CompoundTag.CODEC)
-                .ifPresent(energyState -> energy.setAmount(NbtCompat.getLong(energyState, "Amount", 0L)));
-
-        view.read("MiningState", CompoundTag.CODEC).ifPresent(miningState -> {
-            phaseRunner.loadLegacy(miningState);
-            armController.loadLegacy(miningState);
-        });
-
-        view.read("CustomBounds", CompoundTag.CODEC)
-                .ifPresent(customBoundsNbt -> bounds.loadLegacy(
-                        NbtCompat.getInt(customBoundsNbt, "MinX", 0),
-                        NbtCompat.getInt(customBoundsNbt, "MinZ", 0),
-                        NbtCompat.getInt(customBoundsNbt, "MaxX", 0),
-                        NbtCompat.getInt(customBoundsNbt, "MaxZ", 0)));
     }
 
     // ==================== Lifecycle ====================

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBounds.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryBounds.java
@@ -75,8 +75,4 @@ public final class QuarryBounds {
             maxZ = 0;
         }
     }
-
-    public void loadLegacy(int minX, int minZ, int maxX, int maxZ) {
-        setCustom(minX, minZ, maxX, maxZ);
-    }
 }

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryPhaseRunner.java
@@ -477,21 +477,4 @@ public final class QuarryPhaseRunner {
             phase = Phase.CLEARING;
         }
     }
-
-    /** Load from the legacy {@code MiningState} compound. */
-    public void loadLegacy(CompoundTag miningStateTag) {
-        miningX = NbtCompat.getInt(miningStateTag, "X", 0);
-        miningY = NbtCompat.getInt(miningStateTag, "Y", 0);
-        miningZ = NbtCompat.getInt(miningStateTag, "Z", 0);
-        breakProgress = NbtCompat.getFloat(miningStateTag, "Progress", 0f);
-        finished = NbtCompat.getBoolean(miningStateTag, "Finished", false);
-        frameBuildIndex = NbtCompat.getInt(miningStateTag, "FrameBuildIndex", 0);
-
-        String phaseName = NbtCompat.getString(miningStateTag, "Phase", "CLEARING");
-        try {
-            phase = Phase.valueOf(phaseName);
-        } catch (IllegalArgumentException e) {
-            phase = Phase.CLEARING;
-        }
-    }
 }

--- a/common/src/main/java/com/logistics/automation/marker/MarkerBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/marker/MarkerBlockEntity.java
@@ -204,35 +204,6 @@ public class MarkerBlockEntity extends BaseBlockEntity {
         }
     }
 
-    @Override
-    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
-        super.loadLegacyData(view);
-
-        view.read("MarkerData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
-            connectedMarkers.clear();
-            boundMin = null;
-            boundMax = null;
-            isCornerMarker = false;
-
-            loadConnectedMarkers(data);
-
-            // Convert old key names to new format for loadBounds
-            CompoundTag massaged = new CompoundTag();
-            if (data.contains("MinX")) massaged.putInt("BoundMinX", NbtCompat.getInt(data, "MinX", 0));
-            if (data.contains("MinY")) massaged.putInt("BoundMinY", NbtCompat.getInt(data, "MinY", 0));
-            if (data.contains("MinZ")) massaged.putInt("BoundMinZ", NbtCompat.getInt(data, "MinZ", 0));
-            if (data.contains("MaxX")) massaged.putInt("BoundMaxX", NbtCompat.getInt(data, "MaxX", 0));
-            if (data.contains("MaxY")) massaged.putInt("BoundMaxY", NbtCompat.getInt(data, "MaxY", 0));
-            if (data.contains("MaxZ")) massaged.putInt("BoundMaxZ", NbtCompat.getInt(data, "MaxZ", 0));
-            if (data.contains("IsCorner")) massaged.putBoolean("IsCornerMarker", NbtCompat.getBoolean(data, "IsCorner", false));
-
-            loadBounds(massaged);
-            if (!hasValidBounds()) {
-                isCornerMarker = false;
-            }
-        });
-    }
-
     private void loadBounds(CompoundTag data) {
         boolean hasMin = data.contains("BoundMinX");
         boolean hasMax = data.contains("BoundMaxX");

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -426,18 +426,6 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
         heatStage = HeatStage.fromOrdinal(NbtCompat.getInt(engineData, "HeatStage", 0));
     }
 
-    @Override
-    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
-        view.read("Engine", CompoundTag.CODEC).ifPresent(engineData -> {
-            // Load old key names (before BaseBlockEntity refactoring)
-            energyBuffer.setAmount(NbtCompat.getLong(engineData, "energy", 0L));
-            temperature = NbtCompat.getDouble(engineData, "heat", 0.0);
-            progress = NbtCompat.getFloat(engineData, "progress", 0f);
-            cyclePhase = CyclePhase.fromOrdinal(NbtCompat.getInt(engineData, "cyclePhase", 0));
-            heatStage = HeatStage.fromOrdinal(NbtCompat.getInt(engineData, "stage", 0));
-        });
-    }
-
     // ==================== Lifecycle ====================
 
     /**

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -37,7 +37,6 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
@@ -306,46 +305,6 @@ public class PipeBlockEntity extends BaseBlockEntity
                     durationMs,
                     travelingItems.size());
         }
-    }
-
-    @Override
-    protected void loadLegacyData(ValueInput view) {
-        super.loadLegacyData(view);
-        HolderLookup.Provider registries = view.lookup();
-
-        view.read("PipeData", CompoundTag.CODEC).ifPresent(oldData -> {
-            long readStart = System.nanoTime();
-
-            // Massage old format to new format
-            CompoundTag massaged = new CompoundTag();
-
-            // Rename "TravelingItems" -> "ItemsInTransit"
-            if (oldData.contains("TravelingItems")) {
-                massaged.put("ItemsInTransit", Objects.requireNonNull(oldData.get("TravelingItems")));
-            }
-
-            // "ModuleState" has same key name
-            if (oldData.contains("ModuleState")) {
-                massaged.put("ModuleState", Objects.requireNonNull(oldData.get("ModuleState")));
-            }
-
-            // Rename "Connections" -> "ConnectionTypes"
-            if (oldData.contains("Connections")) {
-                massaged.put("ConnectionTypes", Objects.requireNonNull(oldData.get("Connections")));
-            }
-
-            // Now load using the standard loader which expects new keys
-            loadLogisticsData(massaged, registries);
-
-            long durationMs = (System.nanoTime() - readStart) / 1_000_000L;
-            if (durationMs >= 2L && Boolean.getBoolean("logistics.timing")) {
-                LogisticsMod.LOGGER.debug(
-                        "[timing] PipeBlockEntity loadLegacyData at {} took {} ms (items={})",
-                        getBlockPos(),
-                        durationMs,
-                        travelingItems.size());
-            }
-        });
     }
 
     public static void tick(

--- a/common/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ItemFilterModule.java
@@ -3,7 +3,6 @@ package com.logistics.pipe.modules;
 import com.logistics.core.lib.pipe.RoutingModule;
 
 import com.logistics.core.lib.items.ItemMatcher;
-import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.pipe.network.NetDbg;
 import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.compat.NbtCompat;
@@ -21,7 +20,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
-import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
@@ -32,7 +30,6 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 
 /**
@@ -165,48 +162,10 @@ public class ItemFilterModule implements Module, RoutingModule {
         }
     }
 
-    public List<String> getFilterSlots(PipeContext ctx, Direction direction) {
-        CompoundTag filters = ctx.getCompoundTag(this, FILTERS);
-        List<String> slots = new ArrayList<>(FILTER_SLOTS_PER_SIDE);
-
-        ListTag list = NbtCompat.getListOrEmpty(filters, direction.getName());
-        for (int i = 0; i < FILTER_SLOTS_PER_SIDE; i++) {
-            slots.add(NbtCompat.getStringAt(list, i, ""));
-        }
-        return slots;
-    }
-
-    public void setFilterSlots(PipeContext ctx, Direction direction, List<String> slots) {
-        CompoundTag filters = ctx.getCompoundTag(this, FILTERS);
-        ListTag list = new ListTag();
-        boolean hasAny = false;
-
-        for (String slot : slots) {
-            String value = slot == null ? "" : slot;
-            if (!value.isEmpty()) {
-                hasAny = true;
-            }
-            list.add(StringTag.valueOf(value));
-        }
-
-        if (hasAny) {
-            filters.put(direction.getName(), list);
-        } else {
-            filters.remove(direction.getName());
-        }
-
-        if (!filters.isEmpty()) {
-            ctx.putCompoundTag(this, FILTERS, filters);
-        } else {
-            ctx.remove(this, FILTERS);
-        }
-    }
-
     /**
      * Returns the filter stacks for {@code direction}, preserving full component data.
-     * Handles both old format (ListTag of StringTag item IDs) and new format
-     * (ListTag of CompoundTag full ItemStack). Always returns exactly
-     * {@link #FILTER_SLOTS_PER_SIDE} entries, padding with {@link ItemStack#EMPTY}.
+     * Always returns exactly {@link #FILTER_SLOTS_PER_SIDE} entries, padding with
+     * {@link ItemStack#EMPTY}.
      */
     public List<ItemStack> getFilterStacks(PipeContext ctx, Direction direction) {
         CompoundTag filters = ctx.getCompoundTag(this, FILTERS);
@@ -222,22 +181,9 @@ public class ItemFilterModule implements Module, RoutingModule {
             if (i < list.size()) {
                 var compoundOpt = list.getCompound(i);
                 if (compoundOpt.isPresent()) {
-                    // New format: full ItemStack encoded with ItemStack.CODEC
                     CompoundTag tag = compoundOpt.get();
                     if (!tag.isEmpty() && ops != null) {
                         stack = ItemStack.CODEC.parse(ops, tag).result().orElse(ItemStack.EMPTY);
-                    }
-                } else {
-                    // Old format: item registry ID string
-                    String id = NbtCompat.getStringAt(list, i, "");
-                    if (!id.isEmpty()) {
-                        ResourceId resource = ResourceId.tryParse(id);
-                        if (resource != null) {
-                            var itemOpt = BuiltInRegistries.ITEM.get(resource.toIdentifier());
-                            if (itemOpt.isPresent() && itemOpt.get().value() != Items.AIR) {
-                                stack = new ItemStack(itemOpt.get().value());
-                            }
-                        }
                     }
                 }
             }

--- a/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProcessModule.java
@@ -166,33 +166,7 @@ public class ProcessModule implements Module, TickingModule, RoutingModule, Disp
     // ==================== Queue Helpers ====================
 
     private ListTag getQueue(PipeContext ctx) {
-        CompoundTag state = ctx.moduleState(this);
-        ListTag queue = NbtCompat.getListOrEmpty(state, QUEUE);
-        if (!queue.isEmpty()) return queue;
-
-        // One-shot migration: convert a legacy "active_job" CompoundTag into a queue entry
-        if (!state.contains("active_job")) return queue;
-        CompoundTag legacy = NbtCompat.getCompoundOrEmpty(state, "active_job");
-
-        CompoundTag migrated = new CompoundTag();
-        migrated.putString(ENTRY_REQ, NbtCompat.getString(legacy, "req", ""));
-        String legacyDlv = NbtCompat.getString(legacy, "dlv", "");
-        if (!legacyDlv.isEmpty()) migrated.putString(ENTRY_DLV, legacyDlv);
-        migrated.putLong(ENTRY_EXEC, NbtCompat.getLong(legacy, "exec", 0));
-        migrated.putLong(ENTRY_EXTR, NbtCompat.getLong(legacy, "extr", 0));
-        migrated.putLong(ENTRY_REQUESTED, NbtCompat.getLong(legacy, "req_amount", 0));
-        migrated.put(ENTRY_ORDERS, NbtCompat.getListOrEmpty(legacy, "orders"));
-        // Populate output snapshot from current config (best-effort; may be empty if config changed)
-        String outputItem = getOutputItem(ctx, 0);
-        migrated.putString(ENTRY_OUTPUT_ITEM, outputItem);
-        migrated.putInt(ENTRY_OUTPUT_COUNT, outputItem.isEmpty() ? 0 : getOutputCount(ctx, 0));
-
-        queue = new ListTag();
-        queue.add(migrated);
-        state.put(QUEUE, queue);
-        state.remove("active_job");
-        ctx.markDirtyAndSync();
-        return queue;
+        return NbtCompat.getListOrEmpty(ctx.moduleState(this), QUEUE);
     }
 
     private void saveQueue(PipeContext ctx, ListTag queue) {

--- a/common/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/block/entity/CreativeSinkBlockEntity.java
@@ -130,13 +130,4 @@ public class CreativeSinkBlockEntity extends BaseBlockEntity
         drainState.restore(NbtCompat.getInt(nbt, "DrainRateIndex", 4));
         // Note: totalEnergyReceived not loaded - testing-only counter, starts at 0
     }
-
-    @Override
-    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
-        super.loadLegacyData(view);
-        view.read("CreativeSink", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(data -> {
-            // Load old key name (before BaseBlockEntity refactoring)
-            drainState.restore(NbtCompat.getInt(data, "drainRateIndex", 4));
-        });
-    }
 }

--- a/common/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -136,14 +136,4 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
         super.loadLogisticsData(nbt, registries);
         outputLevels.restore(NbtCompat.getInt(nbt, "OutputLevelIndex", 0));
     }
-
-    @Override
-    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
-        super.loadLegacyData(view); // Loads engine data from "Engine" tag
-
-        // Load Creative-specific data from old "CreativeData" tag
-        view.read("CreativeData", CompoundTag.CODEC).ifPresent(creativeData -> {
-            outputLevels.restore(NbtCompat.getInt(creativeData, "outputLevelIndex", 0));
-        });
-    }
 }

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -18,7 +18,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
@@ -419,36 +418,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
                 NbtCompat.getDouble(nbt, "GenerationCarryover", 0.0),
                 NbtCompat.getDouble(nbt, "PIDIntegral", 0.0));
 
-        // Load fuel inventory (try new key first, fall back to legacy)
-        if (nbt.contains("Inventory")) {
-            inventory.readNbt(nbt, "Inventory", registries);
-        } else if (nbt.contains("FuelStack")) {
-            // Legacy: single item stored with CODEC
-            inventory.setItem(0, ItemStack.EMPTY);
-            var ops = registries.createSerializationContext(NbtOps.INSTANCE);
-            ItemStack.CODEC.parse(ops, nbt.get("FuelStack"))
-                    .result()
-                    .ifPresent(stack -> inventory.setItem(0, stack));
-        }
-    }
-
-    @Override
-    protected void loadLegacyData(net.minecraft.world.level.storage.ValueInput view) {
-        super.loadLegacyData(view); // Loads engine data from "Engine" tag
-
-        // Load Stirling-specific data from old "StirlingData" tag
-        view.read("StirlingData", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(stirlingData -> {
-            fuelState.restore(
-                    NbtCompat.getInt(stirlingData, "burnTime", 0),
-                    NbtCompat.getInt(stirlingData, "fuelTime", 0));
-            generationPlanner.restore(
-                    NbtCompat.getDouble(stirlingData, "currentGeneration", DEFAULT_MIN_GENERATION),
-                    NbtCompat.getDouble(stirlingData, "generationCarry", 0.0),
-                    NbtCompat.getDouble(stirlingData, "pidIntegral", 0.0));
-        });
-
-        // Load fuel from old "Fuel" tag at root level
-        inventory.setItem(0, ItemStack.EMPTY);
-        view.read("Fuel", ItemStack.CODEC).ifPresent(stack -> inventory.setItem(0, stack));
+        // Load fuel inventory
+        inventory.readNbt(nbt, "Inventory", registries);
     }
 }

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryBoundsTest.java
@@ -110,17 +110,4 @@ class QuarryBoundsTest extends MinecraftTestEnvironment {
         assertThat(bounds.getMaxX()).isZero();
         assertThat(bounds.getMaxZ()).isZero();
     }
-
-    @Test
-    @DisplayName("loadLegacy promotes raw values to a custom configuration")
-    void loadLegacyApplies() {
-        QuarryBounds bounds = new QuarryBounds();
-        bounds.loadLegacy(-1, -2, 5, 6);
-
-        assertThat(bounds.isCustom()).isTrue();
-        assertThat(bounds.getMinX()).isEqualTo(-1);
-        assertThat(bounds.getMinZ()).isEqualTo(-2);
-        assertThat(bounds.getMaxX()).isEqualTo(5);
-        assertThat(bounds.getMaxZ()).isEqualTo(6);
-    }
 }

--- a/common/src/test/java/com/logistics/pipe/modules/ChassisModuleConfigScopingTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/ChassisModuleConfigScopingTest.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.modules;
 
 import com.logistics.core.lib.block.capability.PipeConnection;
+import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.pipe.IPipeAccess;
@@ -115,19 +116,27 @@ class ChassisModuleConfigScopingTest extends MinecraftTestEnvironment {
     }
 
     @Test
-    @DisplayName("ItemFilter per-direction filter slots are scoped")
-    void itemFilter_filterSlotsScoped() {
+    @DisplayName("ItemFilter filter state is scoped")
+    void itemFilter_filterStateScoped() {
         ItemFilterModule module = new ItemFilterModule();
         Scope scope = scopeFor(module);
 
-        module.setFilterSlots(scope.scoped(), Direction.NORTH, List.of("minecraft:iron_ingot"));
-        module.setFilterSlots(scope.base(), Direction.NORTH, List.of("minecraft:gold_ingot"));
+        // The filter's on-disk format (ItemStack CODEC) needs a live world to encode, which this
+        // layer lacks; assert the FILTERS compound is partitioned per scope at the raw-state level.
+        CompoundTag scopedFilters = new CompoundTag();
+        scopedFilters.putString("marker", "scoped");
+        scope.scoped().putCompoundTag(module, ItemFilterModule.FILTERS, scopedFilters);
 
-        // getFilterSlots returns a fixed-size, blank-padded list; only the first entry is set.
-        assertThat(module.getFilterSlots(scope.scoped(), Direction.NORTH).get(0))
-                .isEqualTo("minecraft:iron_ingot");
-        assertThat(module.getFilterSlots(scope.base(), Direction.NORTH).get(0))
-                .isEqualTo("minecraft:gold_ingot");
+        CompoundTag baseFilters = new CompoundTag();
+        baseFilters.putString("marker", "base");
+        scope.base().putCompoundTag(module, ItemFilterModule.FILTERS, baseFilters);
+
+        assertThat(NbtCompat.getString(
+                        scope.scoped().getCompoundTag(module, ItemFilterModule.FILTERS), "marker", ""))
+                .isEqualTo("scoped");
+        assertThat(NbtCompat.getString(
+                        scope.base().getCompoundTag(module, ItemFilterModule.FILTERS), "marker", ""))
+                .isEqualTo("base");
     }
 
     // ==================== Helpers ====================

--- a/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleSerializationGoldenTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleSerializationGoldenTest.java
@@ -54,108 +54,12 @@ class ItemFilterModuleSerializationGoldenTest {
         ctx = new PipeContext(null, BlockPos.ZERO, null, access);
     }
 
-    // ---------------------------------------------------------------------------
-    // 0.5.5 format: filters stored as CompoundTag keyed by direction name,
-    //               each direction holds a ListTag of 8 StringTag item IDs.
-    // ---------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("0.5.5 format: loads single configured direction correctly")
-    void golden_0_5_5_singleDirectionWithFilters() {
-        // Inject NBT in the exact format written by 0.5.5
-        injectFilters(filtersWithNorth("minecraft:diamond", "minecraft:emerald"));
-
-        List<String> slots = module.getFilterSlots(ctx, Direction.NORTH);
-
-        assertThat(slots).hasSize(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
-        assertThat(slots.get(0)).isEqualTo("minecraft:diamond");
-        assertThat(slots.get(1)).isEqualTo("minecraft:emerald");
-        assertThat(slots.get(2)).isEmpty();
-    }
-
-    @Test
-    @DisplayName("0.5.5 format: unconfigured directions return empty slots (no silent data corruption)")
-    void golden_0_5_5_unconfiguredDirectionIsEmpty() {
-        injectFilters(filtersWithNorth("minecraft:diamond"));
-
-        // SOUTH was not in the saved data — must return empty, not throw
-        List<String> south = module.getFilterSlots(ctx, Direction.SOUTH);
-        assertThat(south).hasSize(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
-        assertThat(south).allMatch(String::isEmpty);
-    }
-
-    @Test
-    @DisplayName("0.5.5 format: all six directions load independently")
-    void golden_0_5_5_allSixDirections() {
-        CompoundTag filters = new CompoundTag();
-        filters.put("north",  singleItemList("minecraft:diamond"));
-        filters.put("south",  singleItemList("minecraft:emerald"));
-        filters.put("east",   singleItemList("minecraft:iron_ingot"));
-        filters.put("west",   singleItemList("minecraft:gold_ingot"));
-        filters.put("up",     singleItemList("minecraft:copper_ingot"));
-        filters.put("down",   singleItemList("minecraft:iron_nugget"));
-        injectFilters(filters);
-
-        assertThat(module.getFilterSlots(ctx, Direction.NORTH).get(0)).isEqualTo("minecraft:diamond");
-        assertThat(module.getFilterSlots(ctx, Direction.SOUTH).get(0)).isEqualTo("minecraft:emerald");
-        assertThat(module.getFilterSlots(ctx, Direction.EAST).get(0)).isEqualTo("minecraft:iron_ingot");
-        assertThat(module.getFilterSlots(ctx, Direction.WEST).get(0)).isEqualTo("minecraft:gold_ingot");
-        assertThat(module.getFilterSlots(ctx, Direction.UP).get(0)).isEqualTo("minecraft:copper_ingot");
-        assertThat(module.getFilterSlots(ctx, Direction.DOWN).get(0)).isEqualTo("minecraft:iron_nugget");
-    }
-
-    @Test
-    @DisplayName("0.5.5 format: partially-filled list (fewer than 8 items) pads with empty strings")
-    void golden_0_5_5_shortListPadsWithEmpty() {
-        // A save that only stored 3 items in a filter slot (could happen if the slot count ever changes)
-        ListTag shortList = new ListTag();
-        shortList.add(StringTag.valueOf("minecraft:diamond"));
-        shortList.add(StringTag.valueOf("minecraft:coal"));
-        shortList.add(StringTag.valueOf(""));
-        CompoundTag filters = new CompoundTag();
-        filters.put("north", shortList);
-        injectFilters(filters);
-
-        List<String> slots = module.getFilterSlots(ctx, Direction.NORTH);
-        assertThat(slots).hasSize(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
-        assertThat(slots.get(0)).isEqualTo("minecraft:diamond");
-        assertThat(slots.get(1)).isEqualTo("minecraft:coal");
-        assertThat(slots.get(2)).isEmpty();
-        // Indices beyond the saved list are padded with empty
-        assertThat(slots.get(3)).isEmpty();
-        assertThat(slots.get(7)).isEmpty();
-    }
-
     @Test
     @DisplayName("state key is stable — module rename would break existing saves")
     void moduleStateKeyIsStable() {
         // This test intentionally checks the key string. If ItemFilterModule is ever
         // renamed, getStateKey() MUST be overridden to keep returning "itemfiltermodule".
         assertThat(module.getStateKey()).isEqualTo(MODULE_STATE_KEY);
-    }
-
-    // ---------------------------------------------------------------------------
-    // Backward-compat: getFilterStacks() must read old StringTag format correctly.
-    // (New CompoundTag round-trip tests require RegistryAccess and run in-game.)
-    // ---------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("getFilterStacks: old StringTag format returns item-only stacks (no NPE)")
-    void getFilterStacks_readsOldStringFormat() {
-        injectFilters(filtersWithNorth("minecraft:diamond"));
-
-        // getFilterStacks() with null world falls back to item-ID only for old format
-        List<ItemStack> stacks = module.getFilterStacks(ctx, Direction.NORTH);
-
-        assertThat(stacks).hasSize(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
-        // First slot is non-empty (item loaded by ID)
-        assertThat(stacks.get(0).isEmpty()).isFalse();
-        // Component-less (components patch is empty for a plain stack)
-        assertThat(stacks.get(0).getComponentsPatch().isEmpty()).isTrue();
-        // Remaining slots are empty
-        for (int i = 1; i < ItemFilterModule.FILTER_SLOTS_PER_SIDE; i++) {
-            assertThat(stacks.get(i).isEmpty()).isTrue();
-        }
     }
 
     @Test
@@ -200,10 +104,5 @@ class ItemFilterModuleSerializationGoldenTest {
             list.add(StringTag.valueOf(value));
         }
         return list;
-    }
-
-    /** Build a padded ListTag with one item ID and the rest empty. */
-    private ListTag singleItemList(String itemId) {
-        return itemList(itemId);
     }
 }

--- a/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/ItemFilterModuleTest.java
@@ -7,10 +7,7 @@ import net.minecraft.core.Direction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -49,57 +46,6 @@ class ItemFilterModuleTest {
         assertThat(ItemFilterModule.FILTER_ORDER).contains(
                 Direction.NORTH, Direction.SOUTH, Direction.WEST,
                 Direction.EAST, Direction.UP, Direction.DOWN);
-    }
-
-    // ==================== getFilterSlots — defaults ====================
-
-    @ParameterizedTest
-    @DisplayName("getFilterSlots returns FILTER_SLOTS_PER_SIDE empty strings when nothing configured")
-    @EnumSource(Direction.class)
-    void getFilterSlots_emptyByDefault(Direction direction) {
-        List<String> slots = module.getFilterSlots(ctx, direction);
-        assertThat(slots).hasSize(ItemFilterModule.FILTER_SLOTS_PER_SIDE);
-        assertThat(slots).allMatch(String::isEmpty);
-    }
-
-    // ==================== setFilterSlots / getFilterSlots round-trip ====================
-
-    @Test
-    @DisplayName("setFilterSlots persists items for the given direction")
-    void setFilterSlots_persistsAndReadsBack() {
-        List<String> slots = List.of("minecraft:diamond", "minecraft:iron_ingot", "", "", "", "", "", "");
-        module.setFilterSlots(ctx, Direction.NORTH, slots);
-
-        List<String> result = module.getFilterSlots(ctx, Direction.NORTH);
-        assertThat(result.get(0)).isEqualTo("minecraft:diamond");
-        assertThat(result.get(1)).isEqualTo("minecraft:iron_ingot");
-        assertThat(result.get(2)).isEmpty();
-    }
-
-    @Test
-    @DisplayName("setFilterSlots for different directions are independent")
-    void setFilterSlots_differentDirectionsAreIndependent() {
-        List<String> northSlots = List.of("minecraft:diamond", "", "", "", "", "", "", "");
-        List<String> southSlots = List.of("minecraft:iron_ingot", "", "", "", "", "", "", "");
-
-        module.setFilterSlots(ctx, Direction.NORTH, northSlots);
-        module.setFilterSlots(ctx, Direction.SOUTH, southSlots);
-
-        assertThat(module.getFilterSlots(ctx, Direction.NORTH).get(0)).isEqualTo("minecraft:diamond");
-        assertThat(module.getFilterSlots(ctx, Direction.SOUTH).get(0)).isEqualTo("minecraft:iron_ingot");
-        assertThat(module.getFilterSlots(ctx, Direction.EAST).get(0)).isEmpty();
-    }
-
-    @Test
-    @DisplayName("setFilterSlots with all empty strings clears the direction's filter")
-    void setFilterSlots_allEmpty_clearsFilter() {
-        List<String> slots = List.of("minecraft:diamond", "", "", "", "", "", "", "");
-        module.setFilterSlots(ctx, Direction.NORTH, slots);
-
-        List<String> empty = List.of("", "", "", "", "", "", "", "");
-        module.setFilterSlots(ctx, Direction.NORTH, empty);
-
-        assertThat(module.getFilterSlots(ctx, Direction.NORTH)).allMatch(String::isEmpty);
     }
 
     // ==================== getFilterColor ====================


### PR DESCRIPTION
## Summary

Caps backward-compatibility support to a single major version while we're still in pre-release, cutting accumulated alias/migration debt. Under the new policy a major (the 2nd version digit, currently `0.7.x`) keeps compatibility bridges for the **previous major** (`0.6.x`) only.

Every alias and legacy save-reader currently in the tree was introduced in the `0.6.0` cutover (the `#318` multiloader restructure and `#350` core.lib reorg) or earlier — so a `0.6.x` world already writes today's IDs/format, and all of it now only served pre-`0.6.0` worlds.

## Changes

- **Registry ID aliases** — emptied the `ALIAS` blocks in `LogisticsCore` / `LogisticsAutomation` / `LogisticsPipe` (gears/wrench, marker, quarry→laser_quarry, `core/kiln`, `core/marker`, `automation/quartz_crystal`, the pipe block-entity + marking-fluid aliases, the `item_filter` menu and `weathering_state` component aliases). The alias-helper plumbing and (now empty) `ALIAS` extension points are kept for future use.
- **NBT save migrations** — removed the `loadLegacyData` readers on the engine base, Stirling (+`FuelStack` fallback), Creative engine/sink, pipe (tag massage), marker (boundary massage) and laser quarry, plus the `ProcessModule` `active_job`→queue migration and the laser-quarry `StoredEnergy` fallback. The live `loadLogisticsData` paths are untouched.
- **Item filter** — retired the legacy StringTag filter representation (`getFilterSlots`/`setFilterSlots`), which had no production callers; the module now uses only the component-preserving `ItemStack` format.
- **Docs** — added a "Backward Compatibility Policy" section to `CLAUDE.md` / `AGENTS.md` and a world-upgrade note to the README.

## Compatibility

Worlds must now be loaded in the **latest release of each major in sequence** before skipping ahead (e.g. pre-`0.6` → latest `0.6.x` → `0.7+`). Skipping a major may drop renamed blocks/items or saved machine state. Worlds from `0.6.x` onward are unaffected.

## Verification

`./gradlew :common:test` and `./gradlew build` (Fabric + NeoForge + spotlessCheck) both green.

## Follow-up

Cherry-pick to `mc/26.1`, `mc/1.21.11`, `mc/1.21.1` after merge.