### PR TITLE
fix(quarry): give the laser quarry frame a display name

### DIFF
--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -217,6 +217,7 @@
   "gui.logistics.process.state.idle": "Idle",
   "gui.logistics.process.state.active": "Active",
   "block.logistics.automation.laser_quarry": "Laser Quarry",
+  "block.logistics.automation.laser_quarry_frame": "Laser Quarry Frame",
   "laser_quarry.area_preview": "Mining area: %sx%s blocks",
   "block.logistics.automation.macerator": "Macerator",
   "container.logistics.macerator": "Macerator",


### PR DESCRIPTION
## Summary

The laser quarry frame block had no lang key, so its name showed as the raw translation string (e.g. in the Jade HUD / debug screen). It's a structural block placed by the quarry rather than a craftable item, but it should still read as a proper name when surfaced.

## Changes

- Add `block.logistics.automation.laser_quarry_frame` = "Laser Quarry Frame".

🤖 Generated with [Claude Code](https://claude.com/claude-code)