### PR TITLE
change(energy)!: power extraction pipes only from a direct engine

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/power/AbstractBatteryBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractBatteryBlockEntity.java
@@ -5,7 +5,6 @@ import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.energy.EnergyPushService;
 import com.logistics.core.lib.energy.IEnergyStorage;
-import com.logistics.core.lib.pipe.IPipeAccess;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -82,7 +81,7 @@ public abstract class AbstractBatteryBlockEntity extends BaseBlockEntity
         if (pushService == null) return;
         for (Direction dir : Direction.values()) {
             BlockPos neighborPos = pos.relative(dir);
-            if (level.getBlockEntity(neighborPos) instanceof IPipeAccess) continue;
+            if (level.getBlockEntity(neighborPos) instanceof DirectEnergyReceiver) continue;
             long maxSend = Math.min(MAX_OUTPUT_PER_SIDE, energy.getAmount());
             if (maxSend <= 0) break;
             long sent = pushService.push(level, neighborPos, dir.getOpposite(), energy, maxSend);

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
@@ -4,6 +4,8 @@ import static com.logistics.core.lib.power.AbstractEngineBlockEntity.STAGE;
 
 import com.logistics.core.lib.block.MachineBlock;
 import com.logistics.core.lib.block.behavior.WrenchBehavior;
+import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import java.util.Collections;
 import java.util.List;
 import net.minecraft.core.BlockPos;
@@ -253,8 +255,13 @@ public abstract class AbstractEngineBlock<E extends AbstractEngineBlockEntity> e
      * @return true if an energy-accepting storage exists in that direction
      */
     private static boolean hasEnergyStorage(Level world, BlockPos pos, Direction direction) {
-        // Extraction pipes / pump are off the loader grid; the presence checker can't see them.
-        if (world.getBlockEntity(pos.relative(direction)) instanceof DirectEnergyReceiver) return true;
+        // Extraction pipes / pump are off the loader grid; the presence checker can't see them. Only
+        // count the face the receiver actually accepts power on (e.g. not the pump's null DOWN intake).
+        if (world.getBlockEntity(pos.relative(direction)) instanceof DirectEnergyReceiver receiver
+                && receiver instanceof HasEnergyStorage hasStorage) {
+            IEnergyStorage storage = hasStorage.energyStorage(direction.getOpposite());
+            return storage != null && storage.canInsert();
+        }
         if (energyPresenceChecker == null) return false;
         return energyPresenceChecker.hasEnergyStorage(world, pos, direction);
     }

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
@@ -253,6 +253,8 @@ public abstract class AbstractEngineBlock<E extends AbstractEngineBlockEntity> e
      * @return true if an energy-accepting storage exists in that direction
      */
     private static boolean hasEnergyStorage(Level world, BlockPos pos, Direction direction) {
+        // Extraction pipes / pump are off the loader grid; the presence checker can't see them.
+        if (world.getBlockEntity(pos.relative(direction)) instanceof DirectEnergyReceiver) return true;
         if (energyPresenceChecker == null) return false;
         return energyPresenceChecker.hasEnergyStorage(world, pos, direction);
     }

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -310,21 +310,34 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
         }
     }
 
-    /** Sends energy to the block this engine is facing via the loader-specific energy push service. */
+    /**
+     * Sends energy to the block this engine is facing. Extraction pipes and the Fluid Pump are
+     * {@link DirectEnergyReceiver}s kept off the loader energy grid, so they are fed directly through
+     * their own energy buffer; everything else goes through the loader-specific energy push service.
+     */
     protected void sendEnergy() {
-        EnergyPushService pushService = EnergyPushService.get();
-        if (level == null || !isRedstonePowered() || pushService == null) return;
+        if (level == null || !isRedstonePowered()) return;
 
         Direction outputDir = getOutputDirection();
         BlockPos targetPos = getBlockPos().relative(outputDir);
         long maxSend = Math.min(getOutputPower(), energyBuffer.getAmount());
         if (maxSend <= 0) return;
 
-        long sent = pushService.push(level, targetPos, outputDir.getOpposite(), energyBuffer, maxSend);
+        long sent = sendEnergyTo(targetPos, outputDir.getOpposite(), maxSend);
         if (sent > 0) {
             energyBuffer.consume(Math.min(sent, energyBuffer.getAmount()));
             setChanged();
         }
+    }
+
+    private long sendEnergyTo(BlockPos targetPos, Direction fromDirection, long maxSend) {
+        if (level.getBlockEntity(targetPos) instanceof DirectEnergyReceiver receiver
+                && receiver instanceof HasEnergyStorage hasStorage) {
+            IEnergyStorage storage = hasStorage.energyStorage(fromDirection);
+            return storage == null ? 0L : storage.insert(maxSend, false);
+        }
+        EnergyPushService pushService = EnergyPushService.get();
+        return pushService == null ? 0L : pushService.push(level, targetPos, fromDirection, energyBuffer, maxSend);
     }
 
     /** Adds energy to the buffer, capped at max capacity. */

--- a/common/src/main/java/com/logistics/core/lib/power/DirectEnergyReceiver.java
+++ b/common/src/main/java/com/logistics/core/lib/power/DirectEnergyReceiver.java
@@ -1,0 +1,15 @@
+package com.logistics.core.lib.power;
+
+/**
+ * Marker for blocks that may receive energy <em>only</em> from a directly-adjacent engine — never
+ * from cables, batteries, or any loader energy grid (including other mods' conduits).
+ *
+ * <p>Extraction pipes and the Fluid Pump are powered the classic way: an engine placed against them.
+ * They still keep an internal energy buffer (via {@link com.logistics.core.lib.block.capability.HasEnergyStorage}),
+ * but that buffer is kept off the loader-exposed energy capability so grid devices cannot find it.
+ * Engines deliver by inserting straight into the receiver's {@code energyStorage(side)}.
+ *
+ * <p>This is the transfer-time complement to {@link AcceptsLowTierEnergy}, which only gates whether a
+ * low-tier engine (Redstone Engine) is willing to run.
+ */
+public interface DirectEnergyReceiver {}

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPipeBlockEntity.java
@@ -20,6 +20,7 @@ import com.logistics.core.lib.pipe.DestinationPriority;
 import com.logistics.core.lib.pipe.IModuleHost;
 import com.logistics.core.lib.pipe.PipeContext;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import com.logistics.core.lib.power.DirectEnergyReceiver;
 import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.pipe.block.FluidConnection;
 import com.logistics.pipe.block.FluidPipeBlock;
@@ -58,7 +59,7 @@ import org.jetbrains.annotations.Nullable;
  * backpressure. Gravity is intentionally ignored (predictable transport over physical accuracy).
  */
 public class FluidPipeBlockEntity extends BaseBlockEntity
-        implements HasFluidStorage, HasEnergyStorage, AcceptsLowTierEnergy, IModuleHost {
+        implements HasFluidStorage, HasEnergyStorage, AcceptsLowTierEnergy, DirectEnergyReceiver, IModuleHost {
 
     private static final long ENERGY_CAPACITY = 20;
     private static final int SYNC_STEPS = 16;

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
@@ -7,6 +7,7 @@ import com.logistics.core.lib.fluids.FluidTankComponent;
 import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.core.lib.fluids.IFluidStorage;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import com.logistics.core.lib.power.DirectEnergyReceiver;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
@@ -26,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
  * {@link FluidPumpComponent} that owns the pumping logic. Energy and fluid are exposed on every face
  * except the bottom, which is the intake. The pump has no GUI.
  */
-public class FluidPumpBlockEntity extends MachineEntity implements AcceptsLowTierEnergy {
+public class FluidPumpBlockEntity extends MachineEntity implements AcceptsLowTierEnergy, DirectEnergyReceiver {
 
     public enum Phase {
         DESCENDING,

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -12,6 +12,7 @@ import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.network.ILogisticsNetwork;
 import com.logistics.core.lib.pipe.IPipeAccess;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
+import com.logistics.core.lib.power.DirectEnergyReceiver;
 import com.logistics.pipe.ChassisPipe;
 import com.logistics.pipe.ItemPipe;
 import com.logistics.core.lib.pipe.PipeContext;
@@ -44,7 +45,7 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
 public class PipeBlockEntity extends BaseBlockEntity
-        implements PipeConnection, AcceptsLowTierEnergy, HasItemStorage, HasEnergyStorage, IPipeAccess {
+        implements PipeConnection, AcceptsLowTierEnergy, DirectEnergyReceiver, HasItemStorage, HasEnergyStorage, IPipeAccess {
     public static final int VIRTUAL_CAPACITY = 5 * 64;
     private final List<TravelingItem> travelingItems = new ArrayList<>();
     private final CompoundTag moduleState = new CompoundTag();

--- a/common/src/main/java/com/logistics/power/cable/CableBlock.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlock.java
@@ -3,6 +3,7 @@ package com.logistics.power.cable;
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.block.ConnectedShapeCache;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.power.DirectEnergyReceiver;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -224,6 +225,11 @@ public class CableBlock extends BaseEntityBlock implements SimpleWaterloggedBloc
         BlockEntity neighbor = level.getBlockEntity(neighborPos);
         if (neighbor instanceof CableBlockEntity) {
             return ConnectionType.CABLE;
+        }
+
+        // Extraction pipes / pump are engine-powered only; cables never connect to them.
+        if (neighbor instanceof DirectEnergyReceiver) {
+            return ConnectionType.NONE;
         }
 
         if (neighbor instanceof HasEnergyStorage energyBlock

--- a/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
@@ -502,10 +502,10 @@ public class CableGameTest {
             return;
         }
 
-        // The cable must report NO connection toward the pipe.
+        // The cable must report NO connection toward the pipe, via the cached path the game actually uses.
         CableBlock cableBlock = (CableBlock) LogisticsPower.BLOCK.COPPER_CABLE;
         CableBlock.ConnectionType connection =
-                cableBlock.getDynamicConnectionType(context.getLevel(), context.absolutePos(cablePos), Direction.EAST);
+                cableBlock.getConnectionType(context.getLevel(), context.absolutePos(cablePos), Direction.EAST);
         if (connection != CableBlock.ConnectionType.NONE) {
             context.fail("Cable should not connect to an extraction pipe, got: " + connection);
             return;

--- a/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
@@ -1,9 +1,12 @@
 package com.logistics.gametest.power;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsPipe;
 import com.logistics.LogisticsPower;
 import com.logistics.automation.macerator.MaceratorBlockEntity;
+import com.logistics.core.lib.energy.IEnergyStorage;
 import com.logistics.core.lib.power.AbstractEngineBlock;
+import com.logistics.pipe.block.entity.PipeBlockEntity;
 import com.logistics.power.cable.CableBlock;
 import com.logistics.power.cable.CableBlockEntity;
 import com.logistics.power.block.entity.CreativeSinkBlockEntity;
@@ -477,6 +480,52 @@ public class CableGameTest {
                 context.succeed();
             });
         });
+    }
+
+    /**
+     * Extraction pipes are powered only by a directly-adjacent engine: a cable must not connect to
+     * one, and the pipe's energy buffer must stay off the loader grid (so cables, batteries, and
+     * other mods cannot find it). The engine's direct path — inserting into {@code energyStorage} —
+     * must still fill the buffer.
+     */
+    @GameTest
+    public void testCableDoesNotPowerExtractionPipe(GameTestHelper context) {
+        BlockPos cablePos = new BlockPos(1, 1, 1);
+        BlockPos pipePos = new BlockPos(2, 1, 1);
+
+        context.setBlock(cablePos, LogisticsPower.BLOCK.COPPER_CABLE);
+        context.setBlock(pipePos, LogisticsPipe.BLOCK.ITEM_EXTRACTOR_PIPE);
+
+        PipeBlockEntity pipe = context.getBlockEntity(pipePos, PipeBlockEntity.class);
+        if (pipe == null) {
+            context.fail("Item extractor pipe should have a block entity");
+            return;
+        }
+
+        // The cable must report NO connection toward the pipe.
+        CableBlock cableBlock = (CableBlock) LogisticsPower.BLOCK.COPPER_CABLE;
+        CableBlock.ConnectionType connection =
+                cableBlock.getDynamicConnectionType(context.getLevel(), context.absolutePos(cablePos), Direction.EAST);
+        if (connection != CableBlock.ConnectionType.NONE) {
+            context.fail("Cable should not connect to an extraction pipe, got: " + connection);
+            return;
+        }
+
+        // The pipe's energy buffer must be invisible to the loader energy grid.
+        EnergyStorage gridView = EnergyStorage.SIDED.find(context.getLevel(), context.absolutePos(pipePos), Direction.WEST);
+        if (gridView != null) {
+            context.fail("Extraction pipe must not expose energy to the grid; got a non-null storage");
+            return;
+        }
+
+        // But an engine's direct delivery (insert into energyStorage) still fills the buffer.
+        IEnergyStorage buffer = pipe.energyStorage(Direction.WEST);
+        if (buffer == null || buffer.insert(10, false) <= 0 || buffer.getAmount() <= 0) {
+            context.fail("Engine direct delivery into the pipe's energy buffer should still work");
+            return;
+        }
+
+        context.succeed();
     }
 
     private static EnergyStorage findStorage(GameTestHelper ctx, BlockPos relPos, Direction dir) {

--- a/fabric/src/main/java/com/logistics/fabric/energy/EnergyStorageAccess.java
+++ b/fabric/src/main/java/com/logistics/fabric/energy/EnergyStorageAccess.java
@@ -2,6 +2,7 @@ package com.logistics.fabric.energy;
 
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
 import com.logistics.core.lib.energy.IEnergyStorage;
+import com.logistics.core.lib.power.DirectEnergyReceiver;
 import team.reborn.energy.api.EnergyStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 
@@ -31,6 +32,8 @@ public final class EnergyStorageAccess {
     public static void register() {
         EnergyStorage.SIDED.registerFallback((world, pos, state, blockEntity, direction) -> {
             if (!(blockEntity instanceof HasEnergyStorage hasStorage)) return null;
+            // Extraction pipes / pump are engine-powered only; keep their buffer off the grid.
+            if (blockEntity instanceof DirectEnergyReceiver) return null;
             IEnergyStorage storage = hasStorage.energyStorage(direction);
             if (storage == null) return null;
             // FabricEnergyStorage is already a TR EnergyStorage — hand it directly

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCapabilityRegistration.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCapabilityRegistration.java
@@ -66,13 +66,11 @@ public final class NeoForgeCapabilityRegistration {
         registerEnergy(event, LogisticsPower.ENTITY.CREATIVE_SINK_BLOCK_ENTITY);
         registerEnergy(event, LogisticsPower.ENTITY.BATTERY_BLOCK_ENTITY);
         registerEnergy(event, LogisticsPower.ENTITY.CABLE_BLOCK_ENTITY);
-        registerEnergy(event, LogisticsPipe.ENTITY.PIPE_BLOCK_ENTITY);
         registerEnergy(event, LogisticsPipe.ENTITY.POWER_JUNCTION_BLOCK_ENTITY);
         registerEnergy(event, LogisticsAutomation.ENTITY.LASER_QUARRY_BLOCK_ENTITY);
         registerEnergy(event, LogisticsAutomation.ENTITY.KILN_BLOCK_ENTITY);
-        // Fluid Extractor Pipes receive engine RF; copper pipes return a null energy handler.
-        registerEnergy(event, LogisticsFluid.ENTITY.FLUID_PIPE_BLOCK_ENTITY);
-        registerEnergy(event, LogisticsFluid.ENTITY.FLUID_PUMP_BLOCK_ENTITY);
+        // Extraction pipes (item + fluid) and the Fluid Pump are DirectEnergyReceivers: kept off the
+        // energy grid so only a directly-adjacent engine can power them (engines feed them directly).
 
         registerItems(event, LogisticsAutomation.ENTITY.MACERATOR_BLOCK_ENTITY);
         registerItems(event, LogisticsPower.ENTITY.STIRLING_ENGINE_BLOCK_ENTITY);


### PR DESCRIPTION
## Summary

Extraction pipes (item + fluid) and the Fluid Pump are now powered **only by a directly-adjacent
engine** — the classic BuildCraft model. Cables, batteries, and other mods' energy conduits can no
longer feed them.

This closes a power leak: a battery wired through cables into wooden extraction pipes silently drained
the battery, because pipes exposed a generic energy capability that the whole grid could reach.

## Changes

- Extraction pipes and the Fluid Pump leave the loader energy grid entirely — their energy handler is
  no longer exposed via NeoForge `Capabilities.Energy.BLOCK` or Fabric Team Reborn `EnergyStorage.SIDED`,
  so nothing on the grid (cables, batteries, or other mods) can discover or push into them.
- Engines deliver to these blocks through a direct channel instead of the grid, so engine power works
  exactly as before — including auto-orientation when placed against a pipe.
- Cables no longer render a connection toward an extraction pipe or the pump.
- The Power Junction is unchanged: networks still take power from cables through it.

## Notes

- Internally this is a new `DirectEnergyReceiver` marker that selects which blocks stay off the grid
  and which engines feed directly.
- Backport to `mc/1.21.11` then `mc/1.21.1` after merge.

BREAKING CHANGE: Cables and batteries no longer power extraction pipes or the Fluid Pump. Only a
directly-adjacent engine can power them. Existing setups that fed pipes through cables/batteries will
stop working — place an engine against the pipe instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)