### PR TITLE
refactor(fluids): guard fluid unit and traveling-fluid invariants

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/fluids/FluidUnits.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/FluidUnits.java
@@ -9,8 +9,9 @@ import com.logistics.core.lib.platform.PlatformService;
  * so capacities and transfer rates expressed in mB in config must be converted at the world
  * boundary before being handed to {@link com.logistics.core.lib.fluids.IFluidStorage}.
  *
- * <p>Not used in unit tests — tests operate directly in native units to avoid depending on a
- * loader {@link PlatformService}.
+ * <p>The public conversions read the loader factor from {@link PlatformService}, so production code
+ * outside tests operates directly in native units; the package-private overloads take the factor
+ * explicitly and are unit-tested directly.
  */
 public final class FluidUnits {
 
@@ -18,11 +19,29 @@ public final class FluidUnits {
 
     /** Converts a millibucket amount to platform-native fluid units. */
     public static long mb(long millibuckets) {
-        return millibuckets * PlatformService.INSTANCE.fluidUnitsPerMillibucket();
+        return mb(millibuckets, PlatformService.INSTANCE.fluidUnitsPerMillibucket());
     }
 
     /** Converts platform-native fluid units back to millibuckets, rounding down. */
     public static long toMillibuckets(long nativeUnits) {
-        return nativeUnits / PlatformService.INSTANCE.fluidUnitsPerMillibucket();
+        return toMillibuckets(nativeUnits, PlatformService.INSTANCE.fluidUnitsPerMillibucket());
+    }
+
+    // Package-private overloads take the factor explicitly so the conversion math is unit-testable
+    // without a bootstrapped loader PlatformService.
+
+    static long mb(long millibuckets, long factor) {
+        return Math.multiplyExact(millibuckets, requirePositive(factor));
+    }
+
+    static long toMillibuckets(long nativeUnits, long factor) {
+        return nativeUnits / requirePositive(factor);
+    }
+
+    private static long requirePositive(long factor) {
+        if (factor <= 0) {
+            throw new IllegalArgumentException("fluidUnitsPerMillibucket must be positive, was " + factor);
+        }
+        return factor;
     }
 }

--- a/common/src/main/java/com/logistics/core/lib/pipe/FluidBuffer.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/FluidBuffer.java
@@ -52,8 +52,10 @@ public final class FluidBuffer<F> {
      * callers must pass an already-valid amount.
      */
     public void restore(F fluid, long amountMb) {
-        this.amountMb = Math.max(0, Math.min(amountMb, CAPACITY_MB));
-        this.fluid = this.amountMb > 0 ? fluid : null;
+        long clamped = Math.max(0, Math.min(amountMb, CAPACITY_MB));
+        // Normalize to empty rather than persist the invalid "some amount, no fluid" state.
+        this.fluid = clamped > 0 ? fluid : null;
+        this.amountMb = this.fluid == null ? 0 : clamped;
     }
 
     /**

--- a/common/src/main/java/com/logistics/core/lib/pipe/TravelingFluid.java
+++ b/common/src/main/java/com/logistics/core/lib/pipe/TravelingFluid.java
@@ -3,6 +3,7 @@ package com.logistics.core.lib.pipe;
 import com.logistics.core.lib.fluids.IFluidKey;
 import com.logistics.core.lib.fluids.SimpleFluidKey;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponentPatch;
@@ -51,8 +52,13 @@ public final class TravelingFluid {
                         FLUID_KEY
                                 .fieldOf("fluid")
                                 .forGetter(t -> new SimpleFluidKey(t.fluid.getFluid(), t.fluid.getComponents())),
-                        Codec.LONG.fieldOf("amount").forGetter(t -> t.amount),
-                        Codec.INT
+                        Codec.LONG
+                                .validate(amount -> amount < 0
+                                        ? DataResult.error(() -> "amount must be non-negative, was " + amount)
+                                        : DataResult.success(amount))
+                                .fieldOf("amount")
+                                .forGetter(t -> t.amount),
+                        Codec.intRange(0, 5)
                                 .xmap(Direction::from3DDataValue, Direction::get3DDataValue)
                                 .fieldOf("heading")
                                 .forGetter(t -> t.heading),
@@ -76,9 +82,16 @@ public final class TravelingFluid {
 
     public TravelingFluid(IFluidKey fluid, long amount, Direction heading, int countdown) {
         this.fluid = fluid;
-        this.amount = amount;
+        this.amount = requireNonNegative(amount);
         this.heading = heading;
         this.countdown = countdown;
+    }
+
+    private static long requireNonNegative(long amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("fluid amount must be non-negative, was " + amount);
+        }
+        return amount;
     }
 
     public IFluidKey fluid() {
@@ -94,11 +107,11 @@ public final class TravelingFluid {
     }
 
     public void setAmount(long amount) {
-        this.amount = amount;
+        this.amount = requireNonNegative(amount);
     }
 
     public void add(long delta) {
-        this.amount += delta;
+        this.amount = requireNonNegative(this.amount + delta);
     }
 
     public Direction heading() {

--- a/common/src/main/java/com/logistics/pipe/item/FluidPipeBlockItem.java
+++ b/common/src/main/java/com/logistics/pipe/item/FluidPipeBlockItem.java
@@ -51,11 +51,11 @@ public class FluidPipeBlockItem extends BlockItem {
         consumer.accept(Component.translatable("tooltip.logistics.fluid." + def.modelBase())
                 .withStyle(ChatFormatting.GRAY));
 
-        consumer.accept(Component.translatable("tooltip.logistics.fluid.capacity", (int) def.capacity(cfg))
+        consumer.accept(Component.translatable("tooltip.logistics.fluid.capacity", def.capacity(cfg))
                 .withStyle(ChatFormatting.GRAY));
         // Extractors are paced by engine power, not a fixed rate; void destroys rather than transfers.
         if (!def.isExtractor() && !def.isVoid()) {
-            consumer.accept(Component.translatable("tooltip.logistics.fluid.transfer", (int) def.transferRate(cfg))
+            consumer.accept(Component.translatable("tooltip.logistics.fluid.transfer", def.transferRate(cfg))
                     .withStyle(ChatFormatting.GRAY));
         }
         consumer.accept(Component.translatable("tooltip.logistics.fluid.no_item_pipes")

--- a/common/src/test/java/com/logistics/core/lib/fluids/FluidUnitsTest.java
+++ b/common/src/test/java/com/logistics/core/lib/fluids/FluidUnitsTest.java
@@ -1,0 +1,40 @@
+package com.logistics.core.lib.fluids;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Fluid unit conversion")
+class FluidUnitsTest {
+
+    @Test
+    @DisplayName("converts millibuckets to native units and back with the platform factor")
+    void roundTrip() {
+        assertThat(FluidUnits.mb(250, 81)).isEqualTo(20_250);
+        assertThat(FluidUnits.toMillibuckets(20_250, 81)).isEqualTo(250);
+        assertThat(FluidUnits.mb(250, 1)).isEqualTo(250);
+    }
+
+    @Test
+    @DisplayName("toMillibuckets rounds down")
+    void roundsDown() {
+        assertThat(FluidUnits.toMillibuckets(80, 81)).isZero();
+        assertThat(FluidUnits.toMillibuckets(162, 81)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("a non-positive factor is rejected instead of dividing by zero")
+    void rejectsNonPositiveFactor() {
+        assertThatThrownBy(() -> FluidUnits.toMillibuckets(100, 0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FluidUnits.toMillibuckets(100, -1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FluidUnits.mb(100, 0)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("overflowing the native range throws rather than silently wrapping")
+    void overflowThrows() {
+        assertThatThrownBy(() -> FluidUnits.mb(Long.MAX_VALUE, 81)).isInstanceOf(ArithmeticException.class);
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/pipe/FluidBufferTest.java
+++ b/common/src/test/java/com/logistics/core/lib/pipe/FluidBufferTest.java
@@ -279,6 +279,17 @@ class FluidBufferTest {
         assertThat(pipe.fluid()).isEqualTo(WATER);
     }
 
+    @Test
+    @DisplayName("restore normalizes to empty rather than holding an amount with no fluid")
+    void restoreNormalizesNullFluidToEmpty() {
+        FluidBuffer<String> pipe = FluidBuffer.extractor();
+        pipe.restore(WATER, 100); // seed some real contents first
+
+        pipe.restore(null, 100); // a positive amount with no fluid is invalid
+        assertThat(pipe.fluid()).isNull();
+        assertThat(pipe.amount()).isZero();
+    }
+
     /** A water provider with effectively unlimited fluid, for tests where the source isn't the constraint. */
     private static FakeFluidProvider ampleProvider() {
         return new FakeFluidProvider(WATER, 1_000_000);

--- a/common/src/test/java/com/logistics/core/lib/pipe/TravelingFluidTest.java
+++ b/common/src/test/java/com/logistics/core/lib/pipe/TravelingFluidTest.java
@@ -1,0 +1,69 @@
+package com.logistics.core.lib.pipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.logistics.test.MinecraftTestEnvironment;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.core.Direction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Traveling fluid invariants")
+class TravelingFluidTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("rejects a negative amount at construction")
+    void rejectsNegativeAtConstruction() {
+        // The amount invariant doesn't touch the fluid identity, so a null key keeps this off the registry.
+        assertThatThrownBy(() -> new TravelingFluid(null, -1, Direction.NORTH, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("rejects mutations that would drive the amount negative")
+    void rejectsNegativeMutation() {
+        TravelingFluid parcel = new TravelingFluid(null, 10, Direction.NORTH, 0);
+        assertThatThrownBy(() -> parcel.setAmount(-1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> parcel.add(-11)).isInstanceOf(IllegalArgumentException.class);
+
+        parcel.add(-10); // draining exactly to empty is allowed
+        assertThat(parcel.amount()).isZero();
+    }
+
+    @Test
+    @DisplayName("decodes a valid parcel (positive control)")
+    void decodesValidParcel() {
+        assertThat(parse(parcelJson(5, 2)).isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("decode rejects a negative amount")
+    void decodeRejectsNegativeAmount() {
+        assertThat(parse(parcelJson(-5, 2)).isError()).isTrue();
+    }
+
+    @Test
+    @DisplayName("decode rejects a heading outside 0..5")
+    void decodeRejectsOutOfRangeHeading() {
+        assertThat(parse(parcelJson(5, 6)).isError()).isTrue();
+        assertThat(parse(parcelJson(5, -1)).isError()).isTrue();
+    }
+
+    private static DataResult<TravelingFluid> parse(JsonObject json) {
+        return TravelingFluid.codec().parse(JsonOps.INSTANCE, json);
+    }
+
+    private static JsonObject parcelJson(long amount, int heading) {
+        JsonObject fluid = new JsonObject();
+        fluid.add("fluid", new JsonPrimitive("minecraft:water"));
+        JsonObject json = new JsonObject();
+        json.add("fluid", fluid);
+        json.add("amount", new JsonPrimitive(amount));
+        json.add("heading", new JsonPrimitive(heading));
+        return json;
+    }
+}


### PR DESCRIPTION
## Summary
Defensive hardening of the fluid core on the load/conversion boundaries. No player-facing behavior change.

## Changes
- `FluidUnits`: validate the platform conversion factor is positive (no divide-by-zero) and use checked multiplication so a conversion can't silently overflow.
- `TravelingFluid`: reject negative amounts at construction, mutation, and codec decode; restrict the heading codec to valid directions (0..5).
- `FluidBuffer.restore`: normalize to empty rather than persist an "amount > 0 with no fluid" state.
- `FluidPipeBlockItem`: drop narrowing long→int casts in the capacity/transfer tooltip.
- Adds unit tests for each invariant.

Refs #559.