### PR TITLE
fix(fluids): stop fluid extractor pipes from connecting to each other

### DIFF
--- a/common/src/main/java/com/logistics/pipe/PipeTypes.java
+++ b/common/src/main/java/com/logistics/pipe/PipeTypes.java
@@ -152,9 +152,11 @@ public final class PipeTypes {
             new FluidMergerModule());
 
     // Fluid extractor - pulls fluid from an adjacent handler when powered.
+    // Like the item extractor, it must not chain into another extractor of its own kind.
     public static final FluidPipe FLUID_EXTRACTOR_PIPE = new FluidPipe(
             new FluidTransportModule(FlowRate.SLOW),
-            new FluidExtractorModule())
+            new FluidExtractorModule(),
+            new BlockConnectionModule(() -> PipeTypes.FLUID_EXTRACTOR_PIPE))
             .withEnergy();
 
     // Void fluid pipe - destroys fluid; connects to pipes only.

--- a/common/src/main/java/com/logistics/pipe/modules/BlockConnectionModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/BlockConnectionModule.java
@@ -1,26 +1,32 @@
 package com.logistics.pipe.modules;
 
+import com.logistics.core.lib.pipe.ModularPipe;
+import com.logistics.core.lib.pipe.ModularPipeBlock;
 import com.logistics.core.lib.pipe.Module;
 import com.logistics.core.lib.pipe.PipeContext;
-import com.logistics.pipe.Pipe;
 import java.util.function.Supplier;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Vetoes a connection to a neighbouring pipe of the blocked type. Used so extractors never chain into
+ * one another (each should only reach its source handler and downstream transport pipes). Works for
+ * both item and fluid pipe families since both blocks implement {@link ModularPipeBlock}.
+ */
 public class BlockConnectionModule implements Module {
-    private final Supplier<Pipe> blockedPipe;
+    private final Supplier<? extends ModularPipe> blockedPipe;
 
-    public BlockConnectionModule(Supplier<Pipe> blockedPipe) {
+    public BlockConnectionModule(Supplier<? extends ModularPipe> blockedPipe) {
         this.blockedPipe = blockedPipe;
     }
 
     @Override
     public boolean allowsConnection(
             @Nullable PipeContext ctx, Direction direction, Block neighborBlock) {
-        if (neighborBlock instanceof com.logistics.pipe.block.PipeBlock neighborPipeBlock) {
-            Pipe neighborPipe = neighborPipeBlock.getPipe();
-            Pipe blocked = blockedPipe.get();
+        if (neighborBlock instanceof ModularPipeBlock neighborPipeBlock) {
+            ModularPipe neighborPipe = neighborPipeBlock.modularPipe();
+            ModularPipe blocked = blockedPipe.get();
             return neighborPipe == null || neighborPipe != blocked;
         }
         return true;

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidConnectionGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidConnectionGameTest.java
@@ -1,0 +1,57 @@
+package com.logistics.gametest.pipe;
+
+import com.logistics.LogisticsFluid;
+import com.logistics.pipe.block.FluidConnection;
+import com.logistics.pipe.block.entity.FluidPipeBlockEntity;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTestHelper;
+
+public class FluidConnectionGameTest {
+
+    /**
+     * Two fluid extractors placed side by side must not connect to each other — each extractor is an
+     * independent endpoint that only reaches its source handler and downstream transport pipes.
+     * Regression test for #676.
+     */
+    @GameTest
+    public void fluidExtractorsDoNotConnectToEachOther(GameTestHelper context) {
+        BlockPos a = new BlockPos(0, 1, 0);
+        BlockPos b = a.east();
+        context.setBlock(a, LogisticsFluid.BLOCK.FLUID_EXTRACTOR_PIPE);
+        context.setBlock(b, LogisticsFluid.BLOCK.FLUID_EXTRACTOR_PIPE);
+
+        context.succeedWhen(() -> {
+            FluidPipeBlockEntity pipe = context.getBlockEntity(a, FluidPipeBlockEntity.class);
+            if (pipe == null) {
+                throw context.assertionException("Fluid extractor should have a block entity");
+            }
+            if (pipe.connection(Direction.EAST) != FluidConnection.NONE) {
+                throw context.assertionException("Fluid extractors must not connect to each other");
+            }
+        });
+    }
+
+    /**
+     * A fluid extractor still connects to a downstream transport pipe (positive control for the
+     * connection veto above).
+     */
+    @GameTest
+    public void fluidExtractorConnectsToTransportPipe(GameTestHelper context) {
+        BlockPos a = new BlockPos(0, 1, 0);
+        BlockPos b = a.east();
+        context.setBlock(a, LogisticsFluid.BLOCK.FLUID_EXTRACTOR_PIPE);
+        context.setBlock(b, LogisticsFluid.BLOCK.STONE_FLUID_PIPE);
+
+        context.succeedWhen(() -> {
+            FluidPipeBlockEntity pipe = context.getBlockEntity(a, FluidPipeBlockEntity.class);
+            if (pipe == null) {
+                throw context.assertionException("Fluid extractor should have a block entity");
+            }
+            if (pipe.connection(Direction.EAST) != FluidConnection.PIPE) {
+                throw context.assertionException("Fluid extractor should connect to a transport pipe");
+            }
+        });
+    }
+}

--- a/fabric/src/gametest/resources/fabric.mod.json
+++ b/fabric/src/gametest/resources/fabric.mod.json
@@ -23,6 +23,7 @@
 			"com.logistics.gametest.pipe.ModuleGameTest",
 			"com.logistics.gametest.pipe.PipeFlowGameTest",
 			"com.logistics.gametest.pipe.FluidPumpGameTest",
+			"com.logistics.gametest.pipe.FluidConnectionGameTest",
 			"com.logistics.gametest.pipe.PowerJunctionGameTest",
 			"com.logistics.gametest.power.BatteryGameTest",
 			"com.logistics.gametest.power.CableGameTest",


### PR DESCRIPTION
## Summary

Fluid **extractor** pipes could connect to one another. Like the item extractor, each fluid extractor should be an independent endpoint — reaching only its source handler and downstream transport pipes, never another extractor.

Fixes #676.

## Changes

- **fix(fluids):** attach a connection veto to `FLUID_EXTRACTOR_PIPE` so two extractors placed side by side no longer connect.
- Generalized the existing `BlockConnectionModule` to serve both the item and fluid pipe families (both blocks implement `ModularPipeBlock`), rather than adding a parallel fluid-only module. Item extractor behaviour is unchanged.
- Added `FluidConnectionGameTest` covering the regression (two extractors → no connection) plus a positive control (extractor still connects to a transport pipe).

## Notes

- The root cause is in common code, so this fixes both Fabric and NeoForge despite being reported on NeoForge.
- `VOID_FLUID_PIPE` was intentionally left unchanged: it already connects to pipes only (`FluidBypassModule`), and void-to-void chaining is harmless and mirrors `ITEM_VOID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)