### PR TITLE
perf(fluids): speed up fluid split allocation

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/pipe/FluidSplit.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/FluidSplit.java
@@ -1,5 +1,8 @@
 package com.logistics.core.lib.pipe;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Pure helper for splitting a quantity of fluid across a pipe junction's outputs. Kept free of Minecraft
  * types so it is unit-testable without a bootstrapped game.
@@ -9,22 +12,60 @@ public final class FluidSplit {
     private FluidSplit() {}
 
     /**
-     * Distributes {@code total} mB across the outputs, 1 mB at a time round-robin, each output capped by its
-     * available {@code room}. Spreads as evenly as the caps allow, hands any remainder to the earliest outputs,
-     * and conserves the total (up to the sum of room).
+     * Distributes {@code total} mB across the outputs as evenly as the caps allow: each output is filled equally
+     * until it hits its available {@code room}, with any indivisible remainder handed to the earliest outputs.
+     * Conserves the total up to the sum of room.
+     *
+     * <p>This is a max-min fair (water-filling) allocation computed arithmetically in passes over the outputs —
+     * one pass per output that caps out — rather than a per-millibucket loop, so its cost is bounded by the
+     * number of outputs and never by {@code total}.
      */
     public static long[] split(long total, long[] room) {
         long[] alloc = new long[room.length];
-        long left = total;
-        boolean progress = true;
-        while (left > 0 && progress) {
-            progress = false;
-            for (int i = 0; i < room.length && left > 0; i++) {
-                if (alloc[i] < room[i]) {
-                    alloc[i]++;
-                    left--;
-                    progress = true;
+        if (total <= 0) {
+            return alloc;
+        }
+        // Indices still able to take more fluid, kept in order so the remainder favors the earliest outputs.
+        List<Integer> active = new ArrayList<>(room.length);
+        for (int i = 0; i < room.length; i++) {
+            if (room[i] > 0) {
+                active.add(i);
+            }
+        }
+
+        long remaining = total;
+        while (remaining > 0 && !active.isEmpty()) {
+            long share = remaining / active.size();
+            if (share == 0) {
+                // Fewer mB left than outputs: hand one each to the earliest, which all still have room.
+                for (int idx : active) {
+                    if (remaining == 0) {
+                        break;
+                    }
+                    alloc[idx]++;
+                    remaining--;
                 }
+                break;
+            }
+
+            long minRoomLeft = Long.MAX_VALUE;
+            for (int idx : active) {
+                minRoomLeft = Math.min(minRoomLeft, room[idx] - alloc[idx]);
+            }
+            if (minRoomLeft <= share) {
+                // An even fill of minRoomLeft caps the tightest outputs; apply it and drop the now-full ones.
+                for (int idx : active) {
+                    alloc[idx] += minRoomLeft;
+                }
+                remaining -= minRoomLeft * active.size();
+                active.removeIf(idx -> alloc[idx] >= room[idx]);
+            } else {
+                // No output caps this pass: even share to all, the indivisible remainder to the earliest.
+                long rem = remaining - share * active.size();
+                for (int idx : active) {
+                    alloc[idx] += share + (rem-- > 0 ? 1 : 0);
+                }
+                remaining = 0;
             }
         }
         return alloc;

--- a/common/src/test/java/com/logistics/core/lib/pipe/FluidSplitTest.java
+++ b/common/src/test/java/com/logistics/core/lib/pipe/FluidSplitTest.java
@@ -1,0 +1,71 @@
+package com.logistics.core.lib.pipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Fluid split allocation")
+class FluidSplitTest {
+
+    @Test
+    @DisplayName("splits a huge budget without looping per millibucket")
+    void largeBudget() {
+        long[] alloc = FluidSplit.split(1_000_000, new long[] {600_000, 600_000});
+        assertThat(alloc).containsExactly(500_000, 500_000);
+        assertThat(alloc[0] + alloc[1]).isEqualTo(1_000_000);
+    }
+
+    @Test
+    @DisplayName("conserves the total up to the sum of room and never exceeds a cap")
+    void conservesAndRespectsCaps() {
+        long[] room = {50, 1_000_000, 7, 9_999_999};
+        long[] alloc = FluidSplit.split(2_500_000, room);
+        long sum = 0;
+        for (int i = 0; i < room.length; i++) {
+            assertThat(alloc[i]).isBetween(0L, room[i]);
+            sum += alloc[i];
+        }
+        assertThat(sum).isEqualTo(2_500_000); // total <= sum of room, so all of it lands
+    }
+
+    @Test
+    @DisplayName("matches the original round-robin distribution exactly")
+    void matchesRoundRobinReference() {
+        long[][] rooms = {
+            {250, 250},
+            {250, 250, 250},
+            {3, 250},
+            {0, 0},
+            {5, 5, 5, 5},
+            {1, 100, 100},
+            {10, 0, 10},
+            {7, 13, 2, 40},
+        };
+        for (long[] room : rooms) {
+            for (long total : new long[] {0, 1, 2, 5, 13, 20, 47, 200, 5000}) {
+                assertThat(FluidSplit.split(total, room))
+                        .as("total=%d room=%s", total, java.util.Arrays.toString(room))
+                        .containsExactly(roundRobin(total, room));
+            }
+        }
+    }
+
+    /** The original 1-mB-at-a-time round-robin, kept here as the behavioral oracle for the rewrite. */
+    private static long[] roundRobin(long total, long[] room) {
+        long[] alloc = new long[room.length];
+        long left = total;
+        boolean progress = true;
+        while (left > 0 && progress) {
+            progress = false;
+            for (int i = 0; i < room.length && left > 0; i++) {
+                if (alloc[i] < room[i]) {
+                    alloc[i]++;
+                    left--;
+                    progress = true;
+                }
+            }
+        }
+        return alloc;
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the fluid-junction split's per-millibucket round-robin with an arithmetic max-min (water-filling) allocation. Cost is now bounded by the number of outputs instead of by the amount of fluid, removing a potential tick-time spike on large transfers.

## Notes
- Distribution is unchanged: an equivalence test pins the new result against the original round-robin across many budget/cap combinations.
- Adds a large-budget allocation test.

Refs #559.