### PR TITLE
fix(crafting): restore valve and quartz crystal recipes

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/core/apatite_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/apatite_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/apatite_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/blazing_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/blazing_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/blazing_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/bronze_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/bronze_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/bronze_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/copper_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/copper_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/copper_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/diamond_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/diamond_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/diamond_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/emerald_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/emerald_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/emerald_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/ender_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/ender_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/ender_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/gold_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/gold_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/gold_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/iron_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/iron_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/iron_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/lapis_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/lapis_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/lapis_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/netherite_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/netherite_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/netherite_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/obsidian_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/obsidian_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/obsidian_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"

--- a/common/src/main/resources/data/logistics/recipe/core/quartz_crystal_from_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/core/quartz_crystal_from_dust.json
@@ -2,7 +2,7 @@
   "type": "minecraft:smelting",
   "ingredient": "logistics:core/quartz_dust",
   "result": {
-    "id": "logistics:automation/quartz_crystal"
+    "id": "logistics:core/quartz_crystal"
   },
   "cookingtime": 200,
   "experience": 0.1

--- a/common/src/main/resources/data/logistics/recipe/core/wooden_valve.json
+++ b/common/src/main/resources/data/logistics/recipe/core/wooden_valve.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "pattern": ["QQQ", "QFQ", "IGI"],
   "key": {
-    "Q": "logistics:automation/quartz_crystal",
+    "Q": "logistics:core/quartz_crystal",
     "F": "logistics:core/wooden_core",
     "I": "minecraft:iron_nugget",
     "G": "minecraft:gold_nugget"


### PR DESCRIPTION
## Summary
Every valve recipe (and the quartz-crystal smelting recipe) failed to load — they referenced `logistics:automation/quartz_crystal`, but the item is registered in the `core` domain as `logistics:core/quartz_crystal`. The result: no valves were craftable and quartz dust couldn't be smelted into crystal.

This was a long-standing latent bug (the wrong id predates the current branch), surfaced by a client launch.

## Changes
- Repoint all 13 `*_valve.json` recipes and `quartz_crystal_from_dust.json` to `logistics:core/quartz_crystal`.

## Suggested squash commit
```
fix(crafting): restore valve and quartz crystal recipes
```