### PR TITLE
feat(core): drop niter from the breeze

### DIFF
--- a/fabric/src/main/java/com/logistics/fabric/FabricMobLootModifier.java
+++ b/fabric/src/main/java/com/logistics/fabric/FabricMobLootModifier.java
@@ -1,0 +1,36 @@
+package com.logistics.fabric;
+
+import com.logistics.LogisticsCore;
+import com.logistics.core.lib.resource.ResourceId;
+import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.functions.EnchantedCountIncreaseFunction;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+
+public final class FabricMobLootModifier {
+    private FabricMobLootModifier() {}
+
+    private static final ResourceKey<LootTable> BREEZE = ResourceKey.create(Registries.LOOT_TABLE,
+        ResourceId.parse("minecraft:entities/breeze").toIdentifier());
+
+    public static void register() {
+        LootTableEvents.MODIFY.register((key, tableBuilder, source, registries) -> {
+            // The Breeze (modern air-elemental analogue of TE's Blitz) drops niter,
+            // at the same rate a creeper drops gunpowder: 0-2 + a Looting bonus.
+            if (BREEZE.equals(key)) {
+                tableBuilder.pool(LootPool.lootPool()
+                    .setRolls(ConstantValue.exactly(1))
+                    .add(LootItem.lootTableItem(LogisticsCore.ITEM.NITER)
+                        .apply(SetItemCountFunction.setCount(UniformGenerator.between(0, 2)))
+                        .apply(EnchantedCountIncreaseFunction.lootingMultiplier(registries, UniformGenerator.between(0, 1))))
+                    .build());
+            }
+        });
+    }
+}

--- a/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
+++ b/fabric/src/main/java/com/logistics/fabric/LogisticsFabric.java
@@ -28,6 +28,7 @@ public final class LogisticsFabric implements ModInitializer {
         registerEnergyServices();
         FabricCapabilityRegistration.register();
         FabricChestLootModifier.register();
+        FabricMobLootModifier.register();
         FabricNetworkTickHandler.register();
         FabricCommandRegistration.register();
         FabricServerLevelEvents.register();

--- a/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/LogisticsNeoForge.java
@@ -30,6 +30,7 @@ public final class LogisticsNeoForge {
         NeoForgePacketRegistration.register(modBus);
         NeoForgeCommandRegistration.register(NeoForge.EVENT_BUS);
         NeoForgeChestLootModifier.register(NeoForge.EVENT_BUS);
+        NeoForgeMobLootModifier.register(NeoForge.EVENT_BUS);
         NeoForgeNetworkTickHandler.register(NeoForge.EVENT_BUS);
         NeoForgeServerLevelEvents.register(NeoForge.EVENT_BUS);
         NeoForgePlayerJoinEvents.register(NeoForge.EVENT_BUS);

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgeMobLootModifier.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgeMobLootModifier.java
@@ -1,0 +1,39 @@
+package com.logistics.neoforge;
+
+import com.logistics.LogisticsCore;
+import com.logistics.core.lib.resource.ResourceId;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.functions.EnchantedCountIncreaseFunction;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.event.LootTableLoadEvent;
+
+public final class NeoForgeMobLootModifier {
+    private NeoForgeMobLootModifier() {}
+
+    private static final ResourceKey<LootTable> BREEZE = ResourceKey.create(Registries.LOOT_TABLE,
+        ResourceId.parse("minecraft:entities/breeze").toIdentifier());
+
+    public static void register(IEventBus gameBus) {
+        gameBus.addListener(NeoForgeMobLootModifier::onLootTableLoad);
+    }
+
+    private static void onLootTableLoad(LootTableLoadEvent event) {
+        // The Breeze (modern air-elemental analogue of TE's Blitz) drops niter,
+        // at the same rate a creeper drops gunpowder: 0-2 + a Looting bonus.
+        if (BREEZE.equals(event.getKey()) && event.getTable().getPool("logistics:breeze_niter") == null) {
+            event.getTable().addPool(LootPool.lootPool().name("logistics:breeze_niter")
+                .setRolls(ConstantValue.exactly(1))
+                .add(LootItem.lootTableItem(LogisticsCore.ITEM.NITER)
+                    .apply(SetItemCountFunction.setCount(UniformGenerator.between(0, 2)))
+                    .apply(EnchantedCountIncreaseFunction.lootingMultiplier(event.getRegistries(), UniformGenerator.between(0, 1))))
+                .build());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The **Breeze** now drops **Niter** when killed — the modern air-elemental analogue of Thermal
Expansion's Blitz, which dropped niter (saltpeter). The rate mirrors how a creeper drops gunpowder.

## Drop rate

- **0–2 niter** on death (`set_count` uniform 0–2)
- **+0–1 per Looting level** (`enchanted_count_increase`)
- No player-kill requirement — identical to creeper → gunpowder

## Changes

- `FabricMobLootModifier` / `NeoForgeMobLootModifier` — inject a niter pool into the vanilla
  `minecraft:entities/breeze` loot table, mirroring the existing chest-loot-injection pattern on each
  loader.

## Notes

- **Stacked on #643** (`macerator-byproducts`): the Niter item is added there, so this targets that
  branch and should merge after it. Retarget to `mc/26.1` once #643 lands.
- Backports to all branches (Breeze + the loot APIs exist on 1.21.1+); cherry-pick after #643's niter
  item ports down.
- Part of the TE Blitz→Breeze mapping (Blitz=air→Breeze, Basalz=earth→Creaking, Blizz=ice→none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)