### PR TITLE
balance(quarry): yield one marker per craft

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/core/marker.json
+++ b/common/src/main/resources/data/logistics/recipe/core/marker.json
@@ -7,6 +7,6 @@
   },
   "result": {
     "id": "logistics:core/marker",
-    "count": 2
+    "count": 1
   }
 }


### PR DESCRIPTION
## Summary
The marker recipe (lapis dust + stick) produced **two** markers per craft. That's generous for a cheap, reusable placement tool — drop it to one.

## Changes
- Marker crafting recipe now yields 1 marker instead of 2.

## Suggested squash commit
```
balance(quarry): yield one marker per craft
```