### PR TITLE
fix(kiln): accept energy from the power network

### DIFF
--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -74,10 +74,10 @@ public class KilnBlockEntity extends MachineEntity {
 
     @Override
     protected void configure(MachineBuilder machine) {
-        // No demand provider: the Kiln is powered by adjacent capability push, not the pipe network.
         energy = machine.energy("energy")
                 .capacity(ENERGY_CAPACITY)
                 .maxInput(MAX_ENERGY_INPUT)
+                .providesDemand()
                 .build();
 
         var items = machine.items("inventory")


### PR DESCRIPTION
## Summary
The electric kiln couldn't be powered through the energy network — cables delivered nothing to it, so it never smelted.

Machine block entities always implement `EnergyDemandProvider`, so the cable network sizes each delivery from the machine's reported `networkDemandPerTick()`. The kiln was built without a demand provider, so it reported **zero** demand and the network skipped it entirely (it could never fall back to filling free buffer room). Every other machine (macerator, sawmill, laser quarry, fluid pump) already reports demand.

## Changes
- Build the kiln's energy buffer with `providesDemand()` so it advertises real demand and the cable network powers it.

## Suggested squash commit
```
fix(kiln): accept energy from the power network
```