### PR TITLE
ci(release): harden code-change detection against rewritten history

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -53,6 +53,14 @@ jobs:
             exit 0
           fi
 
+          # A rewritten/force-pushed base may no longer exist; treat a failed diff as "code changed"
+          # so CI runs the full checks rather than silently skipping them on an empty diff.
+          if ! changed_files=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null); then
+            echo "git diff against base '$BASE' failed (rewritten history?); assuming code changed."
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           code_changed=false
           while IFS= read -r file; do
             case "$file" in
@@ -63,7 +71,7 @@ jobs:
                 break
                 ;;
             esac
-          done < <(git diff --name-only "$BASE" "$HEAD")
+          done <<< "$changed_files"
 
           echo "code_changed=$code_changed" >> "$GITHUB_OUTPUT"
           echo "code_changed=$code_changed"


### PR DESCRIPTION
## Summary
The Check Code workflow diffs against a base commit to decide whether to run lint/tests. After a force-push or history rewrite that base can be gone, and the old process-substitution form could silently yield an empty diff (skipping CI on real changes) or fail the job.

## Changes
- Capture the diff and treat any `git diff` failure as `code_changed=true`, so CI runs the full checks rather than skipping them.

Refs #559.