### PR TITLE
ci(release): fail CodeRabbit status when a review can't run

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   review_status: false
+  # Fail the commit status when CodeRabbit can't review (e.g. rate-limited), so an
+  # unreviewed PR shows red instead of a misleading pass.
+  fail_commit_status: true
   # Don't append the high-level summary to the PR description.
   high_level_summary: false
   auto_review:


### PR DESCRIPTION
## Summary
When CodeRabbit can't review a PR (most often because it's rate-limited), it reported a passing/neutral commit status — indistinguishable from a clean review that found nothing. PRs could merge believing CodeRabbit had vetted them when it never ran.

## Changes
- Set `reviews.fail_commit_status: true` in `.coderabbit.yaml`. CodeRabbit now marks its commit status **failure** when it cannot complete a review, so an unreviewed PR shows red instead of a silent pass.

## Notes
- This is the visibility fix. Making the CodeRabbit check *required* (via the `release-branches` ruleset) is a separate, intentional follow-up — deferred until CodeRabbit's review capacity is restored, since a required check while CodeRabbit is down would freeze all `mc/*` merges.