### PR TITLE
fix(fluids): show correct fill level on tank and pipe HUDs

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/fluids/FluidTankComponent.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/FluidTankComponent.java
@@ -86,9 +86,11 @@ public class FluidTankComponent implements IFluidStorage {
         if (fluid == Fluids.EMPTY || amount <= 0) return Collections.emptyList();
         IFluidKey key = currentKey();
         long currentAmount = amount;
+        long currentCapacity = capacity;
         return Collections.singletonList(new IFluidView() {
             @Override public IFluidKey resource() { return key; }
             @Override public long amount() { return currentAmount; }
+            @Override public long capacity() { return currentCapacity; }
         });
     }
 

--- a/common/src/main/java/com/logistics/core/lib/fluids/IFluidView.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/IFluidView.java
@@ -17,4 +17,13 @@ public interface IFluidView {
 
     /** The amount of fluid available in this view, in platform-native units. Always {@code > 0}. */
     long amount();
+
+    /**
+     * The total capacity backing this view's resource, in platform-native units. Used for HUD/fill
+     * displays; always {@code >= amount()}. Defaults to {@link #amount()} for storages that don't
+     * track a distinct capacity.
+     */
+    default long capacity() {
+        return amount();
+    }
 }

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeFluidStorage.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeFluidStorage.java
@@ -56,6 +56,7 @@ public final class PipeFluidStorage implements IFluidStorage {
             return Collections.emptyList();
         }
         long nativeAmount = FluidUnits.mb(total);
+        long nativeCapacity = FluidUnits.mb(pipe.capacityMillibuckets());
         return List.of(new IFluidView() {
             @Override
             public IFluidKey resource() {
@@ -65,6 +66,11 @@ public final class PipeFluidStorage implements IFluidStorage {
             @Override
             public long amount() {
                 return nativeAmount;
+            }
+
+            @Override
+            public long capacity() {
+                return nativeCapacity;
             }
         });
     }

--- a/common/src/main/java/com/logistics/pipe/tank/TankColumnStorage.java
+++ b/common/src/main/java/com/logistics/pipe/tank/TankColumnStorage.java
@@ -43,6 +43,7 @@ public final class TankColumnStorage implements IFluidStorage {
             return Collections.emptyList();
         }
         long amount = total;
+        long capacity = column.capacity();
         return List.of(new IFluidView() {
             @Override
             public IFluidKey resource() {
@@ -52,6 +53,11 @@ public final class TankColumnStorage implements IFluidStorage {
             @Override
             public long amount() {
                 return amount;
+            }
+
+            @Override
+            public long capacity() {
+                return capacity;
             }
         });
     }

--- a/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidStorage.java
+++ b/fabric/src/main/java/com/logistics/fabric/fluids/FabricFluidStorage.java
@@ -118,9 +118,11 @@ public final class FabricFluidStorage implements IFluidStorage {
                 pending = advance();
                 IFluidKey key = FabricFluidKey.of(view.getResource());
                 long amt = view.getAmount();
+                long cap = view.getCapacity();
                 return new IFluidView() {
                     @Override public IFluidKey resource() { return key; }
                     @Override public long amount() { return amt; }
+                    @Override public long capacity() { return cap; }
                 };
             }
         };
@@ -204,6 +206,7 @@ public final class FabricFluidStorage implements IFluidStorage {
                     IFluidView view = inner.next();
                     FluidVariant variant = toVariant(view.resource());
                     long amount = view.amount();
+                    long capacity = view.capacity();
                     StagedStorage staged = StagedStorage.this;
                     return new StorageView<>() {
                         @Override
@@ -221,7 +224,7 @@ public final class FabricFluidStorage implements IFluidStorage {
                         @Override public boolean isResourceBlank() { return variant.isBlank(); }
                         @Override public FluidVariant getResource() { return variant; }
                         @Override public long getAmount() { return amount; }
-                        @Override public long getCapacity() { return amount; }
+                        @Override public long getCapacity() { return capacity; }
                     };
                 }
             };

--- a/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidStorage.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidStorage.java
@@ -71,9 +71,11 @@ public final class NeoForgeFluidStorage implements IFluidStorage {
                 continue;
             }
             IFluidKey key = NeoForgeFluidKey.of(resource);
+            long capacity = handler.getCapacityAsLong(i, resource);
             views.add(new IFluidView() {
                 @Override public IFluidKey resource() { return key; }
                 @Override public long amount() { return amount; }
+                @Override public long capacity() { return capacity; }
             });
         }
         return views;
@@ -130,6 +132,10 @@ public final class NeoForgeFluidStorage implements IFluidStorage {
             checkIndex(index);
             if (resource.isEmpty()) {
                 return 0;
+            }
+            // Report the live capacity backing the stored fluid; only fall back to free room when empty.
+            for (IFluidView view : storage.contents()) {
+                return view.capacity();
             }
             return storage.insert(NeoForgeFluidKey.of(resource), Integer.MAX_VALUE, true);
         }

--- a/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidStorage.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/fluids/NeoForgeFluidStorage.java
@@ -133,9 +133,12 @@ public final class NeoForgeFluidStorage implements IFluidStorage {
             if (resource.isEmpty()) {
                 return 0;
             }
-            // Report the live capacity backing the stored fluid; only fall back to free room when empty.
+            // Report the live capacity backing the stored fluid when the resource matches;
+            // otherwise fall back to the room a fresh insert would find (0 for an incompatible fluid).
             for (IFluidView view : storage.contents()) {
-                return view.capacity();
+                if (resource.equals(toResource(view.resource()))) {
+                    return view.capacity();
+                }
             }
             return storage.insert(NeoForgeFluidKey.of(resource), Integer.MAX_VALUE, true);
         }


### PR DESCRIPTION
## Summary

Jade's fluid bar on the glass tank always rendered **full**, no matter how much fluid was actually inside — and a stacked tank column made it obvious (a big number in a full bar). The same was true for fluid pipes.

The root cause wasn't the column logic: the capability adapters reported **capacity = current amount**, because capacity was never carried through the fluid abstraction. So every fluid block looked full.

## Changes

- `IFluidView` now carries a `capacity()` (defaults to `amount()`, so nothing regresses).
- Storages report their real capacity: the glass tank reports its whole **column** capacity, fluid pipes report their buffer capacity, and the tank cell reports its own.
- The Fabric and NeoForge capability adapters now surface that capacity to the platform fluid API instead of echoing the amount.

## Result

- Jade's native fluid bar now fills correctly on the **glass tank** (whole column total / column capacity) and **fluid pipes** — fluid sprite and all, no custom HUD rendering needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)