### PR TITLE
fix(fluids): stop drained pipes rendering a checkerboard

### DIFF
--- a/common/src/client/java/com/logistics/core/lib/client/render/FluidBoxRenderer.java
+++ b/common/src/client/java/com/logistics/core/lib/client/render/FluidBoxRenderer.java
@@ -35,6 +35,10 @@ public final class FluidBoxRenderer {
     /** Look up the still sprite + model for a fluid, or {@code null} if it has no still sprite. */
     @Nullable
     private static Resolved resolveModel(Fluid fluid) {
+        // Empty fluid has no model; resolving it yields the missing-texture sprite, so skip it.
+        if (fluid == Fluids.EMPTY) {
+            return null;
+        }
         FluidState fluidState = fluid.defaultFluidState();
         FluidModel model = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(fluidState);
         TextureAtlasSprite sprite = model.stillMaterial().sprite();


### PR DESCRIPTION
## Summary

A fluid pipe would flash the magenta/black missing-texture checkerboard as it drained down to nothing. This reproduces on **both loaders** (Fabric and NeoForge).

Closes #675.

## Root cause

The pipe renderer eases its display fill toward the target (20%/frame), so the on-screen level keeps fading for several frames after the pipe's fluid parcels are already empty. During that tail the renderer still tries to draw, but the pipe now holds `Fluids.EMPTY` — and resolving the empty fluid's model returns the missing-texture sprite rather than null. That's why it only appeared at very small amounts, in the drain's eased-out tail.

## Fix

`FluidBoxRenderer.resolveModel` (shared client code) now bails for `Fluids.EMPTY`. The pipe and tank renderers and the GUI already treat a null result as "draw nothing", so the drain tail is hidden at the root cause, uniformly on both loaders. The normal shrinking-drain animation is unaffected, since the fluid stays present until the last millibucket is gone.

## Notes

- Render-only change in shared client code, so it applies to both loaders; not exercised by the gametest suite. Confirmed in-game: the checkerboard reproduces on both Fabric and NeoForge without the guard and is gone with it.
- The glass tank already guarded against an empty fluid, so this is defensive there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
