### PR TITLE
fix(energy): stop battery items from crashing world saves

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/power/AbstractBatteryBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractBatteryBlockEntity.java
@@ -106,6 +106,9 @@ public abstract class AbstractBatteryBlockEntity extends BaseBlockEntity
         CompoundTag logisticsData = new CompoundTag();
         energy.writeNbt(logisticsData, "Energy");
         CompoundTag tag = new CompoundTag();
+        // block_entity_data must carry the block-entity id, or encoding the stack on save throws
+        // "Missing id for entity". TypedEntityData supplies this automatically on newer versions.
+        tag.putString("id", BlockEntityType.getKey(getType()).toString());
         tag.put("LogisticsData", logisticsData);
         builder.set(DataComponents.BLOCK_ENTITY_DATA, CustomData.of(tag));
     }

--- a/common/src/test/java/com/logistics/core/lib/power/AbstractBatteryBlockEntityTest.java
+++ b/common/src/test/java/com/logistics/core/lib/power/AbstractBatteryBlockEntityTest.java
@@ -88,7 +88,10 @@ class AbstractBatteryBlockEntityTest extends MinecraftTestEnvironment {
 
         CustomData data = builder.build().get(DataComponents.BLOCK_ENTITY_DATA);
         assertNotNull(data, "battery should expose block_entity_data so a broken battery keeps its charge");
-        CompoundTag logisticsData = NbtCompat.getCompoundOrEmpty(data.copyTag(), "LogisticsData");
+        CompoundTag tag = data.copyTag();
+        // block_entity_data without an "id" fails to encode on save ("Missing id for entity").
+        assertEquals("minecraft:furnace", tag.getString("id"), "block_entity_data must carry the block-entity id");
+        CompoundTag logisticsData = NbtCompat.getCompoundOrEmpty(tag, "LogisticsData");
         assertEquals(30_000, NbtCompat.getLong(logisticsData, "Energy", 0));
     }
 }


### PR DESCRIPTION
## Summary

Fixes a hard crash on world save (`IllegalStateException: Missing id for entity`) caused by battery items carrying malformed `block_entity_data`. Affects **NeoForge 1.21.1** only.

## Cause

A battery's dropped/carried item exposes its stored charge via the `minecraft:block_entity_data` component. On 1.21.1 this was hand-built as `{LogisticsData:{Energy:...}}` with no block-entity `id`. NeoForge strictly encodes that component on save, rejects the missing `id`, and crashes the whole player/inventory save.

The `mc/26.2` and `mc/1.21.11` branches already write the `id` automatically via `TypedEntityData`; 1.21.1 predates it and fell back to raw `CustomData`, dropping the `id`.

## Changes

- Write the block-entity `id` into the battery's `block_entity_data` tag (matching vanilla `BlockEntity.saveId`).
- Add a regression assertion that the component carries `id`.

## Notes

- 1.21.1 only — no backport needed.
- Fixes newly collected batteries. Items already saved from a prior session carry the id-less component; a player breaking/replacing them refreshes the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)