### PR TITLE
refactor(automation): derive machine energy demand from the buffer

### DIFF
--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -77,7 +77,6 @@ public class KilnBlockEntity extends MachineEntity {
         energy = machine.energy("energy")
                 .capacity(ENERGY_CAPACITY)
                 .maxInput(MAX_ENERGY_INPUT)
-                .providesDemand()
                 .build();
 
         var items = machine.items("inventory")

--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/LaserQuarryBlockEntity.java
@@ -45,7 +45,6 @@ public class LaserQuarryBlockEntity extends MachineEntity implements PipeConnect
         energy = machine.energy("energy")
                 .capacity(cfg.energyCapacity())
                 .maxInput(cfg.maxEnergyInput())
-                .providesDemand()
                 .build();
         quarry = machine.add(new QuarryComponent("quarry", getBlockPos(), energy, upgrades.modifiers()));
         machine.chunkLoader("chunks")

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
@@ -76,7 +76,6 @@ public class MaceratorBlockEntity extends MachineEntity {
         energy = machine.energy("energy")
                 .capacity(ENERGY_CAPACITY)
                 .maxInput(MAX_ENERGY_INPUT)
-                .providesDemand()
                 .build();
 
         var items = machine.items("inventory")

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
@@ -79,7 +79,6 @@ public class SawmillBlockEntity extends MachineEntity {
         energy = machine.energy("energy")
                 .capacity(ENERGY_CAPACITY)
                 .maxInput(MAX_ENERGY_INPUT)
-                .providesDemand()
                 .build();
 
         var items = machine.items("inventory")

--- a/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineBuilder.java
@@ -95,7 +95,6 @@ public final class MachineBuilder {
         private long capacity;
         private long maxInput;
         private long maxOutput;
-        private boolean providesDemand;
 
         private EnergyBuilder(String id) {
             this.id = id;
@@ -116,15 +115,10 @@ public final class MachineBuilder {
             return this;
         }
 
-        /** Track energy received per tick and report it as logistics-network demand. */
-        public EnergyBuilder providesDemand() {
-            this.providesDemand = true;
-            return this;
-        }
-
         public EnergyStorageComponent build() {
-            return components.add(new EnergyStorageComponent(
-                    id, capacity, maxInput, maxOutput, providesDemand, providesDemand, onChanged));
+            // A buffer that accepts input (maxInput > 0) reports demand and pulls from the power
+            // network automatically; no opt-in needed.
+            return components.add(new EnergyStorageComponent(id, capacity, maxInput, maxOutput, onChanged));
         }
     }
 

--- a/common/src/main/java/com/logistics/core/machine/component/EnergyStorageComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/EnergyStorageComponent.java
@@ -12,8 +12,10 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Energy buffer component wrapping the loader-agnostic {@link EnergyComponent} holder.
  *
- * <p>Optionally tracks energy received this tick and reports it as network demand, mirroring the
- * tracking-storage pattern that machines like the Macerator use today. Demand and received-tick
+ * <p>Reports power-network demand derived from the buffer itself — the remaining per-tick input
+ * ({@code maxInsert}) minus what was already received this tick, clamped to free room. A buffer with
+ * {@code maxInsert > 0} therefore pulls from the cable network automatically; a machine opts out of
+ * network power simply by not accepting input ({@code maxInsert == 0}). Demand and received-tick
  * tracking require this component to tick before any work component that spends energy — which the
  * host guarantees by registration order.
  */
@@ -25,8 +27,6 @@ public final class EnergyStorageComponent implements MachineComponent, MachineCo
     private final EnergyComponent storage;
     private final long capacity;
     private final long maxInsert;
-    private final boolean trackReceived;
-    private final boolean exposeDemand;
 
     private long receivedThisTick;
     private long receivedLastTick;
@@ -35,7 +35,7 @@ public final class EnergyStorageComponent implements MachineComponent, MachineCo
         @Override
         public long insert(long maxAmount, boolean simulate) {
             long inserted = storage.insert(maxAmount, simulate);
-            if (trackReceived && !simulate && inserted > 0) {
+            if (!simulate && inserted > 0) {
                 receivedThisTick += inserted;
             }
             return inserted;
@@ -68,19 +68,11 @@ public final class EnergyStorageComponent implements MachineComponent, MachineCo
     };
 
     public EnergyStorageComponent(
-            String id,
-            long capacity,
-            long maxInsert,
-            long maxExtract,
-            boolean trackReceived,
-            boolean exposeDemand,
-            Runnable onChanged) {
+            String id, long capacity, long maxInsert, long maxExtract, Runnable onChanged) {
         this.id = id;
         this.storage = new EnergyComponent(capacity, maxInsert, maxExtract, onChanged);
         this.capacity = capacity;
         this.maxInsert = maxInsert;
-        this.trackReceived = trackReceived;
-        this.exposeDemand = exposeDemand;
     }
 
     @Override
@@ -94,7 +86,7 @@ public final class EnergyStorageComponent implements MachineComponent, MachineCo
         receivedThisTick = 0;
     }
 
-    /** Energy received during the previous tick (for HUD readouts); requires {@code trackReceived}. */
+    /** Energy received during the previous tick (for HUD readouts). */
     public long receivedLastTick() {
         return receivedLastTick;
     }
@@ -107,9 +99,6 @@ public final class EnergyStorageComponent implements MachineComponent, MachineCo
 
     @Override
     public long networkDemandPerTick() {
-        if (!exposeDemand) {
-            return 0;
-        }
         long storageRoom = Math.max(0, capacity - storage.getAmount());
         long remainingInput = Math.max(0, maxInsert - receivedThisTick);
         return Math.min(remainingInput, storageRoom);

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
@@ -48,7 +48,6 @@ public class FluidPumpBlockEntity extends MachineEntity implements AcceptsLowTie
         energy = machine.energy("energy")
                 .capacity(cfg.energyCapacity)
                 .maxInput(cfg.maxEnergyInput)
-                .providesDemand()
                 .build();
         fluidStore = machine.fluids("tank")
                 .capacity(FluidUnits.mb(cfg.tankCapacityMb))

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryMigrationTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryMigrationTest.java
@@ -22,7 +22,7 @@ class QuarryMigrationTest extends MinecraftTestEnvironment {
             RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
 
     private static EnergyStorageComponent energyComponent() {
-        return new EnergyStorageComponent("energy", 10_000L, 128L, 0L, true, true, () -> {});
+        return new EnergyStorageComponent("energy", 10_000L, 128L, 0L, () -> {});
     }
 
     @Test

--- a/common/src/test/java/com/logistics/core/machine/MachineEntityPersistenceTest.java
+++ b/common/src/test/java/com/logistics/core/machine/MachineEntityPersistenceTest.java
@@ -36,7 +36,7 @@ class MachineEntityPersistenceTest extends MinecraftTestEnvironment {
 
         @Override
         protected void configure(MachineBuilder machine) {
-            machine.energy("energy").capacity(10_000).maxInput(128).providesDemand().build();
+            machine.energy("energy").capacity(10_000).maxInput(128).build();
             machine.items("inventory").slots(SlotRole.INPUT, SlotRole.OUTPUT).bottomOutAccess().build();
         }
 

--- a/common/src/test/java/com/logistics/core/machine/component/EnergyStorageComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/EnergyStorageComponentTest.java
@@ -8,13 +8,13 @@ import org.junit.jupiter.api.Test;
 
 class EnergyStorageComponentTest extends MinecraftTestEnvironment {
 
-    private EnergyStorageComponent withDemand() {
-        return new EnergyStorageComponent("energy", 1_000, 128, 0, true, true, () -> {});
+    private EnergyStorageComponent buffer() {
+        return new EnergyStorageComponent("energy", 1_000, 128, 0, () -> {});
     }
 
     @Test
     void demandReflectsRoomAndRemainingInput() {
-        EnergyStorageComponent energy = withDemand();
+        EnergyStorageComponent energy = buffer();
 
         // Empty buffer: demand is limited by max input (128), not the 1000 of room.
         assertThat(energy.networkDemandPerTick()).isEqualTo(128);
@@ -22,7 +22,7 @@ class EnergyStorageComponentTest extends MinecraftTestEnvironment {
 
     @Test
     void receivedEnergyReducesDemandUntilTickReset() {
-        EnergyStorageComponent energy = withDemand();
+        EnergyStorageComponent energy = buffer();
         FakeMachineContext ctx = new FakeMachineContext();
 
         energy.energy(null).insert(50, false);
@@ -36,7 +36,7 @@ class EnergyStorageComponentTest extends MinecraftTestEnvironment {
 
     @Test
     void demandClampedByRemainingRoom() {
-        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100, 128, 0, true, true, () -> {});
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100, 128, 0, () -> {});
 
         energy.energy(null).insert(100, false); // fill to capacity
         energy.serverTick(new FakeMachineContext()); // clear received counter
@@ -44,14 +44,15 @@ class EnergyStorageComponentTest extends MinecraftTestEnvironment {
     }
 
     @Test
-    void demandIsZeroWhenNotExposed() {
-        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 1_000, 128, 0, true, false, () -> {});
+    void demandIsZeroWhenInputDisabled() {
+        // A buffer that accepts no input (maxInsert == 0) reports no demand — the natural opt-out.
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 1_000, 0, 0, () -> {});
         assertThat(energy.networkDemandPerTick()).isZero();
     }
 
     @Test
     void consumeReducesStoredEnergy() {
-        EnergyStorageComponent energy = withDemand();
+        EnergyStorageComponent energy = buffer();
         energy.energy(null).insert(100, false);
         energy.consume(30);
         assertThat(energy.amount()).isEqualTo(70);

--- a/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
@@ -172,7 +172,7 @@ class RecipeProcessorComponentTest extends MinecraftTestEnvironment {
                 new SlotRole[] {SlotRole.INPUT, SlotRole.OUTPUT, SlotRole.OUTPUT},
                 SidedLayout.furnace(new int[] {0}, new int[] {1, 2}, stack -> true),
                 noop);
-        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 0, false, false, noop);
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 0, noop);
         energy.energy(null).insert(100_000, false);
 
         items.container().setItem(0, new ItemStack(Items.RAW_IRON, 1));


### PR DESCRIPTION
## Summary
A machine's energy buffer required an explicit `.providesDemand()` call to pull from the power network. Forgetting it left the machine **silently unpowered** — exactly the kiln bug (#602): `MachineEntity` always advertises energy demand, so the cable network asked the machine how much it wanted, and without the opt-in the answer was `0`.

Demand is fully determined by the buffer itself, so the opt-in was redundant ceremony. This removes it: a buffer that accepts input (`maxInput > 0`) reports demand and pulls from the power network automatically. A machine opts out of network power by simply not accepting input (`maxInput == 0`) — which reads exactly like what it does.

## Changes
- `EnergyStorageComponent`: demand is now always `min(maxInput − receivedThisTick, free room)`; dropped the `trackReceived`/`exposeDemand` flags and simplified the constructor.
- `MachineBuilder`: removed the `providesDemand()` builder method.
- Removed the now-unnecessary `.providesDemand()` call from all five machines (pump, quarry, macerator, kiln, sawmill).
- Updated tests; replaced the `not-exposed` case with a `maxInput == 0` opt-out case.

## Notes
- No player-visible change — every machine already opted in, so behavior is identical.
- Also clears up misleading wording: the dropped method's doc called this "logistics-network demand," but it's the **power/cable network** (`EnergyDemandProvider` lives in the power domain). Machines never interacted with the item-logistics network for energy in either direction.

## Suggested squash commit
```
refactor(automation): derive machine energy demand from the buffer
```