### PR TITLE
feat(sawmill): show recipes in JEI and details in the Jade HUD

### DIFF
--- a/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillJeiPlugin.java
+++ b/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillJeiPlugin.java
@@ -1,0 +1,64 @@
+package com.logistics.automation.sawmill.jei;
+
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsMod;
+import com.logistics.automation.sawmill.SawmillRecipe;
+import com.logistics.core.lib.resource.ResourceId;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+import net.minecraft.client.Minecraft;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * JEI plugin that registers the Sawmill recipe category and all sawmill recipes.
+ * Discovered by JEI via the "jei_mod_plugin" Fabric entrypoint in fabric.mod.json.
+ */
+@JeiPlugin
+public class SawmillJeiPlugin implements IModPlugin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("Logistics/JEI");
+    private static final ResourceId PLUGIN_ID = LogisticsMod.modId("jei_sawmill_plugin");
+
+    @Override
+    public net.minecraft.resources.Identifier getPluginUid() { // raw-id-ok: JEI IModPlugin signature
+        return PLUGIN_ID.toIdentifier();
+    }
+
+    @Override
+    public void registerCategories(IRecipeCategoryRegistration registration) {
+        LOGGER.info("Registering sawmill recipe category");
+        registration.addRecipeCategories(
+            new SawmillRecipeCategory(registration.getJeiHelpers().getGuiHelper()));
+    }
+
+    @Override
+    public void registerRecipes(IRecipeRegistration registration) {
+        // Full recipe data only exists on the (integrated) server; clients are not sent the
+        // recipe list in modern Minecraft, so JEI shows sawmill recipes in singleplayer.
+        MinecraftServer server = Minecraft.getInstance().getSingleplayerServer();
+        if (server == null) {
+            return;
+        }
+        List<SawmillRecipe> recipes = server.getRecipeManager().getRecipes().stream()
+            .map(RecipeHolder::value)
+            .filter(SawmillRecipe.class::isInstance)
+            .map(SawmillRecipe.class::cast)
+            .toList();
+        LOGGER.info("Registering {} sawmill recipes with JEI", recipes.size());
+        registration.addRecipes(SawmillRecipeCategory.RECIPE_TYPE, recipes);
+    }
+
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+        registration.addCraftingStation(
+            SawmillRecipeCategory.RECIPE_TYPE, LogisticsAutomation.BLOCK.SAWMILL);
+    }
+}

--- a/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillRecipeCategory.java
+++ b/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillRecipeCategory.java
@@ -1,0 +1,97 @@
+package com.logistics.automation.sawmill.jei;
+
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsMod;
+import com.logistics.automation.sawmill.SawmillRecipe;
+import com.logistics.core.lib.resource.ResourceId;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.types.IRecipeType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * JEI recipe category for the Sawmill.
+ * Displays an input ingredient cut into a primary product, plus a chance-based byproduct.
+ */
+public class SawmillRecipeCategory implements IRecipeCategory<SawmillRecipe> {
+
+    public static final IRecipeType<SawmillRecipe> RECIPE_TYPE =
+        IRecipeType.create(LogisticsMod.MOD_ID, "sawmill", SawmillRecipe.class);
+
+    // Matches SawmillScreen.TEXTURE
+    private static final ResourceId TEXTURE =
+        LogisticsMod.modId("textures/gui/automation/sawmill.png");
+
+    // Compact JEI layout: input -> arrow -> primary output, with the byproduct beside it.
+    // The filled progress arrow sprite lives at UV (183,24) in the GUI texture (see SawmillScreen).
+    private static final int INPUT_X = 8, INPUT_Y = 9;
+    private static final int ARROW_X = 30, ARROW_Y = 10;
+    private static final int OUTPUT_X = 60, OUTPUT_Y = 9;
+    private static final int BYPRODUCT_X = 82, BYPRODUCT_Y = 9;
+
+    private static final int WIDTH = 104;
+    private static final int HEIGHT = 28;
+
+    private final IDrawable icon;
+    private final IDrawable arrow;
+
+    public SawmillRecipeCategory(IGuiHelper guiHelper) {
+        this.icon = guiHelper.createDrawableItemStack(
+            new ItemStack(LogisticsAutomation.BLOCK.SAWMILL));
+        this.arrow = guiHelper.createDrawable(TEXTURE.toIdentifier(), 183, 24, 22, 14);
+    }
+
+    @Override
+    public IRecipeType<SawmillRecipe> getRecipeType() {
+        return RECIPE_TYPE;
+    }
+
+    @Override
+    public Component getTitle() {
+        return Component.translatable("block.logistics.automation.sawmill");
+    }
+
+    @Override
+    public int getWidth() {
+        return WIDTH;
+    }
+
+    @Override
+    public int getHeight() {
+        return HEIGHT;
+    }
+
+    @Override
+    public IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void createRecipeExtras(IRecipeExtrasBuilder builder, SawmillRecipe recipe, IFocusGroup focuses) {
+        builder.addDrawable(arrow, ARROW_X, ARROW_Y);
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, SawmillRecipe recipe, IFocusGroup focuses) {
+        builder.addSlot(RecipeIngredientRole.INPUT, INPUT_X, INPUT_Y)
+            .add(recipe.ingredient());
+        builder.addSlot(RecipeIngredientRole.OUTPUT, OUTPUT_X, OUTPUT_Y)
+            .add(recipe.getResultItem());
+
+        ItemStack byproduct = recipe.byproduct().stack(1);
+        if (!byproduct.isEmpty()) {
+            float pct = recipe.byproduct().chance() * 100f;
+            String pctStr = pct == Math.rint(pct) ? String.valueOf((int) pct) : String.format("%.1f", pct);
+            builder.addSlot(RecipeIngredientRole.OUTPUT, BYPRODUCT_X, BYPRODUCT_Y)
+                .add(byproduct)
+                .addRichTooltipCallback((view, tooltip) ->
+                    tooltip.add(Component.translatable("jei.logistics.sawmill.byproduct_chance", pctStr)));
+        }
+    }
+}

--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -26,6 +26,7 @@
   "block.logistics.fluid.bypass_fluid_pipe": "Bypass Fluid Pipe",
   "block.logistics.fluid.glass_tank": "Glass Tank",
   "block.logistics.fluid.fluid_pump": "Fluid Pump",
+  "jei.logistics.sawmill.byproduct_chance": "%s%% chance",
   "tooltip.logistics.fluid.tank_capacity": "Holds %s buckets",
   "tooltip.logistics.fluid.tank_empty": "Empty",
   "tooltip.logistics.fluid.tank_contents": "%1$s: %2$s / %3$s mB",

--- a/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
@@ -14,6 +14,7 @@
     "logistics:core/apatite_block",
     "logistics:automation/kiln",
     "logistics:automation/macerator",
-    "logistics:fluid/fluid_pump"
+    "logistics:fluid/fluid_pump",
+    "logistics:automation/sawmill"
   ]
 }

--- a/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
@@ -10,6 +10,7 @@
     "logistics:core/apatite_block",
     "logistics:automation/kiln",
     "logistics:automation/macerator",
-    "logistics:fluid/fluid_pump"
+    "logistics:fluid/fluid_pump",
+    "logistics:automation/sawmill"
   ]
 }

--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -5,6 +5,7 @@ import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.automation.macerator.MaceratorBlock;
+import com.logistics.automation.sawmill.SawmillBlock;
 import com.logistics.pipe.block.FluidPipeBlock;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.power.block.CreativeSinkBlock;
@@ -21,8 +22,8 @@ import snownee.jade.api.WailaPlugin;
  * <p>Per-block content is added in stacked passes; see {@code EngineServerDataProvider} /
  * {@code EngineComponentProvider} for engines, {@code PowerInfra*Provider} for cables and the sink,
  * {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser quarry,
- * {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln, and
- * {@code PipeComponentProvider} for pipes.
+ * {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator, kiln, and
+ * sawmill, and {@code PipeComponentProvider} for pipes.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -34,6 +35,7 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(QuarryServerDataProvider.INSTANCE, LaserQuarryBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, MaceratorBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, KilnBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, SawmillBlock.class);
     }
 
     @Override
@@ -44,6 +46,7 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, MaceratorBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, FluidPipeBlock.class);
     }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,7 +17,10 @@
   "entrypoints": {
     "client": ["com.logistics.LogisticsModClient"],
     "main": ["com.logistics.fabric.LogisticsFabric"],
-    "jei_mod_plugin": ["com.logistics.automation.macerator.jei.MaceratorJeiPlugin"],
+    "jei_mod_plugin": [
+      "com.logistics.automation.macerator.jei.MaceratorJeiPlugin",
+      "com.logistics.automation.sawmill.jei.SawmillJeiPlugin"
+    ],
     "jade": ["com.logistics.compat.jade.JadeLogisticsPlugin"]
   },
   "environment": "*",

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -5,6 +5,7 @@ import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.automation.macerator.MaceratorBlock;
+import com.logistics.automation.sawmill.SawmillBlock;
 import com.logistics.pipe.block.FluidPipeBlock;
 import com.logistics.pipe.block.PipeBlock;
 import com.logistics.power.block.CreativeSinkBlock;
@@ -22,8 +23,8 @@ import snownee.jade.api.WailaPlugin;
  * required by the NeoForge source-isolation rules. Per-block content is added in stacked passes; see
  * {@code EngineServerDataProvider} / {@code EngineComponentProvider} for engines, {@code PowerInfra*Provider}
  * for cables and the sink, {@code QuarryServerDataProvider} / {@code QuarryComponentProvider} for the laser
- * quarry, {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator and kiln,
- * and {@code PipeComponentProvider} for pipes.
+ * quarry, {@code MachineServerDataProvider} / {@code MachineComponentProvider} for the macerator, kiln,
+ * and sawmill, and {@code PipeComponentProvider} for pipes.
  */
 @WailaPlugin(LogisticsMod.MOD_ID)
 public class JadeLogisticsPlugin implements IWailaPlugin {
@@ -35,6 +36,7 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(QuarryServerDataProvider.INSTANCE, LaserQuarryBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, MaceratorBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, KilnBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, SawmillBlock.class);
     }
 
     @Override
@@ -45,6 +47,7 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(QuarryComponentProvider.INSTANCE, LaserQuarryBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, MaceratorBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, FluidPipeBlock.class);
     }


### PR DESCRIPTION
## Summary

The Sawmill was registered but only half-finished: its recipes never showed up in JEI, it exposed nothing to the Jade/WAILA HUD, and — because it had no mineable tag — it couldn't be harvested with the correct tool and **dropped nothing when broken**. This brings it up to parity with the Macerator and Kiln.

balance(sawmill): make the sawmill mineable with a stone-tier pickaxe

## Changes

- **JEI** — new Sawmill recipe category and catalyst: input → primary product, plus the chance-based byproduct shown with a "% chance" tooltip. Discovered on Fabric via the `jei_mod_plugin` entrypoint and on NeoForge via `@JeiPlugin`, mirroring the Macerator.
- **Jade/WAILA** — the Sawmill now shows machine details on the HUD (registered on both Fabric and NeoForge through the shared `Machine*Provider`, since it's a `MachineEntity` like the Kiln).
- **Mining** — added the Sawmill to `mineable/pickaxe` and `needs_stone_tool`, so a stone-or-better pickaxe harvests it and it drops itself (previously unharvestable).

## Notes

- Surfaced by a pre-release QA audit — the Sawmill was the one machine missing the JEI/Jade/tool wiring the others already had.
- Out of scope: the Sawmill's loot table still doesn't `copy_components`, but that's shared with the Macerator and Kiln (a mod-wide consistency decision for another change).