### PR TITLE
ci(build): use build and ci scopes for dependabot prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
-      prefix-development: "chore(update)"
+      prefix: "chore(build)"
+      prefix-development: "chore(build)"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
+      prefix: "chore(ci)"
 
   # --- mc/26.1 ---
   - package-ecosystem: "gradle"
@@ -25,8 +25,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
-      prefix-development: "chore(update)"
+      prefix: "chore(build)"
+      prefix-development: "chore(build)"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -34,7 +34,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
+      prefix: "chore(ci)"
 
   # --- mc/1.21.11 ---
   - package-ecosystem: "gradle"
@@ -43,8 +43,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
-      prefix-development: "chore(update)"
+      prefix: "chore(build)"
+      prefix-development: "chore(build)"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -52,7 +52,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
+      prefix: "chore(ci)"
 
   # --- mc/1.21.1 ---
   - package-ecosystem: "gradle"
@@ -61,8 +61,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
-      prefix-development: "chore(update)"
+      prefix: "chore(build)"
+      prefix-development: "chore(build)"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -70,5 +70,5 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(update)"
+      prefix: "chore(ci)"
       


### PR DESCRIPTION
@coderabbitai ignore

## Summary

Dependabot's commit prefix was `chore(update)`, but `update` is not an allowed scope in the `lint (pr)` job (`requireScope: true`), so every Dependabot PR failed the PR lint. The automerge workflow requires `lint (pr)` to conclude `success`, so these PRs could never auto-merge.

## Changes

- Gradle dependency updates now use `chore(build)` (dependencies fall under the documented `build` scope).
- GitHub Actions updates now use `chore(ci)`.

Both are existing allowed scopes, so Dependabot titles now pass the lint and can auto-merge.

## Notes

- `.github/dependabot.yml` is only read from the default branch (`mc/26.2`), but the change is cherry-picked to all `mc/*` branches to keep the file consistent.
- Follow-up: the leftover `if: github.actor != 'dependabot[bot]'` skip on `mc/1.21.11` and `mc/1.21.1` should be removed so `lint (pr)` runs (and reports `success`) uniformly — handled during the cherry-picks.