### PR TITLE
perf(common): cache pipe and cable collision shapes

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/block/ConnectedShapeCache.java
+++ b/common/src/main/java/com/logistics/core/lib/block/ConnectedShapeCache.java
@@ -1,0 +1,44 @@
+package com.logistics.core.lib.block;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+/**
+ * Precomputes the 64 collision shapes a connected block can take — a core shape unioned with any
+ * subset of six directional arms — so {@code getShape} is an array lookup instead of rebuilding the
+ * union with {@link Shapes#or} on every call (which collision and ray-tracing hit frequently).
+ *
+ * <p>Arms are indexed by {@link Direction#get3DDataValue()}, and the cache key is a 6-bit mask of
+ * the connected directions. Connection state is still resolved live by the caller; only the shape
+ * union is cached.
+ */
+public final class ConnectedShapeCache {
+    private final VoxelShape[] byMask = new VoxelShape[64];
+
+    /**
+     * @param core the always-present center shape
+     * @param arms six arm shapes indexed by {@link Direction#get3DDataValue()}
+     */
+    public ConnectedShapeCache(VoxelShape core, VoxelShape[] arms) {
+        for (int mask = 0; mask < byMask.length; mask++) {
+            VoxelShape shape = core;
+            for (Direction dir : Direction.values()) {
+                if ((mask & bit(dir)) != 0) {
+                    shape = Shapes.or(shape, arms[dir.get3DDataValue()]);
+                }
+            }
+            byMask[mask] = shape;
+        }
+    }
+
+    /** Bit for a direction within a connection mask. */
+    public static int bit(Direction dir) {
+        return 1 << dir.get3DDataValue();
+    }
+
+    /** @param connectionMask OR of {@link #bit(Direction)} for each connected direction */
+    public VoxelShape get(int connectionMask) {
+        return byMask[connectionMask];
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/block/ConnectedShapeCache.java
+++ b/common/src/main/java/com/logistics/core/lib/block/ConnectedShapeCache.java
@@ -28,7 +28,8 @@ public final class ConnectedShapeCache {
                     shape = Shapes.or(shape, arms[dir.get3DDataValue()]);
                 }
             }
-            byMask[mask] = shape;
+            // Simplify once up front so cached collision/raycast lookups use the fewest boxes.
+            byMask[mask] = shape.optimize();
         }
     }
 

--- a/common/src/main/java/com/logistics/pipe/block/FluidPipeBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/FluidPipeBlock.java
@@ -1,6 +1,7 @@
 package com.logistics.pipe.block;
 
 import com.logistics.LogisticsFluid;
+import com.logistics.core.lib.block.ConnectedShapeCache;
 import com.logistics.core.lib.block.behavior.WrenchBehavior;
 import com.logistics.core.lib.fluids.FluidStorageLookup;
 import com.logistics.core.lib.pipe.ModularPipe;
@@ -40,7 +41,6 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.redstone.Orientation;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
@@ -77,6 +77,8 @@ public class FluidPipeBlock extends BaseEntityBlock
         ARM_SHAPES[Direction.DOWN.get3DDataValue()] = Block.box(
                 8 - PIPE_SIZE / 2, 0, 8 - PIPE_SIZE / 2, 8 + PIPE_SIZE / 2, 8 - PIPE_SIZE / 2, 8 + PIPE_SIZE / 2);
     }
+
+    private static final ConnectedShapeCache SHAPE_CACHE = new ConnectedShapeCache(CORE_SHAPE, ARM_SHAPES);
 
     @Nullable
     private final FluidPipe fluidPipe;
@@ -244,13 +246,13 @@ public class FluidPipeBlock extends BaseEntityBlock
 
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
-        VoxelShape shape = CORE_SHAPE;
+        int mask = 0;
         for (Direction direction : Direction.values()) {
             if (isConnected(world, pos, direction)) {
-                shape = Shapes.or(shape, ARM_SHAPES[direction.get3DDataValue()]);
+                mask |= ConnectedShapeCache.bit(direction);
             }
         }
-        return shape;
+        return SHAPE_CACHE.get(mask);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/PipeBlock.java
@@ -1,5 +1,6 @@
 package com.logistics.pipe.block;
 
+import com.logistics.core.lib.block.ConnectedShapeCache;
 import com.logistics.core.lib.block.behavior.WrenchBehavior;
 import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.pipe.network.NetworkRegistry;
@@ -42,7 +43,6 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.level.ScheduledTickAccess;
 import net.minecraft.world.entity.player.Player;
@@ -79,6 +79,19 @@ public class PipeBlock extends BaseEntityBlock
             8 - PIPE_SIZE / 2, 8 + PIPE_SIZE / 2, 8 - PIPE_SIZE / 2, 8 + PIPE_SIZE / 2, 16, 8 + PIPE_SIZE / 2);
     private static final VoxelShape DOWN_SHAPE = Block.box(
             8 - PIPE_SIZE / 2, 0, 8 - PIPE_SIZE / 2, 8 + PIPE_SIZE / 2, 8 - PIPE_SIZE / 2, 8 + PIPE_SIZE / 2);
+
+    private static final ConnectedShapeCache SHAPE_CACHE;
+
+    static {
+        VoxelShape[] arms = new VoxelShape[6];
+        arms[Direction.NORTH.get3DDataValue()] = NORTH_SHAPE;
+        arms[Direction.SOUTH.get3DDataValue()] = SOUTH_SHAPE;
+        arms[Direction.EAST.get3DDataValue()] = EAST_SHAPE;
+        arms[Direction.WEST.get3DDataValue()] = WEST_SHAPE;
+        arms[Direction.UP.get3DDataValue()] = UP_SHAPE;
+        arms[Direction.DOWN.get3DDataValue()] = DOWN_SHAPE;
+        SHAPE_CACHE = new ConnectedShapeCache(CORE_SHAPE, arms);
+    }
 
     private final ItemPipe pipe;
 
@@ -211,28 +224,13 @@ public class PipeBlock extends BaseEntityBlock
 
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
-        VoxelShape shape = CORE_SHAPE;
-
-        if (getConnectionType(world, pos, Direction.NORTH) != PipeConnection.Type.NONE) {
-            shape = Shapes.or(shape, NORTH_SHAPE);
+        int mask = 0;
+        for (Direction dir : Direction.values()) {
+            if (getConnectionType(world, pos, dir) != PipeConnection.Type.NONE) {
+                mask |= ConnectedShapeCache.bit(dir);
+            }
         }
-        if (getConnectionType(world, pos, Direction.SOUTH) != PipeConnection.Type.NONE) {
-            shape = Shapes.or(shape, SOUTH_SHAPE);
-        }
-        if (getConnectionType(world, pos, Direction.EAST) != PipeConnection.Type.NONE) {
-            shape = Shapes.or(shape, EAST_SHAPE);
-        }
-        if (getConnectionType(world, pos, Direction.WEST) != PipeConnection.Type.NONE) {
-            shape = Shapes.or(shape, WEST_SHAPE);
-        }
-        if (getConnectionType(world, pos, Direction.UP) != PipeConnection.Type.NONE) {
-            shape = Shapes.or(shape, UP_SHAPE);
-        }
-        if (getConnectionType(world, pos, Direction.DOWN) != PipeConnection.Type.NONE) {
-            shape = Shapes.or(shape, DOWN_SHAPE);
-        }
-
-        return shape;
+        return SHAPE_CACHE.get(mask);
     }
 
     @Nullable @Override

--- a/common/src/main/java/com/logistics/power/cable/CableBlock.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlock.java
@@ -1,6 +1,7 @@
 package com.logistics.power.cable;
 
 import com.logistics.LogisticsPower;
+import com.logistics.core.lib.block.ConnectedShapeCache;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
@@ -28,7 +29,6 @@ import net.minecraft.world.level.redstone.Orientation;
 import net.minecraft.world.level.ScheduledTickAccess;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import com.logistics.core.lib.energy.EnergyCapabilityLookup;
 import org.jetbrains.annotations.Nullable;
@@ -68,6 +68,19 @@ public class CableBlock extends BaseEntityBlock implements SimpleWaterloggedBloc
     private static final VoxelShape DOWN_SHAPE = Block.box(
             8 - CABLE_SIZE / 2, 0, 8 - CABLE_SIZE / 2,
             8 + CABLE_SIZE / 2, 8 - CABLE_SIZE / 2, 8 + CABLE_SIZE / 2);
+
+    private static final ConnectedShapeCache SHAPE_CACHE;
+
+    static {
+        VoxelShape[] arms = new VoxelShape[6];
+        arms[Direction.NORTH.get3DDataValue()] = NORTH_SHAPE;
+        arms[Direction.SOUTH.get3DDataValue()] = SOUTH_SHAPE;
+        arms[Direction.EAST.get3DDataValue()] = EAST_SHAPE;
+        arms[Direction.WEST.get3DDataValue()] = WEST_SHAPE;
+        arms[Direction.UP.get3DDataValue()] = UP_SHAPE;
+        arms[Direction.DOWN.get3DDataValue()] = DOWN_SHAPE;
+        SHAPE_CACHE = new ConnectedShapeCache(CORE_SHAPE, arms);
+    }
 
     private final CableTier tier;
 
@@ -116,24 +129,13 @@ public class CableBlock extends BaseEntityBlock implements SimpleWaterloggedBloc
 
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
-        VoxelShape shape = CORE_SHAPE;
+        int mask = 0;
         for (Direction dir : Direction.values()) {
             if (getConnectionType(world, pos, dir) != ConnectionType.NONE) {
-                shape = Shapes.or(shape, getShapeForDirection(dir));
+                mask |= ConnectedShapeCache.bit(dir);
             }
         }
-        return shape;
-    }
-
-    private VoxelShape getShapeForDirection(Direction dir) {
-        return switch (dir) {
-            case NORTH -> NORTH_SHAPE;
-            case SOUTH -> SOUTH_SHAPE;
-            case EAST -> EAST_SHAPE;
-            case WEST -> WEST_SHAPE;
-            case UP -> UP_SHAPE;
-            case DOWN -> DOWN_SHAPE;
-        };
+        return SHAPE_CACHE.get(mask);
     }
 
     @Nullable @Override


### PR DESCRIPTION
## Summary

Pipes and cables rebuilt their collision shape from scratch on **every** `getShape` call — looping the six sides and unioning `VoxelShape`s with `Shapes.or`. Because `getShape` is hit constantly by entity collision and ray-tracing, this showed up in a Spark profile (`CableBlock.getShape` / `PipeBlock.getShape`) as the most visible Logistics frames on the server thread.

A connected block has only **64 possible shapes** (a core plus any subset of six arms), so we now precompute all 64 once and look them up by a 6-bit connection mask. Connection state is still resolved live each call — only the shape union is cached.

## Changes

- New `ConnectedShapeCache` (`core.lib.block`): builds the 64 core+arms unions up front, indexed by a `Direction.get3DDataValue()` bit mask.
- `PipeBlock`, `FluidPipeBlock`, and `CableBlock` `getShape` now compute a connection mask and return the cached shape instead of rebuilding the union per call.

## Notes

- Geometry is unchanged — same boxes, same unions, just precomputed and shared (`VoxelShape` is immutable, so sharing is safe).
- Covers collision too (`getCollisionShape` delegates to `getShape` by default).
- Found via the new dev profiling tooling (Spark + `logistics:*` sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)