### PR TITLE
refactor(automation): add a cross-version recipe-codec shim

### DIFF
--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeSerializer.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeSerializer.java
@@ -1,12 +1,13 @@
 package com.logistics.automation.macerator;
 
+import com.logistics.core.lib.recipe.MachineRecipeSerializers;
+import com.logistics.core.lib.recipe.MachineResult;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
@@ -22,7 +23,7 @@ public class MaceratorRecipeSerializer {
 
     public static final MapCodec<MaceratorRecipeWrapper> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
         Ingredient.CODEC.fieldOf("ingredient").forGetter(MaceratorRecipeWrapper::ingredient),
-        ItemStackTemplate.CODEC.fieldOf("result").forGetter(MaceratorRecipeWrapper::result),
+        MachineResult.CODEC.fieldOf("result").forGetter(MaceratorRecipeWrapper::result),
         Codec.INT.fieldOf("energyrequired").forGetter(MaceratorRecipeWrapper::energyRequired),
         Codec.FLOAT.optionalFieldOf("experience", MaceratorRecipeWrapper.DEFAULT_EXPERIENCE).forGetter(MaceratorRecipeWrapper::experience)
     ).apply(i, MaceratorRecipeWrapper::new));
@@ -30,14 +31,14 @@ public class MaceratorRecipeSerializer {
     public static final StreamCodec<RegistryFriendlyByteBuf, MaceratorRecipeWrapper> STREAM_CODEC =
         StreamCodec.composite(
             Ingredient.CONTENTS_STREAM_CODEC, MaceratorRecipeWrapper::ingredient,
-            ItemStackTemplate.STREAM_CODEC, MaceratorRecipeWrapper::result,
+            MachineResult.STREAM_CODEC, MaceratorRecipeWrapper::result,
             ByteBufCodecs.VAR_INT, MaceratorRecipeWrapper::energyRequired,
             ByteBufCodecs.FLOAT, MaceratorRecipeWrapper::experience,
             MaceratorRecipeWrapper::new
         );
 
     public static final RecipeSerializer<MaceratorRecipeWrapper> INSTANCE =
-        new RecipeSerializer<>(CODEC, STREAM_CODEC);
+        MachineRecipeSerializers.create(CODEC, STREAM_CODEC);
 
     private MaceratorRecipeSerializer() {}
 }

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeSerializer.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeSerializer.java
@@ -24,7 +24,7 @@ public class MaceratorRecipeSerializer {
     public static final MapCodec<MaceratorRecipeWrapper> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
         Ingredient.CODEC.fieldOf("ingredient").forGetter(MaceratorRecipeWrapper::ingredient),
         MachineResult.CODEC.fieldOf("result").forGetter(MaceratorRecipeWrapper::result),
-        Codec.INT.fieldOf("energyrequired").forGetter(MaceratorRecipeWrapper::energyRequired),
+        Codec.intRange(1, Integer.MAX_VALUE).fieldOf("energyrequired").forGetter(MaceratorRecipeWrapper::energyRequired),
         Codec.FLOAT.optionalFieldOf("experience", MaceratorRecipeWrapper.DEFAULT_EXPERIENCE).forGetter(MaceratorRecipeWrapper::experience)
     ).apply(i, MaceratorRecipeWrapper::new));
 

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeWrapper.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeWrapper.java
@@ -1,8 +1,8 @@
 package com.logistics.automation.macerator;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.MachineResult;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.PlacementInfo;
 import net.minecraft.world.item.crafting.Recipe;
@@ -32,12 +32,12 @@ public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
     public static final float DEFAULT_EXPERIENCE = 0.0f;
 
     private final Ingredient ingredient;
-    private final ItemStackTemplate result;
+    private final MachineResult result;
     private final int energyRequired;
     private final float experience;
     @Nullable private PlacementInfo placementInfo;
 
-    public MaceratorRecipeWrapper(Ingredient ingredient, ItemStackTemplate result, int energyRequired, float experience) {
+    public MaceratorRecipeWrapper(Ingredient ingredient, MachineResult result, int energyRequired, float experience) {
         if (energyRequired <= 0) {
             throw new IllegalArgumentException("energyRequired must be positive, got " + energyRequired);
         }
@@ -51,7 +51,7 @@ public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
         return ingredient;
     }
 
-    public ItemStackTemplate result() {
+    public MachineResult result() {
         return result;
     }
 
@@ -71,7 +71,7 @@ public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
 
     /** Convenience for machine/JEI: the result as a fresh stack (avoids the version-specific assemble signature). */
     public ItemStack getResultItem() {
-        return result.create();
+        return result.toStack();
     }
 
     @Override
@@ -86,7 +86,7 @@ public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
 
     @Override
     public @NotNull ItemStack assemble(@NotNull SingleRecipeInput input) {
-        return result.create();
+        return result.toStack();
     }
 
     @Override
@@ -126,7 +126,7 @@ public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
     public @NotNull List<RecipeDisplay> display() {
         return List.of(new MaceratorRecipeDisplay(
             ingredient.display(),
-            new SlotDisplay.ItemStackSlotDisplay(result),
+            result.slotDisplay(),
             new SlotDisplay.ItemSlotDisplay(LogisticsAutomation.BLOCK.MACERATOR.asItem()),
             energyRequired,
             experience

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipe.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipe.java
@@ -1,9 +1,9 @@
 package com.logistics.automation.sawmill;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.MachineResult;
 import java.util.List;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.PlacementInfo;
 import net.minecraft.world.item.crafting.Recipe;
@@ -28,12 +28,12 @@ public class SawmillRecipe implements Recipe<SingleRecipeInput> {
 
     private final Ingredient ingredient;
     private final int ingredientCount;
-    private final ItemStackTemplate result;
+    private final MachineResult result;
     private final SawmillByproduct byproduct;
     private final int energy;
     @Nullable private PlacementInfo placementInfo;
 
-    public SawmillRecipe(Ingredient ingredient, int ingredientCount, ItemStackTemplate result, SawmillByproduct byproduct, int energy) {
+    public SawmillRecipe(Ingredient ingredient, int ingredientCount, MachineResult result, SawmillByproduct byproduct, int energy) {
         this.ingredient = ingredient;
         this.ingredientCount = ingredientCount;
         this.result = result;
@@ -50,7 +50,7 @@ public class SawmillRecipe implements Recipe<SingleRecipeInput> {
         return ingredientCount;
     }
 
-    public ItemStackTemplate result() {
+    public MachineResult result() {
         return result;
     }
 
@@ -65,7 +65,7 @@ public class SawmillRecipe implements Recipe<SingleRecipeInput> {
 
     /** The primary product as a fresh stack. */
     public ItemStack getResultItem() {
-        return result.create();
+        return result.toStack();
     }
 
     @Override
@@ -80,7 +80,7 @@ public class SawmillRecipe implements Recipe<SingleRecipeInput> {
 
     @Override
     public @NotNull ItemStack assemble(@NotNull SingleRecipeInput input) {
-        return result.create();
+        return result.toStack();
     }
 
     @Override
@@ -120,7 +120,7 @@ public class SawmillRecipe implements Recipe<SingleRecipeInput> {
     public @NotNull List<RecipeDisplay> display() {
         return List.of(new SawmillRecipeDisplay(
             ingredient.display(),
-            new SlotDisplay.ItemStackSlotDisplay(result),
+            result.slotDisplay(),
             new SlotDisplay.ItemSlotDisplay(LogisticsAutomation.BLOCK.SAWMILL.asItem()),
             energy
         ));

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipeSerializer.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipeSerializer.java
@@ -1,12 +1,13 @@
 package com.logistics.automation.sawmill;
 
+import com.logistics.core.lib.recipe.MachineRecipeSerializers;
+import com.logistics.core.lib.recipe.MachineResult;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
@@ -21,7 +22,7 @@ public class SawmillRecipeSerializer {
         Codec.intRange(1, Integer.MAX_VALUE)
             .optionalFieldOf("count", SawmillRecipe.DEFAULT_INGREDIENT_COUNT)
             .forGetter(SawmillRecipe::ingredientCount),
-        ItemStackTemplate.CODEC.fieldOf("result").forGetter(SawmillRecipe::result),
+        MachineResult.CODEC.fieldOf("result").forGetter(SawmillRecipe::result),
         SawmillByproduct.CODEC.fieldOf("byproduct").forGetter(SawmillRecipe::byproduct),
         Codec.intRange(0, Integer.MAX_VALUE)
             .optionalFieldOf("energy", SawmillRecipe.DEFAULT_ENERGY)
@@ -32,14 +33,14 @@ public class SawmillRecipeSerializer {
         StreamCodec.composite(
             Ingredient.CONTENTS_STREAM_CODEC, SawmillRecipe::ingredient,
             ByteBufCodecs.VAR_INT, SawmillRecipe::ingredientCount,
-            ItemStackTemplate.STREAM_CODEC, SawmillRecipe::result,
+            MachineResult.STREAM_CODEC, SawmillRecipe::result,
             SawmillByproduct.STREAM_CODEC, SawmillRecipe::byproduct,
             ByteBufCodecs.VAR_INT, SawmillRecipe::energy,
             SawmillRecipe::new
         );
 
     public static final RecipeSerializer<SawmillRecipe> INSTANCE =
-        new RecipeSerializer<>(CODEC, STREAM_CODEC);
+        MachineRecipeSerializers.create(CODEC, STREAM_CODEC);
 
     private SawmillRecipeSerializer() {}
 }

--- a/common/src/main/java/com/logistics/core/lib/recipe/MachineRecipeSerializers.java
+++ b/common/src/main/java/com/logistics/core/lib/recipe/MachineRecipeSerializers.java
@@ -1,0 +1,25 @@
+package com.logistics.core.lib.recipe;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+
+/**
+ * Builds a {@link RecipeSerializer} from its codecs, hiding the per-version shape difference: 26.x
+ * exposes a concrete {@code RecipeSerializer} class, while 1.21.x makes it an interface to implement.
+ * Machine serializers call {@link #create} and stay byte-identical across branches.
+ *
+ * <p>Mirrors the {@code ResourceId} / {@code NbtCompat} compat-shim pattern: this file is the single
+ * per-version implementation; the machine serializers above it are shared.
+ */
+public final class MachineRecipeSerializers {
+
+    private MachineRecipeSerializers() {}
+
+    public static <R extends Recipe<?>> RecipeSerializer<R> create(
+            MapCodec<R> codec, StreamCodec<RegistryFriendlyByteBuf, R> streamCodec) {
+        return new RecipeSerializer<>(codec, streamCodec);
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/recipe/MachineResult.java
+++ b/common/src/main/java/com/logistics/core/lib/recipe/MachineResult.java
@@ -1,0 +1,49 @@
+package com.logistics.core.lib.recipe;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemStackTemplate;
+import net.minecraft.world.item.crafting.display.SlotDisplay;
+import net.minecraft.world.level.ItemLike;
+
+/**
+ * Version-agnostic result of a custom-recipe machine. Wraps the vanilla result type, which differs
+ * across MC versions (26.x: {@code ItemStackTemplate}; 1.21.x: plain {@code ItemStack}), so machine
+ * recipe and serializer code names only {@code MachineResult} and stays byte-identical across branches.
+ *
+ * <p>Mirrors the {@code ResourceId} / {@code NbtCompat} compat-shim pattern: this file is the single
+ * per-version implementation; the machine code above it is shared.
+ */
+public final class MachineResult {
+
+    private final ItemStackTemplate template;
+
+    private MachineResult(ItemStackTemplate template) {
+        this.template = template;
+    }
+
+    /** A result of {@code count} of {@code item}. */
+    public static MachineResult of(ItemLike item, int count) {
+        return new MachineResult(new ItemStackTemplate(item.asItem(), count));
+    }
+
+    /** Codec for the recipe {@code "result"} field. */
+    public static final Codec<MachineResult> CODEC =
+            ItemStackTemplate.CODEC.xmap(MachineResult::new, r -> r.template);
+
+    /** Network codec for syncing the result to clients. */
+    public static final StreamCodec<RegistryFriendlyByteBuf, MachineResult> STREAM_CODEC =
+            ItemStackTemplate.STREAM_CODEC.map(MachineResult::new, r -> r.template);
+
+    /** A fresh result stack. */
+    public ItemStack toStack() {
+        return template.create();
+    }
+
+    /** The result as a recipe-book {@link SlotDisplay}. */
+    public SlotDisplay slotDisplay() {
+        return new SlotDisplay.ItemStackSlotDisplay(template);
+    }
+}

--- a/common/src/test/java/com/logistics/automation/macerator/MaceratorRecipeTest.java
+++ b/common/src/test/java/com/logistics/automation/macerator/MaceratorRecipeTest.java
@@ -1,5 +1,6 @@
 package com.logistics.automation.macerator;
 
+import com.logistics.core.lib.recipe.MachineResult;
 import com.logistics.test.MinecraftTestEnvironment;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -8,7 +9,6 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +25,7 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
     private static MaceratorRecipeWrapper rawIronRecipe() {
         return new MaceratorRecipeWrapper(
             Ingredient.of(Items.RAW_IRON),
-            new ItemStackTemplate(Items.IRON_INGOT, 2),
+            MachineResult.of(Items.IRON_INGOT, 2),
             MaceratorRecipeWrapper.DEFAULT_ENERGY_REQUIRED,
             MaceratorRecipeWrapper.DEFAULT_EXPERIENCE
         );
@@ -72,7 +72,7 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
     void energyRequired() {
         MaceratorRecipeWrapper recipe = new MaceratorRecipeWrapper(
             Ingredient.of(Items.RAW_IRON),
-            new ItemStackTemplate(Items.IRON_INGOT, 2),
+            MachineResult.of(Items.IRON_INGOT, 2),
             500,
             MaceratorRecipeWrapper.DEFAULT_EXPERIENCE
         );
@@ -85,7 +85,7 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
         for (int energy : new int[] {0, -1}) {
             assertThatThrownBy(() -> new MaceratorRecipeWrapper(
                     Ingredient.of(Items.RAW_IRON),
-                    new ItemStackTemplate(Items.IRON_INGOT, 2),
+                    MachineResult.of(Items.IRON_INGOT, 2),
                     energy,
                     MaceratorRecipeWrapper.DEFAULT_EXPERIENCE))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -97,7 +97,7 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
     void experience() {
         MaceratorRecipeWrapper recipe = new MaceratorRecipeWrapper(
             Ingredient.of(Items.RAW_IRON),
-            new ItemStackTemplate(Items.IRON_INGOT, 2),
+            MachineResult.of(Items.IRON_INGOT, 2),
             MaceratorRecipeWrapper.DEFAULT_ENERGY_REQUIRED,
             0.7f
         );
@@ -123,7 +123,7 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
         void roundTripPreservesFields() {
             MaceratorRecipeWrapper original = new MaceratorRecipeWrapper(
                 Ingredient.of(Items.IRON_ORE),
-                new ItemStackTemplate(Items.IRON_INGOT, 2),
+                MachineResult.of(Items.IRON_INGOT, 2),
                 2000,
                 0.7f
             );
@@ -144,7 +144,7 @@ class MaceratorRecipeTest extends MinecraftTestEnvironment {
         void defaultExperienceIsOptional() {
             MaceratorRecipeWrapper original = new MaceratorRecipeWrapper(
                 Ingredient.of(Items.IRON_ORE),
-                new ItemStackTemplate(Items.IRON_INGOT, 1),
+                MachineResult.of(Items.IRON_INGOT, 1),
                 200,
                 MaceratorRecipeWrapper.DEFAULT_EXPERIENCE
             );


### PR DESCRIPTION
## Summary

Introduces a small shared shim so custom-recipe machine **serializers are byte-identical across `mc/26.2`, `mc/1.21.11`, and `mc/1.21.1`** — removing the two divergences that conflicted on every backport. No player-facing or behavior change.

## Changes

- Add `core.lib.recipe.MachineResult` — wraps the recipe result, exposing a version-agnostic `CODEC` / `STREAM_CODEC`, `toStack()`, `slotDisplay()`, and an `of(ItemLike, int)` factory. Hides `ItemStackTemplate` (26.x) vs `ItemStack` (1.21.x).
- Add `core.lib.recipe.MachineRecipeSerializers.create(codec, streamCodec)` — hides the concrete-class (26.x) vs interface (1.21.x) `RecipeSerializer` split.
- Route the Macerator and Sawmill recipes + serializers (and the macerator test) through the shim.

These two shim files are the single per-version implementation (the `ResourceId` / `NbtCompat` pattern); the machine serializers above them are now shared.

## Notes

- First of a two-step rollout: this lands the abstraction on `mc/26.2`; the legacy branches each get a small follow-up to introduce their `ItemStack` / interface impls and adopt it, after which these serializer files cherry-pick cleanly.
- The recipe **classes** still diverge on `assemble()` arity and the recipe-display package (absent on 1.21.1); folding those in is a possible later step.