### PR TITLE
fix(pump): clamp the fluid pump search radius

### DIFF
--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -109,6 +109,9 @@ public final class LogisticsConfig {
 
     // ==================== Config Entry Registry (for commands) ====================
 
+    /** Largest pump search radius whose square still fits in an int ({@code 46340^2 < Integer.MAX_VALUE}). */
+    private static final long MAX_PUMP_SEARCH_RADIUS = 46_340L;
+
     public static final Map<String, ConfigEntry<?>> ENTRIES;
 
     static {
@@ -278,7 +281,8 @@ public final class LogisticsConfig {
                 () -> (long) INSTANCE.fluidPump.searchRadius,
                 v -> INSTANCE.fluidPump.searchRadius = v.intValue(),
                 Long::parseLong,
-                v -> requireRange(v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
+                // Capped so the radius can be squared as an int downstream without overflowing.
+                v -> requireRange(v, 1L, MAX_PUMP_SEARCH_RADIUS, "must be between 1 and " + MAX_PUMP_SEARCH_RADIUS));
         reg(map, "fluid_pump_arm_speed", "Fluid Pump arm movement speed (blocks/tick)",
                 () -> (double) INSTANCE.fluidPump.armSpeed,
                 v -> INSTANCE.fluidPump.armSpeed = v.floatValue(),

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -490,7 +490,8 @@ public final class LogisticsConfig {
                 v -> requireRange(v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
         sanitizeInt("fluid_pump_search_radius", () -> (long) config.fluidPump.searchRadius,
                 v -> config.fluidPump.searchRadius = v.intValue(), () -> (long) defaults.fluidPump.searchRadius,
-                v -> requireRange(v, 1L, (long) Integer.MAX_VALUE, "must be between 1 and " + Integer.MAX_VALUE));
+                // Same cap as the command path so a hand-edited config can't reach the downstream squaring.
+                v -> requireRange(v, 1L, MAX_PUMP_SEARCH_RADIUS, "must be between 1 and " + MAX_PUMP_SEARCH_RADIUS));
         sanitizeFloat("fluid_pump_arm_speed", () -> (double) config.fluidPump.armSpeed,
                 v -> config.fluidPump.armSpeed = v.floatValue(), () -> (double) defaults.fluidPump.armSpeed,
                 v -> requireFiniteFloatGreaterThan(v, 0.0, "must be finite and greater than 0"));

--- a/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
@@ -77,6 +77,12 @@ class LogisticsConfigTest {
         assertThatThrownBy(() -> LogisticsConfig.ENTRIES.get("fluid_pump_search_radius").setFromString("46341"))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThat(LogisticsConfig.get().fluidPump.searchRadius).isEqualTo(46340); // rejected, unchanged
+
+        // A hand-edited config that exceeds the cap is reset to the default on load.
+        LogisticsConfig parsed = new LogisticsConfig();
+        parsed.fluidPump.searchRadius = 46341;
+        assertThat(LogisticsConfig.sanitize(parsed).fluidPump.searchRadius)
+                .isEqualTo(new LogisticsConfig().fluidPump.searchRadius);
     }
 
     @Test

--- a/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
@@ -66,6 +66,20 @@ class LogisticsConfigTest {
     }
 
     @Test
+    @DisplayName("should clamp the fluid pump search radius so its square fits in an int")
+    void clampsPumpSearchRadius() {
+        LogisticsConfig.useForTests(new LogisticsConfig());
+
+        // 46340^2 fits in an int; one more overflows it once the pump squares the radius.
+        LogisticsConfig.ENTRIES.get("fluid_pump_search_radius").setFromString("46340");
+        assertThat(LogisticsConfig.get().fluidPump.searchRadius).isEqualTo(46340);
+
+        assertThatThrownBy(() -> LogisticsConfig.ENTRIES.get("fluid_pump_search_radius").setFromString("46341"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(LogisticsConfig.get().fluidPump.searchRadius).isEqualTo(46340); // rejected, unchanged
+    }
+
+    @Test
     @DisplayName("should reject pipe speed ranges that invert min and max")
     void rejectsInvertedPipeSpeeds() {
         LogisticsConfig.useForTests(new LogisticsConfig());

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
@@ -21,9 +21,9 @@ import net.minecraft.world.level.material.Fluids;
 public class FluidPumpGameTest {
 
     // The pump arm normally creeps down at 0.01 blocks/tick; these tests speed it up so the pump reaches the
-    // floor within a small tick budget. The gametest framework has no per-test teardown, so the override is
-    // reset to the default on every terminal path ({@link #succeed}/{@link #fail} and each succeedWhen pass)
-    // to keep it from leaking into later tests.
+    // floor within a small tick budget. The gametest framework has no per-test teardown, so each test resets
+    // the override to the default on entry — that guarantees the value never leaks across tests no matter how
+    // the previous one ended (including a succeedWhen timeout). The terminal helpers also restore it promptly.
     private static final float DEFAULT_ARM_SPEED = LogisticsConfig.get().fluidPump.armSpeed;
 
     private static void fastArm() {
@@ -46,6 +46,7 @@ public class FluidPumpGameTest {
 
     @GameTest
     public void testFluidPumpPlacement(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pos = new BlockPos(1, 2, 1);
         context.setBlock(pos, LogisticsFluid.BLOCK.FLUID_PUMP);
         if (context.getBlockEntity(pos, FluidPumpBlockEntity.class) == null) {
@@ -56,6 +57,7 @@ public class FluidPumpGameTest {
 
     @GameTest
     public void testFluidPumpEnergyAndTankAccessibleFromTopAndSides(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pos = new BlockPos(1, 2, 1);
         context.setBlock(pos, LogisticsFluid.BLOCK.FLUID_PUMP);
         FluidPumpBlockEntity pump = context.getBlockEntity(pos, FluidPumpBlockEntity.class);
@@ -85,6 +87,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 40)
     public void testFluidPumpTubeDescendsWithoutEnergy(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(1, 5, 1);
         context.setBlock(pumpPos, LogisticsFluid.BLOCK.FLUID_PUMP);
 
@@ -111,6 +114,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 40)
     public void testFluidPumpRemovesSourceAndFillsTank(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(1, 3, 1);
         BlockPos waterPos = pumpPos.below();
         context.setBlock(pumpPos, LogisticsFluid.BLOCK.FLUID_PUMP);
@@ -141,6 +145,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 40)
     public void testFluidPumpDoesNotDrainWaterloggedBlocks(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(1, 3, 1);
         BlockPos slabPos = pumpPos.below();
         context.setBlock(pumpPos, LogisticsFluid.BLOCK.FLUID_PUMP);
@@ -171,6 +176,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 120)
     public void testFluidPumpFindsConnectedSourceInRadius(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(3, 3, 3);
         BlockPos firstWater = pumpPos.below();
         BlockPos connectedWater = firstWater.east();
@@ -203,6 +209,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 160)
     public void testFluidPumpDrainsFinitePool(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(2, 4, 2);
         BlockPos firstWater = pumpPos.below();
         // 3 sources < infinite threshold (9), in a line that can't reform sources, so the pump carves
@@ -236,6 +243,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 60)
     public void testFluidPumpTreatsLargeBodyAsInfinite(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(3, 5, 3);
         BlockPos center = pumpPos.below();
         context.setBlock(pumpPos, LogisticsFluid.BLOCK.FLUID_PUMP);
@@ -275,6 +283,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 60)
     public void testFluidPumpOutputsToPipeAbove(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(1, 3, 1);
         BlockPos pipePos = pumpPos.above();
         BlockPos waterPos = pumpPos.below();
@@ -296,12 +305,12 @@ public class FluidPumpGameTest {
             if (pipe.totalMillibuckets() <= 0 || pipe.containedFluid().getFluid() != Fluids.WATER) {
                 throw context.assertionException("Fluid pump should push water into the pipe above");
             }
-            resetPumpConfig();
         });
     }
 
     @GameTest(maxTicks = 60)
     public void testFluidPumpOutputsToPipeOnSide(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(1, 3, 1);
         BlockPos pipePos = pumpPos.east();
         BlockPos waterPos = pumpPos.below();
@@ -323,12 +332,12 @@ public class FluidPumpGameTest {
             if (pipe.totalMillibuckets() <= 0 || pipe.containedFluid().getFluid() != Fluids.WATER) {
                 throw context.assertionException("Fluid pump should push water into a pipe on its side");
             }
-            resetPumpConfig();
         });
     }
 
     @GameTest(maxTicks = 80)
     public void testFluidPumpDrainsConnectedLavaSources(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(2, 4, 2);
         BlockPos a = pumpPos.below();
         BlockPos b = a.east();
@@ -360,6 +369,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 80)
     public void testFluidPumpCrossesFlowingToReachSources(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(2, 4, 2);
         BlockPos a = pumpPos.below();
         BlockPos b = a.east();
@@ -390,6 +400,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 200)
     public void testFluidPumpDrainsOpenLavaPool(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(3, 4, 3);
         BlockPos center = pumpPos.below();
         for (int dx = -2; dx <= 2; dx++) {
@@ -431,6 +442,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 80)
     public void testFluidPumpFinishesLayerWithOutputTank(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(2, 4, 2);
         BlockPos tankPos = pumpPos.above();
         BlockPos a = pumpPos.below();
@@ -466,6 +478,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 60)
     public void testFluidPumpStallsAboveSolidFloor(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(2, 5, 2);
         BlockPos water = pumpPos.below();
         BlockPos floor = water.below();
@@ -498,6 +511,7 @@ public class FluidPumpGameTest {
 
     @GameTest(maxTicks = 40)
     public void testFluidPumpDrainsFurthestFirst(GameTestHelper context) {
+        resetPumpConfig();
         BlockPos pumpPos = new BlockPos(1, 4, 2);
         BlockPos near = pumpPos.below();
         BlockPos mid = near.east();

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPumpGameTest.java
@@ -20,14 +20,38 @@ import net.minecraft.world.level.material.Fluids;
 
 public class FluidPumpGameTest {
 
+    // The pump arm normally creeps down at 0.01 blocks/tick; these tests speed it up so the pump reaches the
+    // floor within a small tick budget. The gametest framework has no per-test teardown, so the override is
+    // reset to the default on every terminal path ({@link #succeed}/{@link #fail} and each succeedWhen pass)
+    // to keep it from leaking into later tests.
+    private static final float DEFAULT_ARM_SPEED = LogisticsConfig.get().fluidPump.armSpeed;
+
+    private static void fastArm() {
+        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+    }
+
+    private static void resetPumpConfig() {
+        LogisticsConfig.get().fluidPump.armSpeed = DEFAULT_ARM_SPEED;
+    }
+
+    private static void succeed(GameTestHelper context) {
+        resetPumpConfig();
+        context.succeed();
+    }
+
+    private static void fail(GameTestHelper context, String message) {
+        resetPumpConfig();
+        context.fail(message);
+    }
+
     @GameTest
     public void testFluidPumpPlacement(GameTestHelper context) {
         BlockPos pos = new BlockPos(1, 2, 1);
         context.setBlock(pos, LogisticsFluid.BLOCK.FLUID_PUMP);
         if (context.getBlockEntity(pos, FluidPumpBlockEntity.class) == null) {
-            context.fail("Fluid pump should create a block entity");
+            fail(context, "Fluid pump should create a block entity");
         }
-        context.succeed();
+        succeed(context);
     }
 
     @GameTest
@@ -36,7 +60,7 @@ public class FluidPumpGameTest {
         context.setBlock(pos, LogisticsFluid.BLOCK.FLUID_PUMP);
         FluidPumpBlockEntity pump = context.getBlockEntity(pos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         for (Direction direction : Direction.values()) {
@@ -44,19 +68,19 @@ public class FluidPumpGameTest {
             IEnergyStorage energy = pump.energyStorage(direction);
             boolean hasEnergy = energy != null && energy.canInsert();
             if (hasEnergy != expectAccess) {
-                context.fail("Fluid pump energy access from " + direction + " should be " + expectAccess);
+                fail(context, "Fluid pump energy access from " + direction + " should be " + expectAccess);
                 return;
             }
             if ((pump.fluidStorage(direction) != null) != expectAccess) {
-                context.fail("Fluid pump tank access from " + direction + " should be " + expectAccess);
+                fail(context, "Fluid pump tank access from " + direction + " should be " + expectAccess);
                 return;
             }
             if (pump.acceptsLowTierEnergyFrom(direction) != expectAccess) {
-                context.fail("Fluid pump low-tier energy from " + direction + " should be " + expectAccess);
+                fail(context, "Fluid pump low-tier energy from " + direction + " should be " + expectAccess);
                 return;
             }
         }
-        context.succeed();
+        succeed(context);
     }
 
     @GameTest(maxTicks = 40)
@@ -66,22 +90,22 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
         float startArmY = pump.armY();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 2L, () -> {
             if (pump.energyAmount() != 0) {
-                context.fail("Precondition failed: pump should have no energy");
+                fail(context, "Precondition failed: pump should have no energy");
                 return;
             }
             if (pump.armY() >= startArmY - 1.0f) {
-                context.fail("Fluid pump tube should descend without energy");
+                fail(context, "Fluid pump tube should descend without energy");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -94,24 +118,24 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         pump.energyStorage(Direction.NORTH).insert(LogisticsConfig.get().fluidPump.energyCapacity, false);
 
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks + 2, () -> {
             if (!context.getBlockState(waterPos).isAir()) {
-                context.fail("Fluid pump should remove the water source");
+                fail(context, "Fluid pump should remove the water source");
                 return;
             }
             if (pump.tank().getAmount() < FluidUnits.mb(1_000)
                     || pump.tank().getFluidKey().getFluid() != Fluids.WATER) {
-                context.fail("Fluid pump should store 1000 mB of water");
+                fail(context, "Fluid pump should store 1000 mB of water");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -125,23 +149,23 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks + 2, () -> {
             if (!context.getBlockState(slabPos).is(Blocks.OAK_SLAB)
                     || !context.getBlockState(slabPos).getValue(BlockStateProperties.WATERLOGGED)) {
-                context.fail("Fluid pump must not drain or replace a waterlogged block");
+                fail(context, "Fluid pump must not drain or replace a waterlogged block");
                 return;
             }
             if (pump.tank().getAmount() > 0) {
-                context.fail("Fluid pump must not pump fluid out of a waterlogged block");
+                fail(context, "Fluid pump must not pump fluid out of a waterlogged block");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -157,23 +181,23 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 4L, () -> {
             if (context.getBlockState(firstWater).getFluidState().isSource()
                     || context.getBlockState(connectedWater).getFluidState().isSource()) {
-                context.fail("Fluid pump should remove connected source blocks on the same body");
+                fail(context, "Fluid pump should remove connected source blocks on the same body");
                 return;
             }
             if (pump.tank().getAmount() < FluidUnits.mb(2_000)) {
-                context.fail("Fluid pump should store both connected sources");
+                fail(context, "Fluid pump should store both connected sources");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -193,20 +217,20 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 6L, () -> {
             for (BlockPos water : pool) {
                 if (context.getBlockState(water).getFluidState().isSource()) {
-                    context.fail("Fluid pump should carve every source from a finite pool");
+                    fail(context, "Fluid pump should carve every source from a finite pool");
                     return;
                 }
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -229,23 +253,23 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         pump.energyStorage(Direction.NORTH).insert(LogisticsConfig.get().fluidPump.energyCapacity, false);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 2L + 4, () -> {
             if (pump.tank().getAmount() < FluidUnits.mb(1_000)
                     || pump.tank().getFluidKey().getFluid() != Fluids.WATER) {
-                context.fail("Fluid pump should draw fluid from a large body");
+                fail(context, "Fluid pump should draw fluid from a large body");
                 return;
             }
             if (!context.getBlockState(center).getFluidState().isSource()) {
-                context.fail("Fluid pump should not carve source blocks from a large body");
+                fail(context, "Fluid pump should not carve source blocks from a large body");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -261,17 +285,18 @@ public class FluidPumpGameTest {
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         FluidPipeBlockEntity pipe = context.getBlockEntity(pipePos, FluidPipeBlockEntity.class);
         if (pump == null || pipe == null) {
-            context.fail("Expected pump and fluid pipe block entities");
+            fail(context, "Expected pump and fluid pipe block entities");
             return;
         }
         pump.energyStorage(Direction.NORTH).insert(LogisticsConfig.get().fluidPump.energyCapacity, false);
 
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.succeedWhen(() -> {
             if (pipe.totalMillibuckets() <= 0 || pipe.containedFluid().getFluid() != Fluids.WATER) {
                 throw context.assertionException("Fluid pump should push water into the pipe above");
             }
+            resetPumpConfig();
         });
     }
 
@@ -287,17 +312,18 @@ public class FluidPumpGameTest {
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         FluidPipeBlockEntity pipe = context.getBlockEntity(pipePos, FluidPipeBlockEntity.class);
         if (pump == null || pipe == null) {
-            context.fail("Expected pump and fluid pipe block entities");
+            fail(context, "Expected pump and fluid pipe block entities");
             return;
         }
         pump.energyStorage(Direction.NORTH).insert(LogisticsConfig.get().fluidPump.energyCapacity, false);
 
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.succeedWhen(() -> {
             if (pipe.totalMillibuckets() <= 0 || pipe.containedFluid().getFluid() != Fluids.WATER) {
                 throw context.assertionException("Fluid pump should push water into a pipe on its side");
             }
+            resetPumpConfig();
         });
     }
 
@@ -315,20 +341,20 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 5L, () -> {
             if (!context.getBlockState(a).isAir()
                     || !context.getBlockState(b).isAir()
                     || !context.getBlockState(c).isAir()) {
-                context.fail("Fluid pump should drain all connected lava sources at the same layer");
+                fail(context, "Fluid pump should drain all connected lava sources at the same layer");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -347,18 +373,18 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 5L, () -> {
             if (!context.getBlockState(a).isAir() || !context.getBlockState(c).isAir()) {
-                context.fail("Fluid pump should reach sources across flowing fluid in the same layer");
+                fail(context, "Fluid pump should reach sources across flowing fluid in the same layer");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -384,22 +410,22 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         // Lava flows (UPDATE_ALL), so flowing remnants decay on vanilla's slow schedule; the pump's job
         // is to remove every source block in the pool.
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 12L, () -> {
             for (BlockPos p : pool) {
                 if (context.getBlockState(p).getFluidState().isSource()) {
-                    context.fail("Open lava pool still has a source block at " + p);
+                    fail(context, "Open lava pool still has a source block at " + p);
                     return;
                 }
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -419,11 +445,11 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         // The tank instantly empties the pump's buffer each pump; the pump must still finish the layer.
         // Water flows (UPDATE_ALL), so assert no sources remain rather than full air.
@@ -431,10 +457,10 @@ public class FluidPumpGameTest {
             if (context.getBlockState(a).getFluidState().isSource()
                     || context.getBlockState(b).getFluidState().isSource()
                     || context.getBlockState(c).getFluidState().isSource()) {
-                context.fail("Fluid pump should finish the layer even while a tank empties its buffer");
+                fail(context, "Fluid pump should finish the layer even while a tank empties its buffer");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -450,23 +476,23 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks * 3L, () -> {
             if (!context.getBlockState(water).isAir()) {
-                context.fail("Fluid pump should drain the water");
+                fail(context, "Fluid pump should drain the water");
                 return;
             }
             // The tube tip must not have descended into the solid floor (top of floor = pump Y - 1).
             if (pump.armY() < pump.getBlockPos().getY() - 1.0f) {
-                context.fail("Fluid pump tube descended into the solid floor");
+                fail(context, "Fluid pump tube descended into the solid floor");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 
@@ -484,23 +510,23 @@ public class FluidPumpGameTest {
 
         FluidPumpBlockEntity pump = context.getBlockEntity(pumpPos, FluidPumpBlockEntity.class);
         if (pump == null) {
-            context.fail("Expected FluidPumpBlockEntity");
+            fail(context, "Expected FluidPumpBlockEntity");
             return;
         }
         fillEnergy(pump);
-        LogisticsConfig.get().fluidPump.armSpeed = 16f;
+        fastArm();
 
         // After the first pump the furthest source is gone but the one under the tube remains.
         context.runAfterDelay(LogisticsConfig.get().fluidPump.pumpIntervalTicks + 6L, () -> {
             if (context.getBlockState(far).getFluidState().isSource()) {
-                context.fail("Fluid pump should drain the furthest source first");
+                fail(context, "Fluid pump should drain the furthest source first");
                 return;
             }
             if (!context.getBlockState(near).getFluidState().isSource()) {
-                context.fail("The source under the tube should be drained last");
+                fail(context, "The source under the tube should be drained last");
                 return;
             }
-            context.succeed();
+            succeed(context);
         });
     }
 


### PR DESCRIPTION
## Summary
Caps the configurable fluid pump search radius at 46340. Above that the radius overflows when squared as an int, corrupting the circular range check (it could wrap negative and skip valid sources). 46340² is the largest square that still fits in an int.

## Notes
- Also resets the pump's `armSpeed` config between game tests so the test-only override no longer leaks across test order (the gametest framework has no per-test teardown).

Refs #559.