### PR TITLE
fix(pump): make the pump tank output-only

### DIFF
--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpBlockEntity.java
@@ -52,6 +52,7 @@ public class FluidPumpBlockEntity extends MachineEntity implements AcceptsLowTie
                 .build();
         fluidStore = machine.fluids("tank")
                 .capacity(FluidUnits.mb(cfg.tankCapacityMb))
+                .outputOnly()
                 .build();
         pump = machine.add(new FluidPumpComponent("pump", energy, fluidStore, getBlockPos()));
     }


### PR DESCRIPTION
@coderabbitai ignore

## Summary

The Fluid Pump's output tank was exposed to pipes as full read/write, so a pipe aimed at the pump could insert fluid into its tank. The pump is conceptually an **output** — it generates fluid from the world internally and hands it off via extraction — so external insertion doesn't make sense.

Fixes #689.

## Changes

- **fix(pump):** mark the pump tank `outputOnly()` so the exposed fluid capability rejects insertion but still allows extraction. Uses the plumbing already added for the Crucible (`FluidStoreComponent` output-only mode via `MachineBuilder`).

## Notes

- A pipe pointed into the pump can no longer fill its tank, but still pulls the pumped fluid out.
- Pumping from the world and bucket/tank interactions are unaffected — those go through `tank()` internally, not the exposed capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)