### PR TITLE
feat(sawmill): add a recipe book to the sawmill GUI

### DIFF
--- a/common/src/client/java/com/logistics/automation/sawmill/SawmillRecipeBookComponent.java
+++ b/common/src/client/java/com/logistics/automation/sawmill/SawmillRecipeBookComponent.java
@@ -1,0 +1,67 @@
+package com.logistics.automation.sawmill;
+
+import com.logistics.LogisticsAutomation;
+import net.minecraft.client.gui.components.WidgetSprites;
+import net.minecraft.client.gui.screens.recipebook.GhostSlots;
+import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
+import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
+import net.minecraft.network.chat.Component;
+import com.logistics.core.lib.resource.ResourceId;
+import net.minecraft.util.context.ContextMap;
+import net.minecraft.world.entity.player.StackedItemContents;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.crafting.display.RecipeDisplay;
+
+import java.util.List;
+
+/**
+ * Recipe book component for the Sawmill screen.
+ * Shows all sawmill recipes in a single custom tab.
+ */
+public class SawmillRecipeBookComponent extends RecipeBookComponent<SawmillScreenHandler> {
+
+    private static final WidgetSprites FILTER_SPRITES = new WidgetSprites(
+        ResourceId.in("minecraft", "recipe_book/furnace_filter_enabled").toIdentifier(),
+        ResourceId.in("minecraft", "recipe_book/furnace_filter_disabled").toIdentifier(),
+        ResourceId.in("minecraft", "recipe_book/furnace_filter_enabled_highlighted").toIdentifier(),
+        ResourceId.in("minecraft", "recipe_book/furnace_filter_disabled_highlighted").toIdentifier()
+    );
+
+    private static final Component FILTER_NAME = Component.translatable("gui.recipebook.toggleRecipes.smeltable");
+
+    private static final List<TabInfo> TABS = List.of(
+        new TabInfo(LogisticsAutomation.BLOCK.SAWMILL.asItem(), LogisticsAutomation.RECIPE.SAWMILL_CATEGORY)
+    );
+
+    public SawmillRecipeBookComponent(SawmillScreenHandler handler) {
+        super(handler, TABS);
+    }
+
+    @Override
+    protected WidgetSprites getFilterButtonTextures() {
+        return FILTER_SPRITES;
+    }
+
+    @Override
+    protected boolean isCraftingSlot(Slot slot) {
+        return slot.index == SawmillBlockEntity.INPUT_SLOT || slot.index == SawmillBlockEntity.PRIMARY_OUTPUT_SLOT;
+    }
+
+    @Override
+    protected void selectMatchingRecipes(RecipeCollection collection, StackedItemContents contents) {
+        collection.selectRecipes(contents, d -> d instanceof SawmillRecipeDisplay);
+    }
+
+    @Override
+    protected Component getRecipeFilterName() {
+        return FILTER_NAME;
+    }
+
+    @Override
+    protected void fillGhostRecipe(GhostSlots ghostSlots, RecipeDisplay display, ContextMap context) {
+        ghostSlots.setResult(this.menu.getSlot(SawmillBlockEntity.PRIMARY_OUTPUT_SLOT), context, display.result());
+        if (display instanceof SawmillRecipeDisplay sd) {
+            ghostSlots.setInput(this.menu.getSlot(SawmillBlockEntity.INPUT_SLOT), context, sd.ingredient());
+        }
+    }
+}

--- a/common/src/client/java/com/logistics/automation/sawmill/SawmillScreen.java
+++ b/common/src/client/java/com/logistics/automation/sawmill/SawmillScreen.java
@@ -3,7 +3,8 @@ package com.logistics.automation.sawmill;
 import com.logistics.LogisticsMod;
 import com.logistics.core.lib.resource.ResourceId;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.navigation.ScreenPosition;
+import net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
@@ -12,20 +13,25 @@ import net.minecraft.world.entity.player.Inventory;
  * Client-side screen for the Sawmill GUI.
  * Shows the input, primary/secondary outputs, a saw-progress arrow, and an energy bar.
  */
-public class SawmillScreen extends AbstractContainerScreen<SawmillScreenHandler> {
+public class SawmillScreen extends AbstractRecipeBookScreen<SawmillScreenHandler> {
 
     private static final ResourceId TEXTURE = LogisticsMod.modId("textures/gui/automation/sawmill.png");
     private static final int TEXTURE_WIDTH = 256;
     private static final int TEXTURE_HEIGHT = 256;
 
     public SawmillScreen(SawmillScreenHandler handler, Inventory inventory, Component title) {
-        super(handler, inventory, title);
+        super(handler, new SawmillRecipeBookComponent(handler), inventory, title);
     }
 
     @Override
     protected void init() {
         super.init();
         this.titleLabelX = (this.imageWidth - this.font.width(this.title)) / 2;
+    }
+
+    @Override
+    protected ScreenPosition getRecipeBookButtonPosition() {
+        return new ScreenPosition(this.leftPos + 20, this.height / 2 - 49);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillScreenHandler.java
@@ -1,22 +1,30 @@
 package com.logistics.automation.sawmill;
 
 import com.logistics.LogisticsAutomation;
+import net.minecraft.recipebook.ServerPlaceRecipe;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.entity.player.StackedItemContents;
 import net.minecraft.world.inventory.ContainerData;
+import net.minecraft.world.inventory.RecipeBookMenu;
+import net.minecraft.world.inventory.RecipeBookType;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.SingleRecipeInput;
+
+import java.util.List;
 
 /**
  * Screen handler for the Sawmill GUI.
  * Input slot plus primary (planks/sticks) and secondary (Wood Pulp) output slots, with
  * progress + energy synced to the client.
  */
-public class SawmillScreenHandler extends AbstractContainerMenu {
+public class SawmillScreenHandler extends RecipeBookMenu {
 
     private static final int MACHINE_SLOT_COUNT = SawmillBlockEntity.TOTAL_SLOTS;
     private static final int PLAYER_INVENTORY_START = MACHINE_SLOT_COUNT;
@@ -62,6 +70,52 @@ public class SawmillScreenHandler extends AbstractContainerMenu {
         }
 
         this.addDataSlots(data);
+    }
+
+    // ==================== RecipeBookMenu ====================
+
+    @Override
+    public RecipeBookType getRecipeBookType() {
+        return RecipeBookType.FURNACE;
+    }
+
+    @Override
+    public void fillCraftSlotsStackedContents(StackedItemContents contents) {
+        ItemStack input = inventory.getItem(SawmillBlockEntity.INPUT_SLOT);
+        if (!input.isEmpty()) {
+            contents.accountSimpleStack(input);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public PostPlaceAction handlePlacement(boolean placeAll, boolean isCreative, RecipeHolder<?> recipe, ServerLevel level, Inventory playerInventory) {
+        List<Slot> relevant = List.of(this.getSlot(SawmillBlockEntity.INPUT_SLOT));
+        return ServerPlaceRecipe.placeRecipe(
+            new ServerPlaceRecipe.CraftingMenuAccess<SawmillRecipe>() {
+                @Override
+                public void fillCraftSlotsStackedContents(StackedItemContents contents) {
+                    SawmillScreenHandler.this.fillCraftSlotsStackedContents(contents);
+                }
+
+                @Override
+                public void clearCraftingContent() {
+                    relevant.forEach(s -> s.set(ItemStack.EMPTY));
+                }
+
+                @Override
+                public boolean recipeMatches(RecipeHolder<SawmillRecipe> r) {
+                    return r.value().matches(new SingleRecipeInput(inventory.getItem(SawmillBlockEntity.INPUT_SLOT)), level);
+                }
+            },
+            1, 1,
+            relevant,
+            relevant,
+            playerInventory,
+            (RecipeHolder<SawmillRecipe>) recipe,
+            placeAll,
+            isCreative
+        );
     }
 
     @Override


### PR DESCRIPTION
## Summary

The Sawmill now has a recipe book button, matching the Kiln and Macerator. Click it to browse and
one-click-fill Sawmill recipes.

## Changes

- Sawmill GUI gains the recipe book button and panel.
- Picking a recipe places its ingredient into the input slot.

## Notes

The recipe-book backend already existed (Sawmill recipes declare their category and display); this
just surfaces it in the menu and screen, mirroring the Macerator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)