### PR TITLE
fix(routing): refresh neighbor pipe arms when markings change

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/pipe/IModuleHost.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/IModuleHost.java
@@ -36,6 +36,9 @@ public interface IModuleHost {
     /** Mark the block entity as changed so it is saved on the next world save. */
     void markDirty();
 
+    /** Force the connection arms to be recomputed on the next tick. */
+    void invalidateConnectionCache();
+
     /**
      * Return the cached connection type for the given direction.
      * Always uses the value computed on the last tick without re-probing neighbours.

--- a/common/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/PipeContext.java
@@ -164,6 +164,25 @@ public record PipeContext(
     }
 
     /**
+     * Sync this pipe and force it plus any neighboring pipes to recompute their connection arms.
+     * Use after a change that can connect/disconnect arms (e.g. markings) but doesn't go through a
+     * block update — neighbors otherwise keep a stale arm because their cache is never invalidated.
+     */
+    public void markConnectionsChanged() {
+        markDirtyAndSync();
+
+        if (world == null || world.isClientSide()) {
+            return;
+        }
+        blockEntity.invalidateConnectionCache();
+        for (Direction direction : Direction.values()) {
+            if (world.getBlockEntity(pos.relative(direction)) instanceof IModuleHost neighbor) {
+                neighbor.invalidateConnectionCache();
+            }
+        }
+    }
+
+    /**
      * Check if this pipe is receiving redstone power.
      * Used by modules like BoostModule to conditionally enable behaviors.
      *

--- a/common/src/main/java/com/logistics/pipe/modules/PipeMarkingModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/PipeMarkingModule.java
@@ -86,7 +86,7 @@ public class PipeMarkingModule implements Module {
         }
 
         ctx.saveString(this, COLOR_KEY, colorId);
-        ctx.markDirtyAndSync();
+        ctx.markConnectionsChanged();
         EquipmentSlot slot = usage.getHand() == InteractionHand.MAIN_HAND
                 ? EquipmentSlot.MAINHAND
                 : EquipmentSlot.OFFHAND;
@@ -105,7 +105,7 @@ public class PipeMarkingModule implements Module {
                     return InteractionResult.SUCCESS;
                 }
                 ctx.remove(this, COLOR_KEY);
-                ctx.markDirtyAndSync();
+                ctx.markConnectionsChanged();
             }
             return InteractionResult.SUCCESS;
         }

--- a/common/src/test/java/com/logistics/pipe/modules/ChassisModuleConfigScopingTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/ChassisModuleConfigScopingTest.java
@@ -185,6 +185,9 @@ class ChassisModuleConfigScopingTest extends MinecraftTestEnvironment {
         public void markDirty() {}
 
         @Override
+        public void invalidateConnectionCache() {}
+
+        @Override
         public PipeConnection.Type getCachedConnectionType(Direction direction) {
             return PipeConnection.Type.NONE;
         }

--- a/common/src/test/java/com/logistics/pipe/ui/PipeModuleHelperTest.java
+++ b/common/src/test/java/com/logistics/pipe/ui/PipeModuleHelperTest.java
@@ -128,6 +128,9 @@ class PipeModuleHelperTest extends MinecraftTestEnvironment {
         public void markDirty() {}
 
         @Override
+        public void invalidateConnectionCache() {}
+
+        @Override
         public PipeConnection.Type getCachedConnectionType(Direction direction) {
             return PipeConnection.Type.NONE;
         }

--- a/common/src/test/java/com/logistics/test/FakePipeAccess.java
+++ b/common/src/test/java/com/logistics/test/FakePipeAccess.java
@@ -63,6 +63,11 @@ public class FakePipeAccess implements IPipeAccess {
     }
 
     @Override
+    public void invalidateConnectionCache() {
+        // no-op in tests
+    }
+
+    @Override
     public PipeConnection.Type getCachedConnectionType(Direction direction) {
         return connections.getOrDefault(direction, PipeConnection.Type.NONE);
     }


### PR DESCRIPTION
## Summary
Marking a pipe (or clearing its marking) can connect or disconnect it from a differently-marked neighbor. Routing updated correctly, but the **neighbor kept rendering an arm** toward the now-disconnected pipe.

A pipe only recomputes its connection arms when its connection cache is invalidated, which normally happens through a neighbor block update. Applying a marking only re-rendered the marked pipe — it never invalidated the neighbors' caches, so they held onto stale arms until some other block update nudged them.

## Changes
- `PipeContext.markConnectionsChanged()` — syncs the pipe and invalidates the connection cache on it **and** every adjacent pipe, so all sides recompute their arms next tick.
- The marking module uses it when applying and when clearing a marking.
- Added `invalidateConnectionCache()` to the `IModuleHost` contract (both item and fluid pipe hosts already implement it).

## Suggested squash commit
```
fix(routing): refresh neighbor pipe arms when markings change
```