### PR TITLE
refactor(automation): support multi-input recipe processing

### DIFF
--- a/common/src/main/java/com/logistics/core/machine/component/ItemStoreComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/ItemStoreComponent.java
@@ -23,7 +23,7 @@ public final class ItemStoreComponent implements MachineComponent, MachineCompon
     private final ItemInventoryComponent inventory;
     private final SlotRole[] roles;
     private final SidedLayout layout;
-    private final int inputSlot;
+    private final int[] inputSlots;
     private final int[] outputSlots;
 
     public ItemStoreComponent(String id, SlotRole[] roles, SidedLayout layout, Runnable onChanged) {
@@ -31,17 +31,8 @@ public final class ItemStoreComponent implements MachineComponent, MachineCompon
         this.inventory = new ItemInventoryComponent(roles.length, onChanged);
         this.roles = roles.clone();
         this.layout = layout;
-        this.inputSlot = firstSlot(roles, SlotRole.INPUT);
+        this.inputSlots = slotsWithRole(roles, SlotRole.INPUT);
         this.outputSlots = slotsWithRole(roles, SlotRole.OUTPUT);
-    }
-
-    private static int firstSlot(SlotRole[] roles, SlotRole role) {
-        for (int i = 0; i < roles.length; i++) {
-            if (roles[i] == role) {
-                return i;
-            }
-        }
-        return -1;
     }
 
     private static int[] slotsWithRole(SlotRole[] roles, SlotRole role) {
@@ -55,13 +46,31 @@ public final class ItemStoreComponent implements MachineComponent, MachineCompon
 
     // ----- processing helpers -----
 
+    /** Number of input slots (in declaration order). */
+    public int inputCount() {
+        return inputSlots.length;
+    }
+
     public ItemStack input() {
-        return inputSlot >= 0 ? inventory.getItem(inputSlot) : ItemStack.EMPTY;
+        return input(0);
+    }
+
+    /** The stack in the input slot at {@code inputIndex} (declaration order), or empty when absent. */
+    public ItemStack input(int inputIndex) {
+        if (inputIndex < 0 || inputIndex >= inputSlots.length) {
+            return ItemStack.EMPTY;
+        }
+        return inventory.getItem(inputSlots[inputIndex]);
     }
 
     public void consumeInput(int count) {
-        if (inputSlot >= 0 && count > 0) {
-            inventory.getItem(inputSlot).shrink(count);
+        consumeInput(0, count);
+    }
+
+    /** Consumes {@code count} from the input slot at {@code inputIndex} (declaration order). */
+    public void consumeInput(int inputIndex, int count) {
+        if (inputIndex >= 0 && inputIndex < inputSlots.length && count > 0) {
+            inventory.getItem(inputSlots[inputIndex]).shrink(count);
             inventory.setChanged();
         }
     }

--- a/common/src/main/java/com/logistics/core/machine/component/ProcessIO.java
+++ b/common/src/main/java/com/logistics/core/machine/component/ProcessIO.java
@@ -9,13 +9,31 @@ import net.minecraft.world.item.ItemStack;
  * {@link EnergyStorageComponent}; tests supply a fake to exercise the processor's tick flow.
  *
  * <p>Supports a primary result plus ordered byproducts: byproduct {@code i} targets the
- * {@code (i+1)}-th output slot.
+ * {@code (i+1)}-th output slot. Multi-input machines expose more than one input slot via the
+ * indexed overloads; single-input implementations get them for free from the defaults.
  */
 public interface ProcessIO {
 
     ItemStack input();
 
     void consumeInput(int count);
+
+    /** Number of input slots this IO exposes. */
+    default int inputSlotCount() {
+        return 1;
+    }
+
+    /** The stack in input slot {@code index}; defaults to the single input for index 0, empty otherwise. */
+    default ItemStack input(int index) {
+        return index == 0 ? input() : ItemStack.EMPTY;
+    }
+
+    /** Consumes {@code count} from input slot {@code index}; defaults to the single input for index 0. */
+    default void consumeInput(int index, int count) {
+        if (index == 0) {
+            consumeInput(count);
+        }
+    }
 
     long energyStored();
 

--- a/common/src/main/java/com/logistics/core/machine/component/RecipePlan.java
+++ b/common/src/main/java/com/logistics/core/machine/component/RecipePlan.java
@@ -5,15 +5,29 @@ import net.minecraft.world.item.ItemStack;
 
 /**
  * A resolved recipe in RF-cost terms: the total energy the machine must spend, how many input items
- * one run consumes, the primary output, any chance-based byproducts, and an experience reward.
- * Resolvers translate a machine's current inputs (custom or vanilla recipes) into this executable
- * form.
+ * each input slot consumes per run, the primary output, any chance-based byproducts, and an
+ * experience reward. Resolvers translate a machine's current inputs (custom or vanilla recipes) into
+ * this executable form.
+ *
+ * <p>{@code inputCounts} carries one entry per input slot in slot order; single-input machines pass a
+ * length-1 array via the convenience constructors.
  */
 public record RecipePlan(
-        long energyRequired, int inputCount, ItemStack result, List<ChanceOutput> byproducts, float experience) {
+        long energyRequired, int[] inputCounts, ItemStack result, List<ChanceOutput> byproducts, float experience) {
 
     /** Single-input, single-output recipe with no byproducts (the macerator/kiln case). */
     public RecipePlan(long energyRequired, ItemStack result, float experience) {
-        this(energyRequired, 1, result, List.of(), experience);
+        this(energyRequired, new int[] {1}, result, List.of(), experience);
+    }
+
+    /** Single-input recipe with an explicit input count and byproducts (the sawmill case). */
+    public RecipePlan(
+            long energyRequired, int inputCount, ItemStack result, List<ChanceOutput> byproducts, float experience) {
+        this(energyRequired, new int[] {inputCount}, result, byproducts, experience);
+    }
+
+    /** The count consumed from the primary input slot. */
+    public int inputCount() {
+        return inputCounts.length > 0 ? inputCounts[0] : 0;
     }
 }

--- a/common/src/main/java/com/logistics/core/machine/component/RecipePlan.java
+++ b/common/src/main/java/com/logistics/core/machine/component/RecipePlan.java
@@ -15,6 +15,17 @@ import net.minecraft.world.item.ItemStack;
 public record RecipePlan(
         long energyRequired, int[] inputCounts, ItemStack result, List<ChanceOutput> byproducts, float experience) {
 
+    public RecipePlan {
+        // Own the array (callers reuse buffers) and reject negative counts — a negative reaches
+        // ItemStack.shrink as a grow.
+        inputCounts = inputCounts.clone();
+        for (int count : inputCounts) {
+            if (count < 0) {
+                throw new IllegalArgumentException("input counts must be non-negative, got " + count);
+            }
+        }
+    }
+
     /** Single-input, single-output recipe with no byproducts (the macerator/kiln case). */
     public RecipePlan(long energyRequired, ItemStack result, float experience) {
         this(energyRequired, new int[] {1}, result, List.of(), experience);

--- a/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
@@ -87,8 +87,7 @@ public final class RecipeProcessorComponent
             energySpent = 0;
         }
 
-        boolean canRun = io.input().getCount() >= plan.inputCount()
-                && io.canAcceptOutputs(plan.result(), plan.byproducts());
+        boolean canRun = hasInputs(plan) && io.canAcceptOutputs(plan.result(), plan.byproducts());
         RecipeProcessPlan.Result result =
                 RecipeProcessPlan.advance(energySpent, plan.energyRequired(), io.energyStored(), rfPerTick, canRun);
 
@@ -103,13 +102,32 @@ public final class RecipeProcessorComponent
         onChanged.run();
 
         if (result.complete()) {
-            io.consumeInput(plan.inputCount());
+            consumeInputs(plan);
             io.produceOutputs(plan.result(), rollByproducts(plan.byproducts(), ctx.random()));
             if (plan.experience() > 0) {
                 storedExperience += plan.experience();
             }
             energySpent = 0;
             activePlan = null;
+        }
+    }
+
+    /** Whether every input slot holds at least the count the plan consumes from it. */
+    private boolean hasInputs(RecipePlan plan) {
+        int[] counts = plan.inputCounts();
+        for (int i = 0; i < counts.length; i++) {
+            if (io.input(i).getCount() < counts[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Consumes each input slot's per-run count. */
+    private void consumeInputs(RecipePlan plan) {
+        int[] counts = plan.inputCounts();
+        for (int i = 0; i < counts.length; i++) {
+            io.consumeInput(i, counts[i]);
         }
     }
 
@@ -202,13 +220,28 @@ public final class RecipeProcessorComponent
         }
 
         @Override
+        public int inputSlotCount() {
+            return items.inputCount();
+        }
+
+        @Override
         public ItemStack input() {
             return items.input();
         }
 
         @Override
+        public ItemStack input(int index) {
+            return items.input(index);
+        }
+
+        @Override
         public void consumeInput(int count) {
             items.consumeInput(count);
+        }
+
+        @Override
+        public void consumeInput(int index, int count) {
+            items.consumeInput(index, count);
         }
 
         @Override

--- a/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
@@ -4,6 +4,7 @@ import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.machine.MachineComponent;
 import com.logistics.core.machine.MachineContext;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -151,7 +152,25 @@ public final class RecipeProcessorComponent
 
     private static boolean sameRecipe(RecipePlan a, RecipePlan b) {
         return a.energyRequired() == b.energyRequired()
-                && ItemStack.isSameItemSameComponents(a.result(), b.result());
+                && a.experience() == b.experience()
+                && Arrays.equals(a.inputCounts(), b.inputCounts())
+                && ItemStack.isSameItemSameComponents(a.result(), b.result())
+                && sameByproducts(a.byproducts(), b.byproducts());
+    }
+
+    // Compared element-wise on item + chance; ItemStack has no value equals, so List.equals is unusable.
+    private static boolean sameByproducts(List<ChanceOutput> a, List<ChanceOutput> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            ChanceOutput x = a.get(i);
+            ChanceOutput y = b.get(i);
+            if (x.chance() != y.chance() || !ItemStack.isSameItemSameComponents(x.template(), y.template())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
@@ -333,6 +333,30 @@ class RecipeProcessorComponentTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    void doesNotCarryProgressBetweenDifferentInputLayouts() {
+        FakeProcessIO io = new FakeProcessIO();
+        io.energy = 1_000;
+        io.inputCount = 4; // enough for either layout
+        // Same energy + result, different per-slot cost: must be treated as a different recipe.
+        RecipePlan layoutA = new RecipePlan(40, new int[] {1}, new ItemStack(Items.IRON_INGOT), List.of(), 0f);
+        RecipePlan layoutB = new RecipePlan(40, new int[] {2}, new ItemStack(Items.IRON_INGOT), List.of(), 0f);
+        RecipePlan[] active = {layoutA};
+        RecipeResolver resolver = (i, ctx) -> active[0];
+        RecipeProcessorComponent processor =
+                new RecipeProcessorComponent("processor", resolver, 10, io, (ctx, lit) -> {}, () -> {});
+        FakeMachineContext ctx = new FakeMachineContext();
+
+        processor.serverTick(ctx); // 10
+        processor.serverTick(ctx); // 20 on layout A
+        assertThat(processor.energySpent()).isEqualTo(20);
+
+        active[0] = layoutB; // switch to the different-cost layout
+        processor.serverTick(ctx);
+        // Progress reset to 0 then spent 10 this tick — it did NOT inherit the 20 (which would give 30).
+        assertThat(processor.energySpent()).isEqualTo(10);
+    }
+
+    @Test
     void stallsWhenAnyInputSlotIsShort() {
         Runnable noop = () -> {};
         ItemStoreComponent items = twoInputStore(noop);

--- a/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
@@ -333,24 +333,28 @@ class RecipeProcessorComponentTest extends MinecraftTestEnvironment {
     }
 
     @Test
-    void doesNotCarryProgressBetweenDifferentInputLayouts() {
-        FakeProcessIO io = new FakeProcessIO();
-        io.energy = 1_000;
-        io.inputCount = 4; // enough for either layout
-        // Same energy + result, different per-slot cost: must be treated as a different recipe.
-        RecipePlan layoutA = new RecipePlan(40, new int[] {1}, new ItemStack(Items.IRON_INGOT), List.of(), 0f);
-        RecipePlan layoutB = new RecipePlan(40, new int[] {2}, new ItemStack(Items.IRON_INGOT), List.of(), 0f);
+    void doesNotCarryProgressWhenASecondaryInputCostChanges() {
+        Runnable noop = () -> {};
+        ItemStoreComponent items = twoInputStore(noop);
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 0, noop);
+        energy.energy(null).insert(100_000, false);
+        items.container().setItem(0, new ItemStack(Items.COPPER_INGOT, 16));
+        items.container().setItem(1, new ItemStack(Items.RAW_IRON, 16));
+
+        // Identical energy, result, and PRIMARY count; only the secondary slot's cost differs, so the
+        // two must still count as different recipes (secondary inputs affect recipe identity).
+        RecipePlan layoutA = new RecipePlan(40, new int[] {1, 1}, new ItemStack(Items.IRON_INGOT), List.of(), 0f);
+        RecipePlan layoutB = new RecipePlan(40, new int[] {1, 2}, new ItemStack(Items.IRON_INGOT), List.of(), 0f);
         RecipePlan[] active = {layoutA};
-        RecipeResolver resolver = (i, ctx) -> active[0];
-        RecipeProcessorComponent processor =
-                new RecipeProcessorComponent("processor", resolver, 10, io, (ctx, lit) -> {}, () -> {});
+        RecipeProcessorComponent processor = new RecipeProcessorComponent(
+                "processor", (io, ctx) -> active[0], 10, items, energy, (ctx, lit) -> {}, noop);
         FakeMachineContext ctx = new FakeMachineContext();
 
         processor.serverTick(ctx); // 10
         processor.serverTick(ctx); // 20 on layout A
         assertThat(processor.energySpent()).isEqualTo(20);
 
-        active[0] = layoutB; // switch to the different-cost layout
+        active[0] = layoutB; // only the secondary slot's cost changed
         processor.serverTick(ctx);
         // Progress reset to 0 then spent 10 this tick — it did NOT inherit the 20 (which would give 30).
         assertThat(processor.energySpent()).isEqualTo(10);

--- a/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
+++ b/common/src/test/java/com/logistics/core/machine/component/RecipeProcessorComponentTest.java
@@ -291,4 +291,65 @@ class RecipeProcessorComponentTest extends MinecraftTestEnvironment {
         assertThat(processor.energySpent()).isZero();
         assertThat(io.energy).isEqualTo(1_000);
     }
+
+    /** Two-input store: slots 0,1 are inputs and 2,3 are outputs (the alloy-smelter shape). */
+    private static ItemStoreComponent twoInputStore(Runnable onChanged) {
+        return new ItemStoreComponent(
+                "items",
+                new SlotRole[] {SlotRole.INPUT, SlotRole.INPUT, SlotRole.OUTPUT, SlotRole.OUTPUT},
+                SidedLayout.bottomOut(new int[] {0, 1}, new int[] {2, 3}, stack -> true),
+                onChanged);
+    }
+
+    @Test
+    void consumesPerSlotCountsForMultipleInputs() {
+        Runnable noop = () -> {};
+        ItemStoreComponent items = twoInputStore(noop);
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 0, noop);
+        energy.energy(null).insert(100_000, false);
+
+        items.container().setItem(0, new ItemStack(Items.COPPER_INGOT, 5));
+        items.container().setItem(1, new ItemStack(Items.RAW_IRON, 2));
+
+        // Consumes 3 from slot 0 and 1 from slot 1, producing the primary plus a guaranteed byproduct.
+        RecipePlan plan = new RecipePlan(
+                20,
+                new int[] {3, 1},
+                new ItemStack(Items.IRON_INGOT, 4),
+                List.of(new ChanceOutput(new ItemStack(Items.GUNPOWDER), 1.0f)),
+                0f);
+        RecipeProcessorComponent processor = new RecipeProcessorComponent(
+                "processor", (io, ctx) -> plan, 10, items, energy, (ctx, lit) -> {}, noop);
+
+        FakeMachineContext ctx = new FakeMachineContext();
+        processor.serverTick(ctx); // 10
+        processor.serverTick(ctx); // 20 -> complete
+
+        assertThat(items.container().getItem(0).getCount()).isEqualTo(2); // 5 - 3
+        assertThat(items.container().getItem(1).getCount()).isEqualTo(1); // 2 - 1
+        assertThat(items.container().getItem(2).getItem()).isEqualTo(Items.IRON_INGOT);
+        assertThat(items.container().getItem(2).getCount()).isEqualTo(4);
+        assertThat(items.container().getItem(3).getItem()).isEqualTo(Items.GUNPOWDER);
+    }
+
+    @Test
+    void stallsWhenAnyInputSlotIsShort() {
+        Runnable noop = () -> {};
+        ItemStoreComponent items = twoInputStore(noop);
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 0, noop);
+        energy.energy(null).insert(100_000, false);
+
+        items.container().setItem(0, new ItemStack(Items.COPPER_INGOT, 5));
+        // slot 1 left empty -> the recipe needs one there and must not run
+
+        RecipePlan plan = new RecipePlan(
+                20, new int[] {3, 1}, new ItemStack(Items.IRON_INGOT, 4), List.of(), 0f);
+        RecipeProcessorComponent processor = new RecipeProcessorComponent(
+                "processor", (io, ctx) -> plan, 10, items, energy, (ctx, lit) -> {}, noop);
+
+        processor.serverTick(new FakeMachineContext());
+
+        assertThat(processor.energySpent()).isZero();
+        assertThat(items.container().getItem(0).getCount()).isEqualTo(5); // untouched
+    }
 }


### PR DESCRIPTION
## Summary

Generalizes the machine processing core to support machines with more than one input slot, backward-compatibly. Foundation for the Alloy Smelter (the first two-input machine); the macerator, kiln, and sawmill are unaffected.

## Changes

- `ProcessIO`: adds default `inputSlotCount()` / `input(int)` / `consumeInput(int, int)` so existing single-input implementations and test fakes keep working unchanged.
- `RecipePlan`: carries per-slot `int[] inputCounts` (slot order); both existing convenience constructors and the `inputCount()` accessor are preserved.
- `ItemStoreComponent`: tracks all input slots and exposes indexed `input(i)` / `consumeInput(i, n)`.
- `RecipeProcessorComponent`: gates and consumes per input slot.

## Notes

- Single-input machines compile and behave identically.
- Adds two-input processor unit tests (`:common:test`).