### PR TITLE
feat(fluids): light-emitting fluids glow in pipes and tanks

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -15,7 +15,9 @@ import com.logistics.core.worldgen.OilSeepFeature;
 import com.logistics.core.worldgen.OilSandsConfiguration;
 import com.logistics.core.worldgen.OilSandsFeature;
 import net.minecraft.world.level.levelgen.feature.LakeFeature;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -36,6 +38,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.material.FlowingFluid;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.PushReaction;
 
 public final class LogisticsCore extends LogisticsMod implements DomainBootstrap {
@@ -60,22 +64,28 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
      * baked {@code still}/{@code flow} sprites (color + per-fluid alpha pre-applied in the texture), so the
      * {@code tint} stays {@code 0xFFFFFFFF} (untinted). {@code overlay} may be null.
      */
-    public record FluidDef(String name, int tint, String still, String flow, String overlay, WorldFlow world) {
+    public record FluidDef(
+            String name, int tint, String still, String flow, String overlay, WorldFlow world, int luminance) {
 
         /** Flow tuning for a {@link #world()} fluid — a placeable {@code LiquidBlock} that spreads. */
         public record WorldFlow(int slopeFindDistance, int dropOff, int tickDelay) {}
 
-        /** A fluid rendered from its baked textures under {@code block/core/fluid/}, untinted. */
+        /** A fluid rendered from its baked textures under {@code block/core/fluid/}, untinted, dark. */
         public static FluidDef core(String name) {
+            return core(name, 0);
+        }
+
+        /** A {@link #core} fluid that emits {@code luminance} (0-15) when held in a pipe or tank. */
+        public static FluidDef core(String name, int luminance) {
             String base = "logistics:block/core/fluid/" + name;
-            return new FluidDef(name, 0xFFFFFFFF, base + "_still", base + "_flow", null, null);
+            return new FluidDef(name, 0xFFFFFFFF, base + "_still", base + "_flow", null, null, luminance);
         }
 
         /** A {@link #core} fluid that also has a world block, spreading with the given flow tuning. */
         public static FluidDef world(String name, int slopeFindDistance, int dropOff, int tickDelay) {
             String base = "logistics:block/core/fluid/" + name;
             return new FluidDef(name, 0xFFFFFFFF, base + "_still", base + "_flow", null,
-                new WorldFlow(slopeFindDistance, dropOff, tickDelay));
+                new WorldFlow(slopeFindDistance, dropOff, tickDelay), 0);
         }
 
         /** Whether this fluid can be placed in the world (has a {@code LiquidBlock}). */
@@ -88,9 +98,45 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
     public static final List<FluidDef> CUSTOM_FLUIDS = List.of(
         FluidDef.core("liquid_redstone"),
         FluidDef.core("liquid_ender"),
-        FluidDef.core("liquid_glowstone"),
+        FluidDef.core("liquid_glowstone", 15),
         FluidDef.world("crude_oil", 2, 2, 15),
         FluidDef.core("liquid_biomass"));
+
+    private static Map<Fluid, Integer> fluidLuminance;
+
+    /**
+     * Block light level (0-15) a pipe or tank should emit while holding {@code fluid}. Vanilla lava
+     * glows at 15; a custom fluid glows at its {@link FluidDef#luminance()}; everything else is dark.
+     */
+    public static int fluidLuminance(Fluid fluid) {
+        if (fluid == Fluids.LAVA || fluid == Fluids.FLOWING_LAVA) {
+            return 15;
+        }
+        if (fluidLuminance == null) {
+            fluidLuminance = buildFluidLuminance();
+        }
+        return fluidLuminance.getOrDefault(fluid, 0);
+    }
+
+    /** Map each glowing custom fluid (source + flowing) to its luminance, resolved after registration. */
+    private static Map<Fluid, Integer> buildFluidLuminance() {
+        Map<Fluid, Integer> map = new IdentityHashMap<>();
+        for (FluidDef def : CUSTOM_FLUIDS) {
+            if (def.luminance() <= 0) {
+                continue;
+            }
+            putIfRegistered(map, resource(def.name()), def.luminance());
+            putIfRegistered(map, resource("flowing_" + def.name()), def.luminance());
+        }
+        return map;
+    }
+
+    private static void putIfRegistered(Map<Fluid, Integer> map, ResourceId id, int luminance) {
+        Fluid fluid = BuiltInRegistries.FLUID.getValue(id.toIdentifier());
+        if (fluid != Fluids.EMPTY) {
+            map.put(fluid, luminance);
+        }
+    }
 
     @Override
     public int order() {

--- a/common/src/main/java/com/logistics/core/lib/fluids/FluidLight.java
+++ b/common/src/main/java/com/logistics/core/lib/fluids/FluidLight.java
@@ -1,0 +1,37 @@
+package com.logistics.core.lib.fluids;
+
+import java.util.function.ToIntFunction;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.material.Fluid;
+
+/** Drives a block's light-level property from the fluid it holds — shared by the fluid pipe and glass tank. */
+public final class FluidLight {
+
+    private FluidLight() {}
+
+    /**
+     * Set {@code property} to the held fluid's luminance while the block contains fluid, else 0 — writing to
+     * the level only when the value changes. No-op if the block lacks {@code property}. {@code luminance}
+     * resolves a fluid's block-light level, injected so this stays independent of the mod's fluid table.
+     */
+    public static void update(
+            Level level,
+            BlockPos pos,
+            BlockState state,
+            IntegerProperty property,
+            Fluid fluid,
+            long amount,
+            ToIntFunction<Fluid> luminance) {
+        if (!state.hasProperty(property)) {
+            return;
+        }
+        int light = amount > 0 ? luminance.applyAsInt(fluid) : 0;
+        if (state.getValue(property) != light) {
+            level.setBlock(pos, state.setValue(property, light), Block.UPDATE_CLIENTS);
+        }
+    }
+}

--- a/common/src/main/java/com/logistics/pipe/block/FluidPipeBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/FluidPipeBlock.java
@@ -37,6 +37,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.redstone.Orientation;
@@ -56,6 +57,9 @@ public class FluidPipeBlock extends BaseEntityBlock
     public static final MapCodec<FluidPipeBlock> CODEC = simpleCodec(FluidPipeBlock::new);
 
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+
+    /** Block light (0-15) emitted while the pipe holds a light-emitting fluid; driven by the block entity. */
+    public static final IntegerProperty LIGHT_LEVEL = IntegerProperty.create("light_level", 0, 15);
 
     private static final double PIPE_SIZE = 8.0;
     private static final VoxelShape CORE_SHAPE = Block.box(
@@ -89,12 +93,12 @@ public class FluidPipeBlock extends BaseEntityBlock
     }
 
     public FluidPipeBlock(BlockBehaviour.Properties settings, @Nullable FluidPipe fluidPipe) {
-        super(settings);
+        super(settings.lightLevel(state -> state.getValue(LIGHT_LEVEL)));
         this.fluidPipe = fluidPipe;
         if (fluidPipe != null) {
             fluidPipe.setPipeBlock(this);
         }
-        registerDefaultState(defaultBlockState().setValue(WATERLOGGED, false));
+        registerDefaultState(defaultBlockState().setValue(WATERLOGGED, false).setValue(LIGHT_LEVEL, 0));
     }
 
     /** The fluid pipe definition backing this block (its transport policy + cosmetic/connection modules). */
@@ -120,7 +124,7 @@ public class FluidPipeBlock extends BaseEntityBlock
 
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
-        builder.add(WATERLOGGED);
+        builder.add(WATERLOGGED, LIGHT_LEVEL);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/block/GlassTankBlock.java
+++ b/common/src/main/java/com/logistics/pipe/block/GlassTankBlock.java
@@ -36,6 +36,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
@@ -53,9 +54,12 @@ public class GlassTankBlock extends BaseEntityBlock {
     /** True when a tank sits directly below, so the seamless {@code side_stacked} texture is used. */
     public static final BooleanProperty JOINED_BELOW = BooleanProperty.create("joined_below");
 
+    /** Block light (0-15) emitted while the tank holds a light-emitting fluid; driven by the block entity. */
+    public static final IntegerProperty LIGHT_LEVEL = IntegerProperty.create("light_level", 0, 15);
+
     public GlassTankBlock(Properties properties) {
-        super(properties);
-        registerDefaultState(defaultBlockState().setValue(JOINED_BELOW, false));
+        super(properties.lightLevel(state -> state.getValue(LIGHT_LEVEL)));
+        registerDefaultState(defaultBlockState().setValue(JOINED_BELOW, false).setValue(LIGHT_LEVEL, 0));
     }
 
     @Override
@@ -65,7 +69,7 @@ public class GlassTankBlock extends BaseEntityBlock {
 
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
-        builder.add(JOINED_BELOW);
+        builder.add(JOINED_BELOW, LIGHT_LEVEL);
     }
 
     @Nullable

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPipeBlockEntity.java
@@ -10,6 +10,7 @@ import com.logistics.core.lib.block.capability.PipeConnection;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.energy.EnergyComponent;
 import com.logistics.core.lib.energy.IEnergyStorage;
+import com.logistics.core.lib.fluids.FluidLight;
 import com.logistics.core.lib.fluids.FluidStorageLookup;
 import com.logistics.core.lib.fluids.IFluidKey;
 import com.logistics.core.lib.fluids.IFluidStorage;
@@ -45,7 +46,6 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
@@ -495,14 +495,9 @@ public class FluidPipeBlockEntity extends BaseBlockEntity
 
     /** Emit the contained fluid's light through the block state so a glowing fluid lights the pipe. */
     private void updateLightLevel(Level level) {
-        BlockState state = getBlockState();
-        if (!state.hasProperty(FluidPipeBlock.LIGHT_LEVEL)) {
-            return;
-        }
-        int light = totalMillibuckets() > 0 ? LogisticsCore.fluidLuminance(containedFluid().getFluid()) : 0;
-        if (state.getValue(FluidPipeBlock.LIGHT_LEVEL) != light) {
-            level.setBlock(getBlockPos(), state.setValue(FluidPipeBlock.LIGHT_LEVEL, light), Block.UPDATE_CLIENTS);
-        }
+        FluidLight.update(
+                level, getBlockPos(), getBlockState(), FluidPipeBlock.LIGHT_LEVEL,
+                containedFluid().getFluid(), totalMillibuckets(), LogisticsCore::fluidLuminance);
     }
 
     /** Extractor: pull fluid from the handler on the wrench-selected pull face into this pipe. */

--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPipeBlockEntity.java
@@ -23,6 +23,7 @@ import com.logistics.core.lib.power.AcceptsLowTierEnergy;
 import com.logistics.core.lib.power.DirectEnergyReceiver;
 import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.pipe.block.FluidConnection;
+import com.logistics.LogisticsCore;
 import com.logistics.pipe.block.FluidPipeBlock;
 import com.logistics.pipe.FluidPipe;
 import com.logistics.core.lib.pipe.FluidExtraction;
@@ -44,6 +45,7 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
@@ -487,7 +489,20 @@ public class FluidPipeBlockEntity extends BaseBlockEntity
         }
 
         parcels.removeIf(parcel -> parcel.amount() <= 0);
+        updateLightLevel(level);
         syncIfChanged();
+    }
+
+    /** Emit the contained fluid's light through the block state so a glowing fluid lights the pipe. */
+    private void updateLightLevel(Level level) {
+        BlockState state = getBlockState();
+        if (!state.hasProperty(FluidPipeBlock.LIGHT_LEVEL)) {
+            return;
+        }
+        int light = totalMillibuckets() > 0 ? LogisticsCore.fluidLuminance(containedFluid().getFluid()) : 0;
+        if (state.getValue(FluidPipeBlock.LIGHT_LEVEL) != light) {
+            level.setBlock(getBlockPos(), state.setValue(FluidPipeBlock.LIGHT_LEVEL, light), Block.UPDATE_CLIENTS);
+        }
     }
 
     /** Extractor: pull fluid from the handler on the wrench-selected pull face into this pipe. */

--- a/common/src/main/java/com/logistics/pipe/block/entity/GlassTankBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/GlassTankBlockEntity.java
@@ -4,6 +4,7 @@ import com.logistics.LogisticsCore;
 import com.logistics.LogisticsFluid;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.block.capability.HasFluidStorage;
+import com.logistics.core.lib.fluids.FluidLight;
 import com.logistics.core.lib.fluids.FluidTankComponent;
 import com.logistics.core.lib.fluids.IFluidKey;
 import com.logistics.core.lib.fluids.IFluidStorage;
@@ -20,7 +21,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
@@ -109,14 +109,9 @@ public class GlassTankBlockEntity extends BaseBlockEntity implements HasFluidSto
 
     /** Emit the contained fluid's light through the block state so a glowing fluid lights the tank. */
     private void updateLightLevel(Level level) {
-        BlockState state = getBlockState();
-        if (!state.hasProperty(GlassTankBlock.LIGHT_LEVEL)) {
-            return;
-        }
-        int light = amount() > 0 ? LogisticsCore.fluidLuminance(fluid().getFluid()) : 0;
-        if (state.getValue(GlassTankBlock.LIGHT_LEVEL) != light) {
-            level.setBlock(getBlockPos(), state.setValue(GlassTankBlock.LIGHT_LEVEL, light), Block.UPDATE_CLIENTS);
-        }
+        FluidLight.update(
+                level, getBlockPos(), getBlockState(), GlassTankBlock.LIGHT_LEVEL,
+                fluid().getFluid(), amount(), LogisticsCore::fluidLuminance);
     }
 
     // ==================== Persistence ====================

--- a/common/src/main/java/com/logistics/pipe/block/entity/GlassTankBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/GlassTankBlockEntity.java
@@ -1,5 +1,6 @@
 package com.logistics.pipe.block.entity;
 
+import com.logistics.LogisticsCore;
 import com.logistics.LogisticsFluid;
 import com.logistics.core.lib.block.BaseBlockEntity;
 import com.logistics.core.lib.block.capability.HasFluidStorage;
@@ -10,6 +11,7 @@ import com.logistics.core.lib.tank.TankCell;
 import com.logistics.core.lib.tank.TankCellLookup;
 import com.logistics.core.lib.tank.TankColumn;
 import com.logistics.core.lib.tank.TankColumns;
+import com.logistics.pipe.block.GlassTankBlock;
 import com.logistics.pipe.tank.TankColumnStorage;
 import com.logistics.pipe.tank.TankTier;
 import java.util.List;
@@ -18,6 +20,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
@@ -100,6 +103,19 @@ public class GlassTankBlockEntity extends BaseBlockEntity implements HasFluidSto
         // Only the bottom cell drives the rebalance, so each (possibly cross-mod) column settles once per tick.
         if (TankColumns.isColumnBottom(level, pos)) {
             TankColumns.columnAt(level, pos).rebalance();
+        }
+        be.updateLightLevel(level);
+    }
+
+    /** Emit the contained fluid's light through the block state so a glowing fluid lights the tank. */
+    private void updateLightLevel(Level level) {
+        BlockState state = getBlockState();
+        if (!state.hasProperty(GlassTankBlock.LIGHT_LEVEL)) {
+            return;
+        }
+        int light = amount() > 0 ? LogisticsCore.fluidLuminance(fluid().getFluid()) : 0;
+        if (state.getValue(GlassTankBlock.LIGHT_LEVEL) != light) {
+            level.setBlock(getBlockPos(), state.setValue(GlassTankBlock.LIGHT_LEVEL, light), Block.UPDATE_CLIENTS);
         }
     }
 

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidLightGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidLightGameTest.java
@@ -1,0 +1,85 @@
+package com.logistics.gametest.pipe;
+
+import com.logistics.LogisticsCore;
+import com.logistics.LogisticsFluid;
+import com.logistics.core.lib.fluids.FluidUnits;
+import com.logistics.core.lib.fluids.SimpleFluidKey;
+import com.logistics.pipe.block.FluidPipeBlock;
+import com.logistics.pipe.block.GlassTankBlock;
+import com.logistics.pipe.block.entity.FluidPipeBlockEntity;
+import com.logistics.pipe.block.entity.GlassTankBlockEntity;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+
+/**
+ * Light-emitting fluids (issue #677): a pipe or tank holding lava or a glowing custom fluid drives its
+ * block's {@code LIGHT_LEVEL} state, and stops glowing once drained.
+ */
+public class FluidLightGameTest {
+
+    private static Fluid liquidGlowstone() {
+        return BuiltInRegistries.FLUID.getValue(LogisticsCore.resource("liquid_glowstone").toIdentifier());
+    }
+
+    private static void assertTankLight(GameTestHelper context, BlockPos pos, Fluid fluid, long mb, int expected) {
+        context.setBlock(pos, LogisticsFluid.BLOCK.GLASS_TANK);
+        GlassTankBlockEntity tank = context.getBlockEntity(pos, GlassTankBlockEntity.class);
+        if (tank == null) {
+            throw context.assertionException("Glass tank should have a block entity");
+        }
+        tank.tank().setContents(SimpleFluidKey.of(fluid), FluidUnits.mb(mb));
+        context.succeedWhen(() -> context.assertBlockProperty(pos, GlassTankBlock.LIGHT_LEVEL, expected));
+    }
+
+    /** A tank of lava glows at 15. */
+    @GameTest
+    public void tankOfLavaGlows(GameTestHelper context) {
+        assertTankLight(context, new BlockPos(0, 1, 0), Fluids.LAVA, 1_000, 15);
+    }
+
+    /** A tank of a glowing custom fluid glows at its luminance. */
+    @GameTest
+    public void tankOfLiquidGlowstoneGlows(GameTestHelper context) {
+        assertTankLight(context, new BlockPos(0, 1, 0), liquidGlowstone(), 1_000, 15);
+    }
+
+    /** A tank of a non-glowing fluid stays dark. */
+    @GameTest
+    public void tankOfWaterStaysDark(GameTestHelper context) {
+        assertTankLight(context, new BlockPos(0, 1, 0), Fluids.WATER, 1_000, 0);
+    }
+
+    /** Draining a glowing tank turns its light back off. */
+    @GameTest
+    public void drainedTankStopsGlowing(GameTestHelper context) {
+        BlockPos pos = new BlockPos(0, 1, 0);
+        context.setBlock(pos, LogisticsFluid.BLOCK.GLASS_TANK);
+        GlassTankBlockEntity tank = context.getBlockEntity(pos, GlassTankBlockEntity.class);
+        if (tank == null) {
+            throw context.assertionException("Glass tank should have a block entity");
+        }
+        tank.tank().setContents(SimpleFluidKey.of(Fluids.LAVA), FluidUnits.mb(1_000));
+        context.runAfterDelay(2, () -> {
+            context.assertBlockProperty(pos, GlassTankBlock.LIGHT_LEVEL, 15);
+            tank.tank().setContents(SimpleFluidKey.BLANK, 0);
+            context.succeedWhen(() -> context.assertBlockProperty(pos, GlassTankBlock.LIGHT_LEVEL, 0));
+        });
+    }
+
+    /** A pipe carrying a glowing fluid emits its light. */
+    @GameTest
+    public void pipeOfLavaGlows(GameTestHelper context) {
+        BlockPos pos = new BlockPos(0, 1, 0);
+        context.setBlock(pos, LogisticsFluid.BLOCK.COPPER_FLUID_PIPE);
+        FluidPipeBlockEntity pipe = context.getBlockEntity(pos, FluidPipeBlockEntity.class);
+        if (pipe == null) {
+            throw context.assertionException("Fluid pipe should have a block entity");
+        }
+        pipe.fluidStorage(null).insert(SimpleFluidKey.of(Fluids.LAVA), FluidUnits.mb(100), false);
+        context.succeedWhen(() -> context.assertBlockProperty(pos, FluidPipeBlock.LIGHT_LEVEL, 15));
+    }
+}

--- a/fabric/src/gametest/resources/fabric.mod.json
+++ b/fabric/src/gametest/resources/fabric.mod.json
@@ -24,6 +24,7 @@
 			"com.logistics.gametest.pipe.PipeFlowGameTest",
 			"com.logistics.gametest.pipe.FluidPumpGameTest",
 			"com.logistics.gametest.pipe.FluidConnectionGameTest",
+			"com.logistics.gametest.pipe.FluidLightGameTest",
 			"com.logistics.gametest.pipe.PowerJunctionGameTest",
 			"com.logistics.gametest.power.BatteryGameTest",
 			"com.logistics.gametest.power.CableGameTest",


### PR DESCRIPTION
## Summary

A fluid pipe or glass tank holding a light-emitting fluid now glows. Lava and **liquid glowstone** light up their pipe/tank; the light turns off again once the fluid is drained.

Closes #677.

## Changes

- **feat(fluids):** fluid pipes and glass tanks emit block light based on their contents.
- Fluids now carry a luminance value (`FluidDef.luminance`); liquid glowstone glows at 15, vanilla lava at 15, everything else stays dark.
- Added a `light_level` block state (0–15) to the fluid pipe and glass tank, driven from the block entity each tick.

## Notes

- Implemented entirely in common code — the light comes from the block's own state, so both Fabric and NeoForge get it with no loader-specific work.
- On/off above any fill (not scaled by amount), matching the simplest approach in the issue.
- Scope kept tight: liquid redstone and the Fluid Pump are intentionally left non-glowing for now — easy follow-ups.
- Covered by `FluidLightGameTest` (lava/glowstone glow, water stays dark, draining turns it off, pipes glow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)