### PR TITLE
fix(pump): accept power from any energy source

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlock.java
@@ -255,8 +255,8 @@ public abstract class AbstractEngineBlock<E extends AbstractEngineBlockEntity> e
      * @return true if an energy-accepting storage exists in that direction
      */
     private static boolean hasEnergyStorage(Level world, BlockPos pos, Direction direction) {
-        // Extraction pipes / pump are off the loader grid; the presence checker can't see them. Only
-        // count the face the receiver actually accepts power on (e.g. not the pump's null DOWN intake).
+        // Extraction pipes are off the loader grid; the presence checker can't see them. Only
+        // count the face the receiver actually accepts power on.
         if (world.getBlockEntity(pos.relative(direction)) instanceof DirectEnergyReceiver receiver
                 && receiver instanceof HasEnergyStorage hasStorage) {
             IEnergyStorage storage = hasStorage.energyStorage(direction.getOpposite());

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractEngineBlockEntity.java
@@ -311,7 +311,7 @@ public abstract class AbstractEngineBlockEntity extends BaseBlockEntity implemen
     }
 
     /**
-     * Sends energy to the block this engine is facing. Extraction pipes and the Fluid Pump are
+     * Sends energy to the block this engine is facing. Extraction pipes are
      * {@link DirectEnergyReceiver}s kept off the loader energy grid, so they are fed directly through
      * their own energy buffer; everything else goes through the loader-specific energy push service.
      */

--- a/common/src/main/java/com/logistics/core/lib/power/DirectEnergyReceiver.java
+++ b/common/src/main/java/com/logistics/core/lib/power/DirectEnergyReceiver.java
@@ -4,7 +4,7 @@ package com.logistics.core.lib.power;
  * Marker for blocks that may receive energy <em>only</em> from a directly-adjacent engine — never
  * from cables, batteries, or any loader energy grid (including other mods' conduits).
  *
- * <p>Extraction pipes and the Fluid Pump are powered the classic way: an engine placed against them.
+ * <p>Extraction pipes are powered the classic way: an engine placed against them.
  * They still keep an internal energy buffer (via {@link com.logistics.core.lib.block.capability.HasEnergyStorage}),
  * but that buffer is kept off the loader-exposed energy capability so grid devices cannot find it.
  * Engines deliver by inserting straight into the receiver's {@code energyStorage(side)}.

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
@@ -7,7 +7,6 @@ import com.logistics.core.lib.fluids.FluidTankComponent;
 import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.core.lib.fluids.IFluidStorage;
 import com.logistics.core.lib.power.AcceptsLowTierEnergy;
-import com.logistics.core.lib.power.DirectEnergyReceiver;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
@@ -25,9 +24,10 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Composed from machine components — an energy buffer (reports network demand), a tank, and a
  * {@link FluidPumpComponent} that owns the pumping logic. Energy and fluid are exposed on every face
- * except the bottom, which is the intake. The pump has no GUI.
+ * except the bottom, which is the intake. Like the other machines it accepts power from any source
+ * (engines, cables, batteries). The pump has no GUI.
  */
-public class FluidPumpBlockEntity extends MachineEntity implements AcceptsLowTierEnergy, DirectEnergyReceiver {
+public class FluidPumpBlockEntity extends MachineEntity implements AcceptsLowTierEnergy {
 
     public enum Phase {
         DESCENDING,

--- a/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCapabilityRegistration.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/NeoForgeCapabilityRegistration.java
@@ -69,8 +69,9 @@ public final class NeoForgeCapabilityRegistration {
         registerEnergy(event, LogisticsPipe.ENTITY.POWER_JUNCTION_BLOCK_ENTITY);
         registerEnergy(event, LogisticsAutomation.ENTITY.LASER_QUARRY_BLOCK_ENTITY);
         registerEnergy(event, LogisticsAutomation.ENTITY.KILN_BLOCK_ENTITY);
-        // Extraction pipes (item + fluid) and the Fluid Pump are DirectEnergyReceivers: kept off the
-        // energy grid so only a directly-adjacent engine can power them (engines feed them directly).
+        registerEnergy(event, LogisticsFluid.ENTITY.FLUID_PUMP_BLOCK_ENTITY);
+        // Extraction pipes (item + fluid) are DirectEnergyReceivers: kept off the energy grid so only
+        // a directly-adjacent engine can power them (engines feed them directly).
 
         registerItems(event, LogisticsAutomation.ENTITY.MACERATOR_BLOCK_ENTITY);
         registerItems(event, LogisticsPower.ENTITY.STIRLING_ENGINE_BLOCK_ENTITY);


### PR DESCRIPTION
## Summary

Fixes a bug where the Fluid Pump could only be powered by a directly-adjacent engine. It now accepts power from any source — engines, cables, and batteries — like every other machine. Only extraction pipes remain intentionally engine-only.

## Changes

- Drop the `DirectEnergyReceiver` marker from the Fluid Pump, so its energy buffer is exposed on the loader energy capability again.
- Register the pump's energy capability on NeoForge (Fabric exposes it automatically via the shared fallback).
- Engine power still works: an adjacent engine now feeds the pump through the normal energy grid, and engine auto-orientation still detects it.

## Notes

- The pump keeps its existing behavior: power accepted on every face except the bottom intake.
- Updates the now-stale docs that described the pump as engine-only.