### PR TITLE
fix(kiln): bank smelting XP and pay it out like a furnace

### DIFF
--- a/common/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.kiln;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.block.MachineResultSlot;
 import net.minecraft.recipebook.ServerPlaceRecipe;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
@@ -52,13 +53,8 @@ public class KilnScreenHandler extends RecipeBookMenu {
         // Input slot (0)
         this.addSlot(new Slot(inventory, KilnBlockEntity.INPUT_SLOT, 56, 35));
 
-        // Output slot (1) — no insertion allowed
-        this.addSlot(new Slot(inventory, KilnBlockEntity.OUTPUT_SLOT, 116, 35) {
-            @Override
-            public boolean mayPlace(ItemStack stack) {
-                return false;
-            }
-        });
+        // Output slot (1) — no insertion; releases banked smelting XP to the player on take
+        this.addSlot(new MachineResultSlot(inventory, KilnBlockEntity.OUTPUT_SLOT, 116, 35));
 
         // Player inventory (3 rows of 9)
         for (int row = 0; row < 3; row++) {

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.macerator;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.block.MachineResultSlot;
 import net.minecraft.recipebook.ServerPlaceRecipe;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
@@ -51,13 +52,8 @@ public class MaceratorScreenHandler extends RecipeBookMenu {
         // Input slot (0) — left side of GUI
         this.addSlot(new Slot(inventory, MaceratorBlockEntity.INPUT_SLOT, 56, 35));
 
-        // Output slot (1) — right side of GUI, no insertion allowed
-        this.addSlot(new Slot(inventory, MaceratorBlockEntity.OUTPUT_SLOT, 116, 35) {
-            @Override
-            public boolean mayPlace(ItemStack stack) {
-                return false;
-            }
-        });
+        // Output slot (1) — no insertion; releases banked maceration XP to the player on take
+        this.addSlot(new MachineResultSlot(inventory, MaceratorBlockEntity.OUTPUT_SLOT, 116, 35));
 
         // Player inventory (3 rows of 9)
         for (int row = 0; row < 3; row++) {

--- a/common/src/main/java/com/logistics/core/lib/block/MachineBlock.java
+++ b/common/src/main/java/com/logistics/core/lib/block/MachineBlock.java
@@ -1,9 +1,12 @@
 package com.logistics.core.lib.block;
 
 import com.logistics.core.lib.block.behavior.MenuBehavior;
+import com.logistics.core.lib.block.capability.HasExperienceStorage;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -14,6 +17,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +43,19 @@ public abstract class MachineBlock extends BaseEntityBlock {
     @Override
     protected RenderShape getRenderShape(BlockState blockState) {
         return RenderShape.MODEL;
+    }
+
+    @Override
+    public BlockState playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player) {
+        // Release banked processing experience (furnace-style) before the block entity is gone.
+        if (level instanceof ServerLevel serverLevel
+                && serverLevel.getBlockEntity(pos) instanceof HasExperienceStorage xpStore) {
+            int xp = xpStore.drainExperience(serverLevel.getRandom());
+            if (xp > 0) {
+                ExperienceOrb.award(serverLevel, Vec3.atCenterOf(pos), xp);
+            }
+        }
+        return super.playerWillDestroy(level, pos, state, player);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/core/lib/block/MachineResultSlot.java
+++ b/common/src/main/java/com/logistics/core/lib/block/MachineResultSlot.java
@@ -1,0 +1,36 @@
+package com.logistics.core.lib.block;
+
+import com.logistics.core.lib.block.capability.HasExperienceStorage;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.ExperienceOrb;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Output slot for a machine GUI: rejects insertion and, when a player takes the result, releases the
+ * machine's banked processing experience at the player — the way a vanilla furnace result slot does.
+ */
+public class MachineResultSlot extends Slot {
+
+    public MachineResultSlot(Container container, int slot, int x, int y) {
+        super(container, slot, x, y);
+    }
+
+    @Override
+    public boolean mayPlace(ItemStack stack) {
+        return false;
+    }
+
+    @Override
+    public void onTake(Player player, ItemStack stack) {
+        if (player.level() instanceof ServerLevel level && this.container instanceof HasExperienceStorage xpStore) {
+            int xp = xpStore.drainExperience(level.getRandom());
+            if (xp > 0) {
+                ExperienceOrb.award(level, player.position(), xp);
+            }
+        }
+        super.onTake(player, stack);
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/block/capability/HasExperienceStorage.java
+++ b/common/src/main/java/com/logistics/core/lib/block/capability/HasExperienceStorage.java
@@ -1,0 +1,15 @@
+package com.logistics.core.lib.block.capability;
+
+import net.minecraft.util.RandomSource;
+
+/**
+ * Marker interface for block entities that bank smelting/processing experience internally and
+ * release it when the block is broken, the way a vanilla furnace does.
+ */
+public interface HasExperienceStorage {
+    /**
+     * Removes all banked experience and returns the whole XP points to drop, rounding the
+     * fractional remainder with {@code random}.
+     */
+    int drainExperience(RandomSource random);
+}

--- a/common/src/main/java/com/logistics/core/machine/MachineComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineComponent.java
@@ -5,6 +5,7 @@ import com.logistics.core.lib.fluids.IFluidStorage;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -73,5 +74,10 @@ public interface MachineComponent {
         float progress();
 
         boolean isProcessing();
+    }
+
+    /** Banks processing experience and releases it on demand (e.g. when the machine is broken). */
+    interface ExperienceStore {
+        int drainExperience(RandomSource random);
     }
 }

--- a/common/src/main/java/com/logistics/core/machine/MachineEntity.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineEntity.java
@@ -4,6 +4,7 @@ import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.block.ProcessingMachine;
 import com.logistics.core.lib.block.behavior.MenuBehavior;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.block.capability.HasExperienceStorage;
 import com.logistics.core.lib.block.capability.HasFluidStorage;
 import com.logistics.core.lib.block.capability.HasItemStorage;
 import com.logistics.core.lib.energy.IEnergyStorage;
@@ -41,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public abstract class MachineEntity extends BaseBlockEntity
         implements MachineContext, HasItemStorage, HasEnergyStorage, HasFluidStorage,
-                WorldlyContainer, MenuBehavior.HasMenu, EnergyDemandProvider, ProcessingMachine {
+                HasExperienceStorage, WorldlyContainer, MenuBehavior.HasMenu, EnergyDemandProvider, ProcessingMachine {
 
     private static final int[] NO_SLOTS = new int[0];
 
@@ -87,6 +88,11 @@ public abstract class MachineEntity extends BaseBlockEntity
     @Override
     public long networkDemandPerTick() {
         return components.find(MachineComponent.Demand.class).map(MachineComponent.Demand::networkDemandPerTick).orElse(0L);
+    }
+
+    @Override
+    public int drainExperience(RandomSource random) {
+        return components.find(MachineComponent.ExperienceStore.class).map(s -> s.drainExperience(random)).orElse(0);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
@@ -7,11 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,7 +19,8 @@ import org.jetbrains.annotations.Nullable;
  * <p>The pure spend/complete decision lives in {@link RecipeProcessPlan} for unit-testing; this
  * class wires it to sibling item/energy components and toggles the machine's "lit" state.
  */
-public final class RecipeProcessorComponent implements MachineComponent, MachineComponent.ProcessState {
+public final class RecipeProcessorComponent
+        implements MachineComponent, MachineComponent.ProcessState, MachineComponent.ExperienceStore {
 
     /** Toggles the machine's working/lit block state. */
     @FunctionalInterface
@@ -38,6 +36,7 @@ public final class RecipeProcessorComponent implements MachineComponent, Machine
     private final Runnable onChanged;
 
     private long energySpent;
+    private float storedExperience;
     @Nullable
     private RecipePlan activePlan;
 
@@ -106,7 +105,9 @@ public final class RecipeProcessorComponent implements MachineComponent, Machine
         if (result.complete()) {
             io.consumeInput(plan.inputCount());
             io.produceOutputs(plan.result(), rollByproducts(plan.byproducts(), ctx.random()));
-            awardExperience(ctx, plan.experience());
+            if (plan.experience() > 0) {
+                storedExperience += plan.experience();
+            }
             energySpent = 0;
             activePlan = null;
         }
@@ -135,17 +136,15 @@ public final class RecipeProcessorComponent implements MachineComponent, Machine
                 && ItemStack.isSameItemSameComponents(a.result(), b.result());
     }
 
-    private void awardExperience(MachineContext ctx, float experience) {
-        if (experience <= 0 || !(ctx.level() instanceof ServerLevel serverLevel)) {
-            return;
-        }
-        int xp = (int) experience;
-        if (ctx.random().nextFloat() < (experience - xp)) {
+    @Override
+    public int drainExperience(RandomSource random) {
+        int xp = (int) storedExperience;
+        float fraction = storedExperience - xp;
+        if (fraction > 0 && random.nextFloat() < fraction) {
             xp++;
         }
-        if (xp > 0) {
-            ExperienceOrb.award(serverLevel, Vec3.atCenterOf(ctx.pos()), xp);
-        }
+        storedExperience = 0;
+        return xp;
     }
 
     // ----- ProcessState -----
@@ -180,11 +179,15 @@ public final class RecipeProcessorComponent implements MachineComponent, Machine
         if (energySpent > 0) {
             tag.putLong("energySpent", energySpent);
         }
+        if (storedExperience > 0) {
+            tag.putFloat("storedExperience", storedExperience);
+        }
     }
 
     @Override
     public void load(CompoundTag tag, HolderLookup.Provider registries) {
         energySpent = NbtCompat.getLong(tag, "energySpent", 0L);
+        storedExperience = NbtCompat.getFloat(tag, "storedExperience", 0f);
         // activePlan is re-resolved on the next tick.
     }
 

--- a/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
@@ -198,6 +198,57 @@ class RecipeProcessorComponentTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    void banksExperienceOnCompletionAndDrainsItOnce() {
+        FakeProcessIO io = new FakeProcessIO();
+        io.energy = 1_000;
+        RecipePlan plan = new RecipePlan(20, 1, new ItemStack(Items.IRON_INGOT), List.of(), 2f);
+        RecipeProcessorComponent processor = processor(io, plan, 10);
+        FakeMachineContext ctx = new FakeMachineContext();
+
+        processor.serverTick(ctx); // 10
+        processor.serverTick(ctx); // 20 -> complete, banks 2 XP
+
+        net.minecraft.util.RandomSource random = net.minecraft.util.RandomSource.create();
+        assertThat(processor.drainExperience(random)).isEqualTo(2);
+        assertThat(processor.drainExperience(random)).isZero(); // drained, not re-awarded
+    }
+
+    @Test
+    void accumulatesFractionalExperienceIntoWholePoints() {
+        FakeProcessIO io = new FakeProcessIO();
+        io.energy = 1_000;
+        RecipePlan plan = new RecipePlan(20, 1, new ItemStack(Items.IRON_INGOT), List.of(), 0.5f);
+        RecipeProcessorComponent processor = processor(io, plan, 10);
+        FakeMachineContext ctx = new FakeMachineContext();
+
+        for (int i = 0; i < 4; i++) {
+            processor.serverTick(ctx); // two completions of 0.5 XP -> 1.0 banked
+        }
+
+        // 0.5 + 0.5 = 1.0 exactly, so the whole point drops regardless of the rounding roll.
+        assertThat(processor.drainExperience(net.minecraft.util.RandomSource.create())).isEqualTo(1);
+    }
+
+    @Test
+    void persistsBankedExperienceAcrossReload() {
+        FakeProcessIO io = new FakeProcessIO();
+        io.energy = 1_000;
+        RecipePlan plan = new RecipePlan(20, 1, new ItemStack(Items.IRON_INGOT), List.of(), 3f);
+        RecipeProcessorComponent processor = processor(io, plan, 10);
+        FakeMachineContext ctx = new FakeMachineContext();
+
+        processor.serverTick(ctx);
+        processor.serverTick(ctx); // complete, banks 3 XP
+
+        net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
+        processor.save(tag, null);
+
+        RecipeProcessorComponent reloaded = processor(new FakeProcessIO(), plan, 10);
+        reloaded.load(tag, null);
+        assertThat(reloaded.drainExperience(net.minecraft.util.RandomSource.create())).isEqualTo(3);
+    }
+
+    @Test
     void stallsUntilInputCountIsAvailable() {
         FakeProcessIO io = new FakeProcessIO();
         io.energy = 1_000;

--- a/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
@@ -249,6 +249,36 @@ class RecipeProcessorComponentTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    void roundsFractionalExperienceUpAfterReload() {
+        // Probe the seeded RNG's first roll so we can bank a fraction guaranteed to round up,
+        // making the rounding branch in drainExperience deterministic.
+        final long seed = 42L;
+        float roll = net.minecraft.util.RandomSource.create(seed).nextFloat();
+        float fraction = (roll + 1.0f) / 2.0f; // strictly between roll and 1 -> always rounds up
+        float experience = 2.0f + fraction;
+
+        FakeProcessIO io = new FakeProcessIO();
+        io.energy = 1_000;
+        RecipePlan plan = new RecipePlan(20, 1, new ItemStack(Items.IRON_INGOT), List.of(), experience);
+        RecipeProcessorComponent processor = processor(io, plan, 10);
+        FakeMachineContext ctx = new FakeMachineContext();
+
+        processor.serverTick(ctx);
+        processor.serverTick(ctx); // complete, banks a fractional XP amount
+
+        net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
+        processor.save(tag, null);
+        assertThat(tag.contains("storedExperience")).isTrue();
+
+        RecipeProcessorComponent reloaded = processor(new FakeProcessIO(), plan, 10);
+        reloaded.load(tag, null);
+
+        // 2 whole points + a fraction that beats the seeded roll -> 3 (rounding branch, not truncation).
+        assertThat(reloaded.drainExperience(net.minecraft.util.RandomSource.create(seed))).isEqualTo(3);
+        assertThat(reloaded.drainExperience(net.minecraft.util.RandomSource.create(seed))).isZero();
+    }
+
+    @Test
     void stallsUntilInputCountIsAvailable() {
         FakeProcessIO io = new FakeProcessIO();
         io.energy = 1_000;


### PR DESCRIPTION
## Summary
The electric kiln (and the macerator) spat out experience orbs the instant each item finished processing. A vanilla furnace instead **banks** the experience and releases it later — these machines should do the same.

Now any machine on the shared recipe processor accumulates processing experience internally, persists it, and releases it like a furnace:
- **When a player takes an item from the output slot** — orbs spawn at the player, the way a furnace pays out.
- **When the block is broken** — any still-banked experience drops at the block so it's never lost.

## Changes
- The shared recipe processor banks recipe experience instead of spawning orbs on completion; the banked amount is saved/loaded with the block entity.
- New `HasExperienceStorage` capability exposes the banked experience.
- `MachineResultSlot` (furnace-style result slot) releases the banked experience to the player on take; the kiln and macerator output slots now use it.
- `MachineBlock` drops any remaining banked experience when the machine is broken.
- Fractional experience accumulates across operations and is rounded once on release, matching vanilla furnace behavior.

## Notes
- The kiln (vanilla smelting XP) and the macerator (ore/gem maceration XP) both benefit. The sawmill's recipes grant no experience, so it's unaffected.
- On-break release happens on player break; like a vanilla furnace, experience isn't recovered if the block is destroyed by other means (explosion, etc.).

## Suggested squash commit
```
fix(kiln): bank smelting XP and pay it out like a furnace

fix(macerator): bank maceration XP and pay it out like a furnace
```