### PR TITLE
fix(ci): unblock release publishing broken by Sentry set-commits

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
+          # Full history so the Sentry release step (set_commits: auto) can
+          # walk back to the previous release's commit; a shallow clone can't.
+          fetch-depth: 0
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:


### PR DESCRIPTION
## Summary

Release builds have been failing on every branch since v0.8.0, blocking publishing to Modrinth/CurseForge. The JARs build fine — the job dies in the **Create Sentry release** step, before `Upload JAR` and before the `publish` job runs.

## Root cause

`set_commits: auto` runs `sentry-cli releases set-commits … --auto`, which walks git history back to the *previous* release's commit to compute the commit range. The build job's `actions/checkout` uses the default shallow clone (`fetch-depth: 1`), so that commit isn't in history and the step fails:

```
error: Could not find the SHA of the previous release in the git history.
       If you limit the clone depth, try to increase it.
```

`mc26.2-v0.8.0` passed only because it was the first release Sentry had ever seen (no previous release to walk back to); every release after it failed.

## Changes

- Add `fetch-depth: 0` to the build-job checkout so the Sentry step can reach the previous release's commit.

## Notes

- All four release branches share this workflow and failed identically — cherry-pick down after merge.
- After this lands, re-run the failed `v0.8.0`/`v0.8.1` releases via **Build (Release)** workflow_dispatch (`publish: true`) to actually publish them.