### PR TITLE
fix(ci): stop Sentry release failing on cross-branch set-commits

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -125,6 +125,10 @@ jobs:
           # Matches the runtime SDK's release: "logistics@" + modVersion (one per loader jar).
           release: logistics@${{ steps.version.outputs.full_version }}
           set_commits: auto
+          # One Sentry project spans all four mc/* branches, so set_commits:auto's
+          # previous release can live on a sibling branch whose commit isn't in this
+          # branch's history. Degrade to default commit count instead of failing.
+          ignore_missing: true
           finalize: true
           environment: production
 


### PR DESCRIPTION
## Summary

Follow-up to #678. Release builds still fail at the **Create Sentry release** step when releases from different `mc/*` branches interleave, blocking publishing.

## Root cause

All four `mc/*` branches publish into a single shared Sentry project (`logistics-mod`). `set_commits: auto` asks Sentry for the *globally* most-recent prior release and diffs from its commit. When that previous release was published from a sibling branch (e.g. `mc/26.2`'s `v0.8.1` right before `mc/26.1`'s `v0.8.0`), its commit isn't in the current branch's history, so sentry-cli hard-fails:

```
error: Could not find the SHA of the previous release in the git history.
       Use --ignore-missing flag to skip it ...
```

`#678`'s `fetch-depth: 0` fixed the same-branch case but can't help here — the commit simply isn't on this branch.

## Changes

- Add `ignore_missing: true` to the `getsentry/action-release` step.

## Notes

- Purely additive: within a branch (sequential `v0.8.0 → v0.8.1`), `--auto` still associates commits normally; it only degrades to default commit count when the previous release's commit genuinely isn't on this branch.
- All four branches share this workflow — cherry-pick down after merge.
- Then re-run the stuck `v0.8.0`/`v0.8.1` releases on each branch.