### PR TITLE
fix(ui): show item tooltips in the Kiln, Sawmill, and Stirling Engine screens

### DIFF
--- a/common/src/client/java/com/logistics/automation/kiln/KilnScreen.java
+++ b/common/src/client/java/com/logistics/automation/kiln/KilnScreen.java
@@ -42,4 +42,10 @@ public class KilnScreen extends AbstractContainerScreen<KilnScreenHandler> {
                 180, 55 + (13 - energyHeight), 7, energyHeight);
         }
     }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+        super.render(graphics, mouseX, mouseY, delta);
+        renderTooltip(graphics, mouseX, mouseY);
+    }
 }

--- a/common/src/client/java/com/logistics/automation/sawmill/SawmillScreen.java
+++ b/common/src/client/java/com/logistics/automation/sawmill/SawmillScreen.java
@@ -43,4 +43,10 @@ public class SawmillScreen extends AbstractContainerScreen<SawmillScreenHandler>
                 TEXTURE, leftPos + 56, topPos + 42 + (13 - energyHeight), 180, 42 + (13 - energyHeight), 7, energyHeight);
         }
     }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+        super.render(graphics, mouseX, mouseY, delta);
+        renderTooltip(graphics, mouseX, mouseY);
+    }
 }

--- a/common/src/client/java/com/logistics/power/screen/StirlingEngineScreen.java
+++ b/common/src/client/java/com/logistics/power/screen/StirlingEngineScreen.java
@@ -62,4 +62,10 @@ public class StirlingEngineScreen extends AbstractContainerScreen<StirlingEngine
                     pixelsToShow);
         }
     }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+        super.render(graphics, mouseX, mouseY, delta);
+        renderTooltip(graphics, mouseX, mouseY);
+    }
 }


### PR DESCRIPTION
## Summary

Hovering an item slot in the Kiln, Sawmill, and Stirling Engine GUIs showed no tooltip. This adds the missing tooltip rendering so all three machines behave like the Macerator.

## Changes

- Render hovered-slot item tooltips in the Kiln, Sawmill, and Stirling Engine screens.

## Notes

- This affects **MC 1.21.1 only**. On 1.21.1 `AbstractContainerScreen.render()` does not draw slot tooltips on its own, so each screen must override `render()` and call `renderTooltip()` (the Macerator already did). On 1.21.11 and 26.x the base class handles slot tooltips automatically, so no equivalent change is needed there.