### PR TITLE
fix(automation): sync machine progress and energy so bars can't overflow

### DIFF
--- a/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.automation.alloysmelter;
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
+import com.logistics.core.machine.MachineData;
 import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
 import com.logistics.core.machine.component.RecipeProcessorComponent;
@@ -41,35 +42,9 @@ public class AlloySmelterBlockEntity extends MachineEntity {
     static final long MAX_ENERGY_INPUT = 128L;
     static final int ENERGY_PER_TICK = 20;
 
-    static final int DATA_PROGRESS = 0;
-    static final int DATA_TOTAL = 1;
-    static final int DATA_ENERGY = 2;
-    public static final int DATA_COUNT = 3;
-
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
-
-    private final ContainerData containerData = new ContainerData() {
-        @Override
-        public int get(int index) {
-            return switch (index) {
-                case DATA_PROGRESS -> (int) Math.min(processor.energySpent(), Integer.MAX_VALUE);
-                case DATA_TOTAL -> (int) Math.min(processor.energyRequired(), Integer.MAX_VALUE);
-                case DATA_ENERGY -> (int) Math.min(energy.amount(), Integer.MAX_VALUE);
-                default -> 0;
-            };
-        }
-
-        @Override
-        public void set(int index, int value) {
-            // Server-side data source only; the client uses a SimpleContainerData populated by sync.
-        }
-
-        @Override
-        public int getCount() {
-            return DATA_COUNT;
-        }
-    };
+    private ContainerData containerData;
 
     public AlloySmelterBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsAutomation.ENTITY.ALLOY_SMELTER_BLOCK_ENTITY, pos, state);
@@ -94,6 +69,8 @@ public class AlloySmelterBlockEntity extends MachineEntity {
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
+
+        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
     }
 
     /** Whether {@code stack} can serve as either input of some recipe (gates hopper insertion). */

--- a/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.alloysmelter;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.machine.MachineData;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.Holder;
@@ -36,14 +37,14 @@ public class AlloySmelterScreenHandler extends RecipeBookMenu {
     /** Client-side constructor. */
     public AlloySmelterScreenHandler(int syncId, Inventory playerInventory) {
         this(syncId, playerInventory, new SimpleContainer(MACHINE_SLOT_COUNT),
-                new SimpleContainerData(AlloySmelterBlockEntity.DATA_COUNT));
+                new SimpleContainerData(MachineData.COUNT));
     }
 
     /** Server-side constructor. */
     public AlloySmelterScreenHandler(int syncId, Inventory playerInventory, Container inventory, ContainerData data) {
         super(LogisticsAutomation.MENU.ALLOY_SMELTER, syncId);
         checkContainerSize(inventory, MACHINE_SLOT_COUNT);
-        checkContainerDataCount(data, AlloySmelterBlockEntity.DATA_COUNT);
+        checkContainerDataCount(data, MachineData.COUNT);
 
         this.inventory = inventory;
         this.data = data;
@@ -249,32 +250,14 @@ public class AlloySmelterScreenHandler extends RecipeBookMenu {
 
     // ==================== Data Getters for GUI Rendering ====================
 
-    public int getProcessProgress() {
-        return data.get(AlloySmelterBlockEntity.DATA_PROGRESS);
-    }
-
-    public int getProcessTotalTicks() {
-        return data.get(AlloySmelterBlockEntity.DATA_TOTAL);
-    }
-
-    public int getEnergyStored() {
-        return data.get(AlloySmelterBlockEntity.DATA_ENERGY);
-    }
-
-    public int getEnergyCapacity() {
-        return (int) AlloySmelterBlockEntity.ENERGY_CAPACITY;
-    }
-
+    /** Progress arrow width (0..24 px) from the synced progress fraction, or 0 if idle. */
     public int getProgressArrowWidth() {
-        int total = getProcessTotalTicks();
-        if (total <= 0) return 0;
-        return 24 * getProcessProgress() / total;
+        return MachineData.barPixels(data, MachineData.PROGRESS, 24);
     }
 
+    /** Energy bar height (0..30 px) from the synced energy fill fraction. */
     public int getEnergyBarHeight() {
-        int capacity = getEnergyCapacity();
-        if (capacity <= 0) return 0;
-        return 30 * getEnergyStored() / capacity;
+        return MachineData.barPixels(data, MachineData.ENERGY, 30);
     }
 
     /** Output slot — players may take but not insert. */

--- a/common/src/main/java/com/logistics/automation/crucible/CrucibleBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/crucible/CrucibleBlockEntity.java
@@ -5,6 +5,7 @@ import com.logistics.core.lib.fluids.FluidTankComponent;
 import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
+import com.logistics.core.machine.MachineData;
 import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
 import com.logistics.core.machine.component.FluidStoreComponent;
@@ -39,15 +40,10 @@ public class CrucibleBlockEntity extends MachineEntity {
 
     static final long TANK_CAPACITY_MB = 10_000L;
 
-    // ContainerData syncs each value as a 16-bit short, so raw RF (recipes run to hundreds of thousands)
-    // would overflow. Progress and energy are synced as a 0..DATA_SCALE fraction instead.
-    static final int DATA_SCALE = 10_000;
-
-    static final int DATA_PROGRESS = 0;
-    static final int DATA_ENERGY = 1;
-    static final int DATA_FLUID_ID = 2;
-    static final int DATA_FLUID_AMOUNT = 3;
-    static final int DATA_COUNT = 4;
+    // Progress + energy sync as 0..MachineData.SCALE fractions (see MachineData); the tank adds two more.
+    static final int DATA_FLUID_ID = MachineData.COUNT;
+    static final int DATA_FLUID_AMOUNT = MachineData.COUNT + 1;
+    static final int DATA_COUNT = MachineData.COUNT + 2;
 
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
@@ -57,10 +53,8 @@ public class CrucibleBlockEntity extends MachineEntity {
         @Override
         public int get(int index) {
             return switch (index) {
-                case DATA_PROGRESS -> Math.round(processor.progress() * DATA_SCALE);
-                case DATA_ENERGY -> ENERGY_CAPACITY <= 0
-                        ? 0
-                        : (int) (energy.amount() * DATA_SCALE / ENERGY_CAPACITY);
+                case MachineData.PROGRESS -> MachineData.progressFraction(processor);
+                case MachineData.ENERGY -> MachineData.energyFraction(energy, ENERGY_CAPACITY);
                 case DATA_FLUID_ID -> fluidStore.tank().isEmpty()
                         ? -1
                         : BuiltInRegistries.FLUID.getId(fluidStore.tank().getFluidKey().getFluid());

--- a/common/src/main/java/com/logistics/automation/crucible/CrucibleScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/crucible/CrucibleScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.crucible;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.machine.MachineData;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
@@ -103,14 +104,14 @@ public class CrucibleScreenHandler extends AbstractContainerMenu {
 
     // ==================== Data Getters for GUI Rendering ====================
 
-    /** Progress arrow width (0..24 px) from the synced 0..{@code DATA_SCALE} progress fraction. */
+    /** Progress arrow width (0..24 px) from the synced progress fraction. */
     public int getProgressArrowWidth() {
-        return Math.min(24, 24 * data.get(CrucibleBlockEntity.DATA_PROGRESS) / CrucibleBlockEntity.DATA_SCALE);
+        return MachineData.barPixels(data, MachineData.PROGRESS, 24);
     }
 
-    /** Energy bar height (0..30 px) from the synced 0..{@code DATA_SCALE} energy fill fraction. */
+    /** Energy bar height (0..30 px) from the synced energy fill fraction. */
     public int getEnergyBarHeight() {
-        return Math.min(30, 30 * data.get(CrucibleBlockEntity.DATA_ENERGY) / CrucibleBlockEntity.DATA_SCALE);
+        return MachineData.barPixels(data, MachineData.ENERGY, 30);
     }
 
     /** Registry id of the fluid in the tank, or {@code -1} when empty. */

--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.automation.kiln;
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
+import com.logistics.core.machine.MachineData;
 import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
 import com.logistics.core.machine.component.RecipeProcessorComponent;
@@ -38,35 +39,9 @@ public class KilnBlockEntity extends MachineEntity {
 
     static final int ENERGY_PER_TICK = 20;
 
-    private static final int DATA_PROGRESS = 0;
-    private static final int DATA_TOTAL = 1;
-    private static final int DATA_ENERGY = 2;
-    static final int DATA_COUNT = 3;
-
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
-
-    private final ContainerData containerData = new ContainerData() {
-        @Override
-        public int get(int index) {
-            return switch (index) {
-                case DATA_PROGRESS -> (int) Math.min(processor.energySpent(), Integer.MAX_VALUE);
-                case DATA_TOTAL -> (int) Math.min(processor.energyRequired(), Integer.MAX_VALUE);
-                case DATA_ENERGY -> (int) Math.min(energy.amount(), Integer.MAX_VALUE);
-                default -> 0;
-            };
-        }
-
-        @Override
-        public void set(int index, int value) {
-            // Server-side data source only; the client uses a SimpleContainerData populated by sync.
-        }
-
-        @Override
-        public int getCount() {
-            return DATA_COUNT;
-        }
-    };
+    private ContainerData containerData;
 
     public KilnBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsAutomation.ENTITY.KILN_BLOCK_ENTITY, pos, state);
@@ -91,6 +66,8 @@ public class KilnBlockEntity extends MachineEntity {
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
+
+        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
     }
 
     private boolean canSmelt(ItemStack stack) {

--- a/common/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnScreenHandler.java
@@ -2,6 +2,7 @@ package com.logistics.automation.kiln;
 
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.lib.block.MachineResultSlot;
+import com.logistics.core.machine.MachineData;
 import net.minecraft.recipebook.ServerPlaceRecipe;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
@@ -36,14 +37,14 @@ public class KilnScreenHandler extends RecipeBookMenu {
 
     /** Client-side constructor. */
     public KilnScreenHandler(int syncId, Inventory playerInventory) {
-        this(syncId, playerInventory, new SimpleContainer(MACHINE_SLOT_COUNT), new SimpleContainerData(KilnBlockEntity.DATA_COUNT));
+        this(syncId, playerInventory, new SimpleContainer(MACHINE_SLOT_COUNT), new SimpleContainerData(MachineData.COUNT));
     }
 
     /** Server-side constructor. */
     public KilnScreenHandler(int syncId, Inventory playerInventory, Container inventory, ContainerData data) {
         super(LogisticsAutomation.MENU.KILN, syncId);
         checkContainerSize(inventory, MACHINE_SLOT_COUNT);
-        checkContainerDataCount(data, KilnBlockEntity.DATA_COUNT);
+        checkContainerDataCount(data, MachineData.COUNT);
 
         this.inventory = inventory;
         this.data = data;
@@ -166,33 +167,13 @@ public class KilnScreenHandler extends RecipeBookMenu {
 
     // ==================== Data Getters for GUI Rendering ====================
 
-    /** Energy spent so far toward the active recipe (RF). */
-    public int getEnergySpent() {
-        return data.get(0);
-    }
-
-    /** Total energy the active recipe requires (RF), or 0 if idle. */
-    public int getEnergyRequired() {
-        return data.get(1);
-    }
-
-    public int getEnergyStored() {
-        return data.get(2);
-    }
-
-    public int getEnergyCapacity() {
-        return (int) KilnBlockEntity.ENERGY_CAPACITY;
-    }
-
+    /** Progress arrow width (0..24 px) from the synced progress fraction, or 0 if idle. */
     public int getProgressArrowWidth() {
-        int required = getEnergyRequired();
-        if (required <= 0) return 0;
-        return 24 * getEnergySpent() / required;
+        return MachineData.barPixels(data, MachineData.PROGRESS, 24);
     }
 
+    /** Energy bar height (0..30 px) from the synced energy fill fraction. */
     public int getEnergyBarHeight() {
-        int capacity = getEnergyCapacity();
-        if (capacity <= 0) return 0;
-        return 30 * getEnergyStored() / capacity;
+        return MachineData.barPixels(data, MachineData.ENERGY, 30);
     }
 }

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.automation.macerator;
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
+import com.logistics.core.machine.MachineData;
 import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
 import com.logistics.core.machine.component.RecipeProcessorComponent;
@@ -36,37 +37,9 @@ public class MaceratorBlockEntity extends MachineEntity {
     // Tuned so 1 coal in a Stirling Engine (16,000 RF) macerates 8 items (8 × 2,000 RF each).
     static final int ENERGY_PER_TICK = 10;
 
-    // ContainerData indices for GUI sync. Progress/total are RF-denominated under the RF-cost model.
-    // Package-visible so MaceratorScreenHandler reads the same layout instead of raw literals.
-    static final int DATA_PROGRESS = 0;
-    static final int DATA_TOTAL = 1;
-    static final int DATA_ENERGY = 2;
-    static final int DATA_COUNT = 3;
-
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
-
-    private final ContainerData containerData = new ContainerData() {
-        @Override
-        public int get(int index) {
-            return switch (index) {
-                case DATA_PROGRESS -> (int) Math.min(processor.energySpent(), Integer.MAX_VALUE);
-                case DATA_TOTAL -> (int) Math.min(processor.energyRequired(), Integer.MAX_VALUE);
-                case DATA_ENERGY -> (int) Math.min(energy.amount(), Integer.MAX_VALUE);
-                default -> 0;
-            };
-        }
-
-        @Override
-        public void set(int index, int value) {
-            // Server-side data source only; the client uses a SimpleContainerData populated by sync.
-        }
-
-        @Override
-        public int getCount() {
-            return DATA_COUNT;
-        }
-    };
+    private ContainerData containerData;
 
     public MaceratorBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsAutomation.ENTITY.MACERATOR_BLOCK_ENTITY, pos, state);
@@ -91,6 +64,8 @@ public class MaceratorBlockEntity extends MachineEntity {
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
+
+        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
     }
 
     private void setLit(MachineContext ctx, boolean lit) {

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorScreenHandler.java
@@ -2,6 +2,7 @@ package com.logistics.automation.macerator;
 
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.lib.block.MachineResultSlot;
+import com.logistics.core.machine.MachineData;
 import net.minecraft.recipebook.ServerPlaceRecipe;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
@@ -35,14 +36,14 @@ public class MaceratorScreenHandler extends RecipeBookMenu {
 
     /** Client-side constructor. */
     public MaceratorScreenHandler(int syncId, Inventory playerInventory) {
-        this(syncId, playerInventory, new SimpleContainer(MACHINE_SLOT_COUNT), new SimpleContainerData(MaceratorBlockEntity.DATA_COUNT));
+        this(syncId, playerInventory, new SimpleContainer(MACHINE_SLOT_COUNT), new SimpleContainerData(MachineData.COUNT));
     }
 
     /** Server-side constructor. */
     public MaceratorScreenHandler(int syncId, Inventory playerInventory, Container inventory, ContainerData data) {
         super(LogisticsAutomation.MENU.MACERATOR, syncId);
         checkContainerSize(inventory, MACHINE_SLOT_COUNT);
-        checkContainerDataCount(data, MaceratorBlockEntity.DATA_COUNT);
+        checkContainerDataCount(data, MachineData.COUNT);
 
         this.inventory = inventory;
         this.data = data;
@@ -167,38 +168,14 @@ public class MaceratorScreenHandler extends RecipeBookMenu {
 
     // ==================== Data Getters for GUI Rendering ====================
 
-    /** Energy spent so far toward the active recipe (RF). */
-    public int getEnergySpent() {
-        return data.get(MaceratorBlockEntity.DATA_PROGRESS);
-    }
-
-    /** Total energy the active recipe requires (RF), or 0 if idle. */
-    public int getEnergyRequired() {
-        return data.get(MaceratorBlockEntity.DATA_TOTAL);
-    }
-
-    /** Current energy stored (RF). */
-    public int getEnergyStored() {
-        return data.get(MaceratorBlockEntity.DATA_ENERGY);
-    }
-
-    /** Max energy capacity (RF). */
-    public int getEnergyCapacity() {
-        return (int) MaceratorBlockEntity.ENERGY_CAPACITY;
-    }
-
-    /** Processing progress as a 0–25 pixel width for the arrow (the sprite width), or 0 if idle. */
+    /** Progress arrow width (0..24 px) from the synced progress fraction, or 0 if idle. */
     public int getProgressArrowWidth() {
-        int required = getEnergyRequired();
-        if (required <= 0) return 0;
-        return 24 * getEnergySpent() / required;
+        return MachineData.barPixels(data, MachineData.PROGRESS, 24);
     }
 
-    /** Energy bar height in pixels (0–13). */
+    /** Energy bar height (0..30 px) from the synced energy fill fraction. */
     public int getEnergyBarHeight() {
-        int capacity = getEnergyCapacity();
-        if (capacity <= 0) return 0;
-        return 30 * getEnergyStored() / capacity;
+        return MachineData.barPixels(data, MachineData.ENERGY, 30);
     }
 
     /** Output slot — players may take but not insert. */

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.automation.sawmill;
 import com.logistics.LogisticsAutomation;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
+import com.logistics.core.machine.MachineData;
 import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
 import com.logistics.core.machine.component.RecipeProcessorComponent;
@@ -40,35 +41,9 @@ public class SawmillBlockEntity extends MachineEntity {
     static final long MAX_ENERGY_INPUT = 128L;
     static final int ENERGY_PER_TICK = 20;
 
-    private static final int DATA_PROGRESS = 0;
-    private static final int DATA_TOTAL = 1;
-    private static final int DATA_ENERGY = 2;
-    public static final int DATA_COUNT = 3;
-
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
-
-    private final ContainerData containerData = new ContainerData() {
-        @Override
-        public int get(int index) {
-            return switch (index) {
-                case DATA_PROGRESS -> (int) Math.min(processor.energySpent(), Integer.MAX_VALUE);
-                case DATA_TOTAL -> (int) Math.min(processor.energyRequired(), Integer.MAX_VALUE);
-                case DATA_ENERGY -> (int) Math.min(energy.amount(), Integer.MAX_VALUE);
-                default -> 0;
-            };
-        }
-
-        @Override
-        public void set(int index, int value) {
-            // Server-side data source only; the client uses a SimpleContainerData populated by sync.
-        }
-
-        @Override
-        public int getCount() {
-            return DATA_COUNT;
-        }
-    };
+    private ContainerData containerData;
 
     public SawmillBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsAutomation.ENTITY.SAWMILL_BLOCK_ENTITY, pos, state);
@@ -93,6 +68,8 @@ public class SawmillBlockEntity extends MachineEntity {
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
+
+        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
     }
 
     private boolean isSawable(ItemStack stack) {

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.sawmill;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.machine.MachineData;
 import net.minecraft.recipebook.ServerPlaceRecipe;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
@@ -36,14 +37,14 @@ public class SawmillScreenHandler extends RecipeBookMenu {
     /** Client-side constructor. */
     public SawmillScreenHandler(int syncId, Inventory playerInventory) {
         this(syncId, playerInventory, new SimpleContainer(MACHINE_SLOT_COUNT),
-                new SimpleContainerData(SawmillBlockEntity.DATA_COUNT));
+                new SimpleContainerData(MachineData.COUNT));
     }
 
     /** Server-side constructor. */
     public SawmillScreenHandler(int syncId, Inventory playerInventory, Container inventory, ContainerData data) {
         super(LogisticsAutomation.MENU.SAWMILL, syncId);
         checkContainerSize(inventory, MACHINE_SLOT_COUNT);
-        checkContainerDataCount(data, SawmillBlockEntity.DATA_COUNT);
+        checkContainerDataCount(data, MachineData.COUNT);
 
         this.inventory = inventory;
         this.data = data;
@@ -166,32 +167,14 @@ public class SawmillScreenHandler extends RecipeBookMenu {
 
     // ==================== Data Getters for GUI Rendering ====================
 
-    public int getProcessProgress() {
-        return data.get(0);
-    }
-
-    public int getProcessTotalTicks() {
-        return data.get(1);
-    }
-
-    public int getEnergyStored() {
-        return data.get(2);
-    }
-
-    public int getEnergyCapacity() {
-        return (int) SawmillBlockEntity.ENERGY_CAPACITY;
-    }
-
+    /** Progress arrow width (0..24 px) from the synced progress fraction, or 0 if idle. */
     public int getProgressArrowWidth() {
-        int total = getProcessTotalTicks();
-        if (total <= 0) return 0;
-        return 24 * getProcessProgress() / total;
+        return MachineData.barPixels(data, MachineData.PROGRESS, 24);
     }
 
+    /** Energy bar height (0..30 px) from the synced energy fill fraction. */
     public int getEnergyBarHeight() {
-        int capacity = getEnergyCapacity();
-        if (capacity <= 0) return 0;
-        return 30 * getEnergyStored() / capacity;
+        return MachineData.barPixels(data, MachineData.ENERGY, 30);
     }
 
     /** Output slot — players may take but not insert. */

--- a/common/src/main/java/com/logistics/core/machine/MachineData.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineData.java
@@ -1,0 +1,77 @@
+package com.logistics.core.machine;
+
+import com.logistics.core.machine.component.EnergyStorageComponent;
+import com.logistics.core.machine.component.RecipeProcessorComponent;
+import net.minecraft.world.inventory.ContainerData;
+
+/**
+ * Shared {@link ContainerData} plumbing for component machines.
+ *
+ * <p>{@code ContainerData} syncs each value to the client as a signed 16-bit short (−32,768..32,767).
+ * Syncing raw RF overflows once a buffer or recipe exceeds 32,767, so progress and energy fill are
+ * synced as a {@code 0..}{@link #SCALE} fraction instead — correct at any energy magnitude.
+ */
+public final class MachineData {
+    /** Fixed-point denominator for synced fractions. */
+    public static final int SCALE = 10_000;
+
+    /** Data index: recipe progress fill (0..{@link #SCALE}). */
+    public static final int PROGRESS = 0;
+    /** Data index: energy buffer fill (0..{@link #SCALE}). */
+    public static final int ENERGY = 1;
+    /** Slot count for a machine syncing only progress + energy. */
+    public static final int COUNT = 2;
+
+    private MachineData() {}
+
+    /** Active-recipe progress as a 0..{@link #SCALE} fraction. */
+    public static int progressFraction(RecipeProcessorComponent processor) {
+        return Math.round(processor.progress() * SCALE);
+    }
+
+    /** Energy fill as a 0..{@link #SCALE} fraction of the buffer capacity. */
+    public static int energyFraction(EnergyStorageComponent energy, long capacity) {
+        return fraction(energy.amount(), capacity);
+    }
+
+    /**
+     * {@code value} as a 0..{@link #SCALE} fraction of {@code max}. Bounded to {@link #SCALE} (which
+     * fits a 16-bit short) regardless of magnitude — this is what keeps raw RF from overflowing sync.
+     */
+    public static int fraction(long value, long max) {
+        return max <= 0 ? 0 : (int) (Math.min(value, max) * SCALE / max);
+    }
+
+    /**
+     * Server-side {@link ContainerData} syncing only {@link #PROGRESS} and {@link #ENERGY} as
+     * fractions. The client uses a {@code SimpleContainerData} of {@link #COUNT} slots.
+     */
+    public static ContainerData source(
+            RecipeProcessorComponent processor, EnergyStorageComponent energy, long capacity) {
+        return new ContainerData() {
+            @Override
+            public int get(int index) {
+                return switch (index) {
+                    case PROGRESS -> progressFraction(processor);
+                    case ENERGY -> energyFraction(energy, capacity);
+                    default -> 0;
+                };
+            }
+
+            @Override
+            public void set(int index, int value) {
+                // Server-side source only; the client uses a SimpleContainerData populated by sync.
+            }
+
+            @Override
+            public int getCount() {
+                return COUNT;
+            }
+        };
+    }
+
+    /** Bar fill in pixels (0..{@code spritePx}, clamped) from the 0..{@link #SCALE} fraction at {@code index}. */
+    public static int barPixels(ContainerData data, int index, int spritePx) {
+        return Math.min(spritePx, spritePx * data.get(index) / SCALE);
+    }
+}

--- a/common/src/main/java/com/logistics/core/machine/MachineData.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineData.java
@@ -35,11 +35,12 @@ public final class MachineData {
     }
 
     /**
-     * {@code value} as a 0..{@link #SCALE} fraction of {@code max}. Bounded to {@link #SCALE} (which
-     * fits a 16-bit short) regardless of magnitude — this is what keeps raw RF from overflowing sync.
+     * {@code value} as a 0..{@link #SCALE} fraction of {@code max}. {@code value} is clamped to
+     * {@code 0..max}, so the result stays within {@code 0..}{@link #SCALE} (which fits a 16-bit short)
+     * regardless of magnitude — this is what keeps raw RF from overflowing sync.
      */
     public static int fraction(long value, long max) {
-        return max <= 0 ? 0 : (int) (Math.min(value, max) * SCALE / max);
+        return max <= 0 ? 0 : (int) (Math.max(0, Math.min(value, max)) * SCALE / max);
     }
 
     /**
@@ -72,6 +73,6 @@ public final class MachineData {
 
     /** Bar fill in pixels (0..{@code spritePx}, clamped) from the 0..{@link #SCALE} fraction at {@code index}. */
     public static int barPixels(ContainerData data, int index, int spritePx) {
-        return Math.min(spritePx, spritePx * data.get(index) / SCALE);
+        return Math.max(0, Math.min(spritePx, spritePx * data.get(index) / SCALE));
     }
 }

--- a/common/src/test/java/com/logistics/core/machine/MachineDataTest.java
+++ b/common/src/test/java/com/logistics/core/machine/MachineDataTest.java
@@ -1,0 +1,67 @@
+package com.logistics.core.machine;
+
+import net.minecraft.world.inventory.ContainerData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("MachineData")
+class MachineDataTest {
+
+    /** A ContainerData whose single slot returns a fixed value. */
+    private static ContainerData slot(int value) {
+        return new ContainerData() {
+            @Override
+            public int get(int index) {
+                return value;
+            }
+
+            @Override
+            public void set(int index, int v) {}
+
+            @Override
+            public int getCount() {
+                return 1;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("fraction is 0 at empty and SCALE at full")
+    void fractionBounds() {
+        assertThat(MachineData.fraction(0, 40_000)).isZero();
+        assertThat(MachineData.fraction(40_000, 40_000)).isEqualTo(MachineData.SCALE);
+        assertThat(MachineData.fraction(20_000, 40_000)).isEqualTo(MachineData.SCALE / 2);
+    }
+
+    @Test
+    @DisplayName("fraction stays short-safe for RF values far above 32,767 (the sync overflow bug)")
+    void fractionNeverOverflowsAShort() {
+        // Crucible-scale numbers: a 40,000 RF buffer, recipes to 300,000 RF — all past a short's 32,767.
+        for (long value = 0; value <= 300_000; value += 12_345) {
+            int f = MachineData.fraction(value, 300_000);
+            assertThat(f).isBetween(0, MachineData.SCALE);
+            assertThat(f).isLessThanOrEqualTo(Short.MAX_VALUE);
+        }
+        assertThat(MachineData.fraction(300_000, 300_000)).isEqualTo(MachineData.SCALE);
+    }
+
+    @Test
+    @DisplayName("fraction clamps a value above its max and guards a non-positive max")
+    void fractionEdgeCases() {
+        assertThat(MachineData.fraction(50_000, 40_000)).isEqualTo(MachineData.SCALE);
+        assertThat(MachineData.fraction(100, 0)).isZero();
+        assertThat(MachineData.fraction(100, -5)).isZero();
+    }
+
+    @Test
+    @DisplayName("barPixels scales the fraction to the sprite and clamps to its width")
+    void barPixels() {
+        assertThat(MachineData.barPixels(slot(0), 0, 24)).isZero();
+        assertThat(MachineData.barPixels(slot(MachineData.SCALE), 0, 24)).isEqualTo(24);
+        assertThat(MachineData.barPixels(slot(MachineData.SCALE / 2), 0, 24)).isEqualTo(12);
+        // A fraction reported past SCALE never renders past the sprite.
+        assertThat(MachineData.barPixels(slot(MachineData.SCALE * 2), 0, 30)).isEqualTo(30);
+    }
+}


### PR DESCRIPTION
## Summary

Machine GUIs synced raw RF through `ContainerData`, which sends each value to the client as a signed 16-bit short (−32,768..32,767). Any energy/progress value above 32,767 wrapped on the client — the progress arrow filled and kept growing past the GUI into the block atlas, and the energy bar misread.

The Crucible (40,000 RF buffer, recipes to 300,000 RF) hit this and was fixed ad-hoc. The macerator, kiln, sawmill, and alloy smelter share the same raw-RF pattern and are correct today only because their buffers/recipes stay under 32,767 — they would break the moment any of them grows.

Fixes #684.

## Changes

- **fix(automation):** lift the fix into the shared machine framework (`MachineData`). Progress and energy now sync as a `0..10000` fraction, which always fits a short — every machine is correct regardless of energy magnitude.
- Rewired the macerator, kiln, sawmill, alloy smelter, and crucible onto the shared helper and removed the duplicated per-machine `ContainerData` plumbing and raw-RF getters.
- Added `MachineDataTest` covering the overflow property (fractions stay short-safe across Crucible-scale RF values) and bar clamping.

## Notes

- Player-visible effect: machine progress arrows and energy bars render correctly even for machines with large buffers or expensive recipes; no more overflow into the block atlas.
- Net simplification — the same fraction sync now lives in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)