### PR TITLE
fix(fluids): drop fluid pipes and glass tank when broken

### DIFF
--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/bypass_fluid_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/bypass_fluid_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/bypass_fluid_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/copper_fluid_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/copper_fluid_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/copper_fluid_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/fluid_extractor_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/fluid_extractor_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/fluid_extractor_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/glass_tank.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/glass_tank.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/glass_tank",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/gold_fluid_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/gold_fluid_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/gold_fluid_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/insertion_fluid_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/insertion_fluid_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/insertion_fluid_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/merger_fluid_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/merger_fluid_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/merger_fluid_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/stone_fluid_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/stone_fluid_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/stone_fluid_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/logistics/loot_table/blocks/fluid/void_fluid_pipe.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/fluid/void_fluid_pipe.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "name": "logistics:fluid/void_fluid_pipe",
+          "type": "minecraft:item"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
@@ -13,6 +13,7 @@
     "logistics:core/apatite_ore",
     "logistics:core/apatite_block",
     "logistics:automation/kiln",
-    "logistics:automation/macerator"
+    "logistics:automation/macerator",
+    "logistics:fluid/fluid_pump"
   ]
 }

--- a/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
@@ -9,6 +9,7 @@
     "logistics:core/apatite_ore",
     "logistics:core/apatite_block",
     "logistics:automation/kiln",
-    "logistics:automation/macerator"
+    "logistics:automation/macerator",
+    "logistics:fluid/fluid_pump"
   ]
 }


### PR DESCRIPTION
## Summary

Two harvest/drop fixes for fluid blocks found via the release-QA audit on `mc/26.2`. Both are invisible in creative testing.

fix(fluids): drop fluid pipes and glass tank when broken
fix(fluids): make the fluid pump harvestable with a pickaxe

## Changes

- **Loot tables** — all 8 fluid pipes (copper, stone, gold, insertion, merger, fluid extractor, void, bypass) and the glass tank had no loot table, so breaking them in survival dropped **nothing**. Added self-drop tables matching the existing `fluid_pump` structure. The glass tank drops the item only — stored fluid is **not** preserved on break, consistent with every other machine/pipe.
- **Fluid pump tool gate** — the pump uses `requiresCorrectToolForDrops()` but was in no `mineable` or `needs_*_tool` tag, so the gate never passed and it was unharvestable. Added it to `mineable/pickaxe` and `needs_stone_tool` (same tier as the kiln/macerator).

## Notes

- `power/creative_sink` also lacks a loot table but is left as-is (separate call for a creative/admin block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)