### PR TITLE
fix(kiln): mine with the correct pickaxe tier

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
@@ -12,7 +12,7 @@
     "logistics:core/bronze_block",
     "logistics:core/apatite_ore",
     "logistics:core/apatite_block",
-    "logistics:core/kiln",
+    "logistics:automation/kiln",
     "logistics:automation/macerator"
   ]
 }

--- a/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
@@ -8,7 +8,7 @@
     "logistics:core/bronze_block",
     "logistics:core/apatite_ore",
     "logistics:core/apatite_block",
-    "logistics:core/kiln",
+    "logistics:automation/kiln",
     "logistics:automation/macerator"
   ]
 }


### PR DESCRIPTION
## Summary
The kiln was missing from its mining tags — `mineable/pickaxe` and `needs_stone_tool` still referenced `logistics:core/kiln`, but the kiln block is registered in the automation domain as `logistics:automation/kiln`. The stale id meant the kiln wasn't tagged at all (wrong tool/mining behavior, and two tag-load errors at startup).

## Changes
- Repoint the kiln entry in `mineable/pickaxe` and `needs_stone_tool` to `logistics:automation/kiln`.

## Suggested squash commit
```
fix(kiln): mine with the correct pickaxe tier
```