### PR TITLE
docs(release): adopt a player-facing changelog and scope vocabulary

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -28,7 +28,12 @@ jobs:
         with:
           types: |
             feat
+            balance
+            change
+            deprecate
+            remove
             fix
+            security
             docs
             refactor
             perf

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -46,20 +46,29 @@ jobs:
           scopes: |
             core
             automation
+            macerator
+            kiln
+            quarry
+            sawmill
+            pump
+            transport
+            routing
             pipes
+            fluids
             energy
             storage
+            crafting
+            worldgen
             ui
+            api
             compat
+            common
             fabric
             neoforge
             docs
-            release
-            update
-            common
             build
-            fluids
-            api
+            ci
+            release
 
           requireScope: true
           validateSingleCommit: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -552,7 +552,8 @@ Other rules:
 - Use `automation` only for the shared machine framework or behavior that crosses multiple machines
   (shared components, machine base classes, reusable output handling, chunk loading, upgrade seams).
 - Use `core` for low-level shared infrastructure that is not specific to machines.
-- Use `common`, `fabric`, `neoforge` for loader/platform-specific implementation work.
+- Use `common` for shared implementation code with no better product/framework scope.
+- Use `fabric` and `neoforge` for loader-specific implementation work.
 - Repo automation: `build` (Gradle, mappings, dependencies, publishing), `ci` (GitHub Actions /
   validation), `release` (release-please, versions, changelog configuration).
 - Do not use `logistics` (too broad — it's the mod name; use `routing` for smart-pipe behavior) or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,77 +473,128 @@ type(scope): short description
 Examples:
 
 ```text
-feat(pipes): add priority routing mode
+feat(automation): add the sawmill
+balance(automation): increase the laser quarry frame material cost
+change(automation): rename Wood Pulp to Sawdust
 fix(neoforge): fix startup crash on NeoForge
+remove(automation): drop the unused crusher recipe
 perf(automation): reduce idle machine tick cost
 refactor(common): simplify platform service lookup
-test(pipes): add routing tests
 build(fabric): update publishing task
-ci(build): update Gradle cache settings
 chore(release): update release metadata
-chore(update): update dependencies
 ```
 
-### Changelog-visible types
+### Commit types and changelog sections
 
-Only these types should appear in generated player-facing release notes:
+The changelog follows [Keep a Changelog](https://keepachangelog.com). Each type maps to a section:
 
 | Type | Changelog section | Use for |
 |---|---|---|
-| `feat` | Added | New player-visible behavior |
-| `fix` | Fixed | Player-visible bug fixes |
-| `perf` | Improved | Player-visible performance improvements |
+| `feat` | Added | new player-facing capability, block, item, or machine |
+| `balance` | Changed | recipe / cost / rate / output / power / progression tuning (buffs and nerfs) |
+| `change` | Changed | other player-facing change (rename, restyle, behavior shift) |
+| `perf` | Changed | player-visible performance improvement |
+| `deprecate` | Deprecated | content/behavior marked for future removal |
+| `remove` | Removed | removed content or behavior |
+| `fix` | Fixed | corrected broken or unintended behavior |
+| `security` | Security | security-sensitive fix |
+
+Prefer `balance` over `change` when the change is gameplay tuning (recipes, costs, rates,
+progression); `balance` is honest about both buffs and nerfs without implying an improvement.
 
 ### Internal types
 
-These types are allowed, but should be treated as internal/developer-facing and should not be included in Release Please changelog sections:
+These types are allowed but hidden from the changelog (developer-facing):
 
 | Type | Use for |
 |---|---|
-| `refactor` | Code cleanup without player-visible behavior changes |
-| `test` | Test coverage |
+| `refactor` | code restructuring with no player-visible change |
+| `test` | test coverage |
 | `build` | Gradle, publishing, or build system changes |
 | `ci` | GitHub Actions or automation changes |
-| `chore` | Maintenance work |
-| `docs` | Documentation-only changes |
-| `revert` | Revert a previous change |
+| `chore` | maintenance work |
+| `docs` | documentation-only changes |
+| `revert` | revert a previous commit/PR |
+
+### Multi-change squash commits
+
+When one PR makes several distinct player-facing changes, record each as its own changelog entry by
+putting one Conventional Commit line per change in the squash commit BODY (the subject is the first
+entry). Release Please parses each `type(scope): description` line into a separate changelog entry:
+
+```text
+feat(automation): add the sawmill
+
+change(automation): rename Wood Pulp to Sawdust
+balance(automation): move wood processing from the macerator to the sawmill
+remove(automation): drop the macerator's wood-pulp recipes
+```
 
 ### Allowed scopes
 
-Use the scope that best describes the player-facing area of the mod affected:
+Scopes identify the mod's product surface or implementation area.
 
-| Scope | Use for |
-|---|---|
-| `core` | Shared mod behavior, base blocks/items, recipes, world behavior |
-| `automation` | Machines, upgrades, automation logic |
-| `pipes` | Pipes, routing, extraction, insertion, pipe networks |
-| `energy` | Energy transfer and storage behavior |
-| `storage` | Inventories, storage blocks, adapters |
-| `ui` | Screens, tooltips, overlays, visible rendering/UX |
-| `compat` | Integration with other mods |
-| `fabric` | Fabric-specific user-visible behavior |
-| `neoforge` | NeoForge-specific user-visible behavior |
-| `docs` | README, wiki, or user documentation |
-| `release` | Release metadata |
-| `update` | Dependency and automated update PRs |
-| `common` | Shared/internal code changes with no better user-facing scope |
-| `build` | Build tooling or CI support scope |
+**Product scopes** — major player-recognizable systems, machines, and feature areas:
+`macerator`, `kiln`, `quarry`, `sawmill`, `pump`, `transport`, `routing`, `fluids`, `pipes`,
+`energy`, `storage`, `crafting`, `worldgen`, `ui`.
 
-Prefer player-facing scopes for `feat`, `fix`, and `perf`.
+**Framework / internal scopes:** `core`, `automation`, `api`, `common`.
+**Platform scopes:** `fabric`, `neoforge`, `compat`.
+**Project scopes:** `docs`, `build`, `ci`, `release`.
+
+Pipe-related scope rules:
+- `transport` — basic item transport pipes
+- `routing` — smart/routed/requested item logistics pipes
+- `fluids` — fluid pipes, tanks, handlers, transfer rules, pipe sealant, and general fluid mechanics
+- `pipes` — shared pipe framework code used across multiple pipe families (use `transport`/`routing`/`fluids` for one family)
+
+Other rules:
+- Use `automation` only for the shared machine framework or behavior that crosses multiple machines
+  (shared components, machine base classes, reusable output handling, chunk loading, upgrade seams).
+- Use `core` for low-level shared infrastructure that is not specific to machines.
+- Use `common`, `fabric`, `neoforge` for loader/platform-specific implementation work.
+- Repo automation: `build` (Gradle, mappings, dependencies, publishing), `ci` (GitHub Actions /
+  validation), `release` (release-please, versions, changelog configuration).
+- Do not use `logistics` (too broad — it's the mod name; use `routing` for smart-pipe behavior) or
+  `fluid-pipes` (folded into `fluids`).
+
+### Changelog-readable subjects
+
+Let the scope carry the main product noun, but keep enough context that the changelog line stands on
+its own — roughly **4–8 words** after the colon. Prefer changelog-readable over ultra-short.
 
 Good:
 
 ```text
-fix(pipes): fix items getting stuck when a route becomes invalid
+balance(macerator): standardize recipe around machine components
+change(kiln): restyle with machine shell
+fix(pump): stop destroying waterlogged blocks
+feat(transport): add gold item pipe
+fix(routing): respect destination priority
+feat(fluids): add void fluid pipe
+refactor(pipes): share connection logic
+refactor(automation): extract ChunkLoadingComponent
 ```
 
-Avoid for player-facing changes:
+Too short (changelog becomes vague):
 
 ```text
-fix(common): invalidate pipe graph cache on neighbor update
+balance(macerator): rework recipe
+change(kiln): restyle machine
+fix(automation): stop voiding byproducts
 ```
 
-The second title may be technically accurate, but the first produces better release notes.
+Too long / implementation-heavy (the scope already says the machine):
+
+```text
+balance(macerator): rework the macerator recipe to use the shared machine components
+change(kiln): restyle the kiln to match the shared machine-component visual design
+```
+
+For the standardized machine recipes, prefer wording like
+`balance(<machine>): standardize recipe around machine components` — these recipes share a consistent
+structure (machine frame + redstone coil + machine-specific ingredients, e.g. tanks/buckets for the
+pump, a pickaxe for the quarry, flint for the macerator).
 
 ### Guidance for agents
 
@@ -551,8 +602,9 @@ When creating or modifying PRs:
 
 - Use scoped Conventional Commit PR titles.
 - Think about the generated changelog before choosing the PR title.
-- Prefer player-facing wording for `feat`, `fix`, and `perf`.
+- Prefer player-facing wording and a changelog-visible type — most commonly `feat`, `balance`, `change`, `fix`, and `remove` (the type table above lists the full set, including `perf`, `deprecate`, and `security`).
 - Use internal types like `refactor`, `test`, `build`, `ci`, and `chore` for non-player-facing work.
+- For PRs with several player-facing changes, list each as its own Conventional Commit line in the squash body (see "Multi-change squash commits").
 - Do not add `refactor`, `test`, `build`, `ci`, or `chore` to the Release Please changelog sections.
 - Do not attempt to group changelog entries by scope using nested headings unless the release strategy is intentionally changed later.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,40 +474,62 @@ type(scope): short description
 Examples:
 
 ```text
-feat(pipes): add priority routing mode
+feat(automation): add the sawmill
+balance(automation): increase the laser quarry frame material cost
+change(automation): rename Wood Pulp to Sawdust
 fix(neoforge): fix startup crash on NeoForge
+remove(automation): drop the unused crusher recipe
 perf(automation): reduce idle machine tick cost
 refactor(common): simplify platform service lookup
-test(pipes): add routing tests
 build(fabric): update publishing task
-ci(build): update Gradle cache settings
 chore(release): update release metadata
-chore(update): update dependencies
 ```
 
-### Changelog-visible types
+### Commit types and changelog sections
 
-Only these types should appear in generated player-facing release notes:
+The changelog follows [Keep a Changelog](https://keepachangelog.com). Each type maps to a section:
 
 | Type | Changelog section | Use for |
 |---|---|---|
-| `feat` | Added | New player-visible behavior |
-| `fix` | Fixed | Player-visible bug fixes |
-| `perf` | Improved | Player-visible performance improvements |
+| `feat` | Added | new player-facing capability, block, item, or machine |
+| `balance` | Changed | recipe / cost / rate / output / power / progression tuning (buffs and nerfs) |
+| `change` | Changed | other player-facing change (rename, restyle, behavior shift) |
+| `perf` | Changed | player-visible performance improvement |
+| `deprecate` | Deprecated | content/behavior marked for future removal |
+| `remove` | Removed | removed content or behavior |
+| `fix` | Fixed | corrected broken or unintended behavior |
+| `security` | Security | security-sensitive fix |
+
+Prefer `balance` over `change` when the change is gameplay tuning (recipes, costs, rates,
+progression); `balance` is honest about both buffs and nerfs without implying an improvement.
 
 ### Internal types
 
-These types are allowed, but should be treated as internal/developer-facing and should not be included in Release Please changelog sections:
+These types are allowed but hidden from the changelog (developer-facing):
 
 | Type | Use for |
 |---|---|
-| `refactor` | Code cleanup without player-visible behavior changes |
-| `test` | Test coverage |
+| `refactor` | code restructuring with no player-visible change |
+| `test` | test coverage |
 | `build` | Gradle, publishing, or build system changes |
 | `ci` | GitHub Actions or automation changes |
-| `chore` | Maintenance work |
-| `docs` | Documentation-only changes |
-| `revert` | Revert a previous commit/PR |
+| `chore` | maintenance work |
+| `docs` | documentation-only changes |
+| `revert` | revert a previous commit/PR |
+
+### Multi-change squash commits
+
+When one PR makes several distinct player-facing changes, record each as its own changelog entry by
+putting one Conventional Commit line per change in the squash commit BODY (the subject is the first
+entry). Release Please parses each `type(scope): description` line into a separate changelog entry:
+
+```text
+feat(automation): add the sawmill
+
+change(automation): rename Wood Pulp to Sawdust
+balance(automation): move wood processing from the macerator to the sawmill
+remove(automation): drop the macerator's wood-pulp recipes
+```
 
 ### Allowed scopes
 
@@ -530,7 +552,7 @@ Use the scope that best describes the player-facing area of the mod affected:
 | `common` | Shared/internal code changes with no better user-facing scope |
 | `build` | Build tooling or CI support scope |
 
-Prefer player-facing scopes for `feat`, `fix`, and `perf`.
+Prefer player-facing scopes for the player-facing types (`feat`, `balance`, `change`, `fix`, `remove`).
 
 Good:
 
@@ -552,8 +574,9 @@ When creating or modifying PRs:
 
 - Use scoped Conventional Commit PR titles.
 - Think about the generated changelog before choosing the PR title.
-- Prefer player-facing wording for `feat`, `fix`, and `perf`.
+- Prefer player-facing wording and the player-facing types (`feat`, `balance`, `change`, `fix`, `remove`).
 - Use internal types like `refactor`, `test`, `build`, `ci`, and `chore` for non-player-facing work.
+- For PRs with several player-facing changes, list each as its own Conventional Commit line in the squash body (see "Multi-change squash commits").
 - Do not add `refactor`, `test`, `build`, `ci`, or `chore` to the Release Please changelog sections.
 - Do not attempt to group changelog entries by scope using nested headings unless the release strategy is intentionally changed later.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -603,7 +603,7 @@ When creating or modifying PRs:
 
 - Use scoped Conventional Commit PR titles.
 - Think about the generated changelog before choosing the PR title.
-- Prefer player-facing wording and the player-facing types (`feat`, `balance`, `change`, `fix`, `remove`).
+- Prefer player-facing wording and a changelog-visible type — most commonly `feat`, `balance`, `change`, `fix`, and `remove` (the type table above lists the full set, including `perf`, `deprecate`, and `security`).
 - Use internal types like `refactor`, `test`, `build`, `ci`, and `chore` for non-player-facing work.
 - For PRs with several player-facing changes, list each as its own Conventional Commit line in the squash body (see "Multi-change squash commits").
 - Do not add `refactor`, `test`, `build`, `ci`, or `chore` to the Release Please changelog sections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -553,7 +553,8 @@ Other rules:
 - Use `automation` only for the shared machine framework or behavior that crosses multiple machines
   (shared components, machine base classes, reusable output handling, chunk loading, upgrade seams).
 - Use `core` for low-level shared infrastructure that is not specific to machines.
-- Use `common`, `fabric`, `neoforge` for loader/platform-specific implementation work.
+- Use `common` for shared implementation code with no better product/framework scope.
+- Use `fabric` and `neoforge` for loader-specific implementation work.
 - Repo automation: `build` (Gradle, mappings, dependencies, publishing), `ci` (GitHub Actions /
   validation), `release` (release-please, versions, changelog configuration).
 - Do not use `logistics` (too broad — it's the mod name; use `routing` for smart-pipe behavior) or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,40 +533,69 @@ remove(automation): drop the macerator's wood-pulp recipes
 
 ### Allowed scopes
 
-Use the scope that best describes the player-facing area of the mod affected:
+Scopes identify the mod's product surface or implementation area.
 
-| Scope | Use for |
-|---|---|
-| `core` | Shared mod behavior, base blocks/items, recipes, world behavior |
-| `automation` | Machines, upgrades, automation logic |
-| `pipes` | Pipes, routing, extraction, insertion, pipe networks |
-| `energy` | Energy transfer and storage behavior |
-| `storage` | Inventories, storage blocks, adapters |
-| `ui` | Screens, tooltips, overlays, visible rendering/UX |
-| `compat` | Integration with other mods |
-| `fabric` | Fabric-specific user-visible behavior |
-| `neoforge` | NeoForge-specific user-visible behavior |
-| `docs` | README, wiki, or user documentation |
-| `release` | Release metadata |
-| `update` | Dependency and automated update PRs |
-| `common` | Shared/internal code changes with no better user-facing scope |
-| `build` | Build tooling or CI support scope |
+**Product scopes** — major player-recognizable systems, machines, and feature areas:
+`macerator`, `kiln`, `quarry`, `sawmill`, `pump`, `transport`, `routing`, `fluids`, `pipes`,
+`energy`, `storage`, `crafting`, `worldgen`, `ui`.
 
-Prefer player-facing scopes for the player-facing types (`feat`, `balance`, `change`, `fix`, `remove`).
+**Framework / internal scopes:** `core`, `automation`, `api`, `common`.
+**Platform scopes:** `fabric`, `neoforge`, `compat`.
+**Project scopes:** `docs`, `build`, `ci`, `release`.
+
+Pipe-related scope rules:
+- `transport` — basic item transport pipes
+- `routing` — smart/routed/requested item logistics pipes
+- `fluids` — fluid pipes, tanks, handlers, transfer rules, pipe sealant, and general fluid mechanics
+- `pipes` — shared pipe framework code used across multiple pipe families (use `transport`/`routing`/`fluids` for one family)
+
+Other rules:
+- Use `automation` only for the shared machine framework or behavior that crosses multiple machines
+  (shared components, machine base classes, reusable output handling, chunk loading, upgrade seams).
+- Use `core` for low-level shared infrastructure that is not specific to machines.
+- Use `common`, `fabric`, `neoforge` for loader/platform-specific implementation work.
+- Repo automation: `build` (Gradle, mappings, dependencies, publishing), `ci` (GitHub Actions /
+  validation), `release` (release-please, versions, changelog configuration).
+- Do not use `logistics` (too broad — it's the mod name; use `routing` for smart-pipe behavior) or
+  `fluid-pipes` (folded into `fluids`).
+
+### Changelog-readable subjects
+
+Let the scope carry the main product noun, but keep enough context that the changelog line stands on
+its own — roughly **4–8 words** after the colon. Prefer changelog-readable over ultra-short.
 
 Good:
 
 ```text
-fix(pipes): fix items getting stuck when a route becomes invalid
+balance(macerator): standardize recipe around machine components
+change(kiln): restyle with machine shell
+fix(pump): stop destroying waterlogged blocks
+feat(transport): add gold item pipe
+fix(routing): respect destination priority
+feat(fluids): add void fluid pipe
+refactor(pipes): share connection logic
+refactor(automation): extract ChunkLoadingComponent
 ```
 
-Avoid for player-facing changes:
+Too short (changelog becomes vague):
 
 ```text
-fix(common): invalidate pipe graph cache on neighbor update
+balance(macerator): rework recipe
+change(kiln): restyle machine
+fix(automation): stop voiding byproducts
 ```
 
-The second title may be technically accurate, but the first produces better release notes.
+Too long / implementation-heavy (the scope already says the machine):
+
+```text
+balance(macerator): rework the macerator recipe to use the shared machine components
+change(kiln): restyle the kiln to match the shared machine-component visual design
+```
+
+For the standardized machine recipes, prefer wording like
+`balance(<machine>): standardize recipe around machine components` — these recipes share a consistent
+structure (machine frame + redstone coil + machine-specific ingredients, e.g. tanks/buckets for the
+pump, a pickaxe for the quarry, flint for the macerator).
 
 ### Guidance for agents
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,7 +14,18 @@
   },
   "changelog-sections": [
     { "type": "feat", "section": "Added" },
+    { "type": "balance", "section": "Changed" },
+    { "type": "change", "section": "Changed" },
+    { "type": "deprecate", "section": "Deprecated" },
+    { "type": "remove", "section": "Removed" },
     { "type": "fix", "section": "Fixed" },
-    { "type": "perf", "section": "Improved" }
+    { "type": "security", "section": "Security" },
+    { "type": "perf", "section": "Changed" },
+    { "type": "refactor", "section": "Changed", "hidden": true },
+    { "type": "docs", "section": "Changed", "hidden": true },
+    { "type": "build", "section": "Changed", "hidden": true },
+    { "type": "ci", "section": "Changed", "hidden": true },
+    { "type": "test", "section": "Changed", "hidden": true },
+    { "type": "chore", "section": "Changed", "hidden": true }
   ]
 }


### PR DESCRIPTION
## Summary

Reworks our Release Please + PR-title conventions so the changelog reads for **players**, aligned with [Keep a Changelog](https://keepachangelog.com): a new commit-type vocabulary **and** a product-area scope model.

## Changes

**`release-please-config.json`** — new `changelog-sections` mapping:
- `feat` → Added
- `balance`, `change`, `perf` → Changed
- `deprecate` → Deprecated · `remove` → Removed · `fix` → Fixed · `security` → Security
- `refactor` / `docs` / `build` / `ci` / `test` / `chore` → hidden

**`.github/workflows/check-pr.yml`**
- Allow the new types: `balance`, `change`, `deprecate`, `remove`, `security`.
- Rework scopes into a product-area model:
  - **Product:** `macerator`, `kiln`, `quarry`, `sawmill`, `pump`, `transport`, `routing`, `fluids`, `pipes`, `energy`, `storage`, `crafting`, `worldgen`, `ui`
  - **Framework/internal:** `core`, `automation`, `api`, `common`
  - **Platform:** `fabric`, `neoforge`, `compat`
  - **Project:** `docs`, `build`, `ci`, `release`
  - Dropped `update` (too vague).

**`CLAUDE.md`** — documents the type→section table, when to use `balance` vs `change`, the scope model (incl. the `transport`/`routing`/`fluids`/`pipes` rules and "no `logistics`/`fluid-pipes`"), changelog-readable subject guidance (~4–8 words), and how multi-line squash bodies produce multiple changelog entries.

## Why

`perf` was the only non-`feat`/`fix` changelog bucket and it's misleading for gameplay/recipe changes. `balance` honestly covers buffs and nerfs; `change` covers renames/restyles/behavior shifts (both land under **Changed**). Product scopes (machines, pipe families) make changelog lines self-describing — `**macerator:** standardize recipe around machine components` instead of a generic `automation:` label.

## Notes

- **Merge this first.** The open machine PRs (#568, #569, #580, #582, #587, #588–#596) already use the new scopes/types in their titles, so their `lint (pr)` check fails until this lands; re-running the check after merge turns them green.
- Pre-1.0, `feat`/`fix` bump patch; the new changelog-visible types should release as patches too — worth confirming on the next release PR that `balance`/`change`/`remove` commits both appear under their sections and trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
