### PR TITLE
balance(pipes): raise pipe blast resistance to match glass

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsFluid.java
+++ b/common/src/main/java/com/logistics/LogisticsFluid.java
@@ -66,7 +66,7 @@ public final class LogisticsFluid extends LogisticsMod {
 
         private static BlockBehaviour.Properties fluidPipeProps(BlockBehaviour.Properties props) {
             return props.mapColor(MapColor.NONE)
-                    .strength(0.25f)
+                    .strength(0.3f)
                     .sound(SoundType.METAL)
                     .noOcclusion();
         }

--- a/common/src/main/java/com/logistics/LogisticsPipe.java
+++ b/common/src/main/java/com/logistics/LogisticsPipe.java
@@ -94,7 +94,7 @@ public final class LogisticsPipe extends LogisticsMod implements DomainBootstrap
 
         private static Block.Properties pipeProps(Block.Properties props) {
             return props.mapColor(MapColor.NONE)
-                    .strength(0.25f)
+                    .strength(0.3f)
                     .sound(SoundType.METAL)
                     .noOcclusion();
         }


### PR DESCRIPTION
## Summary

Item and fluid pipes were a touch flimsier than glass under explosions (0.25 vs glass's 0.3). Bumps them to match glass exactly, so a stray creeper or TNT treats pipes the same as a glass block.

## Changes

- `pipeProps` and `fluidPipeProps` now use `.strength(0.3f)` (hardness + blast resistance), up from `0.25f`. Sound stays metal.
- Affects all item pipes and all fluid pipes; the glass tank (already 0.5) and fluid pump are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)