### PR TITLE
refactor(pump): rebuild on machine components

### DIFF
--- a/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
@@ -1,6 +1,7 @@
 package com.logistics.core.machine;
 
 import com.logistics.core.machine.component.EnergyStorageComponent;
+import com.logistics.core.machine.component.FluidStoreComponent;
 import com.logistics.core.machine.component.ItemStoreComponent;
 import com.logistics.core.machine.component.RecipeProcessorComponent;
 import com.logistics.core.machine.component.RecipeProcessorComponent.LitController;
@@ -32,6 +33,10 @@ public final class MachineBuilder {
 
     public ItemsBuilder items(String id) {
         return new ItemsBuilder(id);
+    }
+
+    public FluidBuilder fluids(String id) {
+        return new FluidBuilder(id);
     }
 
     public RecipeProcessorBuilder recipeProcessor(String id) {
@@ -79,6 +84,25 @@ public final class MachineBuilder {
         public EnergyStorageComponent build() {
             return components.add(new EnergyStorageComponent(
                     id, capacity, maxInput, maxOutput, providesDemand, providesDemand, onChanged));
+        }
+    }
+
+    /** Builds a single-variant {@link FluidStoreComponent} tank. */
+    public final class FluidBuilder {
+        private final String id;
+        private long capacity;
+
+        private FluidBuilder(String id) {
+            this.id = id;
+        }
+
+        public FluidBuilder capacity(long capacity) {
+            this.capacity = capacity;
+            return this;
+        }
+
+        public FluidStoreComponent build() {
+            return components.add(new FluidStoreComponent(id, capacity, onChanged));
         }
     }
 

--- a/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
@@ -102,6 +102,9 @@ public final class MachineBuilder {
         }
 
         public FluidStoreComponent build() {
+            if (capacity <= 0) {
+                throw new IllegalStateException("fluids(" + id + ") requires a positive capacity, got " + capacity);
+            }
             return components.add(new FluidStoreComponent(id, capacity, onChanged));
         }
     }

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
@@ -2,42 +2,31 @@ package com.logistics.pipe.block.entity;
 
 import com.logistics.LogisticsFluid;
 import com.logistics.core.LogisticsConfig;
-import com.logistics.core.lib.block.BaseBlockEntity;
-import com.logistics.core.lib.block.capability.HasEnergyStorage;
-import com.logistics.core.lib.block.capability.HasFluidStorage;
-import com.logistics.core.lib.compat.NbtCompat;
-import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.energy.IEnergyStorage;
-import com.logistics.core.lib.fluids.FluidStorageLookup;
 import com.logistics.core.lib.fluids.FluidTankComponent;
 import com.logistics.core.lib.fluids.FluidUnits;
-import com.logistics.core.lib.fluids.IFluidKey;
 import com.logistics.core.lib.fluids.IFluidStorage;
-import com.logistics.core.lib.fluids.IFluidView;
-import com.logistics.core.lib.fluids.SimpleFluidKey;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
-import com.logistics.core.lib.power.EnergyDemandProvider;
-import java.util.ArrayDeque;
-import java.util.HashSet;
-import java.util.Queue;
-import java.util.Set;
+import com.logistics.core.machine.MachineBuilder;
+import com.logistics.core.machine.MachineEntity;
+import com.logistics.core.machine.component.EnergyStorageComponent;
+import com.logistics.core.machine.component.FluidStoreComponent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.tags.FluidTags;
+import net.minecraft.world.MenuProvider;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Fluid;
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
 import org.jetbrains.annotations.Nullable;
 
-public class FluidPumpBlockEntity extends BaseBlockEntity
-        implements HasEnergyStorage, HasFluidStorage, EnergyDemandProvider, AcceptsLowTierEnergy {
+/**
+ * Fluid Pump: an RF-powered block that lowers an intake tube and drains connected fluid sources into
+ * a buffer tank, pushing the overflow out to adjacent pipes/tanks.
+ *
+ * <p>Composed from machine components — an energy buffer (reports network demand), a tank, and a
+ * {@link FluidPumpComponent} that owns the pumping logic. Energy and fluid are exposed on every face
+ * except the bottom, which is the intake. The pump has no GUI.
+ */
+public class FluidPumpBlockEntity extends MachineEntity implements AcceptsLowTierEnergy {
 
     public enum Phase {
         DESCENDING,
@@ -45,45 +34,48 @@ public class FluidPumpBlockEntity extends BaseBlockEntity
         STALLED
     }
 
-    private final EnergyComponent energy = new EnergyComponent(
-            () -> LogisticsConfig.get().fluidPump.energyCapacity,
-            LogisticsConfig.get().fluidPump.maxEnergyInput,
-            0,
-            this::markDirtyAndSync);
-    private final FluidTankComponent tank = new FluidTankComponent(
-            FluidUnits.mb(LogisticsConfig.get().fluidPump.tankCapacityMb),
-            this::markDirtyAndSync);
-
-    private Phase phase = Phase.DESCENDING;
-    private int targetY;
-    private float armY;
-    private long tickOffset;
-    private long lastSyncedEnergy = -1;
-    private long lastSyncedTank = -1;
-    private int lastSyncedTargetY = Integer.MIN_VALUE;
-    private final ArrayDeque<BlockPos> sourceQueue = new ArrayDeque<>();
-    private boolean infiniteBody;
-    @Nullable private Fluid queuedFluid;
-    private int queuedY;
+    private EnergyStorageComponent energy;
+    private FluidStoreComponent fluidStore;
+    private FluidPumpComponent pump;
 
     public FluidPumpBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsFluid.ENTITY.FLUID_PUMP_BLOCK_ENTITY, pos, state);
-        this.targetY = pos.getY() - 1;
-        this.armY = pos.getY();
-        this.tickOffset = Math.floorMod(pos.asLong(), 16L);
+    }
+
+    @Override
+    protected void configure(MachineBuilder machine) {
+        LogisticsConfig.FluidPumpConfig cfg = LogisticsConfig.get().fluidPump;
+        energy = machine.energy("energy")
+                .capacity(cfg.energyCapacity)
+                .maxInput(cfg.maxEnergyInput)
+                .providesDemand()
+                .build();
+        fluidStore = machine.fluids("tank")
+                .capacity(FluidUnits.mb(cfg.tankCapacityMb))
+                .build();
+        pump = machine.add(new FluidPumpComponent("pump", energy, fluidStore, getBlockPos()));
+    }
+
+    public static void tick(Level level, BlockPos pos, BlockState state, FluidPumpBlockEntity be) {
+        // Server: run the component logic. Both sides: advance the tube so the descent animates
+        // smoothly between the sparse state syncs.
+        if (!level.isClientSide()) {
+            MachineEntity.tick(level, pos, state, be);
+        }
+        be.pump.advanceArm(be);
     }
 
     @Override
     @Nullable
     public IEnergyStorage energyStorage(@Nullable Direction side) {
         // Top and sides only; the bottom is the intake tube.
-        return side == Direction.DOWN ? null : energy;
+        return side == Direction.DOWN ? null : super.energyStorage(side);
     }
 
     @Override
     @Nullable
     public IFluidStorage fluidStorage(@Nullable Direction side) {
-        return side == Direction.DOWN ? null : tank;
+        return side == Direction.DOWN ? null : super.fluidStorage(side);
     }
 
     @Override
@@ -91,325 +83,26 @@ public class FluidPumpBlockEntity extends BaseBlockEntity
         return from != Direction.DOWN;
     }
 
-    public FluidTankComponent tank() {
-        return tank;
-    }
-
-    public Phase phase() {
-        return phase;
-    }
-
-    public float armY() {
-        return armY;
-    }
-
-    public long energyAmount() {
-        return energy.getAmount();
-    }
-
     @Override
-    public long networkDemandPerTick() {
-        return Math.max(0, energy.getCapacity() - energy.getAmount());
-    }
-
-    public static void tick(Level level, BlockPos pos, BlockState state, FluidPumpBlockEntity be) {
-        // Animate the tube on both sides; the client advances the arm toward the synced targetY so the
-        // descent stays smooth between the sparse state syncs (which only fire on real state changes).
-        be.advanceArm(pos);
-        if (level.isClientSide()) {
-            return;
-        }
-
-        be.pushOut(level, pos);
-
-        LogisticsConfig.FluidPumpConfig cfg = LogisticsConfig.get().fluidPump;
-        if ((level.getGameTime() + be.tickOffset) % cfg.pumpIntervalTicks == 0) {
-            be.work((ServerLevel) level, pos, cfg);
-        }
-
-        if (be.energy.getAmount() != be.lastSyncedEnergy
-                || be.tank.getAmount() != be.lastSyncedTank
-                || be.targetY != be.lastSyncedTargetY) {
-            be.lastSyncedEnergy = be.energy.getAmount();
-            be.lastSyncedTank = be.tank.getAmount();
-            be.lastSyncedTargetY = be.targetY;
-            be.markDirtyAndSync();
-        }
-    }
-
-    // Output faces: top and sides (the bottom is the intake tube).
-    private static final Direction[] OUTPUT_SIDES = {
-        Direction.UP, Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST
-    };
-
-    private void pushOut(Level level, BlockPos pos) {
-        long budget = FluidUnits.mb(LogisticsConfig.get().fluidPump.pushRateMb);
-        for (Direction side : OUTPUT_SIDES) {
-            if (budget <= 0 || tank.isEmpty()) {
-                return;
-            }
-            IFluidStorage target = FluidStorageLookup.find(level, pos.relative(side), side.getOpposite());
-            if (target == null) {
-                continue;
-            }
-            IFluidView view = tank.contents().iterator().next();
-            long max = Math.min(budget, view.amount());
-            long accepted = target.insert(view.resource(), max, true);
-            if (accepted <= 0) {
-                continue;
-            }
-            accepted = target.insert(view.resource(), accepted, false);
-            if (accepted > 0) {
-                tank.extract(view.resource(), accepted, false);
-                budget -= accepted;
-            }
-        }
-    }
-
-    private void advanceArm(BlockPos pos) {
-        float target = targetY + 0.5f;
-        boolean server = level != null && !level.isClientSide();
-        if (armY > target) {
-            armY = Math.max(target, armY - LogisticsConfig.get().fluidPump.armSpeed);
-            if (server) {
-                setChanged();
-            }
-        } else if (armY < target) {
-            armY = Math.min(target, armY + LogisticsConfig.get().fluidPump.armSpeed);
-            if (server) {
-                setChanged();
-            }
-        }
-        if (targetY > pos.getY() - 1) {
-            targetY = pos.getY() - 1;
-        }
-    }
-
-    private void work(ServerLevel level, BlockPos pos, LogisticsConfig.FluidPumpConfig cfg) {
-        if (tank.getCapacity() - tank.getAmount() < FluidUnits.mb(1_000)) {
-            phase = Phase.STALLED;
-            return;
-        }
-
-        BlockPos target = new BlockPos(pos.getX(), targetY, pos.getZ());
-        FluidState fluidState = level.getFluidState(target);
-
-        // Only draw fluid once the tube tip is seated at the middle of the target block (targetY + 0.5),
-        // and don't step down until the layer is exhausted. The tube still descends freely through air /
-        // non-source fluid so it reaches the body smoothly.
-        boolean atLayer = phase == Phase.PUMPING
-                || (phase == Phase.STALLED && !sourceQueue.isEmpty() && queuedFluid != null)
-                || isPumpableSource(fluidState);
-        if (atLayer && armY > targetY + 0.55f) {
-            return;
-        }
-        if (phase == Phase.STALLED && !sourceQueue.isEmpty() && queuedFluid != null) {
-            if (energy.getAmount() < cfg.energyPerSource) {
-                return;
-            }
-            phase = Phase.PUMPING;
-            if (pumpFromLayer(level, pos, target, queuedFluid, cfg)) {
-                return;
-            }
-            descendToNextLayer(level, pos);
-            return;
-        }
-        if (phase == Phase.PUMPING && queuedFluid != null) {
-            if (energy.getAmount() < cfg.energyPerSource) {
-                phase = Phase.STALLED;
-                return;
-            }
-            // Keep draining the layer based on the body being pumped, not the tank's momentary level,
-            // so an attached pipe emptying the tank doesn't cut the layer short.
-            if (pumpFromLayer(level, pos, target, queuedFluid, cfg)) {
-                return;
-            }
-            descendToNextLayer(level, pos);
-            return;
-        }
-        if (isPumpableSource(fluidState)) {
-            if (energy.getAmount() < cfg.energyPerSource) {
-                phase = Phase.STALLED;
-                return;
-            }
-            phase = Phase.PUMPING;
-            if (!pumpFromLayer(level, pos, target, fluidState.getType(), cfg)) {
-                descendToNextLayer(level, pos);
-            }
-            return;
-        }
-
-        // Don't descend the tube into a solid block or below the world; stall instead.
-        if (isBlocked(level, target) || !canDescend(level, pos)) {
-            phase = Phase.STALLED;
-            return;
-        }
-
-        phase = Phase.DESCENDING;
-        targetY--;
-    }
-
-    // The tube can extend one more block down only into air/fluid that's still inside the world.
-    private boolean canDescend(ServerLevel level, BlockPos pos) {
-        int nextY = targetY - 1;
-        return nextY >= level.getMinY() && !isBlocked(level, new BlockPos(pos.getX(), nextY, pos.getZ()));
-    }
-
-    private void descendToNextLayer(ServerLevel level, BlockPos pos) {
-        sourceQueue.clear();
-        infiniteBody = false;
-        queuedFluid = null;
-        // Don't step the tube into a solid block or below the world; stall instead.
-        if (!canDescend(level, pos)) {
-            phase = Phase.STALLED;
-            return;
-        }
-        targetY--;
-        phase = Phase.DESCENDING;
-    }
-
-    private boolean pumpFromLayer(
-            ServerLevel level, BlockPos pumpPos, BlockPos origin, Fluid fluid, LogisticsConfig.FluidPumpConfig cfg) {
-        BlockPos source = findConnectedSource(level, pumpPos, origin, fluid, cfg.searchRadius);
-        if (source == null) {
-            return false;
-        }
-        IFluidKey key = SimpleFluidKey.of(fluid);
-        long bucket = FluidUnits.mb(1_000);
-        if (tank.insert(key, bucket, true) != bucket) {
-            phase = Phase.STALLED;
-            return true;
-        }
-        energy.consume(cfg.energyPerSource);
-        tank.insert(key, bucket, false);
-        if (infiniteBody) {
-            // Effectively infinite body: draw fluid without carving the landscape. Re-queue at the front
-            // so the furthest-first ordering keeps cycling the body.
-            sourceQueue.addFirst(source);
-        } else {
-            // Finite body: remove the source and let neighbors settle normally. Reforming fluids (water)
-            // may flow back in, but draining a sub-9-source pool is the player's choice; a 3x3+ pool is
-            // treated as infinite and skipped entirely.
-            level.setBlock(source, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
-        }
-        markDirtyAndSync();
-        return true;
-    }
-
     @Nullable
-    private BlockPos findConnectedSource(ServerLevel level, BlockPos pumpPos, BlockPos origin, Fluid fluid, int radius) {
-        if (sourceQueue.isEmpty() || queuedFluid != fluid || queuedY != origin.getY()) {
-            rebuildSourceQueue(level, pumpPos, origin, fluid, radius);
-        }
-
-        // Pump the furthest-out source first (BFS order is nearest-first) so the body recedes toward the
-        // tube and the cell under the tube is drained last, instead of vanishing from under it.
-        while (!sourceQueue.isEmpty()) {
-            BlockPos source = sourceQueue.removeLast();
-            FluidState state = level.getFluidState(source);
-            if (state.getType().isSame(fluid) && state.isSource()) {
-                return source;
-            }
-        }
+    public MenuProvider createMenuProvider() {
+        // The pump has no GUI; the block never opens a menu.
         return null;
     }
 
-    // Whether the fluid forms new source blocks (water), so the pump must suppress reflow; lava does not.
-    private static boolean createsSourceBlocks(Fluid fluid) {
-        return fluid.defaultFluidState().is(FluidTags.WATER);
+    public FluidTankComponent tank() {
+        return fluidStore.tank();
     }
 
-    // Floods only the horizontal layer at origin's Y, so the pump exhausts one layer before stepping down.
-    private void rebuildSourceQueue(ServerLevel level, BlockPos pumpPos, BlockPos origin, Fluid fluid, int radius) {
-        sourceQueue.clear();
-        infiniteBody = false;
-        queuedFluid = fluid;
-        queuedY = origin.getY();
-
-        // Only reforming fluids (water) get infinite treatment; lava is always consumed.
-        int threshold = LogisticsConfig.get().fluidPump.infiniteSourceThreshold;
-        boolean canBeInfinite = threshold > 0 && createsSourceBlocks(fluid);
-
-        Queue<BlockPos> queue = new ArrayDeque<>();
-        Set<BlockPos> visited = new HashSet<>();
-        queue.add(origin);
-        visited.add(origin);
-        int radiusSq = radius * radius;
-
-        while (!queue.isEmpty()) {
-            BlockPos current = queue.remove();
-            FluidState state = level.getFluidState(current);
-            if (!state.getType().isSame(fluid)) {
-                continue;
-            }
-            if (state.isSource()) {
-                sourceQueue.add(current);
-                if (canBeInfinite && sourceQueue.size() >= threshold) {
-                    infiniteBody = true;
-                    return;
-                }
-            }
-
-            addFluidNeighbor(level, pumpPos, current.north(), fluid, radiusSq, visited, queue);
-            addFluidNeighbor(level, pumpPos, current.south(), fluid, radiusSq, visited, queue);
-            addFluidNeighbor(level, pumpPos, current.east(), fluid, radiusSq, visited, queue);
-            addFluidNeighbor(level, pumpPos, current.west(), fluid, radiusSq, visited, queue);
-        }
+    public Phase phase() {
+        return pump.phase();
     }
 
-    private void addFluidNeighbor(
-            ServerLevel level,
-            BlockPos pumpPos,
-            BlockPos next,
-            Fluid fluid,
-            int radiusSq,
-            Set<BlockPos> visited,
-            Queue<BlockPos> queue) {
-        int dx = next.getX() - pumpPos.getX();
-        int dz = next.getZ() - pumpPos.getZ();
-        if (dx * dx + dz * dz > radiusSq || next.getY() < level.getMinY() || next.getY() > level.getMaxY()) {
-            return;
-        }
-        if (visited.add(next) && level.getFluidState(next).getType().isSame(fluid)) {
-            queue.add(next);
-        }
+    public float armY() {
+        return pump.armY();
     }
 
-    private boolean isPumpableSource(FluidState state) {
-        Fluid fluid = state.getType();
-        if (fluid == Fluids.EMPTY || !state.isSource()) {
-            return false;
-        }
-        IFluidKey current = tank.getFluidKey();
-        return tank.isEmpty() || current.getFluid() == fluid;
-    }
-
-    private boolean isBlocked(Level level, BlockPos pos) {
-        BlockState state = level.getBlockState(pos);
-        return !state.isAir() && level.getFluidState(pos).isEmpty() && state.blocksMotion();
-    }
-
-    @Override
-    protected void saveLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
-        super.saveLogisticsData(tag, registries);
-        energy.writeNbt(tag, "Energy");
-        tank.writeNbt(tag, "Tank");
-        tag.putString("Phase", phase.name());
-        tag.putInt("TargetY", targetY);
-        tag.putFloat("ArmY", armY);
-    }
-
-    @Override
-    protected void loadLogisticsData(CompoundTag tag, HolderLookup.Provider registries) {
-        super.loadLogisticsData(tag, registries);
-        energy.readNbt(tag, "Energy");
-        tank.readNbt(tag, "Tank");
-        try {
-            phase = Phase.valueOf(NbtCompat.getString(tag, "Phase", Phase.DESCENDING.name()));
-        } catch (IllegalArgumentException e) {
-            phase = Phase.DESCENDING;
-        }
-        targetY = NbtCompat.getInt(tag, "TargetY", worldPosition.getY() - 1);
-        armY = NbtCompat.getFloat(tag, "ArmY", worldPosition.getY());
+    public long energyAmount() {
+        return energy.amount();
     }
 }

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpComponent.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpComponent.java
@@ -1,0 +1,399 @@
+package com.logistics.pipe.block.entity;
+
+import com.logistics.core.LogisticsConfig;
+import com.logistics.core.lib.compat.NbtCompat;
+import com.logistics.core.lib.fluids.FluidStorageLookup;
+import com.logistics.core.lib.fluids.FluidTankComponent;
+import com.logistics.core.lib.fluids.FluidUnits;
+import com.logistics.core.lib.fluids.IFluidKey;
+import com.logistics.core.lib.fluids.IFluidStorage;
+import com.logistics.core.lib.fluids.IFluidView;
+import com.logistics.core.lib.fluids.SimpleFluidKey;
+import com.logistics.core.machine.MachineComponent;
+import com.logistics.core.machine.MachineContext;
+import com.logistics.core.machine.component.EnergyStorageComponent;
+import com.logistics.core.machine.component.FluidStoreComponent;
+import com.logistics.pipe.block.entity.FluidPumpBlockEntity.Phase;
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The fluid pump's work behavior as a {@link MachineComponent}: lowers an intake tube layer by
+ * layer, drains connected source blocks (furthest-first) for RF, and buffers the result in the
+ * machine's tank, pushing the overflow out to adjacent pipes/tanks.
+ *
+ * <p>Reads energy and fluid from its sibling {@link EnergyStorageComponent}/{@link FluidStoreComponent}.
+ * {@link #advanceArm} runs on both sides for smooth tube animation; the rest is server-only.
+ */
+public final class FluidPumpComponent implements MachineComponent {
+
+    // Output faces: top and sides (the bottom is the intake tube).
+    private static final Direction[] OUTPUT_SIDES = {
+        Direction.UP, Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST
+    };
+
+    private final String id;
+    private final EnergyStorageComponent energy;
+    private final FluidStoreComponent fluidStore;
+
+    private Phase phase = Phase.DESCENDING;
+    private int targetY;
+    private float armY;
+    private long tickOffset;
+    private long lastSyncedEnergy = -1;
+    private long lastSyncedTank = -1;
+    private int lastSyncedTargetY = Integer.MIN_VALUE;
+    private final ArrayDeque<BlockPos> sourceQueue = new ArrayDeque<>();
+    private boolean infiniteBody;
+    @Nullable private Fluid queuedFluid;
+    private int queuedY;
+
+    public FluidPumpComponent(String id, EnergyStorageComponent energy, FluidStoreComponent fluidStore, BlockPos pos) {
+        this.id = id;
+        this.energy = energy;
+        this.fluidStore = fluidStore;
+        this.targetY = pos.getY() - 1;
+        this.armY = pos.getY();
+        this.tickOffset = Math.floorMod(pos.asLong(), 16L);
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    private FluidTankComponent tank() {
+        return fluidStore.tank();
+    }
+
+    Phase phase() {
+        return phase;
+    }
+
+    float armY() {
+        return armY;
+    }
+
+    @Override
+    public void serverTick(MachineContext ctx) {
+        Level level = ctx.level();
+        BlockPos pos = ctx.pos();
+
+        pushOut(level, pos);
+
+        LogisticsConfig.FluidPumpConfig cfg = LogisticsConfig.get().fluidPump;
+        if ((level.getGameTime() + tickOffset) % cfg.pumpIntervalTicks == 0) {
+            work((ServerLevel) level, pos, cfg);
+        }
+
+        long currentEnergy = energy.amount();
+        long currentTank = tank().getAmount();
+        if (currentEnergy != lastSyncedEnergy || currentTank != lastSyncedTank || targetY != lastSyncedTargetY) {
+            lastSyncedEnergy = currentEnergy;
+            lastSyncedTank = currentTank;
+            lastSyncedTargetY = targetY;
+            ctx.sync();
+        }
+    }
+
+    /**
+     * Animate the tube toward the synced {@code targetY}. Called on both sides from the block-entity
+     * tick so the client descent stays smooth between the sparse state syncs (which only fire on real
+     * state changes).
+     */
+    void advanceArm(MachineContext ctx) {
+        BlockPos pos = ctx.pos();
+        float target = targetY + 0.5f;
+        boolean server = ctx.isServer();
+        float armSpeed = LogisticsConfig.get().fluidPump.armSpeed;
+        if (armY > target) {
+            armY = Math.max(target, armY - armSpeed);
+            if (server) {
+                ctx.setChanged();
+            }
+        } else if (armY < target) {
+            armY = Math.min(target, armY + armSpeed);
+            if (server) {
+                ctx.setChanged();
+            }
+        }
+        if (targetY > pos.getY() - 1) {
+            targetY = pos.getY() - 1;
+        }
+    }
+
+    private void pushOut(Level level, BlockPos pos) {
+        long budget = FluidUnits.mb(LogisticsConfig.get().fluidPump.pushRateMb);
+        FluidTankComponent tank = tank();
+        for (Direction side : OUTPUT_SIDES) {
+            if (budget <= 0 || tank.isEmpty()) {
+                return;
+            }
+            IFluidStorage target = FluidStorageLookup.find(level, pos.relative(side), side.getOpposite());
+            if (target == null) {
+                continue;
+            }
+            IFluidView view = tank.contents().iterator().next();
+            long max = Math.min(budget, view.amount());
+            long accepted = target.insert(view.resource(), max, true);
+            if (accepted <= 0) {
+                continue;
+            }
+            accepted = target.insert(view.resource(), accepted, false);
+            if (accepted > 0) {
+                tank.extract(view.resource(), accepted, false);
+                budget -= accepted;
+            }
+        }
+    }
+
+    private void work(ServerLevel level, BlockPos pos, LogisticsConfig.FluidPumpConfig cfg) {
+        FluidTankComponent tank = tank();
+        if (tank.getCapacity() - tank.getAmount() < FluidUnits.mb(1_000)) {
+            phase = Phase.STALLED;
+            return;
+        }
+
+        BlockPos target = new BlockPos(pos.getX(), targetY, pos.getZ());
+        FluidState fluidState = level.getFluidState(target);
+
+        // Only draw fluid once the tube tip is seated at the middle of the target block (targetY + 0.5),
+        // and don't step down until the layer is exhausted. The tube still descends freely through air /
+        // non-source fluid so it reaches the body smoothly.
+        boolean atLayer = phase == Phase.PUMPING
+                || (phase == Phase.STALLED && !sourceQueue.isEmpty() && queuedFluid != null)
+                || isPumpableSource(fluidState);
+        if (atLayer && armY > targetY + 0.55f) {
+            return;
+        }
+        if (phase == Phase.STALLED && !sourceQueue.isEmpty() && queuedFluid != null) {
+            if (energy.amount() < cfg.energyPerSource) {
+                return;
+            }
+            phase = Phase.PUMPING;
+            if (pumpFromLayer(level, pos, target, queuedFluid, cfg)) {
+                return;
+            }
+            descendToNextLayer(level, pos);
+            return;
+        }
+        if (phase == Phase.PUMPING && queuedFluid != null) {
+            if (energy.amount() < cfg.energyPerSource) {
+                phase = Phase.STALLED;
+                return;
+            }
+            // Keep draining the layer based on the body being pumped, not the tank's momentary level,
+            // so an attached pipe emptying the tank doesn't cut the layer short.
+            if (pumpFromLayer(level, pos, target, queuedFluid, cfg)) {
+                return;
+            }
+            descendToNextLayer(level, pos);
+            return;
+        }
+        if (isPumpableSource(fluidState)) {
+            if (energy.amount() < cfg.energyPerSource) {
+                phase = Phase.STALLED;
+                return;
+            }
+            phase = Phase.PUMPING;
+            if (!pumpFromLayer(level, pos, target, fluidState.getType(), cfg)) {
+                descendToNextLayer(level, pos);
+            }
+            return;
+        }
+
+        // Don't descend the tube into a solid block or below the world; stall instead.
+        if (isBlocked(level, target) || !canDescend(level, pos)) {
+            phase = Phase.STALLED;
+            return;
+        }
+
+        phase = Phase.DESCENDING;
+        targetY--;
+    }
+
+    // The tube can extend one more block down only into air/fluid that's still inside the world.
+    private boolean canDescend(ServerLevel level, BlockPos pos) {
+        int nextY = targetY - 1;
+        return nextY >= level.getMinY() && !isBlocked(level, new BlockPos(pos.getX(), nextY, pos.getZ()));
+    }
+
+    private void descendToNextLayer(ServerLevel level, BlockPos pos) {
+        sourceQueue.clear();
+        infiniteBody = false;
+        queuedFluid = null;
+        // Don't step the tube into a solid block or below the world; stall instead.
+        if (!canDescend(level, pos)) {
+            phase = Phase.STALLED;
+            return;
+        }
+        targetY--;
+        phase = Phase.DESCENDING;
+    }
+
+    private boolean pumpFromLayer(
+            ServerLevel level, BlockPos pumpPos, BlockPos origin, Fluid fluid, LogisticsConfig.FluidPumpConfig cfg) {
+        BlockPos source = findConnectedSource(level, pumpPos, origin, fluid, cfg.searchRadius);
+        if (source == null) {
+            return false;
+        }
+        FluidTankComponent tank = tank();
+        IFluidKey key = SimpleFluidKey.of(fluid);
+        long bucket = FluidUnits.mb(1_000);
+        if (tank.insert(key, bucket, true) != bucket) {
+            phase = Phase.STALLED;
+            return true;
+        }
+        energy.consume(cfg.energyPerSource);
+        tank.insert(key, bucket, false);
+        if (infiniteBody) {
+            // Effectively infinite body: draw fluid without carving the landscape. Re-queue at the front
+            // so the furthest-first ordering keeps cycling the body.
+            sourceQueue.addFirst(source);
+        } else {
+            // Finite body: remove the source and let neighbors settle normally. Reforming fluids (water)
+            // may flow back in, but draining a sub-9-source pool is the player's choice; a 3x3+ pool is
+            // treated as infinite and skipped entirely.
+            level.setBlock(source, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
+        }
+        // The tank and energy both changed; serverTick's change check pushes the sync this tick.
+        return true;
+    }
+
+    @Nullable
+    private BlockPos findConnectedSource(ServerLevel level, BlockPos pumpPos, BlockPos origin, Fluid fluid, int radius) {
+        if (sourceQueue.isEmpty() || queuedFluid != fluid || queuedY != origin.getY()) {
+            rebuildSourceQueue(level, pumpPos, origin, fluid, radius);
+        }
+
+        // Pump the furthest-out source first (BFS order is nearest-first) so the body recedes toward the
+        // tube and the cell under the tube is drained last, instead of vanishing from under it.
+        while (!sourceQueue.isEmpty()) {
+            BlockPos source = sourceQueue.removeLast();
+            FluidState state = level.getFluidState(source);
+            if (state.getType().isSame(fluid) && state.isSource()) {
+                return source;
+            }
+        }
+        return null;
+    }
+
+    // Whether the fluid forms new source blocks (water), so the pump must suppress reflow; lava does not.
+    private static boolean createsSourceBlocks(Fluid fluid) {
+        return fluid.defaultFluidState().is(FluidTags.WATER);
+    }
+
+    // Floods only the horizontal layer at origin's Y, so the pump exhausts one layer before stepping down.
+    private void rebuildSourceQueue(ServerLevel level, BlockPos pumpPos, BlockPos origin, Fluid fluid, int radius) {
+        sourceQueue.clear();
+        infiniteBody = false;
+        queuedFluid = fluid;
+        queuedY = origin.getY();
+
+        // Only reforming fluids (water) get infinite treatment; lava is always consumed.
+        int threshold = LogisticsConfig.get().fluidPump.infiniteSourceThreshold;
+        boolean canBeInfinite = threshold > 0 && createsSourceBlocks(fluid);
+
+        Queue<BlockPos> queue = new ArrayDeque<>();
+        Set<BlockPos> visited = new HashSet<>();
+        queue.add(origin);
+        visited.add(origin);
+        int radiusSq = radius * radius;
+
+        while (!queue.isEmpty()) {
+            BlockPos current = queue.remove();
+            FluidState state = level.getFluidState(current);
+            if (!state.getType().isSame(fluid)) {
+                continue;
+            }
+            if (state.isSource()) {
+                sourceQueue.add(current);
+                if (canBeInfinite && sourceQueue.size() >= threshold) {
+                    infiniteBody = true;
+                    return;
+                }
+            }
+
+            addFluidNeighbor(level, pumpPos, current.north(), fluid, radiusSq, visited, queue);
+            addFluidNeighbor(level, pumpPos, current.south(), fluid, radiusSq, visited, queue);
+            addFluidNeighbor(level, pumpPos, current.east(), fluid, radiusSq, visited, queue);
+            addFluidNeighbor(level, pumpPos, current.west(), fluid, radiusSq, visited, queue);
+        }
+    }
+
+    private void addFluidNeighbor(
+            ServerLevel level,
+            BlockPos pumpPos,
+            BlockPos next,
+            Fluid fluid,
+            int radiusSq,
+            Set<BlockPos> visited,
+            Queue<BlockPos> queue) {
+        int dx = next.getX() - pumpPos.getX();
+        int dz = next.getZ() - pumpPos.getZ();
+        if (dx * dx + dz * dz > radiusSq || next.getY() < level.getMinY() || next.getY() > level.getMaxY()) {
+            return;
+        }
+        if (visited.add(next) && level.getFluidState(next).getType().isSame(fluid)) {
+            queue.add(next);
+        }
+    }
+
+    private boolean isPumpableSource(FluidState state) {
+        Fluid fluid = state.getType();
+        if (fluid == Fluids.EMPTY || !state.isSource()) {
+            return false;
+        }
+        FluidTankComponent tank = tank();
+        IFluidKey current = tank.getFluidKey();
+        return tank.isEmpty() || current.getFluid() == fluid;
+    }
+
+    private boolean isBlocked(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        return !state.isAir() && level.getFluidState(pos).isEmpty() && state.blocksMotion();
+    }
+
+    @Override
+    public void save(CompoundTag tag, HolderLookup.Provider registries) {
+        tag.putString("Phase", phase.name());
+        tag.putInt("TargetY", targetY);
+        tag.putFloat("ArmY", armY);
+    }
+
+    @Override
+    public void load(CompoundTag tag, HolderLookup.Provider registries) {
+        readState(tag);
+    }
+
+    @Override
+    public void loadLegacy(CompoundTag root, HolderLookup.Provider registries) {
+        readState(root);
+    }
+
+    private void readState(CompoundTag tag) {
+        try {
+            phase = Phase.valueOf(NbtCompat.getString(tag, "Phase", Phase.DESCENDING.name()));
+        } catch (IllegalArgumentException e) {
+            phase = Phase.DESCENDING;
+        }
+        targetY = NbtCompat.getInt(tag, "TargetY", targetY);
+        armY = NbtCompat.getFloat(tag, "ArmY", armY);
+    }
+}

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpComponent.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpComponent.java
@@ -27,6 +27,7 @@ import net.minecraft.tags.FluidTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
@@ -59,6 +60,7 @@ public final class FluidPumpComponent implements MachineComponent {
     private long lastSyncedEnergy = -1;
     private long lastSyncedTank = -1;
     private int lastSyncedTargetY = Integer.MIN_VALUE;
+    @Nullable private Phase lastSyncedPhase;
     private final ArrayDeque<BlockPos> sourceQueue = new ArrayDeque<>();
     private boolean infiniteBody;
     @Nullable private Fluid queuedFluid;
@@ -104,10 +106,14 @@ public final class FluidPumpComponent implements MachineComponent {
 
         long currentEnergy = energy.amount();
         long currentTank = tank().getAmount();
-        if (currentEnergy != lastSyncedEnergy || currentTank != lastSyncedTank || targetY != lastSyncedTargetY) {
+        if (currentEnergy != lastSyncedEnergy
+                || currentTank != lastSyncedTank
+                || targetY != lastSyncedTargetY
+                || phase != lastSyncedPhase) {
             lastSyncedEnergy = currentEnergy;
             lastSyncedTank = currentTank;
             lastSyncedTargetY = targetY;
+            lastSyncedPhase = phase;
             ctx.sync();
         }
     }
@@ -178,7 +184,7 @@ public final class FluidPumpComponent implements MachineComponent {
         // non-source fluid so it reaches the body smoothly.
         boolean atLayer = phase == Phase.PUMPING
                 || (phase == Phase.STALLED && !sourceQueue.isEmpty() && queuedFluid != null)
-                || isPumpableSource(fluidState);
+                || isPumpableSource(level, target, fluidState);
         if (atLayer && armY > targetY + 0.55f) {
             return;
         }
@@ -206,7 +212,7 @@ public final class FluidPumpComponent implements MachineComponent {
             descendToNextLayer(level, pos);
             return;
         }
-        if (isPumpableSource(fluidState)) {
+        if (isPumpableSource(level, target, fluidState)) {
             if (energy.amount() < cfg.energyPerSource) {
                 phase = Phase.STALLED;
                 return;
@@ -287,7 +293,7 @@ public final class FluidPumpComponent implements MachineComponent {
         while (!sourceQueue.isEmpty()) {
             BlockPos source = sourceQueue.removeLast();
             FluidState state = level.getFluidState(source);
-            if (state.getType().isSame(fluid) && state.isSource()) {
+            if (state.getType().isSame(fluid) && state.isSource() && isStandaloneLiquid(level, source)) {
                 return source;
             }
         }
@@ -322,7 +328,7 @@ public final class FluidPumpComponent implements MachineComponent {
             if (!state.getType().isSame(fluid)) {
                 continue;
             }
-            if (state.isSource()) {
+            if (state.isSource() && isStandaloneLiquid(level, current)) {
                 sourceQueue.add(current);
                 if (canBeInfinite && sourceQueue.size() >= threshold) {
                     infiniteBody = true;
@@ -355,14 +361,19 @@ public final class FluidPumpComponent implements MachineComponent {
         }
     }
 
-    private boolean isPumpableSource(FluidState state) {
+    private boolean isPumpableSource(Level level, BlockPos pos, FluidState state) {
         Fluid fluid = state.getType();
-        if (fluid == Fluids.EMPTY || !state.isSource()) {
+        if (fluid == Fluids.EMPTY || !state.isSource() || !isStandaloneLiquid(level, pos)) {
             return false;
         }
         FluidTankComponent tank = tank();
         IFluidKey current = tank.getFluidKey();
         return tank.isEmpty() || current.getFluid() == fluid;
+    }
+
+    /** True only for a standalone liquid block (not a waterlogged solid), so draining won't replace blocks. */
+    private static boolean isStandaloneLiquid(Level level, BlockPos pos) {
+        return level.getBlockState(pos).getBlock() instanceof LiquidBlock;
     }
 
     private boolean isBlocked(Level level, BlockPos pos) {

--- a/common/src/main/resources/data/logistics/recipe/fluid/fluid_pump.json
+++ b/common/src/main/resources/data/logistics/recipe/fluid/fluid_pump.json
@@ -1,19 +1,12 @@
 {
   "type": "minecraft:crafting_shaped",
-  "pattern": [
-    "IRI",
-    "IGI",
-    "TBT"
-  ],
+  "pattern": [" T ", "BMB", "GCG"],
   "key": {
+    "T": "logistics:fluid/glass_tank",
     "B": "minecraft:bucket",
-    "G": "logistics:core/iron_gear",
-    "I": "minecraft:iron_ingot",
-    "R": "minecraft:redstone",
-    "T": "logistics:fluid/glass_tank"
+    "M": "logistics:core/machine_core",
+    "G": "logistics:core/copper_gear",
+    "C": "logistics:core/redstone_reception_coil"
   },
-  "result": {
-    "id": "logistics:fluid/fluid_pump",
-    "count": 1
-  }
+  "result": { "id": "logistics:fluid/fluid_pump", "count": 1 }
 }

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
@@ -132,7 +132,8 @@ public class FluidPumpGameTest {
         LogisticsConfig.get().fluidPump.armSpeed = 16f;
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks + 2, () -> {
-            if (!context.getBlockState(slabPos).is(Blocks.OAK_SLAB)) {
+            if (!context.getBlockState(slabPos).is(Blocks.OAK_SLAB)
+                    || !context.getBlockState(slabPos).getValue(BlockStateProperties.WATERLOGGED)) {
                 context.fail("Fluid pump must not drain or replace a waterlogged block");
                 return;
             }

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
@@ -15,6 +15,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
 
 public class FluidPumpGameTest {
@@ -108,6 +109,35 @@ public class FluidPumpGameTest {
             if (pump.tank().getAmount() < FluidUnits.mb(1_000)
                     || pump.tank().getFluidKey().getFluid() != Fluids.WATER) {
                 context.fail("Fluid pump should store 1000 mB of water");
+                return;
+            }
+            context.succeed();
+        });
+    }
+
+    @GameTest(maxTicks = 40)
+    public void testFluidPumpDoesNotDrainWaterloggedBlocks(GameTestHelper context) {
+        BlockPos pumpPos = new BlockPos(1, 3, 1);
+        BlockPos slabPos = pumpPos.below();
+        context.setBlock(pumpPos, LogisticsFluid.BLOCK.FLUID_PUMP);
+        context.setBlock(
+                slabPos, Blocks.OAK_SLAB.defaultBlockState().setValue(BlockStateProperties.WATERLOGGED, true));
+
+        FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
+        if (pump == null) {
+            context.fail("Expected FluidPumpBlockEntity");
+            return;
+        }
+        fillEnergy(pump);
+        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+
+        context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks + 2, () -> {
+            if (!context.getBlockState(slabPos).is(Blocks.OAK_SLAB)) {
+                context.fail("Fluid pump must not drain or replace a waterlogged block");
+                return;
+            }
+            if (pump.tank().getAmount() > 0) {
+                context.fail("Fluid pump must not pump fluid out of a waterlogged block");
                 return;
             }
             context.succeed();


### PR DESCRIPTION
## Summary

Rebuilds the Fluid Pump on the shared component-hosted machine framework (the same base as the Macerator, Kiln, and Sawmill) and aligns its crafting recipe with the other machines.

## Changes

- **Recipe** now follows the shared machine grammar: a Glass Tank on top, Buckets flanking a Machine Frame, and Copper Gears + a Redstone Reception Coil across the bottom — matching the Macerator/Kiln/Quarry.

  ```
   T      T = Glass Tank
  BMB     B = Bucket   M = Machine Frame
  GCG     G = Copper Gear   C = Redstone Reception Coil
  ```

- **Internals:** the pump's logic moves into a `FluidPumpComponent` on `MachineEntity`; energy and the tank are now first-class machine components (the framework's first real use of `FluidStoreComponent`).

## Notes

- **No change to how the pump works** — source-finding, tube descent, infinite-body handling, push-out, low-tier (redstone-engine) power, and sided access (every face except the bottom intake) all behave exactly as before. All 15 fluid-pump gametests pass.
- **Back-compat:** pumps already placed in a world keep their stored energy, fluid, and tube state via legacy NBT migration.

### Suggested squash commit

```
refactor(pump): rebuild on machine components

balance(pump): standardize recipe around machine components
fix(pump): stop destroying waterlogged blocks
fix(pump): sync tube animation on phase changes
```
