### PR TITLE
fix(automation): pause recipes until byproducts have space

### DIFF
--- a/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
@@ -189,6 +189,10 @@ public final class MachineBuilder {
             java.util.Objects.requireNonNull(resolver, "recipeProcessor(" + id + ") requires a resolver");
             java.util.Objects.requireNonNull(items, "recipeProcessor(" + id + ") requires items");
             java.util.Objects.requireNonNull(energy, "recipeProcessor(" + id + ") requires energy");
+            if (rfPerTick <= 0) {
+                throw new IllegalStateException(
+                        "recipeProcessor(" + id + ") requires a positive rfPerTick, got " + rfPerTick);
+            }
             return components.add(new RecipeProcessorComponent(id, resolver, rfPerTick, items, energy, lit, onChanged));
         }
     }

--- a/common/src/main/java/com/logistics/core/machine/component/ChanceOutput.java
+++ b/common/src/main/java/com/logistics/core/machine/component/ChanceOutput.java
@@ -22,6 +22,12 @@ public record ChanceOutput(ItemStack template, float chance) {
         return (int) chance;
     }
 
+    /** The most a single {@link #roll} can yield: the guaranteed count plus the possible fractional bonus. */
+    public int maxCount() {
+        int guaranteed = (int) chance;
+        return guaranteed + (chance - guaranteed > 0f ? 1 : 0);
+    }
+
     /** Rolls this output's yield: the guaranteed count plus the fractional bonus. */
     public int roll(RandomSource random) {
         int guaranteed = (int) chance;

--- a/common/src/main/java/com/logistics/core/machine/component/ProcessIO.java
+++ b/common/src/main/java/com/logistics/core/machine/component/ProcessIO.java
@@ -21,7 +21,7 @@ public interface ProcessIO {
 
     void consumeEnergy(long rf);
 
-    /** Whether the primary result and every byproduct's guaranteed portion fit their output slots. */
+    /** Whether the primary result and every byproduct's worst-case roll fit their output slots. */
     boolean canAcceptOutputs(ItemStack result, List<ChanceOutput> byproducts);
 
     /** Places the primary result and the already-rolled byproduct stacks into their output slots. */

--- a/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
@@ -225,7 +225,9 @@ public final class RecipeProcessorComponent implements MachineComponent, Machine
             }
             for (int i = 0; i < byproducts.size(); i++) {
                 ChanceOutput byproduct = byproducts.get(i);
-                if (byproduct.guaranteedCount() > 0 && !items.canAcceptInto(i + 1, byproduct.guaranteedStack())) {
+                // Validate the worst-case roll so a fractional bonus is never silently dropped on completion.
+                int maxCount = byproduct.maxCount();
+                if (maxCount > 0 && !items.canAcceptInto(i + 1, byproduct.stack(maxCount))) {
                     return false;
                 }
             }

--- a/common/src/test/java/com/logistics/core/machine/MachineBuilderTest.java
+++ b/common/src/test/java/com/logistics/core/machine/MachineBuilderTest.java
@@ -21,12 +21,14 @@ class MachineBuilderTest extends MinecraftTestEnvironment {
                 machine.items("items").slots(SlotRole.INPUT, SlotRole.OUTPUT).furnaceAccess().build();
         EnergyStorageComponent energy = machine.energy("energy").capacity(1_000).maxInput(1_000).build();
 
-        assertThatThrownBy(() -> machine.recipeProcessor("processor")
-                        .resolver((io, ctx) -> null)
-                        .items(items)
-                        .energy(energy)
-                        .rfPerTick(0)
-                        .build())
-                .isInstanceOf(IllegalStateException.class);
+        for (long rfPerTick : new long[] {0, -1}) {
+            assertThatThrownBy(() -> machine.recipeProcessor("processor")
+                            .resolver((io, ctx) -> null)
+                            .items(items)
+                            .energy(energy)
+                            .rfPerTick(rfPerTick)
+                            .build())
+                    .isInstanceOf(IllegalStateException.class);
+        }
     }
 }

--- a/common/src/test/java/com/logistics/core/machine/MachineBuilderTest.java
+++ b/common/src/test/java/com/logistics/core/machine/MachineBuilderTest.java
@@ -1,0 +1,32 @@
+package com.logistics.core.machine;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.logistics.core.machine.component.EnergyStorageComponent;
+import com.logistics.core.machine.component.ItemStoreComponent;
+import com.logistics.core.machine.component.SlotRole;
+import com.logistics.test.MinecraftTestEnvironment;
+import org.junit.jupiter.api.Test;
+
+class MachineBuilderTest extends MinecraftTestEnvironment {
+
+    private static MachineBuilder builder() {
+        return new MachineBuilder(new MachineComponentContainer(), () -> {});
+    }
+
+    @Test
+    void recipeProcessorRejectsNonPositiveRfPerTick() {
+        MachineBuilder machine = builder();
+        ItemStoreComponent items =
+                machine.items("items").slots(SlotRole.INPUT, SlotRole.OUTPUT).furnaceAccess().build();
+        EnergyStorageComponent energy = machine.energy("energy").capacity(1_000).maxInput(1_000).build();
+
+        assertThatThrownBy(() -> machine.recipeProcessor("processor")
+                        .resolver((io, ctx) -> null)
+                        .items(items)
+                        .energy(energy)
+                        .rfPerTick(0)
+                        .build())
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/common/src/test/java/com/logistics/core/machine/component/ChanceOutputTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/ChanceOutputTest.java
@@ -24,6 +24,15 @@ class ChanceOutputTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    void maxCountIncludesTheFractionalBonus() {
+        assertThat(of(0.0f).maxCount()).isZero();
+        assertThat(of(0.25f).maxCount()).isEqualTo(1); // a purely fractional bonus can still yield one
+        assertThat(of(1.0f).maxCount()).isEqualTo(1);
+        assertThat(of(1.25f).maxCount()).isEqualTo(2);
+        assertThat(of(2.0f).maxCount()).isEqualTo(2);
+    }
+
+    @Test
     void wholeChanceAlwaysRollsExactly() {
         RandomSource random = RandomSource.create(1L);
         for (int i = 0; i < 100; i++) {

--- a/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
@@ -165,6 +165,39 @@ class RecipeProcessorComponentTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    void blocksCompletionWhenFractionalByproductSlotIsFull() {
+        Runnable noop = () -> {};
+        ItemStoreComponent items = new ItemStoreComponent(
+                "items",
+                new SlotRole[] {SlotRole.INPUT, SlotRole.OUTPUT, SlotRole.OUTPUT},
+                SidedLayout.furnace(new int[] {0}, new int[] {1, 2}, stack -> true),
+                noop);
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 0, false, false, noop);
+        energy.energy(null).insert(100_000, false);
+
+        items.container().setItem(0, new ItemStack(Items.RAW_IRON, 1));
+        items.produceInto(1, new ItemStack(Items.GUNPOWDER, 64)); // fill the byproduct output slot
+
+        RecipePlan plan = new RecipePlan(
+                20,
+                1,
+                new ItemStack(Items.IRON_INGOT),
+                List.of(new ChanceOutput(new ItemStack(Items.GUNPOWDER), 0.5f)),
+                0f);
+        RecipeProcessorComponent processor = new RecipeProcessorComponent(
+                "processor", (io, ctx) -> io.input().isEmpty() ? null : plan, 10, items, energy, (ctx, lit) -> {}, noop);
+
+        FakeMachineContext ctx = new FakeMachineContext();
+        for (int i = 0; i < 5; i++) {
+            processor.serverTick(ctx); // 5 x 10 RF >> 20 required: would complete if the bonus slot weren't full
+        }
+
+        // The 0.5 bonus could roll one gunpowder but its slot is full, so the recipe must not complete.
+        assertThat(items.input().getCount()).isEqualTo(1);
+        assertThat(processor.energySpent()).isZero();
+    }
+
+    @Test
     void stallsUntilInputCountIsAvailable() {
         FakeProcessIO io = new FakeProcessIO();
         io.energy = 1_000;


### PR DESCRIPTION
## Summary

Two robustness fixes in the shared machine-component framework, surfaced by CodeRabbit during the machine PRs. They live only in mc/26.2's framework now that the machine branches are rebased, so this fixes the single canonical copy.

## Changes

- **Byproducts no longer silently voided.** The recipe processor now validates each byproduct's worst-case roll (guaranteed amount + the possible fractional bonus) can fit before a recipe completes. Previously only byproducts with a guaranteed (≥1) amount were checked, so a purely-fractional bonus (e.g. a 25% chance of an extra) could roll and then be dropped when its output slot was full. The machine now stalls until there's room instead of destroying the bonus.
- **Fail fast on a non-positive `rfPerTick`.** `recipeProcessor(...).build()` now rejects `rfPerTick <= 0` (alongside the existing resolver/items/energy checks), so a misconfigured machine fails at assembly instead of building fine and never making progress.

## Notes

- Adds `ChanceOutput.maxCount()` (the most a single roll can yield).
- Tests: `ChanceOutputTest.maxCountIncludesTheFractionalBonus`, `RecipeProcessorComponentTest.blocksCompletionWhenFractionalByproductSlotIsFull` (full integration through the real item/energy components), and a new `MachineBuilderTest.recipeProcessorRejectsNonPositiveRfPerTick`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Suggested squash commit

```
fix(automation): pause recipes until byproducts have space
```
