### PR TITLE
refactor(compat): scope the fluid pipe Jade HUD to its own provider

### DIFF
--- a/fabric/src/client/java/com/logistics/compat/jade/FluidPipeComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/FluidPipeComponentProvider.java
@@ -1,0 +1,43 @@
+package com.logistics.compat.jade;
+
+import com.logistics.LogisticsMod;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Jade integration for fluid pipes. A fluid extractor pipe holds a small power buffer to drive its arm, but
+ * that buffer is an internal implementation detail (as with item pipes), so this strips Jade's generic energy
+ * bar. Fluid contents are left to Jade's built-in fluid element.
+ *
+ * <p>Scoped to fluid pipes so the item-pipe {@link PipeComponentProvider} (which reads a {@code PipeBlockEntity})
+ * is never registered against a {@code FluidPipeBlockEntity}.
+ */
+public final class FluidPipeComponentProvider implements IBlockComponentProvider {
+    public static final FluidPipeComponentProvider INSTANCE = new FluidPipeComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("fluid_pipe").toIdentifier();
+
+    private FluidPipeComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        // Run after Jade's built-in energy element (priority 1000) so we can strip it below.
+        return 2000;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        // A fluid pipe's energy buffer is an internal implementation detail — drop Jade's generic energy bar.
+        tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
+    }
+}

--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -48,6 +48,6 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
-        registration.registerBlockComponent(PipeComponentProvider.INSTANCE, FluidPipeBlock.class);
+        registration.registerBlockComponent(FluidPipeComponentProvider.INSTANCE, FluidPipeBlock.class);
     }
 }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/FluidPipeComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/FluidPipeComponentProvider.java
@@ -1,0 +1,43 @@
+package com.logistics.neoforge.client.compat;
+
+import com.logistics.LogisticsMod;
+import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Jade integration for fluid pipes. A fluid extractor pipe holds a small power buffer to drive its arm, but
+ * that buffer is an internal implementation detail (as with item pipes), so this strips Jade's generic energy
+ * bar. Fluid contents are left to Jade's built-in fluid element.
+ *
+ * <p>Scoped to fluid pipes so the item-pipe {@link PipeComponentProvider} (which reads a {@code PipeBlockEntity})
+ * is never registered against a {@code FluidPipeBlockEntity}.
+ */
+public final class FluidPipeComponentProvider implements IBlockComponentProvider {
+    public static final FluidPipeComponentProvider INSTANCE = new FluidPipeComponentProvider();
+
+    private static final Identifier UID = // raw-id-ok: Jade keys providers by Identifier
+            LogisticsMod.modId("fluid_pipe").toIdentifier();
+
+    private FluidPipeComponentProvider() {}
+
+    @Override
+    public Identifier getUid() { // raw-id-ok: overrides Jade API returning Identifier
+        return UID;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        // Run after Jade's built-in energy element (priority 1000) so we can strip it below.
+        return 2000;
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        // A fluid pipe's energy buffer is an internal implementation detail — drop Jade's generic energy bar.
+        tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -49,6 +49,6 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
-        registration.registerBlockComponent(PipeComponentProvider.INSTANCE, FluidPipeBlock.class);
+        registration.registerBlockComponent(FluidPipeComponentProvider.INSTANCE, FluidPipeBlock.class);
     }
 }


### PR DESCRIPTION
## Summary
Fluid pipes were registered against the item-pipe Jade provider, which reads a `PipeBlockEntity`. They now use a dedicated fluid-pipe provider. No player-facing change: it preserves today's behavior of hiding the fluid extractor's internal power buffer (Jade's generic energy bar), consistent with item pipes; fluid contents remain shown by Jade's built-in fluid element.

Refs #559.