### PR TITLE
fix(macerator): restore the JEI integration

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
   "entrypoints": {
     "client": ["com.logistics.LogisticsModClient"],
     "main": ["com.logistics.fabric.LogisticsFabric"],
-    "jei_mod_plugin": ["com.logistics.core.macerator.jei.MaceratorJeiPlugin"],
+    "jei_mod_plugin": ["com.logistics.automation.macerator.jei.MaceratorJeiPlugin"],
     "jade": ["com.logistics.compat.jade.JadeLogisticsPlugin"]
   },
   "environment": "*",


### PR DESCRIPTION
## Summary
The macerator's JEI plugin failed to load on Fabric — `ClassNotFoundException: com.logistics.core.macerator.jei.MaceratorJeiPlugin`.

When the macerator moved from the `core` domain to `automation`, the JEI entrypoint in `fabric.mod.json` was left pointing at the old package, so JEI silently dropped the plugin (no macerator recipe category in JEI).

## Changes
- Point the `jei_mod_plugin` entrypoint at `com.logistics.automation.macerator.jei.MaceratorJeiPlugin`.

## Notes
- NeoForge is unaffected — its JEI plugin is discovered via `@JeiPlugin`, not an entrypoint.

## Suggested squash commit
```
fix(macerator): restore the JEI integration
```