### PR TITLE
fix(sawmill): add the missing crafting recipe

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/automation/sawmill.json
+++ b/common/src/main/resources/data/logistics/recipe/automation/sawmill.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [" A ", "LML", "GCG"],
+  "key": {
+    "A": "minecraft:iron_axe",
+    "L": "#minecraft:planks",
+    "M": "logistics:core/machine_core",
+    "G": "logistics:core/copper_gear",
+    "C": "logistics:core/redstone_reception_coil"
+  },
+  "result": { "id": "logistics:automation/sawmill", "count": 1 }
+}


### PR DESCRIPTION
## Summary
The sawmill block shipped without a crafting recipe, so it was uncraftable in survival (only reachable from the creative tab). This adds one, following the shared tier‑1 machine grammar (identity item on top, `machine_core` center, `redstone_reception_coil` bottom-center, copper gears in the corners).

## Recipe
```
. A .     A = iron axe (cutting identity)
L M L     L = any planks (#minecraft:planks)   M = machine core
G C G     G = copper gear   C = redstone reception coil
```
Yields one sawmill.

## Suggested squash commit
```
fix(sawmill): add the missing crafting recipe
```