### PR TITLE
fix(routing): keep chassis modules when a pipe explodes

### DIFF
--- a/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -5,24 +5,16 @@ import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.pipe.network.NetworkRegistry;
 import com.logistics.core.lib.pipe.PipeConnectionLookup;
 import com.logistics.pipe.ItemPipe;
-import com.logistics.pipe.ChassisPipe;
 import com.logistics.core.lib.pipe.ModularPipe;
 import com.logistics.core.lib.pipe.ModularPipeBlock;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.core.lib.pipe.PipeFamily;
 import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.LogisticsPipe;
-import com.logistics.core.lib.pipe.TravelingItem;
-import com.logistics.pipe.item.ModuleItem;
 import com.mojang.serialization.MapCodec;
 import com.logistics.core.lib.storage.ItemStorageLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtOps;
-import net.minecraft.nbt.Tag;
-import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.level.redstone.Orientation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
@@ -53,7 +45,6 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.level.ScheduledTickAccess;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Nullable;
 
@@ -133,54 +124,9 @@ public class PipeBlock extends BaseEntityBlock
         return RenderShape.INVISIBLE;
     }
 
-    @Override
-    public BlockState playerWillDestroy(
-            Level level, BlockPos pos, BlockState state, net.minecraft.world.entity.player.Player player) {
-        // Drop traveling items and module items when pipe is broken by player
-        if (!level.isClientSide()) {
-            BlockEntity blockEntity = level.getBlockEntity(pos);
-            if (blockEntity instanceof PipeBlockEntity pipeEntity) {
-                for (TravelingItem item : pipeEntity.getTravelingItems()) {
-                    PipeBlockEntity.dropItem(level, pos, item);
-                }
-                dropChassisModules(level, pos, pipeEntity);
-            }
-            // Remove pipe from network
-            NetworkRegistry.removePipe(level, pos);
-        }
-        return super.playerWillDestroy(level, pos, state, player);
-    }
-
-    /** Drop installed chassis module items at the pipe position. */
-    private void dropChassisModules(Level level, BlockPos pos, PipeBlockEntity pipeEntity) {
-        CompoundTag chassisState = pipeEntity.getOrCreateModuleState(ChassisPipe.STATE_KEY);
-        if (chassisState.isEmpty()) return;
-
-        // ItemStack.CODEC needs registry-aware ops for registry-backed components such as enchantments.
-        RegistryOps<Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
-        PipeContext ctx = pipeEntity.createContext();
-
-        for (int slot = 0; slot < ChassisPipe.MAX_SLOTS; slot++) {
-            Tag tag = chassisState.get(String.valueOf(slot));
-            if (tag == null) continue;
-
-            ItemStack.CODEC.parse(ops, tag).result().ifPresent(stack -> {
-                applyModuleStateToStack(ctx, stack);
-                ItemEntity entity = new ItemEntity(
-                        level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
-                entity.setDefaultPickUpDelay();
-                level.addFreshEntity(entity);
-            });
-        }
-    }
-
-    private void applyModuleStateToStack(PipeContext ctx, ItemStack stack) {
-        if (!(stack.getItem() instanceof ModuleItem moduleItem)) return;
-
-        String stateKey = ChassisPipe.moduleStateKey(stack, moduleItem.createModule());
-        CompoundTag moduleData = ctx.moduleState(stateKey);
-        stack.set(DataComponents.CUSTOM_DATA, ModuleItem.customDataWithModuleState(stack, moduleData));
-    }
+    // Pipe break drops (traveling items + chassis modules) and network detach are handled in
+    // PipeBlockEntity.preRemoveSideEffects(), which covers explosions and /setblock, not just
+    // player breaks.
 
     /**
      * Route item use interactions to pipe modules before default block handling.

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -12,9 +12,11 @@ import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.pipe.IPipeAccess;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import com.logistics.pipe.ChassisPipe;
 import com.logistics.pipe.ItemPipe;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.pipe.block.PipeBlock;
+import com.logistics.pipe.item.ModuleItem;
 import com.logistics.pipe.network.NetworkRegistry;
 import com.logistics.pipe.runtime.PipeRuntime;
 import com.logistics.core.lib.pipe.TravelingItem;
@@ -28,6 +30,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
@@ -340,7 +343,61 @@ public class PipeBlockEntity extends BaseBlockEntity
     @Override
     public void setRemoved() {
         super.setRemoved();
-        // Item dropping is handled in PipeBlock.playerWillDestroy() instead
+        // Dropping is handled in preRemoveSideEffects(); setRemoved() also fires on chunk unload.
+    }
+
+    /**
+     * Drop in-transit items and installed chassis modules, then detach from the network, when the
+     * pipe is removed by any means (player break, explosion, /setblock). Runs while the block entity
+     * is still present -- unlike affectNeighborsAfterRemoval -- and is not called on chunk unload.
+     */
+    @Override
+    public void preRemoveSideEffects(BlockPos pos, BlockState state) {
+        super.preRemoveSideEffects(pos, state);
+        if (level == null || level.isClientSide()) {
+            return;
+        }
+        for (TravelingItem item : travelingItems) {
+            dropItem(level, pos, item);
+        }
+        dropChassisModules(pos);
+        NetworkRegistry.removePipe(level, pos);
+    }
+
+    /** Drop installed chassis module items, each carrying its saved configuration. */
+    private void dropChassisModules(BlockPos pos) {
+        CompoundTag chassisState = getOrCreateModuleState(ChassisPipe.STATE_KEY);
+        if (chassisState.isEmpty()) {
+            return;
+        }
+
+        // ItemStack.CODEC needs registry-aware ops for registry-backed components such as enchantments.
+        RegistryOps<Tag> ops = level.registryAccess().createSerializationContext(NbtOps.INSTANCE);
+        PipeContext ctx = createContext();
+
+        for (int slot = 0; slot < ChassisPipe.MAX_SLOTS; slot++) {
+            Tag tag = chassisState.get(String.valueOf(slot));
+            if (tag == null) {
+                continue;
+            }
+
+            ItemStack.CODEC.parse(ops, tag).result().ifPresent(stack -> {
+                applyModuleStateToStack(ctx, stack);
+                ItemEntity entity = new ItemEntity(
+                        level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
+                entity.setDefaultPickUpDelay();
+                level.addFreshEntity(entity);
+            });
+        }
+    }
+
+    private void applyModuleStateToStack(PipeContext ctx, ItemStack stack) {
+        if (!(stack.getItem() instanceof ModuleItem moduleItem)) {
+            return;
+        }
+        String stateKey = ChassisPipe.moduleStateKey(stack, moduleItem.createModule());
+        CompoundTag moduleData = ctx.moduleState(stateKey);
+        stack.set(DataComponents.CUSTOM_DATA, ModuleItem.customDataWithModuleState(stack, moduleData));
     }
 
     public CompoundTag getOrCreateModuleState(String key) {

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/ModuleGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/ModuleGameTest.java
@@ -1,6 +1,7 @@
 package com.logistics.gametest.pipe;
 
 import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.pipe.block.entity.PowerJunctionBlockEntity;
 import com.logistics.pipe.Pipe;
@@ -10,19 +11,25 @@ import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.pipe.modules.ItemFilterModule;
 import com.logistics.pipe.modules.MergerModule;
 import com.logistics.pipe.modules.SinkModule;
+import com.logistics.pipe.ui.ChassisInventory;
 import com.logistics.core.lib.pipe.RoutePlan;
 import com.logistics.core.lib.pipe.TravelingItem;
 import net.fabricmc.fabric.api.gametest.v1.GameTest;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.AABB;
 
 import java.util.List;
 
@@ -522,5 +529,53 @@ public class ModuleGameTest {
         });
 
         context.succeedWhen(() -> context.assertContainerContains(chestPos, Items.DIRT));
+    }
+
+    /**
+     * A chassis pipe destroyed by a non-player removal (explosion, /setblock) must still drop its
+     * installed modules with configuration intact. The drop runs in
+     * {@code PipeBlockEntity.preRemoveSideEffects()}, which fires on every removal path -- not only
+     * the player-break path -- so modules are no longer voided by explosions.
+     */
+    @GameTest
+    public void testChassisDropsModulesOnNonPlayerBreak(GameTestHelper context) {
+        BlockPos pos = new BlockPos(0, 1, 0);
+        context.setBlock(pos, LogisticsPipe.BLOCK.CHASSIS_LOGISTICS_PIPE_MK1);
+
+        PipeBlockEntity pipeEntity = context.getBlockEntity(pos, PipeBlockEntity.class);
+        if (pipeEntity == null) {
+            context.fail("Chassis pipe should have a block entity");
+        }
+
+        // Insert a module carrying a marker so we can confirm its configuration survives the break.
+        ItemStack module = new ItemStack(LogisticsPipe.ITEM.ITEM_SINK_MODULE);
+        CompoundTag marker = new CompoundTag();
+        marker.putString("qa_marker", "kept");
+        module.set(DataComponents.CUSTOM_DATA, CustomData.of(marker));
+
+        ChassisInventory inventory = new ChassisInventory(pipeEntity);
+        inventory.setItem(0, module);
+
+        // Remove the block via a non-player path (the same removal path explosions use).
+        BlockPos absPos = context.absolutePos(pos);
+        ServerLevel level = context.getLevel();
+        level.destroyBlock(absPos, false);
+
+        List<ItemEntity> drops = level.getEntitiesOfClass(
+                ItemEntity.class,
+                new AABB(absPos).inflate(2.0),
+                e -> e.getItem().is(LogisticsPipe.ITEM.ITEM_SINK_MODULE));
+
+        if (drops.size() != 1) {
+            context.fail("Expected exactly one module to drop on break, found " + drops.size());
+        }
+
+        ItemStack dropped = drops.get(0).getItem();
+        CustomData data = dropped.get(DataComponents.CUSTOM_DATA);
+        if (data == null || !"kept".equals(NbtCompat.getString(data.copyTag(), "qa_marker", ""))) {
+            context.fail("Dropped module lost its configuration on break");
+        }
+
+        context.succeed();
     }
 }


### PR DESCRIPTION
## Summary

Chassis pipes dropped their installed modules only when broken by a **player**. Destroying a chassis pipe with an **explosion** (or `/setblock`, or any non-player removal) silently voided the inserted modules and their saved configuration.

## Changes

- Move the pipe-removal drop logic (traveling items + chassis modules) and network detach from `PipeBlock.playerWillDestroy` (player-only) into `PipeBlockEntity.preRemoveSideEffects`, which runs on **every** removal path while the block entity is still present.
- Modules now drop with their configuration intact regardless of how the pipe is destroyed.
- Also detaches the pipe from the logistics network on explosion, closing a latent network-leak that previously only cleaned up on player breaks.

## Notes

- `preRemoveSideEffects` is the modern (1.21.5+) hook for "drop contents on removal"; it fires before the block entity is removed, is skipped for block-property toggles, and is **not** called on chunk unload (so saved worlds keep their modules).
- Scope is limited to item pipes — fluid pipes and the fluid pump use separate block entities and are unaffected. Wrenching opens the module menu rather than removing the block, so there is no double-drop.
- Adds a gametest (`testChassisDropsModulesOnNonPlayerBreak`) that destroys a chassis via a non-player path and asserts the configured module drops intact. Full gametest suite green.