### PR TITLE
fix(macerator): grant XP for macerating ancient debris

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/macerator/netherite_dust.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/netherite_dust.json
@@ -5,5 +5,6 @@
     "id": "logistics:core/netherite_dust",
     "count": 1
   },
-  "energyrequired": 2000
+  "energyrequired": 2000,
+  "experience": 2.0
 }


### PR DESCRIPTION
## Summary
Macerating raw **ancient debris** into netherite dust now awards experience (2.0, matching the vanilla ancient-debris smelt), like every other ore-dust recipe. The XP field had been omitted.

## Notes
- Only the raw-debris recipe grants XP. Macerating netherite *scrap* stays at 0 (its 2 XP is already earned when smelting debris → scrap), and obsidian/crying-obsidian stay at 0 (not smeltable ores).

Refs #559.