### PR TITLE
balance(worldgen): tin ore drops one raw tin

### DIFF
--- a/common/src/main/resources/data/logistics/loot_table/blocks/core/deepslate_tin_ore.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/core/deepslate_tin_ore.json
@@ -32,15 +32,6 @@
               "type": "minecraft:item",
               "functions": [
                 {
-                  "function": "minecraft:set_count",
-                  "count": {
-                    "type": "minecraft:uniform",
-                    "min": 2.0,
-                    "max": 5.0
-                  },
-                  "add": false
-                },
-                {
                   "enchantment": "minecraft:fortune",
                   "formula": "minecraft:ore_drops",
                   "function": "minecraft:apply_bonus"

--- a/common/src/main/resources/data/logistics/loot_table/blocks/core/tin_ore.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/core/tin_ore.json
@@ -32,15 +32,6 @@
               "type": "minecraft:item",
               "functions": [
                 {
-                  "function": "minecraft:set_count",
-                  "count": {
-                    "type": "minecraft:uniform",
-                    "min": 2.0,
-                    "max": 5.0
-                  },
-                  "add": false
-                },
-                {
                   "enchantment": "minecraft:fortune",
                   "formula": "minecraft:ore_drops",
                   "function": "minecraft:apply_bonus"


### PR DESCRIPTION
## Summary
Tin ore and deepslate tin ore dropped **2–5** raw tin each — far more generous than vanilla iron/gold ore (which drop one). Bring tin in line: one raw tin per ore.

## Changes
- Tin ore and deepslate tin ore now drop **1** raw tin (down from 2–5).
- Fortune (`apply_bonus` / ore drops) and explosion decay are unchanged, so Fortune still multiplies the drop exactly like vanilla ores.

## Suggested squash commit
```
balance(worldgen): tin ore drops one raw tin
```