### PR TITLE
feat(core): add opt-in sanitized crash reporting

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -11,9 +11,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    # Non-secret boolean so the "Create Sentry release" step can gate on it (secrets can't be used in
+    # `if`). The token itself is passed only to the steps that need it, never the whole job.
     env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      HAS_SENTRY_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +83,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Create Sentry release
-        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        if: ${{ env.HAS_SENTRY_TOKEN == 'true' }}
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +78,22 @@ jobs:
         run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
         env:
           MOD_VERSION: ${{ steps.version.outputs.full_version }}
+          # Enables Sentry source-context upload during the build (gated on the token being present).
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Create Sentry release
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: indmenity83
+          SENTRY_PROJECT: logistics-mod
+        with:
+          release: logistics@${{ steps.version.outputs.full_version }}
+          set_commits: auto
+          finalize: true
+          # Pre-releases (betas) stay out of the production deploy stream.
+          environment: preview
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,9 +21,10 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    # Non-secret boolean so the "Create Sentry release" step can gate on it (secrets can't be used in
+    # `if`). The token itself is passed only to the steps that need it, never the whole job.
     env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      HAS_SENTRY_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,11 +107,12 @@ jobs:
         run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
         env:
           MOD_VERSION: ${{ steps.version.outputs.full_version }}
-          # Enables Sentry source-context upload during the build (gated on the token being present).
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Enables Sentry source-context upload during the build. Withheld on dry-run dispatches so a
+          # build-only run never uploads source context for a release that won't ship.
+          SENTRY_AUTH_TOKEN: ${{ (github.event_name != 'workflow_dispatch' || inputs.publish) && secrets.SENTRY_AUTH_TOKEN || '' }}
 
       - name: Create Sentry release
-        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.publish) && env.SENTRY_AUTH_TOKEN != '' }}
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.publish) && env.HAS_SENTRY_TOKEN == 'true' }}
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,6 +21,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +106,22 @@ jobs:
         run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
         env:
           MOD_VERSION: ${{ steps.version.outputs.full_version }}
+          # Enables Sentry source-context upload during the build (gated on the token being present).
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Create Sentry release
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.publish) && env.SENTRY_AUTH_TOKEN != '' }}
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: indmenity83
+          SENTRY_PROJECT: logistics-mod
+        with:
+          # Matches the runtime SDK's release: "logistics@" + modVersion (one per loader jar).
+          release: logistics@${{ steps.version.outputs.full_version }}
+          set_commits: auto
+          finalize: true
+          environment: production
 
       - name: List build artifacts
         run: |

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +93,22 @@ jobs:
         run: ./gradlew ${{ steps.version.outputs.gradle_task }} --console=plain
         env:
           MOD_VERSION: ${{ steps.version.outputs.full_version }}
+          # Enables Sentry source-context upload during the build (gated on the token being present).
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Create Sentry release
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: indmenity83
+          SENTRY_PROJECT: logistics-mod
+        with:
+          release: logistics@${{ steps.version.outputs.full_version }}
+          set_commits: auto
+          finalize: true
+          # Snapshots are pre-release; keep them out of the production deploy stream.
+          environment: preview
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -11,9 +11,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    # Non-secret boolean so the "Create Sentry release" step can gate on it (secrets can't be used in
+    # `if`). The token itself is passed only to the steps that need it, never the whole job.
     env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      HAS_SENTRY_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +98,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Create Sentry release
-        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        if: ${{ env.HAS_SENTRY_TOKEN == 'true' }}
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -21,7 +21,9 @@ seriously.
 - ✅ **Opt-in, and easy to opt out.** One command on, one command off.
 - ✅ **Logistics only.** It reports errors from this mod's own code — not from Minecraft, your server,
   or other mods.
-- ✅ **Sanitized.** No player names, UUIDs, IP addresses, server addresses, chat, or world data.
+- ✅ **Sanitized.** Player names, server addresses, chat, and world data are never intentionally
+  collected, and identifying details that could slip into an error message (home-directory paths, IP
+  addresses, UUIDs, and secret-like values) are actively scrubbed.
 - ✅ **You can verify it.** `/logistics diagnostics preview` shows you a real, sanitized example
   report without sending anything.
 - ✅ **Per-install.** Turning it on for a server does **not** turn it on for your players.
@@ -100,7 +102,7 @@ That's it. The goal is "what broke, where, and on what version" — nothing more
 
 ## What is never collected
 
-We deliberately exclude, and actively scrub for:
+None of the following is ever intentionally collected or sent:
 
 - ❌ Player names or player UUIDs
 - ❌ IP addresses
@@ -110,8 +112,10 @@ We deliberately exclude, and actively scrub for:
 - ❌ Your full configuration
 - ❌ Anything that looks like a secret (values labelled `password`, `token`, `secret`, `key`, `dsn`, …)
 
-We never intentionally send any of the above, and the sanitizer below is a second line of defense in
-case any of it ever slipped into an error message.
+As a second line of defense, the sanitizer **actively scrubs** the specific identifiers that could
+slip into an error message: your local OS user name and home-directory paths, IP addresses, UUIDs,
+and secret-like `key=value` pairs. It cannot detect free-form player names, server hostnames, chat,
+or world data, so those are kept out by simply never gathering them rather than by scrubbing.
 
 ---
 

--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -1,0 +1,183 @@
+# Crash Reporting & Privacy
+
+Logistics includes an **optional** crash reporter that can send **sanitized** error diagnostics to
+the developers so bugs get found and fixed faster. We built it to respect you: it is **off by
+default**, it only ever looks at Logistics' own errors, and you can see exactly what it would send
+before you ever turn it on.
+
+This page explains, in plain language, what it does, what it collects, what it deliberately does
+**not** collect, and how to control it. If anything here is unclear or you spot something that looks
+sensitive, please [open an issue](https://github.com/Indemnity83/logistics/issues) — we take this
+seriously.
+
+> Logistics is not an official Minecraft product and is not approved by or associated with Mojang or
+> Microsoft.
+
+---
+
+## The short version
+
+- ✅ **Off by default.** Nothing is sent unless an operator turns it on.
+- ✅ **Opt-in, and easy to opt out.** One command on, one command off.
+- ✅ **Logistics only.** It reports errors from this mod's own code — not from Minecraft, your server,
+  or other mods.
+- ✅ **Sanitized.** No player names, UUIDs, IP addresses, server addresses, chat, or world data.
+- ✅ **You can verify it.** `/logistics diagnostics preview` shows you a real, sanitized example
+  report without sending anything.
+- ✅ **Per-install.** Turning it on for a server does **not** turn it on for your players.
+
+If you do nothing, Logistics sends no diagnostics. That's the default, and it's a perfectly good
+choice.
+
+---
+
+## Why this exists
+
+When Logistics misbehaves in the real world, the developers usually never hear about it. Most players
+don't file bug reports, and even when they do, the useful details are buried in a log file that's
+hard to share. That means bugs can linger for weeks because there's simply no signal that they're
+happening.
+
+Opting in to crash reporting sends a small, sanitized diagnostic whenever Logistics hits an error.
+That gives the developers the one thing they're usually missing: a clear, actionable signal that
+something broke, what it was, and which version it happened on — so it can be fixed quickly. It is
+purely a debugging aid, not analytics, and it is intentionally narrow.
+
+---
+
+## Your choice, always
+
+Crash reporting is **disabled by default** and must be turned on explicitly. The toggle lives in your
+config (`config/logistics.json`) and is controlled with operator-level commands.
+
+**Single-player:** you are the operator, so you decide for your own game.
+
+**Multiplayer:** only a server operator can enable it, and when enabled it reports **server-side**
+Logistics errors. Each install has its own setting, so a server operator opting in does **not** opt
+in any connected player's client. If you run a client and want client-side reporting, that's a
+separate choice you make on your own machine.
+
+---
+
+## Commands
+
+All of these require operator (gamemaster) permission. Turning it off is exactly as easy as turning
+it on.
+
+| Command | What it does |
+| --- | --- |
+| `/logistics diagnostics` | Show whether reporting and the join notice are on or off |
+| `/logistics diagnostics enable` | Opt in to sending sanitized reports |
+| `/logistics diagnostics disable` | Stop sending reports |
+| `/logistics diagnostics preview` | Write an example sanitized report to the log **without sending it** |
+| `/logistics diagnostics notify off` | Hide the one-time join invitation |
+| `/logistics diagnostics notify on` | Show the join invitation again |
+
+### See for yourself: `preview`
+
+The `preview` command is the heart of our "trust, but verify" approach. It builds a sample error and
+runs it through the **exact same sanitization** that a real report goes through, then writes the
+result to the game log (`logs/latest.log`) with a short confirmation in chat — **nothing is sent.**
+The full report is written to the log because it's far too detailed to read in chat. The sample
+deliberately contains fake sensitive values (a home directory, an IP, a UUID, a token) so you can see
+them scrubbed in the output. It works whether or not reporting is enabled, so you can inspect it
+before deciding to opt in.
+
+---
+
+## What is collected (only when enabled)
+
+When reporting is on and Logistics hits an error, a report may include:
+
+- **Mod, Minecraft, and loader versions** — so a bug can be tied to a specific release.
+- **Java version and operating-system family** (e.g. "Windows", "Linux") — common environment context.
+- **The error itself** — the exception type, message, and stack trace, **originating from Logistics'
+  own code**.
+- **Generic runtime context** that the reporting library attaches automatically (e.g. JVM and OS
+  family). This does not include personal identifiers.
+
+That's it. The goal is "what broke, where, and on what version" — nothing more.
+
+## What is never collected
+
+We deliberately exclude, and actively scrub for:
+
+- ❌ Player names or player UUIDs
+- ❌ IP addresses
+- ❌ Server addresses or hostnames
+- ❌ Chat messages
+- ❌ World data, coordinates, or save contents
+- ❌ Your full configuration
+- ❌ Anything that looks like a secret (values labelled `password`, `token`, `secret`, `key`, `dsn`, …)
+
+We never intentionally send any of the above, and the sanitizer below is a second line of defense in
+case any of it ever slipped into an error message.
+
+---
+
+## How your data is protected
+
+Several safeguards work together:
+
+1. **Off by default.** No opt-in, no data. Ever.
+2. **Scoped capture.** Only errors logged by Logistics' own code are eligible. The reporter does
+   **not** install a global error handler, so errors from Minecraft, your server, or other mods are
+   never picked up.
+3. **No PII by default.** The reporting library's "send personal information" setting is left
+   **off**, and the host/server name is never attached.
+4. **Active scrubbing.** Before a report leaves your machine, a sanitizer rewrites the message and
+   error text to remove home-directory paths (e.g. `/Users/you/…` → `~`, Windows paths too), IP
+   addresses (→ `<ip>`), UUIDs (→ `<uuid>`), and secret-like `key=value` pairs (→ `key=<redacted>`).
+5. **Verifiable.** `/logistics diagnostics preview` lets you see the sanitized output yourself.
+
+This sanitization is best-effort and intentionally biased toward over-redaction: when in doubt, it
+strips it.
+
+---
+
+## Where reports go
+
+Reports are processed by [Sentry](https://sentry.io), a widely used error-monitoring service, on a
+project owned by the mod's developers.
+
+**Self-hosting:** if you'd rather send reports to your own Sentry project (or a local endpoint of
+your choosing), set `crashReporting.dsnOverride` in `config/logistics.json` to your own DSN. When set,
+reports go there instead of the default project.
+
+---
+
+## How to check the current state, or turn it off
+
+- Run `/logistics diagnostics` to see the current status at any time.
+- Run `/logistics diagnostics disable` to stop immediately.
+- Or open `config/logistics.json` and set `crashReporting.enabled` to `false`.
+
+When disabled, the reporter sends nothing and runs no background networking.
+
+---
+
+## FAQ
+
+**Will this slow down my game or server?**
+No meaningful impact. Reports are only created on an actual error and are sent on a background thread,
+so the game thread isn't blocked.
+
+**Does enabling it on my server enable it for my players?**
+No. Settings are per-install. A server operator's choice only affects server-side Logistics errors.
+
+**Is it really "anonymous"?**
+We call it **sanitized**, not anonymous, on purpose. We don't intentionally collect identifiers and
+we actively scrub for them, but no scrubber is perfect, so we'd rather be precise than overstate it.
+That's also why `preview` exists — so you can check.
+
+**What if `preview` shows me something sensitive?**
+Please [open an issue](https://github.com/Indemnity83/logistics/issues) and tell us what you saw (you
+don't need to include the sensitive value itself). We'll tighten the sanitizer.
+
+**Can I turn off just the in-game invitation but leave reporting off?**
+Yes — `/logistics diagnostics notify off` hides the prompt without changing anything else.
+
+---
+
+*Thank you for considering it. Opting in is genuinely helpful, and turning it down is completely
+fine — either way, you're in control.*

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ RF energy generation and distribution:
 [Full installation guide →](https://indemnity83.github.io/logistics/getting-started/install/)
 
 
+## Crash Reporting & Privacy
+
+Logistics can optionally send **sanitized** crash diagnostics to help fix bugs. It is **off by
+default** and opt-in per install via `/logistics diagnostics enable`. It never intentionally sends
+player names, UUIDs, IPs, server addresses, chat, or world data. See
+[CRASH_REPORTING.md](CRASH_REPORTING.md) for exactly what is and isn't collected.
+
+
 ## Quick Start
 
 1. **Craft pipes** - Start with stone or copper transport pipes

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     // Team Reborn Energy API (bundled into the Fabric jar via include in fabric/build.gradle)
     implementation("teamreborn:energy:${rootProject.fabric_energy_version}")
 
+    // Sentry SDK for opt-in crash reporting (pure Java, no transitive deps). Bundled per loader
+    // via include (Fabric) / jarJar (NeoForge); here it compiles common and runs the unit tests.
+    implementation("io.sentry:sentry:${rootProject.sentry_version}")
+
     // JEI — compile only; players install separately at runtime
     compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
 

--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -2,6 +2,7 @@ package com.logistics;
 
 import com.logistics.core.LogisticsConfig;
 import com.logistics.core.bootstrap.DomainBootstrap;
+import com.logistics.core.crash.CrashReporting;
 import com.logistics.core.item.WrenchItem;
 import com.logistics.core.lib.platform.LogisticsCreativeTab;
 import com.logistics.core.lib.platform.CreativeTabRegistrar;
@@ -45,6 +46,7 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
         LOGGER.info("Registering {}", domain());
 
         LogisticsConfig.load();
+        CrashReporting.bootstrap();
 
         BLOCK.register();
         ITEM.register();

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -1,13 +1,18 @@
 package com.logistics.core;
 
+import com.logistics.core.crash.CrashReporting;
+import com.logistics.core.lib.platform.PlatformService;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,6 +37,8 @@ import java.util.Set;
 public final class LogisticsCommandTree {
     private LogisticsCommandTree() {}
 
+    private static final Logger LOGGER = LoggerFactory.getLogger("logistics/command");
+
     private static final SuggestionProvider<CommandSourceStack> DOMAIN_SUGGESTIONS =
         (ctx, builder) -> SharedSuggestionProvider.suggest(sortedDomains(), builder);
 
@@ -45,6 +52,68 @@ public final class LogisticsCommandTree {
     }
 
     public static LiteralArgumentBuilder<CommandSourceStack> build() {
+        LiteralArgumentBuilder<CommandSourceStack> diagnostics = Commands.literal("diagnostics")
+            .executes(ctx -> {
+                ctx.getSource().sendSuccess(() -> Component.literal(CrashReporting.statusText()), false);
+                return 1;
+            })
+            .then(Commands.literal("enable")
+                .executes(ctx -> {
+                    if (!CrashReporting.enableReporting()) {
+                        ctx.getSource().sendFailure(Component.literal(
+                            "Could not start crash reporting — no DSN configured or initialization failed. "
+                            + "See the log for details."));
+                        return 0;
+                    }
+                    ctx.getSource().sendSuccess(
+                        () -> Component.literal(
+                            "Sanitized crash reporting enabled. Thank you for helping improve Logistics!"),
+                        true);
+                    return 1;
+                }))
+            .then(Commands.literal("disable")
+                .executes(ctx -> {
+                    CrashReporting.disableReporting();
+                    ctx.getSource().sendSuccess(
+                        () -> Component.literal("Crash reporting disabled."), true);
+                    return 1;
+                }))
+            .then(Commands.literal("preview")
+                .executes(ctx -> {
+                    CrashReporting.logPreviewReport();
+                    ctx.getSource().sendSuccess(LogisticsCommandTree::diagnosticsPreviewSummary, false);
+                    return 1;
+                }))
+            .then(Commands.literal("notify")
+                .then(Commands.literal("on")
+                    .executes(ctx -> {
+                        ctx.getSource().sendSuccess(
+                            () -> Component.literal(CrashReporting.setJoinNotice(true)), true);
+                        return 1;
+                    }))
+                .then(Commands.literal("off")
+                    .executes(ctx -> {
+                        ctx.getSource().sendSuccess(
+                            () -> Component.literal(CrashReporting.setJoinNotice(false)), true);
+                        return 1;
+                    })));
+
+        // Dev-only: send a temporary test crash report to verify the Sentry pipeline.
+        if (inDevelopmentEnvironment()) {
+            diagnostics.then(Commands.literal("test")
+                .executes(ctx -> {
+                    if (!CrashReporting.captureTestReport()) {
+                        ctx.getSource().sendFailure(Component.literal(
+                            "Crash reporting is not active. Run /logistics diagnostics enable first."));
+                        return 0;
+                    }
+                    ctx.getSource().sendSuccess(
+                        () -> Component.literal("Sent a temporary test crash report to Sentry."),
+                        false);
+                    return 1;
+                }));
+        }
+
         return Commands.literal("logistics")
             .requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
             .then(Commands.literal("debug")
@@ -147,6 +216,33 @@ public final class LogisticsCommandTree {
                         ctx.getSource().sendSuccess(
                             () -> Component.literal("Reloaded logistics config from disk"), true);
                         return 1;
-                    })));
+                    })))
+            .then(diagnostics);
+    }
+
+    /**
+     * Resolves the development-environment flag defensively: any failure is treated as production
+     * (false) so dev-only command nodes can never abort registration of the whole command tree.
+     */
+    private static boolean inDevelopmentEnvironment() {
+        try {
+            return PlatformService.INSTANCE.isDevelopmentEnvironment();
+        } catch (Throwable t) {
+            LOGGER.warn("Could not determine development environment; treating as production", t);
+            return false;
+        }
+    }
+
+    /** Chat confirmation for {@code /logistics diagnostics preview} — the full report goes to the log. */
+    private static Component diagnosticsPreviewSummary() {
+        return Component.empty()
+            .append(Component.literal("Wrote an example sanitized crash report to the log.\n")
+                .withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("Includes: ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("mod/Minecraft/loader/Java/OS versions and a Logistics stack trace.\n")
+                .withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("Never includes: ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("names, UUIDs, IPs, server addresses, chat, or world data.")
+                .withStyle(ChatFormatting.WHITE));
     }
 }

--- a/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
+++ b/common/src/main/java/com/logistics/core/LogisticsCommandTree.java
@@ -213,6 +213,7 @@ public final class LogisticsCommandTree {
                 .then(Commands.literal("reload")
                     .executes(ctx -> {
                         LogisticsConfig.reload();
+                        CrashReporting.reconcile();
                         ctx.getSource().sendSuccess(
                             () -> Component.literal("Reloaded logistics config from disk"), true);
                         return 1;

--- a/common/src/main/java/com/logistics/core/LogisticsConfig.java
+++ b/common/src/main/java/com/logistics/core/LogisticsConfig.java
@@ -40,6 +40,7 @@ public final class LogisticsConfig {
     public EngineConfig engine = new EngineConfig();
     public FluidPipeConfig fluidPipe = new FluidPipeConfig();
     public FluidPumpConfig fluidPump = new FluidPumpConfig();
+    public CrashReportingConfig crashReporting = new CrashReportingConfig();
 
     public static final class QuarryConfig {
         public int area = 16;
@@ -105,6 +106,18 @@ public final class LogisticsConfig {
         public int searchRadius = 64;
         public float armSpeed = 0.01f;
         public int infiniteSourceThreshold = 9;
+    }
+
+    /**
+     * Opt-in sanitized crash reporting (Sentry). Disabled by default; an operator opts in via
+     * {@code /logistics diagnostics enable}. Intentionally NOT in the {@link #ENTRIES} registry —
+     * the {@code /logistics diagnostics} commands are the single source of truth so the persisted
+     * value and the live Sentry client never drift apart (e.g. via a generic {@code config set}).
+     */
+    public static final class CrashReportingConfig {
+        public boolean enabled = false;
+        public boolean notifyOperators = true;
+        public String dsnOverride = "";
     }
 
     // ==================== Config Entry Registry (for commands) ====================
@@ -408,6 +421,13 @@ public final class LogisticsConfig {
         if (config.fluidPump == null) {
             LOGGER.warn("Invalid logistics config group fluidPump: missing; using defaults");
             config.fluidPump = defaults.fluidPump;
+        }
+        if (config.crashReporting == null) {
+            LOGGER.warn("Invalid logistics config group crashReporting: missing; using defaults");
+            config.crashReporting = defaults.crashReporting;
+        }
+        if (config.crashReporting.dsnOverride == null) {
+            config.crashReporting.dsnOverride = defaults.crashReporting.dsnOverride;
         }
 
         sanitizeInt("quarry_area", () -> (long) config.quarry.area, v -> config.quarry.area = v.intValue(),

--- a/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReportNotifier.java
@@ -1,0 +1,102 @@
+package com.logistics.core.crash;
+
+import com.logistics.core.LogisticsConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.net.URI;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Shows operators a once-per-server-session crash-reporting status line with clickable toggles.
+ *
+ * <p>Shared by both loaders; the loader-specific hooks call {@link #maybeNotify} on player join and
+ * {@link #reset()} when a server starts so each new world/server session shows the line once. It is
+ * suppressed when an operator silences it via {@code /logistics diagnostics notify off}.
+ */
+public final class CrashReportNotifier {
+    private static final Set<UUID> NOTIFIED_THIS_SESSION = ConcurrentHashMap.newKeySet();
+
+    private static final String ENABLE_COMMAND = "/logistics diagnostics enable";
+    private static final String DISABLE_COMMAND = "/logistics diagnostics disable";
+    private static final String HIDE_COMMAND = "/logistics diagnostics notify off";
+
+    /** Latest crash-reporting & privacy page, opened by the [More Info] link. */
+    private static final String DETAILS_URL =
+            "https://github.com/Indemnity83/logistics/blob/mc/26.2/CRASH_REPORTING.md";
+
+    private CrashReportNotifier() {}
+
+    /** Show operators the once-per-session crash-reporting status line (unless they've silenced it). */
+    public static void maybeNotify(ServerPlayer player) {
+        LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
+        boolean isOperator = Commands.LEVEL_GAMEMASTERS.check(player.permissions());
+        if (!shouldNotify(cfg.notifyOperators, isOperator)) {
+            return;
+        }
+        if (NOTIFIED_THIS_SESSION.add(player.getUUID())) {
+            player.sendSystemMessage(buildInvite(cfg.enabled));
+        }
+    }
+
+    /** Clear the per-session dedup so the next server session shows the status line again. */
+    public static void reset() {
+        NOTIFIED_THIS_SESSION.clear();
+    }
+
+    /** Pure gate: show the status line only to operators who haven't silenced the notice. */
+    static boolean shouldNotify(boolean notifyOperators, boolean isOperator) {
+        return notifyOperators && isOperator;
+    }
+
+    /** Status line whose toggle reflects the current state: [ON] turns it off, [OFF] turns it on. */
+    static Component buildInvite(boolean enabled) {
+        return Component.empty()
+                .append(Component.literal("[Logistics] ").withStyle(ChatFormatting.AQUA))
+                .append(Component.literal("Crash reporting is ").withStyle(ChatFormatting.GRAY))
+                .append(statusToggle(enabled))
+                .append(Component.literal(" "))
+                .append(hideNotificationLink())
+                .append(Component.literal(" "))
+                .append(moreInfoLink());
+    }
+
+    private static Component statusToggle(boolean enabled) {
+        if (enabled) {
+            return Component.literal("[ON]").withStyle(style -> style
+                    .withColor(ChatFormatting.GREEN)
+                    .withClickEvent(new ClickEvent.RunCommand(DISABLE_COMMAND))
+                    .withHoverEvent(new HoverEvent.ShowText(
+                            Component.literal("Click to turn crash reporting off"))));
+        }
+        return Component.literal("[OFF]").withStyle(style -> style
+                .withColor(ChatFormatting.RED)
+                .withClickEvent(new ClickEvent.RunCommand(ENABLE_COMMAND))
+                .withHoverEvent(new HoverEvent.ShowText(
+                        Component.literal("Click to turn on sanitized crash reporting"))));
+    }
+
+    private static Component hideNotificationLink() {
+        return Component.literal("[Hide Notification]").withStyle(style -> style
+                .withColor(ChatFormatting.GRAY)
+                .withUnderlined(true)
+                .withClickEvent(new ClickEvent.RunCommand(HIDE_COMMAND))
+                .withHoverEvent(new HoverEvent.ShowText(
+                        Component.literal("Stop showing this on join (you can still use /logistics diagnostics)"))));
+    }
+
+    private static Component moreInfoLink() {
+        return Component.literal("[More Info]").withStyle(style -> style
+                .withColor(ChatFormatting.AQUA)
+                .withUnderlined(true)
+                .withClickEvent(new ClickEvent.OpenUrl(URI.create(DETAILS_URL)))
+                .withHoverEvent(new HoverEvent.ShowText(
+                        Component.literal("Open the crash reporting & privacy page"))));
+    }
+}

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -1,0 +1,352 @@
+package com.logistics.core.crash;
+
+import com.logistics.core.LogisticsConfig;
+import com.logistics.core.lib.platform.PlatformService;
+import io.sentry.JsonSerializer;
+import io.sentry.SentryClient;
+import io.sentry.SentryEvent;
+import io.sentry.SentryExceptionFactory;
+import io.sentry.SentryOptions;
+import io.sentry.SentryStackTraceFactory;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+/**
+ * Opt-in sanitized crash reporting via Sentry. Loader-agnostic — the SDK is pure Java, so all calls
+ * live in common; loaders only bundle the SDK and provide version/environment via {@link PlatformService}.
+ *
+ * <p>Design:
+ * <ul>
+ *   <li><b>Lazy</b>: nothing initializes until {@link #enable()} is called. A disabled install spins
+ *       up no transport thread and makes no network calls.</li>
+ *   <li><b>Logistics-only</b>: a dedicated {@link SentryClient} is used rather than the global
+ *       {@code Sentry.init()}/{@code Sentry.close()} static API, so we never mutate SDK state shared
+ *       with another mod that bundles Sentry. A standalone client installs no global integrations
+ *       (no uncaught-exception handler, no shutdown hook); exceptions are captured solely through a
+ *       {@link LogisticsErrorLogBridge} scoped to the Logistics loggers, so other mods and vanilla
+ *       are never reported.</li>
+ *   <li><b>Sanitized</b>: PII is off and the host/server name is not attached; messages and exception
+ *       values are scrubbed of home directories, IPs, UUIDs, and secret-like values before send. We
+ *       never intentionally send player names, UUIDs, IPs, server addresses, chat, or world data.</li>
+ * </ul>
+ *
+ * <p>Toggled by the {@code /logistics diagnostics} commands, which persist {@link LogisticsConfig}
+ * and call {@link #enable()}/{@link #disable()} so stored and live state stay in sync.
+ */
+public final class CrashReporting {
+    private static final Logger LOGGER = LoggerFactory.getLogger("logistics/crash");
+
+    /**
+     * Public Sentry ingest key (DSN). NOT a secret — DSNs are designed to be embedded in shipped
+     * clients. Overridable per-install via {@code crashReporting.dsnOverride} in logistics.json.
+     */
+    private static final String DEFAULT_DSN =
+            "https://677897aaa1709d6e63d47ebbed033218@o148290.ingest.us.sentry.io/4511488473169920";
+
+    /** How long the exit hook waits for queued events to flush, in milliseconds. */
+    private static final long FLUSH_TIMEOUT_MS = 2_000L;
+
+    private static final AtomicBoolean ACTIVE = new AtomicBoolean(false);
+    private static final AtomicBoolean SHUTDOWN_HOOK_REGISTERED = new AtomicBoolean(false);
+    private static volatile SentryClient client;
+    private static volatile LogisticsErrorLogBridge bridge;
+
+    private CrashReporting() {}
+
+    /** Called once after config load. Enables reporting only if the operator opted in previously. */
+    public static void bootstrap() {
+        if (LogisticsConfig.get().crashReporting.enabled) {
+            enable();
+        }
+    }
+
+    /** Start sending reports. Idempotent. */
+    public static synchronized void enable() {
+        if (ACTIVE.get()) {
+            return;
+        }
+        String dsn = resolveDsn();
+        if (dsn.isBlank()) {
+            LOGGER.warn("Crash reporting enabled but no DSN is configured; not starting Sentry");
+            return;
+        }
+        SentryOptions options = buildOptions();
+        // Dedicated client — never Sentry.init(), which would replace the global SDK scope shared
+        // with any other mod bundling the same Sentry. The SentryClient constructor swaps in a real
+        // async HTTP transport on its own, so events are actually sent.
+        client = new SentryClient(options);
+        registerExitFlushHookOnce();
+        bridge = newBridge();
+        bridge.attach();
+        ACTIVE.set(true);
+        LOGGER.info("Crash reporting enabled (environment={})", options.getEnvironment());
+    }
+
+    /** Build the Sentry options used for both the live client and the {@link #previewReport()}. */
+    private static SentryOptions buildOptions() {
+        boolean dev = isDevelopmentEnvironment();
+        SentryOptions options = new SentryOptions();
+        options.setDsn(resolveDsn());
+        // Belt-and-suspenders: a standalone client installs no integrations anyway, so there is
+        // never a global uncaught-exception handler that could capture other mods or vanilla.
+        options.setEnableUncaughtExceptionHandler(false);
+        options.setSendDefaultPii(false);
+        options.setAttachServerName(false);
+        // Ignore SENTRY_* env vars / sentry.properties so behavior is fully code-driven.
+        options.setEnableExternalConfiguration(false);
+        options.setRelease("logistics@" + modVersion());
+        options.setEnvironment(dev ? "dev" : "prod");
+        options.setTag("loader", loaderName());
+        options.setTag("minecraft_version", minecraftVersion());
+        options.setTag("mod_version", modVersion());
+        options.setBeforeSend((event, hint) -> scrub(event));
+        options.setDebug(dev);
+        return options;
+    }
+
+    // Platform lookups are defensive: crash reporting is non-critical, so if the SPI is somehow
+    // unavailable (e.g. a unit-test classloader) we fall back rather than failing to report.
+    private static String modVersion() {
+        try {
+            return PlatformService.INSTANCE.modVersion();
+        } catch (Throwable t) {
+            return "unknown";
+        }
+    }
+
+    private static String loaderName() {
+        try {
+            return PlatformService.INSTANCE.loaderName();
+        } catch (Throwable t) {
+            return "unknown";
+        }
+    }
+
+    private static String minecraftVersion() {
+        try {
+            return PlatformService.INSTANCE.minecraftVersion();
+        } catch (Throwable t) {
+            return "unknown";
+        }
+    }
+
+    private static boolean isDevelopmentEnvironment() {
+        try {
+            return PlatformService.INSTANCE.isDevelopmentEnvironment();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /** Stop sending reports and flush. Idempotent. */
+    public static synchronized void disable() {
+        if (!ACTIVE.getAndSet(false)) {
+            return;
+        }
+        if (bridge != null) {
+            bridge.detach();
+            bridge = null;
+        }
+        SentryClient current = client;
+        client = null;
+        if (current != null) {
+            current.close(); // flushes queued events
+        }
+        LOGGER.info("Crash reporting disabled");
+    }
+
+    public static boolean isActive() {
+        return ACTIVE.get();
+    }
+
+    // ==================== Command actions ====================
+    // These back the /logistics diagnostics subcommands. Kept here (not inline in the Brigadier
+    // tree) so the persist-and-toggle logic is unit-testable without a command source.
+
+    /**
+     * Turn reporting on, then persist {@code enabled} to match whether it actually activated.
+     * Returns true if reporting is now active. If activation fails (e.g. no DSN, or init throws
+     * before this returns), the persisted config is left disabled rather than claiming an active
+     * state — so the saved value never lies about a client that isn't running.
+     */
+    public static boolean enableReporting() {
+        try {
+            enable();
+        } catch (Exception e) {
+            LOGGER.error("Failed to start crash reporting", e);
+            LogisticsConfig.get().crashReporting.enabled = false;
+            LogisticsConfig.save();
+            return false;
+        }
+        boolean active = isActive();
+        LogisticsConfig.get().crashReporting.enabled = active;
+        LogisticsConfig.save();
+        return active;
+    }
+
+    /** Turn reporting off and persist the disabled state. */
+    public static void disableReporting() {
+        disable();
+        LogisticsConfig.get().crashReporting.enabled = false;
+        LogisticsConfig.save();
+    }
+
+    /** Persist whether the join invitation is shown. Returns operator feedback. */
+    public static String setJoinNotice(boolean show) {
+        LogisticsConfig.get().crashReporting.notifyOperators = show;
+        LogisticsConfig.save();
+        return "Crash reporting join notice: " + (show ? "ON" : "off");
+    }
+
+    /** Human-readable current state for the status command. */
+    public static String statusText() {
+        LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
+        return "Sanitized crash reporting: " + (cfg.enabled ? "ON" : "off")
+                + "\n  join notice: " + (cfg.notifyOperators ? "on" : "off");
+    }
+
+    /** Report a throwable when active; a no-op otherwise. */
+    public static void capture(Throwable throwable) {
+        if (throwable == null || !ACTIVE.get()) {
+            return;
+        }
+        SentryClient current = client;
+        if (current != null) {
+            current.captureException(throwable);
+        }
+    }
+
+    /** TEMPORARY: send a synthetic report so the Sentry project can be inspected manually. */
+    public static boolean captureTestReport() {
+        if (!ACTIVE.get()) {
+            return false;
+        }
+        SentryClient current = client;
+        if (current == null) {
+            return false;
+        }
+        current.captureException(new RuntimeException(
+                "Temporary Logistics Sentry test report; safe to ignore. marker=" + System.currentTimeMillis()));
+        current.flush(FLUSH_TIMEOUT_MS);
+        return true;
+    }
+
+    /**
+     * Write an example sanitized report to the log so an operator can read/copy exactly what would
+     * be sent. Logged at INFO with no throwable, so the {@link LogisticsErrorLogBridge} never picks
+     * it up — previewing never sends anything, even while reporting is active.
+     */
+    public static void logPreviewReport() {
+        LOGGER.info("Example sanitized crash report (NOT sent — preview):\n{}", previewReport());
+    }
+
+    /**
+     * Build a representative report for a synthetic Logistics error, run it through the exact
+     * sanitization pipeline used before sending, and return it as JSON. Does NOT send and works
+     * whether or not reporting is enabled, so an operator can inspect the output before opting in.
+     * The sample message embeds mock sensitive values so the scrubbing is visible in the result.
+     */
+    public static String previewReport() {
+        SentryOptions options = buildOptions();
+        RuntimeException sample = new RuntimeException(
+                "Logistics crash-report preview (example, not a real crash). Sensitive values are "
+                + "scrubbed before send: home=" + System.getProperty("user.home")
+                + " ip=203.0.113.7 uuid=123e4567-e89b-12d3-a456-426614174000 token=hunter2");
+        SentryEvent event = new SentryEvent(sample);
+        event.setRelease(options.getRelease());
+        event.setEnvironment(options.getEnvironment());
+        SentryExceptionFactory exceptionFactory =
+                new SentryExceptionFactory(new SentryStackTraceFactory(options));
+        event.setExceptions(exceptionFactory.getSentryExceptions(sample));
+        scrub(event);
+        try (StringWriter writer = new StringWriter()) {
+            new JsonSerializer(options).serialize(event, writer);
+            return writer.toString();
+        } catch (IOException e) {
+            return "Failed to build preview: " + e;
+        }
+    }
+
+    private static LogisticsErrorLogBridge newBridge() {
+        return new Log4j2ErrorLogBridge(CrashReporting::capture);
+    }
+
+    /**
+     * Registers a single JVM shutdown hook that flushes the active client's queue on exit. Replaces
+     * the flush-on-exit that {@code Sentry.init()} used to provide via its global shutdown
+     * integration. Process-local and scoped to our own client — it touches no shared SDK state.
+     */
+    private static void registerExitFlushHookOnce() {
+        if (!SHUTDOWN_HOOK_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            SentryClient current = client;
+            if (current != null) {
+                current.flush(FLUSH_TIMEOUT_MS);
+            }
+        }, "logistics-sentry-flush"));
+    }
+
+    private static String resolveDsn() {
+        String override = LogisticsConfig.get().crashReporting.dsnOverride;
+        return override != null && !override.isBlank() ? override.trim() : DEFAULT_DSN;
+    }
+
+    // Free-text identifiers to strip from any text that leaves the process.
+    private static final Pattern IPV4 = Pattern.compile("\\b\\d{1,3}(?:\\.\\d{1,3}){3}\\b");
+    private static final Pattern UUID = Pattern.compile(
+            "\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b");
+    private static final Pattern UNIX_HOME = Pattern.compile("(/(?:Users|home))/[^/\\s]+");
+    private static final Pattern WINDOWS_HOME = Pattern.compile("([A-Za-z]:\\\\Users\\\\)[^\\\\\\s]+");
+    private static final Pattern SECRET_KV = Pattern.compile(
+            "(?i)(password|passwd|token|secret|api[_-]?key|access[_-]?key|dsn)(\\s*[=:]\\s*)\\S+");
+
+    /**
+     * Sanitize an event before it leaves the process: drop the server name and strip identifying
+     * substrings (home directories, IPs, UUIDs, secret-like {@code key=value} pairs) from the event
+     * message and every exception value. Stack frames carry only source file names, not paths, so
+     * they need no scrubbing. Best-effort, biased toward over-redaction.
+     */
+    private static SentryEvent scrub(SentryEvent event) {
+        event.setServerName(null);
+        Message message = event.getMessage();
+        if (message != null) {
+            message.setFormatted(redact(message.getFormatted()));
+            message.setMessage(redact(message.getMessage()));
+        }
+        if (event.getExceptions() != null) {
+            for (SentryException ex : event.getExceptions()) {
+                ex.setValue(redact(ex.getValue()));
+            }
+        }
+        return event;
+    }
+
+    static String redact(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        String home = System.getProperty("user.home");
+        String user = System.getProperty("user.name");
+        if (home != null && !home.isBlank()) {
+            value = value.replace(home, "~");
+        }
+        if (user != null && !user.isBlank()) {
+            value = value.replace(user, "<user>");
+        }
+        value = UNIX_HOME.matcher(value).replaceAll("$1/<user>");
+        value = WINDOWS_HOME.matcher(value).replaceAll("$1<user>");
+        value = UUID.matcher(value).replaceAll("<uuid>");
+        value = IPV4.matcher(value).replaceAll("<ip>");
+        value = SECRET_KV.matcher(value).replaceAll("$1$2<redacted>");
+        return value;
+    }
+}

--- a/common/src/main/java/com/logistics/core/crash/CrashReporting.java
+++ b/common/src/main/java/com/logistics/core/crash/CrashReporting.java
@@ -62,8 +62,31 @@ public final class CrashReporting {
 
     /** Called once after config load. Enables reporting only if the operator opted in previously. */
     public static void bootstrap() {
-        if (LogisticsConfig.get().crashReporting.enabled) {
+        if (!LogisticsConfig.get().crashReporting.enabled) {
+            return;
+        }
+        // Crash reporting is non-critical: a bad persisted DSN must never abort domain startup.
+        try {
             enable();
+        } catch (Exception e) {
+            LOGGER.error("Failed to start crash reporting; continuing without it", e);
+        }
+    }
+
+    /**
+     * Bring the live client in line with the persisted config, e.g. after {@code /logistics config
+     * reload} edits {@code crashReporting} on disk. Rebuilds when enabled so a changed DSN takes
+     * effect; tears down when disabled.
+     */
+    public static synchronized void reconcile() {
+        disable();
+        if (!LogisticsConfig.get().crashReporting.enabled) {
+            return;
+        }
+        try {
+            enable();
+        } catch (Exception e) {
+            LOGGER.error("Failed to restart crash reporting after config reload", e);
         }
     }
 
@@ -84,7 +107,14 @@ public final class CrashReporting {
         client = new SentryClient(options);
         registerExitFlushHookOnce();
         bridge = newBridge();
-        bridge.attach();
+        if (!bridge.attach()) {
+            // No log capture means no reports would actually flow; don't claim an active state.
+            LOGGER.warn("Crash reporting could not attach log capture; not enabling");
+            bridge = null;
+            client.close();
+            client = null;
+            return;
+        }
         ACTIVE.set(true);
         LOGGER.info("Crash reporting enabled (environment={})", options.getEnvironment());
     }

--- a/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
+++ b/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
@@ -33,15 +33,18 @@ final class Log4j2ErrorLogBridge implements LogisticsErrorLogBridge {
 
     /**
      * True when an event should be reported: it carries a throwable and originates from a Logistics
-     * logger. Package-private and parameterized over primitives so it is unit-testable without
-     * constructing a Log4j2 {@link LogEvent}.
+     * logger.
      */
     static boolean shouldForward(String loggerName, boolean hasThrowable) {
         if (!hasThrowable || loggerName == null) {
             return false;
         }
         String lower = loggerName.toLowerCase(Locale.ROOT);
-        return lower.startsWith("logistics") || lower.contains("com.logistics");
+        // Match only our own namespaces — not a foreign "logisticsaddons" or "other.com.logistics".
+        return lower.equals("logistics")
+                || lower.startsWith("logistics/")
+                || lower.startsWith("logistics.")
+                || lower.startsWith("com.logistics.");
     }
 
     @Override
@@ -59,7 +62,8 @@ final class Log4j2ErrorLogBridge implements LogisticsErrorLogBridge {
             return true;
         } catch (Throwable t) {
             LOGGER.warn("Failed to attach crash log capture: {}", t.toString());
-            appender = null;
+            // Undo any partial registration so a half-attached appender can't linger on root.
+            detach();
             return false;
         }
     }

--- a/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
+++ b/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
@@ -1,0 +1,96 @@
+package com.logistics.core.crash;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+import java.util.function.Consumer;
+
+/**
+ * {@link LogisticsErrorLogBridge} backed by Log4j2 (Minecraft's slf4j backend at runtime).
+ *
+ * <p>Adds a forwarding appender to the <em>root</em> logger config, filtered at runtime to ERROR
+ * events that (a) carry a {@link Throwable} and (b) originate from a Logistics logger. Attaching to
+ * root rather than creating a {@code com.logistics} logger config avoids changing any logger's
+ * effective level. All Log4j2-core access is guarded so a non-Log4j2 backend degrades to a no-op.
+ */
+final class Log4j2ErrorLogBridge implements LogisticsErrorLogBridge {
+    private static final Logger LOGGER = LoggerFactory.getLogger("logistics/crash");
+    private static final String APPENDER_NAME = "LogisticsSentryBridge";
+
+    private final Consumer<Throwable> sink;
+    private ForwardingAppender appender;
+
+    Log4j2ErrorLogBridge(Consumer<Throwable> sink) {
+        this.sink = sink;
+    }
+
+    /**
+     * True when an event should be reported: it carries a throwable and originates from a Logistics
+     * logger. Package-private and parameterized over primitives so it is unit-testable without
+     * constructing a Log4j2 {@link LogEvent}.
+     */
+    static boolean shouldForward(String loggerName, boolean hasThrowable) {
+        if (!hasThrowable || loggerName == null) {
+            return false;
+        }
+        String lower = loggerName.toLowerCase(Locale.ROOT);
+        return lower.startsWith("logistics") || lower.contains("com.logistics");
+    }
+
+    @Override
+    public void attach() {
+        try {
+            if (!(LogManager.getContext(false) instanceof LoggerContext ctx)) {
+                LOGGER.warn("Log4j2 backend unavailable; crash log capture disabled");
+                return;
+            }
+            Configuration config = ctx.getConfiguration();
+            appender = new ForwardingAppender(APPENDER_NAME, sink);
+            appender.start();
+            config.getRootLogger().addAppender(appender, Level.ERROR, null);
+            ctx.updateLoggers();
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to attach crash log capture: {}", t.toString());
+            appender = null;
+        }
+    }
+
+    @Override
+    public void detach() {
+        try {
+            if (appender == null || !(LogManager.getContext(false) instanceof LoggerContext ctx)) {
+                return;
+            }
+            ctx.getConfiguration().getRootLogger().removeAppender(APPENDER_NAME);
+            appender.stop();
+            ctx.updateLoggers();
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to detach crash log capture: {}", t.toString());
+        } finally {
+            appender = null;
+        }
+    }
+
+    private static final class ForwardingAppender extends AbstractAppender {
+        private final Consumer<Throwable> sink;
+
+        ForwardingAppender(String name, Consumer<Throwable> sink) {
+            super(name, null, null, true, null);
+            this.sink = sink;
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            if (shouldForward(event.getLoggerName(), event.getThrown() != null)) {
+                sink.accept(event.getThrown());
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
+++ b/common/src/main/java/com/logistics/core/crash/Log4j2ErrorLogBridge.java
@@ -45,20 +45,22 @@ final class Log4j2ErrorLogBridge implements LogisticsErrorLogBridge {
     }
 
     @Override
-    public void attach() {
+    public boolean attach() {
         try {
             if (!(LogManager.getContext(false) instanceof LoggerContext ctx)) {
                 LOGGER.warn("Log4j2 backend unavailable; crash log capture disabled");
-                return;
+                return false;
             }
             Configuration config = ctx.getConfiguration();
             appender = new ForwardingAppender(APPENDER_NAME, sink);
             appender.start();
             config.getRootLogger().addAppender(appender, Level.ERROR, null);
             ctx.updateLoggers();
+            return true;
         } catch (Throwable t) {
             LOGGER.warn("Failed to attach crash log capture: {}", t.toString());
             appender = null;
+            return false;
         }
     }
 

--- a/common/src/main/java/com/logistics/core/crash/LogisticsErrorLogBridge.java
+++ b/common/src/main/java/com/logistics/core/crash/LogisticsErrorLogBridge.java
@@ -8,8 +8,11 @@ package com.logistics.core.crash;
  * missing/incompatible backend can degrade to a no-op.
  */
 public interface LogisticsErrorLogBridge {
-    /** Begin forwarding Logistics ERROR-level exceptions to the sink. */
-    void attach();
+    /**
+     * Begin forwarding Logistics ERROR-level exceptions to the sink. Returns false if it could not
+     * attach (e.g. an incompatible logging backend), so callers don't claim capture is wired.
+     */
+    boolean attach();
 
     /** Stop forwarding and detach from the logging backend. */
     void detach();

--- a/common/src/main/java/com/logistics/core/crash/LogisticsErrorLogBridge.java
+++ b/common/src/main/java/com/logistics/core/crash/LogisticsErrorLogBridge.java
@@ -1,0 +1,16 @@
+package com.logistics.core.crash;
+
+/**
+ * Bridges Logistics' own ERROR log events into a crash-report sink. Implementations attach to the
+ * logging backend (e.g. Log4j2) and forward only exceptions logged under the Logistics loggers.
+ *
+ * <p>Kept as an interface so {@link CrashReporting} stays free of logging-backend imports and so a
+ * missing/incompatible backend can degrade to a no-op.
+ */
+public interface LogisticsErrorLogBridge {
+    /** Begin forwarding Logistics ERROR-level exceptions to the sink. */
+    void attach();
+
+    /** Stop forwarding and detach from the logging backend. */
+    void detach();
+}

--- a/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
+++ b/common/src/main/java/com/logistics/core/lib/platform/PlatformService.java
@@ -52,6 +52,39 @@ public interface PlatformService {
     }
 
     /**
+     * Returns this mod's version string (e.g. {@code "0.7.0+mc26.2.fabric"}). Used as the Sentry
+     * release identifier. Defaults to {@code "unknown"} for any loader that doesn't override it.
+     */
+    default String modVersion() {
+        return "unknown";
+    }
+
+    /**
+     * Returns the loader id used by this runtime (e.g. {@code "fabric"} or {@code "neoforge"}).
+     * Used for diagnostics tags such as Sentry grouping/search.
+     */
+    default String loaderName() {
+        return "unknown";
+    }
+
+    /**
+     * Returns the active Minecraft version string (e.g. {@code "26.2"}). Used for diagnostics
+     * tags so cross-version reports can be filtered without parsing the mod release string.
+     */
+    default String minecraftVersion() {
+        return "unknown";
+    }
+
+    /**
+     * Returns {@code true} in a development/dev-runtime environment, {@code false} in a
+     * production install. Used to pick the Sentry environment tag and enable SDK debug logging.
+     * Defaults to {@code false} (production-safe) for any loader that doesn't override it.
+     */
+    default boolean isDevelopmentEnvironment() {
+        return false;
+    }
+
+    /**
      * Registers {@code oldId} as a legacy alias for the same registry entry as
      * {@code currentEntry}, so saves that used the old ID are remapped on load.
      *
@@ -60,7 +93,7 @@ public interface PlatformService {
      */
     default <T> void registerAlias(Registry<T> registry, ResourceId oldId, T currentEntry) {}
 
-    PlatformService INSTANCE = ServiceLoader.load(PlatformService.class)
+    PlatformService INSTANCE = ServiceLoader.load(PlatformService.class, PlatformService.class.getClassLoader())
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("No PlatformService found"));
 }

--- a/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
@@ -1,0 +1,41 @@
+package com.logistics.core;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import com.mojang.brigadier.tree.CommandNode;
+import net.minecraft.commands.CommandSourceStack;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LogisticsCommandTree")
+class LogisticsCommandTreeTest extends MinecraftTestEnvironment {
+
+    @Test
+    @DisplayName("builds /logistics with the diagnostics subcommands")
+    void buildsDiagnosticsSubtree() {
+        CommandNode<CommandSourceStack> root = LogisticsCommandTree.build().build();
+        assertThat(root.getName()).isEqualTo("logistics");
+
+        CommandNode<CommandSourceStack> diagnostics = root.getChild("diagnostics");
+        assertThat(diagnostics).isNotNull();
+        assertThat(diagnostics.getChild("enable")).isNotNull();
+        assertThat(diagnostics.getChild("disable")).isNotNull();
+        assertThat(diagnostics.getChild("preview")).isNotNull();
+
+        CommandNode<CommandSourceStack> notify = diagnostics.getChild("notify");
+        assertThat(notify).isNotNull();
+        assertThat(notify.getChild("on")).isNotNull();
+        assertThat(notify.getChild("off")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("exposes the dev-only test subcommand in a development environment")
+    void exposesTestSubcommandInDev() {
+        // TestPlatformService reports a development environment, so the dev-gated
+        // /logistics diagnostics test node is registered.
+        CommandNode<CommandSourceStack> root = LogisticsCommandTree.build().build();
+        CommandNode<CommandSourceStack> diagnostics = root.getChild("diagnostics");
+        assertThat(diagnostics.getChild("test")).isNotNull();
+    }
+}

--- a/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsConfigTest.java
@@ -193,4 +193,47 @@ class LogisticsConfigTest {
         assertThat(quarry.energyCapacity()).isZero();
         assertThat(quarry.maxEnergyInput()).isZero();
     }
+
+    @Test
+    @DisplayName("should default crash reporting to opt-in with the join notice on")
+    void crashReportingDefaultsToOptIn() {
+        LogisticsConfig.CrashReportingConfig cfg = new LogisticsConfig().crashReporting;
+
+        assertThat(cfg.enabled).isFalse();
+        assertThat(cfg.notifyOperators).isTrue();
+        assertThat(cfg.dsnOverride).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should recover a null crash reporting group and null dsn override")
+    void sanitizesNullCrashReportingGroup() {
+        LogisticsConfig parsed = new LogisticsConfig();
+        parsed.crashReporting = null;
+
+        LogisticsConfig sanitized = LogisticsConfig.sanitize(parsed);
+
+        assertThat(sanitized.crashReporting).isNotNull();
+        assertThat(sanitized.crashReporting.enabled).isFalse();
+        assertThat(sanitized.crashReporting.notifyOperators).isTrue();
+        assertThat(sanitized.crashReporting.dsnOverride).isEmpty();
+
+        LogisticsConfig withNullDsn = new LogisticsConfig();
+        withNullDsn.crashReporting.dsnOverride = null;
+        assertThat(LogisticsConfig.sanitize(withNullDsn).crashReporting.dsnOverride).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should preserve valid crash reporting values through sanitize")
+    void preservesValidCrashReportingValues() {
+        LogisticsConfig parsed = new LogisticsConfig();
+        parsed.crashReporting.enabled = true;
+        parsed.crashReporting.notifyOperators = false;
+        parsed.crashReporting.dsnOverride = "https://key@example.invalid/1";
+
+        LogisticsConfig sanitized = LogisticsConfig.sanitize(parsed);
+
+        assertThat(sanitized.crashReporting.enabled).isTrue();
+        assertThat(sanitized.crashReporting.notifyOperators).isFalse();
+        assertThat(sanitized.crashReporting.dsnOverride).isEqualTo("https://key@example.invalid/1");
+    }
 }

--- a/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportNotifierTest.java
@@ -1,0 +1,60 @@
+package com.logistics.core.crash;
+
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CrashReportNotifier")
+class CrashReportNotifierTest {
+
+    @Test
+    @DisplayName("shows the status line only to operators who haven't silenced it")
+    void gateLogic() {
+        assertThat(CrashReportNotifier.shouldNotify(true, true)).isTrue();    // notices on + operator
+        assertThat(CrashReportNotifier.shouldNotify(false, true)).isFalse();  // notices silenced
+        assertThat(CrashReportNotifier.shouldNotify(true, false)).isFalse();  // not an operator
+    }
+
+    @Test
+    @DisplayName("OFF state shows [OFF] that enables, with a More Info link")
+    void inviteWhenOff() {
+        Component invite = CrashReportNotifier.buildInvite(false);
+        assertThat(invite.getString())
+                .contains("Crash reporting is").contains("[OFF]").contains("[Hide Notification]").contains("[More Info]");
+        assertThat(commandOf(invite, "[OFF]")).isEqualTo("/logistics diagnostics enable");
+        assertThat(commandOf(invite, "[Hide Notification]")).isEqualTo("/logistics diagnostics notify off");
+        assertThat(infoLinkPresent(invite)).isTrue();
+    }
+
+    @Test
+    @DisplayName("ON state shows [ON] that disables")
+    void inviteWhenOn() {
+        Component invite = CrashReportNotifier.buildInvite(true);
+        assertThat(invite.getString()).contains("[ON]");
+        assertThat(commandOf(invite, "[ON]")).isEqualTo("/logistics diagnostics disable");
+    }
+
+    /** Command bound to the run-command click on the sibling whose visible text equals {@code label}. */
+    private static String commandOf(Component invite, String label) {
+        for (Component part : invite.getSiblings()) {
+            if (part.getString().equals(label)
+                    && part.getStyle().getClickEvent() instanceof ClickEvent.RunCommand run) {
+                return run.command();
+            }
+        }
+        return null;
+    }
+
+    private static boolean infoLinkPresent(Component invite) {
+        for (Component part : invite.getSiblings()) {
+            if (part.getStyle().getClickEvent() instanceof ClickEvent.OpenUrl open
+                    && open.uri().toString().contains("CRASH_REPORTING.md")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -1,0 +1,169 @@
+package com.logistics.core.crash;
+
+import com.logistics.core.LogisticsConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("CrashReporting")
+class CrashReportingTest {
+
+    // A syntactically valid DSN on localhost so enabling never reaches the real Sentry project;
+    // any queued event just fails to connect and is dropped on a background thread.
+    private static final String LOCAL_DSN = "http://examplekey@localhost/1";
+
+    @AfterEach
+    void cleanup() {
+        CrashReporting.disable();
+        LogisticsConfig.CrashReportingConfig cfg = LogisticsConfig.get().crashReporting;
+        cfg.enabled = false;
+        cfg.notifyOperators = true;
+        cfg.dsnOverride = "";
+    }
+
+    @Test
+    @DisplayName("is inactive by default and capture is a no-op when disabled")
+    void captureIsNoOpWhenDisabled() {
+        assertThat(CrashReporting.isActive()).isFalse();
+        assertThatCode(() -> CrashReporting.capture(new RuntimeException("boom"))).doesNotThrowAnyException();
+        assertThatCode(() -> CrashReporting.capture(null)).doesNotThrowAnyException();
+        assertThat(CrashReporting.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("redacts the local user name and home directory")
+    void redactsLocalIdentity() {
+        String home = System.getProperty("user.home");
+        String user = System.getProperty("user.name");
+
+        String message = "failed to read " + home + "/saves by " + user;
+        String redacted = CrashReporting.redact(message);
+
+        assertThat(redacted).doesNotContain(home);
+        assertThat(redacted).contains("~");
+        if (user != null && !user.isBlank()) {
+            assertThat(redacted).doesNotContain("by " + user);
+            assertThat(redacted).contains("<user>");
+        }
+    }
+
+    @Test
+    @DisplayName("redact passes through null and empty unchanged")
+    void redactPassesThroughNullAndEmpty() {
+        assertThat(CrashReporting.redact(null)).isNull();
+        assertThat(CrashReporting.redact("")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("redacts IPs, UUIDs, any-user home paths, and secret-like values")
+    void redactsCommonIdentifiers() {
+        assertThat(CrashReporting.redact("connect to 192.168.1.50:25565"))
+                .contains("<ip>").doesNotContain("192.168.1.50");
+        assertThat(CrashReporting.redact("player 123e4567-e89b-12d3-a456-426614174000 left"))
+                .contains("<uuid>").doesNotContain("123e4567");
+        assertThat(CrashReporting.redact("read /Users/alice/world"))
+                .contains("/Users/<user>").doesNotContain("alice");
+        assertThat(CrashReporting.redact("opening /home/bob/.minecraft"))
+                .contains("/home/<user>").doesNotContain("bob");
+        assertThat(CrashReporting.redact("C:\\Users\\Carol\\saves"))
+                .contains("C:\\Users\\<user>").doesNotContain("Carol");
+        assertThat(CrashReporting.redact("token=abc123secretvalue"))
+                .contains("<redacted>").doesNotContain("abc123secretvalue");
+    }
+
+    @Test
+    @DisplayName("preview builds a scrubbed report without sending or enabling")
+    void previewIsScrubbedAndInert() {
+        String json = CrashReporting.previewReport();
+
+        // Contains the synthetic exception, but the mock sensitive values are redacted.
+        assertThat(json).contains("RuntimeException").contains("preview");
+        assertThat(json).contains("<ip>").doesNotContain("203.0.113.7");
+        assertThat(json).contains("<uuid>").doesNotContain("123e4567-e89b-12d3-a456-426614174000");
+        assertThat(json).contains("<redacted>").doesNotContain("hunter2");
+        assertThat(json).doesNotContain(System.getProperty("user.home"));
+
+        // Previewing neither enables reporting nor sends anything.
+        assertThat(CrashReporting.isActive()).isFalse();
+
+        // The log-writing wrapper is also inert and must not throw.
+        assertThatCode(CrashReporting::logPreviewReport).doesNotThrowAnyException();
+        assertThat(CrashReporting.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("enable/disable toggles the live client and persists the actual state")
+    void enableDisableLifecycle() {
+        LogisticsConfig.get().crashReporting.dsnOverride = LOCAL_DSN;
+
+        assertThat(CrashReporting.enableReporting()).isTrue();
+        assertThat(CrashReporting.isActive()).isTrue();
+        // Config is persisted only to reflect the real active state.
+        assertThat(LogisticsConfig.get().crashReporting.enabled).isTrue();
+
+        // Capturing on an active client is accepted without throwing (sent async to the dead DSN).
+        assertThatCode(() -> CrashReporting.capture(new RuntimeException("test")))
+                .doesNotThrowAnyException();
+
+        CrashReporting.disableReporting();
+        assertThat(CrashReporting.isActive()).isFalse();
+        assertThat(LogisticsConfig.get().crashReporting.enabled).isFalse();
+    }
+
+    @Test
+    @DisplayName("enable failure leaves reporting off and persists the disabled state")
+    void enableFailureIsSafe() {
+        // A malformed DSN makes the Sentry client constructor throw inside enable().
+        LogisticsConfig.get().crashReporting.dsnOverride = "https://localhost";
+
+        boolean active = CrashReporting.enableReporting();
+
+        assertThat(active).isFalse();
+        assertThat(CrashReporting.isActive()).isFalse();
+        assertThat(LogisticsConfig.get().crashReporting.enabled).isFalse();
+    }
+
+    @Test
+    @DisplayName("bootstrap enables only when the config opted in")
+    void bootstrapHonorsConfig() {
+        LogisticsConfig.get().crashReporting.enabled = false;
+        CrashReporting.bootstrap();
+        assertThat(CrashReporting.isActive()).isFalse();
+
+        LogisticsConfig.get().crashReporting.enabled = true;
+        LogisticsConfig.get().crashReporting.dsnOverride = LOCAL_DSN;
+        CrashReporting.bootstrap();
+        assertThat(CrashReporting.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("join-notice and status actions update and report config")
+    void joinNoticeAndStatusActions() {
+        assertThat(CrashReporting.setJoinNotice(false)).contains("off");
+        assertThat(LogisticsConfig.get().crashReporting.notifyOperators).isFalse();
+
+        assertThat(CrashReporting.setJoinNotice(true)).contains("ON");
+        assertThat(LogisticsConfig.get().crashReporting.notifyOperators).isTrue();
+
+        assertThat(CrashReporting.statusText()).contains("Sanitized crash reporting");
+    }
+
+    @Test
+    @DisplayName("forwards only Logistics loggers that carry a throwable")
+    void forwardsOnlyLogisticsErrorsWithThrowable() {
+        // Matches the codebase's logger names (e.g. "logistics", "logistics/config", "Logistics/JEI")
+        assertThat(Log4j2ErrorLogBridge.shouldForward("logistics", true)).isTrue();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("logistics/config", true)).isTrue();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("Logistics/JEI", true)).isTrue();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("com.logistics.pipe.Pipe", true)).isTrue();
+
+        // No throwable, foreign loggers, or null name are not forwarded.
+        assertThat(Log4j2ErrorLogBridge.shouldForward("logistics", false)).isFalse();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("net.minecraft.server.Main", true)).isFalse();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("some.other.mod", true)).isFalse();
+        assertThat(Log4j2ErrorLogBridge.shouldForward(null, true)).isFalse();
+    }
+}

--- a/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
+++ b/common/src/test/java/com/logistics/core/crash/CrashReportingTest.java
@@ -165,5 +165,9 @@ class CrashReportingTest {
         assertThat(Log4j2ErrorLogBridge.shouldForward("net.minecraft.server.Main", true)).isFalse();
         assertThat(Log4j2ErrorLogBridge.shouldForward("some.other.mod", true)).isFalse();
         assertThat(Log4j2ErrorLogBridge.shouldForward(null, true)).isFalse();
+
+        // Look-alike namespaces from other mods must not pass the filter.
+        assertThat(Log4j2ErrorLogBridge.shouldForward("logisticsaddons", true)).isFalse();
+        assertThat(Log4j2ErrorLogBridge.shouldForward("other.com.logistics.Thing", true)).isFalse();
     }
 }

--- a/common/src/test/java/com/logistics/core/crash/Log4j2ErrorLogBridgeTest.java
+++ b/common/src/test/java/com/logistics/core/crash/Log4j2ErrorLogBridgeTest.java
@@ -1,0 +1,41 @@
+package com.logistics.core.crash;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Log4j2ErrorLogBridge")
+class Log4j2ErrorLogBridgeTest {
+
+    @Test
+    @DisplayName("forwards Logistics ERROR exceptions while attached, and stops after detach")
+    void attachForwardsAndDetachStops() {
+        List<Throwable> captured = new ArrayList<>();
+        Log4j2ErrorLogBridge bridge = new Log4j2ErrorLogBridge(captured::add);
+        bridge.attach();
+        try {
+            Logger logistics = LogManager.getLogger("logistics");
+            Logger foreign = LogManager.getLogger("net.minecraft.Foo");
+
+            logistics.error("boom", new IllegalStateException("logistics error")); // forwarded
+            logistics.warn("noise", new RuntimeException("warn level"));            // below ERROR
+            logistics.error("no throwable");                                        // no throwable
+            foreign.error("not ours", new RuntimeException("foreign"));             // foreign logger
+
+            assertThat(captured).hasSize(1);
+            assertThat(captured.get(0)).isInstanceOf(IllegalStateException.class);
+        } finally {
+            bridge.detach();
+        }
+
+        captured.clear();
+        LogManager.getLogger("logistics").error("after detach", new RuntimeException("ignored"));
+        assertThat(captured).isEmpty();
+    }
+}

--- a/common/src/test/java/com/logistics/test/TestPlatformService.java
+++ b/common/src/test/java/com/logistics/test/TestPlatformService.java
@@ -1,0 +1,35 @@
+package com.logistics.test;
+
+import com.logistics.core.lib.platform.PlatformService;
+
+import java.nio.file.Path;
+
+/**
+ * Minimal {@link PlatformService} for unit tests, discovered via
+ * {@code META-INF/services} so {@code PlatformService.INSTANCE} resolves on the
+ * test classpath without a loader-specific (Fabric/NeoForge) implementation.
+ *
+ * <p>Reports a development environment so dev-gated command nodes (e.g.
+ * {@code /logistics diagnostics test}) are present and assertable in tests.
+ */
+public final class TestPlatformService implements PlatformService {
+    @Override
+    public Path configDir() {
+        return Path.of(System.getProperty("java.io.tmpdir"), "logistics-test-config");
+    }
+
+    @Override
+    public long fluidUnitsPerMillibucket() {
+        return 1L;
+    }
+
+    @Override
+    public boolean isLighterThanAir(net.minecraft.world.level.material.Fluid fluid) {
+        return false;
+    }
+
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return true;
+    }
+}

--- a/common/src/test/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
+++ b/common/src/test/resources/META-INF/services/com.logistics.core.lib.platform.PlatformService
@@ -1,0 +1,1 @@
+com.logistics.test.TestPlatformService

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -5,6 +5,7 @@
 plugins {
     id 'multiloader-loader'
     id 'net.fabricmc.fabric-loom'
+    id 'io.sentry.jvm.gradle'
 }
 
 version = System.getenv("MOD_VERSION") ?: "dev-fabric"
@@ -59,6 +60,10 @@ dependencies {
     include("teamreborn:energy:${rootProject.fabric_energy_version}")
     implementation("teamreborn:energy:${rootProject.fabric_energy_version}")
 
+    // Sentry SDK for opt-in crash reporting — bundled jar-in-jar so an opted-in user has it at runtime.
+    include("io.sentry:sentry:${rootProject.sentry_version}")
+    implementation("io.sentry:sentry:${rootProject.sentry_version}")
+
     // JEI — compile against API only; players install separately at runtime
     compileOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
     runtimeOnly("mezz.jei:jei-${rootProject.minecraft_version}-fabric:${rootProject.jei_version}")
@@ -70,6 +75,29 @@ dependencies {
     // Spark profiler (https://spark.lucko.me) — loaded in dev via runClient/runServer, never bundled.
     // If a future MC snapshot has no matching Spark build, comment this out until one ships.
     runtimeOnly("maven.modrinth:spark:${rootProject.spark_fabric_version}")
+}
+
+// Sentry source-context upload (so stack traces show inline source in Sentry). Gated on the
+// SENTRY_AUTH_TOKEN secret: local/PR builds without it skip the upload entirely and never fail.
+// We manage the SDK dependency ourselves above, so the plugin's auto-install/telemetry stay off.
+def sentryAuthToken = System.getenv("SENTRY_AUTH_TOKEN")
+sentry {
+    includeSourceContext = sentryAuthToken != null && !sentryAuthToken.isEmpty()
+    org = "indmenity83"
+    projectName = "logistics-mod"
+    authToken = sentryAuthToken
+    autoInstallation {
+        enabled = false
+    }
+    telemetry = false
+}
+
+// The Sentry plugin emits generated metadata into the main resources, which withSourcesJar() also
+// picks up; declare the dependency so Gradle doesn't reject the implicit one on `build`.
+tasks.named('sourcesJar') {
+    dependsOn(tasks.matching {
+        it.name.toLowerCase().startsWith('generatesentry') || it.name == 'collectExternalDependenciesForSentry'
+    })
 }
 
 processResources {

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlatformService.java
@@ -26,6 +26,32 @@ public final class FabricPlatformService implements PlatformService {
     }
 
     @Override
+    public String modVersion() {
+        return FabricLoader.getInstance()
+                .getModContainer("logistics")
+                .map(c -> c.getMetadata().getVersion().getFriendlyString())
+                .orElse("unknown");
+    }
+
+    @Override
+    public String loaderName() {
+        return "fabric";
+    }
+
+    @Override
+    public String minecraftVersion() {
+        return FabricLoader.getInstance()
+                .getModContainer("minecraft")
+                .map(c -> c.getMetadata().getVersion().getFriendlyString())
+                .orElse("unknown");
+    }
+
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return FabricLoader.getInstance().isDevelopmentEnvironment();
+    }
+
+    @Override
     public String getModName(String namespace) {
         return FabricLoader.getInstance()
                 .getModContainer(namespace)

--- a/fabric/src/main/java/com/logistics/fabric/FabricPlayerJoinEvents.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricPlayerJoinEvents.java
@@ -1,0 +1,19 @@
+package com.logistics.fabric;
+
+import com.logistics.core.crash.CrashReportNotifier;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+
+/**
+ * Shows operators the crash-reporting status line on join, resetting the once-per-session dedup when
+ * a server starts. Pure wiring — the gate and message live in {@link CrashReportNotifier}.
+ */
+public final class FabricPlayerJoinEvents {
+    private FabricPlayerJoinEvents() {}
+
+    public static void register() {
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> CrashReportNotifier.reset());
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->
+                CrashReportNotifier.maybeNotify(handler.player));
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -31,6 +31,7 @@ public final class LogisticsFabric implements ModInitializer {
         FabricNetworkTickHandler.register();
         FabricCommandRegistration.register();
         FabricServerLevelEvents.register();
+        FabricPlayerJoinEvents.register();
         FabricPacketRegistration.register();
         FabricBiomeModifications.register();
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,10 @@ moddev_version=2.0.141
 
 # Dependencies
 jei_version=30.1.0.10
+# Crash reporting (Sentry). sentry_version = runtime SDK (bundled per loader);
+# sentry_gradle_version = the io.sentry.jvm.gradle source-context upload plugin.
+sentry_version=8.43.0
+sentry_gradle_version=5.8.0
 jade_fabric_version=26.2.5+fabric
 jade_neoforge_version=26.2.3+neoforge
 spark_fabric_version=1.10.173-fabric

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -2,6 +2,7 @@
 plugins {
     id 'multiloader-loader'
     id 'net.neoforged.moddev'
+    id 'io.sentry.jvm.gradle'
 }
 
 version = System.getenv("MOD_VERSION") ?: "0.0.0-dev.neoforge"
@@ -77,6 +78,15 @@ dependencies {
     // If a future MC snapshot has no matching Spark build, comment this out until one ships.
     runtimeOnly("maven.modrinth:spark:${rootProject.spark_neoforge_version}")
 
+    // Sentry SDK for opt-in crash reporting. jarJar bundles it (range allows dedup with another mod
+    // shipping Sentry); implementation puts it on compile+runtime so the injected common sources compile.
+    jarJar(implementation("io.sentry:sentry")) {
+        version {
+            strictly "[${rootProject.sentry_version},9.0.0)"
+            prefer "${rootProject.sentry_version}"
+        }
+    }
+
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junit_version}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"
@@ -90,6 +100,29 @@ test {
         events "passed", "skipped", "failed"
         exceptionFormat = "full"
     }
+}
+
+// Sentry source-context upload (so stack traces show inline source in Sentry). Gated on the
+// SENTRY_AUTH_TOKEN secret: local/PR builds without it skip the upload entirely and never fail.
+// We manage the SDK dependency ourselves above, so the plugin's auto-install/telemetry stay off.
+def sentryAuthToken = System.getenv("SENTRY_AUTH_TOKEN")
+sentry {
+    includeSourceContext = sentryAuthToken != null && !sentryAuthToken.isEmpty()
+    org = "indmenity83"
+    projectName = "logistics-mod"
+    authToken = sentryAuthToken
+    autoInstallation {
+        enabled = false
+    }
+    telemetry = false
+}
+
+// The Sentry plugin emits generated metadata into the main resources, which withSourcesJar() also
+// picks up; declare the dependency so Gradle doesn't reject the implicit one on `build`.
+tasks.named('sourcesJar') {
+    dependsOn(tasks.matching {
+        it.name.toLowerCase().startsWith('generatesentry') || it.name == 'collectExternalDependenciesForSentry'
+    })
 }
 
 processResources {

--- a/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
@@ -32,6 +32,7 @@ public final class LogisticsNeoForge {
         NeoForgeChestLootModifier.register(NeoForge.EVENT_BUS);
         NeoForgeNetworkTickHandler.register(NeoForge.EVENT_BUS);
         NeoForgeServerLevelEvents.register(NeoForge.EVENT_BUS);
+        NeoForgePlayerJoinEvents.register(NeoForge.EVENT_BUS);
         if (FMLEnvironment.getDist().isClient()) {
             NeoForgeClientSetup.register(modBus);
         }

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgePlayerJoinEvents.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgePlayerJoinEvents.java
@@ -1,0 +1,30 @@
+package com.logistics.neoforge;
+
+import com.logistics.core.crash.CrashReportNotifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+
+/**
+ * Shows operators the crash-reporting status line on join, resetting the once-per-session dedup when
+ * a server starts. Pure wiring — the gate and message live in {@link CrashReportNotifier}.
+ */
+public final class NeoForgePlayerJoinEvents {
+    private NeoForgePlayerJoinEvents() {}
+
+    public static void register(IEventBus gameBus) {
+        gameBus.addListener(NeoForgePlayerJoinEvents::onServerStarting);
+        gameBus.addListener(NeoForgePlayerJoinEvents::onLogin);
+    }
+
+    private static void onServerStarting(ServerStartingEvent event) {
+        CrashReportNotifier.reset();
+    }
+
+    private static void onLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            CrashReportNotifier.maybeNotify(player);
+        }
+    }
+}

--- a/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/platform/NeoForgePlatformService.java
@@ -2,8 +2,10 @@ package com.logistics.neoforge.platform;
 
 import com.logistics.core.lib.platform.PlatformService;
 import com.logistics.core.lib.resource.ResourceId;
+import net.minecraft.SharedConstants;
 import net.minecraft.core.Registry;
 import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.registries.IRegistryExtension;
 
@@ -28,6 +30,28 @@ public final class NeoForgePlatformService implements PlatformService {
     @Override
     public boolean isLighterThanAir(net.minecraft.world.level.material.Fluid fluid) {
         return fluid.getFluidType().isLighterThanAir();
+    }
+
+    @Override
+    public String modVersion() {
+        return ModList.get().getModContainerById("logistics")
+                .map(c -> c.getModInfo().getVersion().toString())
+                .orElse("unknown");
+    }
+
+    @Override
+    public String loaderName() {
+        return "neoforge";
+    }
+
+    @Override
+    public String minecraftVersion() {
+        return SharedConstants.getCurrentVersion().id();
+    }
+
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return !FMLEnvironment.isProduction();
     }
 
     @Override

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ pluginManagement {
         id 'net.fabricmc.fabric-loom' version "${loom_version}"
         id 'net.neoforged.moddev' version "${moddev_version}"
         id 'com.diffplug.spotless' version '8.7.0'
+        id 'io.sentry.jvm.gradle' version "${sentry_gradle_version}"
     }
 }
 


### PR DESCRIPTION
## Summary

Adds **opt-in, sanitized** crash reporting so real-world bugs surface without waiting for a report. It is **off by default** and enabled per install — a server operator opting in does not affect players' clients.

## Changes

- **Crash reporting (`feat`)** — a dedicated Sentry client captures only Logistics' own errors (a Log4j2 ERROR appender filtered to `logistics` loggers; no global uncaught-exception handler, so other mods and vanilla are never reported). PII is off, the server name is dropped, and messages/exception values are scrubbed of home dirs, IPs, UUIDs, and secret-like `key=value` pairs before send.
- **Operator controls** — a once-per-session clickable status line on join (toggle / hide / more-info), plus `/logistics diagnostics enable|disable|preview|notify on|off`. State persists in `config/logistics.json`.
- **Release tagging + source upload** — the `io.sentry.jvm.gradle` plugin uploads source context and the `getsentry/action-release` step registers each release in the build/snapshot/pre-release workflows. Both are gated on `SENTRY_AUTH_TOKEN`, so token-less builds skip them and never fail.

## Notes

- **New CI secret required:** `SENTRY_AUTH_TOKEN` (org `indmenity83`, project `logistics-mod`). Already added.
- Sentry SDK is bundled per loader (Fabric `include`, NeoForge `jarJar`), so opted-in users have it at runtime. The DSN is committed in code (DSNs are public/embeddable) and overridable via `crashReporting.dsnOverride`.
- Full privacy/data-collection details: `CRASH_REPORTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)