### PR TITLE
fix(compat): add missing Jade fluid-pipe config translation

### DIFF
--- a/common/src/main/resources/assets/logistics/lang/en_us.json
+++ b/common/src/main/resources/assets/logistics/lang/en_us.json
@@ -280,6 +280,7 @@
   "config.jade.plugin_logistics.machine": "Logistics Machines",
   "config.jade.plugin_logistics.power_infra": "Logistics Power Infrastructure",
   "config.jade.plugin_logistics.pipe": "Logistics Pipes",
+  "config.jade.plugin_logistics.fluid_pipe": "Logistics Fluid Pipes",
   "config.jade.plugin_logistics.quarry": "Logistics Quarry",
   "jade.logistics.engine.stage": "Stage",
   "jade.logistics.engine.temperature": "Temperature",


### PR DESCRIPTION
Adds the `config.jade.plugin_logistics.fluid_pipe` translation key. Without it, Jade throws `AssertionError: Missing config translation` while rendering a screen — fatal in the dev client (assertions enabled), and a blank config label in production.

Closes #697.