### PR TITLE
fix(energy): drop the creative sink when broken

### DIFF
--- a/common/src/main/resources/data/logistics/loot_table/blocks/power/creative_sink.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/power/creative_sink.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "logistics:power/creative_sink"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The creative power sink had no loot table, so breaking it in survival destroyed it with no drop. Its sibling `creative_engine` already self-drops; this brings the sink in line.

## Changes

- Add a self-drop loot table for `power/creative_sink` (matches `creative_engine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)