### PR TITLE
feat(fluids): show machine fluid tanks in the Jade HUD

### DIFF
--- a/common/src/client/java/com/logistics/core/machine/MachineHudLines.java
+++ b/common/src/client/java/com/logistics/core/machine/MachineHudLines.java
@@ -1,6 +1,5 @@
 package com.logistics.core.machine;
 
-import com.logistics.core.lib.compat.NbtCompat;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.ChatFormatting;
@@ -8,9 +7,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 
 /**
- * Builds the machine HUD lines from the synced tag written by {@code MachineHudData}. Only a progress line
- * while the machine is actively processing — item slots, energy, and tank contents are already shown by
- * Jade's built-ins.
+ * Builds the text portion of the machine HUD from the model synced by {@code MachineHudData}: a progress
+ * line while the machine is processing. Graphical entries (fluid tanks) are drawn by the loader-specific
+ * Jade provider, since their element API is version-specific.
  */
 public final class MachineHudLines {
 
@@ -18,11 +17,13 @@ public final class MachineHudLines {
 
     public static List<Component> build(CompoundTag data) {
         List<Component> lines = new ArrayList<>();
-        if (NbtCompat.getBoolean(data, MachineHudData.KEY_PROCESSING, false)) {
-            float progress = NbtCompat.getFloat(data, "progress", 0);
-            lines.add(Component.translatable("jade.logistics.machine.progress")
-                    .append(Component.literal(": "))
-                    .append(Component.literal(String.format("%.0f%%", progress * 100)).withStyle(ChatFormatting.GREEN)));
+        for (MachineHudModel.Entry entry : MachineHudModel.entries(data)) {
+            if (entry instanceof MachineHudModel.ProgressEntry progress) {
+                lines.add(Component.translatable("jade.logistics.machine.progress")
+                        .append(Component.literal(": "))
+                        .append(Component.literal(String.format("%.0f%%", progress.fraction() * 100))
+                                .withStyle(ChatFormatting.GREEN)));
+            }
         }
         return lines;
     }

--- a/common/src/main/java/com/logistics/core/machine/MachineComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineComponent.java
@@ -76,6 +76,11 @@ public interface MachineComponent {
         boolean isProcessing();
     }
 
+    /** Contributes look-at (Jade) HUD entries; captured server-side into a portable {@link MachineHudModel}. */
+    interface HudContributor {
+        void contributeHud(MachineHudModel hud);
+    }
+
     /** Banks processing experience and releases it on demand (e.g. when the machine is broken). */
     interface ExperienceStore {
         int drainExperience(RandomSource random);

--- a/common/src/main/java/com/logistics/core/machine/MachineComponentContainer.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineComponentContainer.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 
@@ -42,6 +43,15 @@ public final class MachineComponentContainer {
             }
         }
         return Optional.empty();
+    }
+
+    /** Applies {@code action} to every registered component assignable to {@code type}, in registration order. */
+    public <T> void forEach(Class<T> type, Consumer<T> action) {
+        for (MachineComponent c : ordered) {
+            if (type.isInstance(c)) {
+                action.accept(type.cast(c));
+            }
+        }
     }
 
     public void onLoad(MachineContext ctx) {

--- a/common/src/main/java/com/logistics/core/machine/MachineEntity.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineEntity.java
@@ -105,6 +105,11 @@ public abstract class MachineEntity extends BaseBlockEntity
         return components.find(MachineComponent.ProcessState.class).map(MachineComponent.ProcessState::isProcessing).orElse(false);
     }
 
+    /** Assembles the look-at (Jade) HUD from every component that contributes one. */
+    public void contributeHud(MachineHudModel hud) {
+        components.forEach(MachineComponent.HudContributor.class, c -> c.contributeHud(hud));
+    }
+
     private java.util.Optional<MachineComponent.SidedItems> sidedItems() {
         return components.find(MachineComponent.SidedItems.class);
     }

--- a/common/src/main/java/com/logistics/core/machine/MachineHudData.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineHudData.java
@@ -1,26 +1,24 @@
 package com.logistics.core.machine;
 
-import com.logistics.core.lib.block.ProcessingMachine;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
- * Server-side capture of a processing machine's progress into the tag a look-at HUD (Jade) syncs to the
- * client. Works off the {@link ProcessingMachine} contract, so it covers the macerator, kiln, crucible,
- * and any future machine without depending on a specific domain. Read back by the client-side
- * {@code MachineHudLines}. (Tank contents are left to Jade's built-in fluid element.)
+ * Server-side capture of a machine's look-at HUD into the tag a HUD mod (Jade) syncs to the client.
+ * Delegates to each machine's {@link MachineComponent.HudContributor} components via
+ * {@link MachineEntity#contributeHud}, so progress, tank contents, and any future contribution show up
+ * without machine-specific plumbing. Read back by the client-side {@code MachineHudLines} (text) and the
+ * loader-specific Jade provider (graphical elements).
  */
 public final class MachineHudData {
-
-    /** NBT key whose presence marks that the tag carries machine processing state. */
-    public static final String KEY_PROCESSING = "processing";
 
     private MachineHudData() {}
 
     public static void write(CompoundTag data, BlockEntity blockEntity) {
-        if (blockEntity instanceof ProcessingMachine machine) {
-            data.putBoolean(KEY_PROCESSING, machine.isProcessing());
-            data.putFloat("progress", machine.processProgress());
+        if (blockEntity instanceof MachineEntity machine) {
+            MachineHudModel hud = new MachineHudModel();
+            machine.contributeHud(hud);
+            hud.save(data);
         }
     }
 }

--- a/common/src/main/java/com/logistics/core/machine/MachineHudModel.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineHudModel.java
@@ -1,0 +1,117 @@
+package com.logistics.core.machine;
+
+import com.logistics.core.lib.compat.NbtCompat;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.world.level.material.Fluid;
+
+/**
+ * Loader-agnostic model of a machine's look-at (Jade) HUD, assembled server-side from every
+ * {@link MachineComponent.HudContributor} the machine hosts and synced to the client as NBT.
+ *
+ * <p>Entries persist under a single {@code hud} sub-tag as {@code hud/<index>} compounds (a count plus
+ * numbered keys — never a {@code ListTag}, so reads avoid the {@code ListTag.getCompound(i)}
+ * cross-version delta). The client rebuilds the typed entry list with {@link #entries(CompoundTag)};
+ * text-representable entries render in {@code MachineHudLines}, graphical ones (fluid) in the
+ * loader-specific Jade provider.
+ */
+public final class MachineHudModel {
+
+    /** A single HUD contribution. */
+    public sealed interface Entry permits ProgressEntry, FluidEntry {}
+
+    /** Active-recipe progress as a 0..1 fraction. */
+    public record ProgressEntry(float fraction) implements Entry {}
+
+    /** A fluid tank's fill: fluid id, optional components, and amount/capacity in millibuckets. */
+    public record FluidEntry(String fluidId, DataComponentPatch components, long amountMb, long capacityMb)
+            implements Entry {}
+
+    private static final String HUD_KEY = "hud";
+    private static final String COUNT = "n";
+    private static final String TYPE = "type";
+    private static final String TYPE_PROGRESS = "progress";
+    private static final String TYPE_FLUID = "fluid";
+
+    private final List<Entry> entries = new ArrayList<>();
+
+    public void progress(float fraction) {
+        entries.add(new ProgressEntry(fraction));
+    }
+
+    public void fluid(Fluid fluid, DataComponentPatch components, long amountMb, long capacityMb) {
+        entries.add(new FluidEntry(BuiltInRegistries.FLUID.getKey(fluid).toString(), components, amountMb, capacityMb));
+    }
+
+    public boolean isEmpty() {
+        return entries.isEmpty();
+    }
+
+    /** Serialize the collected entries into the synced HUD tag. Writes nothing when empty. */
+    public void save(CompoundTag data) {
+        if (entries.isEmpty()) {
+            return;
+        }
+        CompoundTag hud = new CompoundTag();
+        hud.putInt(COUNT, entries.size());
+        for (int i = 0; i < entries.size(); i++) {
+            CompoundTag e = new CompoundTag();
+            switch (entries.get(i)) {
+                case ProgressEntry p -> {
+                    e.putString(TYPE, TYPE_PROGRESS);
+                    e.putFloat("fraction", p.fraction());
+                }
+                case FluidEntry f -> {
+                    e.putString(TYPE, TYPE_FLUID);
+                    e.putString("fluid", f.fluidId());
+                    e.putLong("amount", f.amountMb());
+                    e.putLong("capacity", f.capacityMb());
+                    if (!f.components().isEmpty()) {
+                        DataComponentPatch.CODEC
+                                .encodeStart(NbtOps.INSTANCE, f.components())
+                                .result()
+                                .ifPresent(tag -> e.put("components", tag));
+                    }
+                }
+            }
+            hud.put(Integer.toString(i), e);
+        }
+        data.put(HUD_KEY, hud);
+    }
+
+    /** Rebuild the typed entry list synced into {@code data}; empty when no HUD tag was written. */
+    public static List<Entry> entries(CompoundTag data) {
+        CompoundTag hud = NbtCompat.getCompoundOrEmpty(data, HUD_KEY);
+        int count = NbtCompat.getInt(hud, COUNT, 0);
+        if (count <= 0) {
+            return List.of();
+        }
+        List<Entry> result = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            CompoundTag e = NbtCompat.getCompoundOrEmpty(hud, Integer.toString(i));
+            switch (NbtCompat.getString(e, TYPE, "")) {
+                case TYPE_PROGRESS -> result.add(new ProgressEntry(NbtCompat.getFloat(e, "fraction", 0f)));
+                case TYPE_FLUID -> {
+                    DataComponentPatch components = DataComponentPatch.EMPTY;
+                    if (NbtCompat.hasCompound(e, "components")) {
+                        components = DataComponentPatch.CODEC
+                                .parse(NbtOps.INSTANCE, NbtCompat.getCompoundOrEmpty(e, "components"))
+                                .result()
+                                .orElse(DataComponentPatch.EMPTY);
+                    }
+                    result.add(new FluidEntry(
+                            NbtCompat.getString(e, "fluid", ""),
+                            components,
+                            NbtCompat.getLong(e, "amount", 0L),
+                            NbtCompat.getLong(e, "capacity", 0L)));
+                }
+                default -> {}
+            }
+        }
+        return result;
+    }
+}

--- a/common/src/main/java/com/logistics/core/machine/component/FluidStoreComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/FluidStoreComponent.java
@@ -1,9 +1,11 @@
 package com.logistics.core.machine.component;
 
 import com.logistics.core.lib.fluids.FluidTankComponent;
+import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.core.lib.fluids.IFluidStorage;
 import com.logistics.core.lib.fluids.OutputOnlyFluidStorage;
 import com.logistics.core.machine.MachineComponent;
+import com.logistics.core.machine.MachineHudModel;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -15,7 +17,8 @@ import org.jetbrains.annotations.Nullable;
  * <p>When {@code outputOnly}, the externally exposed view ({@link #fluid}) rejects insertion so pipes can
  * only drain the tank — the machine fills it internally via {@link #tank()}.
  */
-public final class FluidStoreComponent implements MachineComponent, MachineComponent.FluidAccess {
+public final class FluidStoreComponent
+        implements MachineComponent, MachineComponent.FluidAccess, MachineComponent.HudContributor {
 
     private static final String LEGACY_KEY = "Tank";
 
@@ -47,6 +50,17 @@ public final class FluidStoreComponent implements MachineComponent, MachineCompo
     @Nullable
     public IFluidStorage fluid(@Nullable Direction side) {
         return exposed;
+    }
+
+    @Override
+    public void contributeHud(MachineHudModel hud) {
+        if (!tank.isEmpty()) {
+            hud.fluid(
+                    tank.getFluidKey().getFluid(),
+                    tank.getFluidKey().getComponents(),
+                    FluidUnits.toMillibuckets(tank.getAmount()),
+                    FluidUnits.toMillibuckets(tank.getCapacity()));
+        }
     }
 
     @Override

--- a/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/RecipeProcessorComponent.java
@@ -4,6 +4,7 @@ import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.core.lib.recipe.FluidResult;
 import com.logistics.core.machine.MachineComponent;
 import com.logistics.core.machine.MachineContext;
+import com.logistics.core.machine.MachineHudModel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -22,7 +23,10 @@ import org.jetbrains.annotations.Nullable;
  * class wires it to sibling item/energy components and toggles the machine's "lit" state.
  */
 public final class RecipeProcessorComponent
-        implements MachineComponent, MachineComponent.ProcessState, MachineComponent.ExperienceStore {
+        implements MachineComponent,
+                MachineComponent.ProcessState,
+                MachineComponent.ExperienceStore,
+                MachineComponent.HudContributor {
 
     /** Toggles the machine's working/lit block state. */
     @FunctionalInterface
@@ -225,6 +229,15 @@ public final class RecipeProcessorComponent
     @Override
     public boolean isProcessing() {
         return activePlan != null;
+    }
+
+    // ----- HudContributor -----
+
+    @Override
+    public void contributeHud(MachineHudModel hud) {
+        if (isProcessing()) {
+            hud.progress(progress());
+        }
     }
 
     /** Energy spent toward the active recipe; drives the menu progress bar. */

--- a/common/src/test/java/com/logistics/core/machine/MachineComponentContainerTest.java
+++ b/common/src/test/java/com/logistics/core/machine/MachineComponentContainerTest.java
@@ -72,6 +72,18 @@ class MachineComponentContainerTest extends MinecraftTestEnvironment {
     }
 
     @Test
+    void forEachVisitsAllMatchingInRegistrationOrder() {
+        MachineComponentContainer container = new MachineComponentContainer();
+        container.add(new RecordingComponent("a", new ArrayList<>(), "A"));
+        container.add(new RecordingComponent("b", new ArrayList<>(), "B"));
+
+        List<String> visited = new ArrayList<>();
+        container.forEach(MachineComponent.class, c -> visited.add(c.id()));
+
+        assertThat(visited).containsExactly("a", "b");
+    }
+
+    @Test
     void duplicateIdRejected() {
         MachineComponentContainer container = new MachineComponentContainer();
         container.add(new RecordingComponent("energy", new ArrayList<>(), "Energy"));

--- a/common/src/test/java/com/logistics/core/machine/MachineHudModelTest.java
+++ b/common/src/test/java/com/logistics/core/machine/MachineHudModelTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.logistics.test.MinecraftTestEnvironment;
 import java.util.List;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.material.Fluids;
 import org.junit.jupiter.api.Test;
 
@@ -39,5 +41,24 @@ class MachineHudModelTest extends MinecraftTestEnvironment {
         assertThat(fluid.fluidId()).isEqualTo(BuiltInRegistries.FLUID.getKey(Fluids.LAVA).toString());
         assertThat(fluid.amountMb()).isEqualTo(500L);
         assertThat(fluid.capacityMb()).isEqualTo(10_000L);
+        assertThat(fluid.components()).isEqualTo(DataComponentPatch.EMPTY);
+    }
+
+    @Test
+    void preservesFluidComponentsThroughRoundTrip() {
+        DataComponentPatch components = DataComponentPatch.builder()
+                .set(DataComponents.CUSTOM_NAME, Component.literal("Molten Steel"))
+                .build();
+
+        MachineHudModel model = new MachineHudModel();
+        model.fluid(Fluids.LAVA, components, 500L, 10_000L);
+
+        CompoundTag data = new CompoundTag();
+        model.save(data);
+        List<MachineHudModel.Entry> entries = MachineHudModel.entries(data);
+
+        assertThat(entries).hasSize(1);
+        MachineHudModel.FluidEntry fluid = (MachineHudModel.FluidEntry) entries.get(0);
+        assertThat(fluid.components()).isEqualTo(components);
     }
 }

--- a/common/src/test/java/com/logistics/core/machine/MachineHudModelTest.java
+++ b/common/src/test/java/com/logistics/core/machine/MachineHudModelTest.java
@@ -1,0 +1,43 @@
+package com.logistics.core.machine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import java.util.List;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.material.Fluids;
+import org.junit.jupiter.api.Test;
+
+class MachineHudModelTest extends MinecraftTestEnvironment {
+
+    @Test
+    void emptyModelWritesNothing() {
+        CompoundTag data = new CompoundTag();
+        new MachineHudModel().save(data);
+
+        assertThat(data.isEmpty()).isTrue();
+        assertThat(MachineHudModel.entries(data)).isEmpty();
+    }
+
+    @Test
+    void roundTripsProgressAndFluidInOrder() {
+        MachineHudModel model = new MachineHudModel();
+        model.progress(0.42f);
+        model.fluid(Fluids.LAVA, DataComponentPatch.EMPTY, 500L, 10_000L);
+
+        CompoundTag data = new CompoundTag();
+        model.save(data);
+        List<MachineHudModel.Entry> entries = MachineHudModel.entries(data);
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0)).isInstanceOf(MachineHudModel.ProgressEntry.class);
+        assertThat(((MachineHudModel.ProgressEntry) entries.get(0)).fraction()).isEqualTo(0.42f);
+
+        MachineHudModel.FluidEntry fluid = (MachineHudModel.FluidEntry) entries.get(1);
+        assertThat(fluid.fluidId()).isEqualTo(BuiltInRegistries.FLUID.getKey(Fluids.LAVA).toString());
+        assertThat(fluid.amountMb()).isEqualTo(500L);
+        assertThat(fluid.capacityMb()).isEqualTo(10_000L);
+    }
+}

--- a/fabric/src/client/java/com/logistics/compat/jade/MachineComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/MachineComponentProvider.java
@@ -1,17 +1,30 @@
 package com.logistics.compat.jade;
 
 import com.logistics.LogisticsMod;
+import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.machine.MachineHudLines;
+import com.logistics.core.machine.MachineHudModel;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
 import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.fluid.JadeFluidObject;
+import snownee.jade.api.ui.BoxStyle;
+import snownee.jade.api.ui.JadeUI;
+import snownee.jade.api.view.FluidView;
+import snownee.jade.api.view.ProgressView;
 
 /**
- * Client half of the processing-machine Jade integration: renders the progress synced by
- * {@link MachineServerDataProvider}. Formatting is shared in {@link MachineHudLines}.
+ * Client half of the machine Jade integration: renders the HUD model synced by
+ * {@link MachineServerDataProvider}. Progress text is shared in {@link MachineHudLines}; fluid tanks are
+ * drawn here as a capacity-relative bar (the built-in Jade fluid element is stripped so they don't
+ * double up), because the Jade element API is version-specific.
  */
 public final class MachineComponentProvider implements IBlockComponentProvider {
     public static final MachineComponentProvider INSTANCE = new MachineComponentProvider();
@@ -27,9 +40,47 @@ public final class MachineComponentProvider implements IBlockComponentProvider {
     }
 
     @Override
+    public int getDefaultPriority() {
+        return 2000; // After Jade's built-in fluid bar (priority 1000) so remove() can replace it.
+    }
+
+    @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
         for (Component line : MachineHudLines.build(accessor.getServerData())) {
             tooltip.add(line);
         }
+        for (MachineHudModel.Entry entry : MachineHudModel.entries(accessor.getServerData())) {
+            if (entry instanceof MachineHudModel.FluidEntry fluid) {
+                renderFluidBar(tooltip, fluid);
+            }
+        }
+    }
+
+    private static void renderFluidBar(ITooltip tooltip, MachineHudModel.FluidEntry entry) {
+        ResourceId id = ResourceId.tryParse(entry.fluidId());
+        if (id == null) {
+            return;
+        }
+        Fluid fluid = BuiltInRegistries.FLUID.getValue(id.toIdentifier());
+        if (fluid == Fluids.EMPTY || entry.capacityMb() <= 0) {
+            return;
+        }
+        // The look-at HUD carries millibuckets; Jade elements measure fluid in native volume.
+        long perMb = JadeFluidObject.bucketVolume() / 1000;
+        JadeFluidObject object = JadeFluidObject.of(fluid, entry.amountMb() * perMb, entry.components());
+        FluidView view = FluidView.readDefault(new FluidView.Data(object, entry.capacityMb() * perMb));
+        if (view == null) {
+            return;
+        }
+        // Replace Jade's inconsistent built-in fluid element with our own bar.
+        tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE);
+        Component text = Component.translatable(
+                "jade.fluid", view.fluidName, Component.translatable("jade.fluid.with_capacity", view.current, view.max));
+        ProgressView bar = new ProgressView(
+                ProgressView.Part.of(view.ratio, view.overlay),
+                text,
+                JadeUI.progressStyle().canDecrease(true),
+                BoxStyle.nestedBox());
+        tooltip.add(JadeUI.progress(bar));
     }
 }

--- a/fabric/src/client/java/com/logistics/compat/jade/MachineComponentProvider.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/MachineComponentProvider.java
@@ -24,7 +24,12 @@ import snownee.jade.api.view.ProgressView;
  * Client half of the machine Jade integration: renders the HUD model synced by
  * {@link MachineServerDataProvider}. Progress text is shared in {@link MachineHudLines}; fluid tanks are
  * drawn here as a capacity-relative bar (the built-in Jade fluid element is stripped so they don't
- * double up), because the Jade element API is version-specific.
+ * double up).
+ *
+ * <p>{@code renderFluidBar} is duplicated in the NeoForge provider rather than shared: Jade is a
+ * per-loader compile-only dependency (absent from the common client classpath), so Jade-touching code
+ * cannot live in {@code common/src/client}. The whole {@code compat.jade} package follows this pattern.
+ * The Jade API itself matches across loaders, so keep the two copies identical.
  */
 public final class MachineComponentProvider implements IBlockComponentProvider {
     public static final MachineComponentProvider INSTANCE = new MachineComponentProvider();

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineComponentProvider.java
@@ -24,7 +24,12 @@ import snownee.jade.api.view.ProgressView;
  * Client half of the machine Jade integration: renders the HUD model synced by
  * {@link MachineServerDataProvider}. Progress text is shared in {@link MachineHudLines}; fluid tanks are
  * drawn here as a capacity-relative bar (the built-in Jade fluid element is stripped so they don't
- * double up), because the Jade element API is version-specific.
+ * double up).
+ *
+ * <p>{@code renderFluidBar} is duplicated in the Fabric provider rather than shared: Jade is a
+ * per-loader compile-only dependency (absent from the common client classpath), so Jade-touching code
+ * cannot live in {@code common/src/client}. The whole {@code compat.jade} package follows this pattern.
+ * The Jade API itself matches across loaders, so keep the two copies identical.
  */
 public final class MachineComponentProvider implements IBlockComponentProvider {
     public static final MachineComponentProvider INSTANCE = new MachineComponentProvider();

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineComponentProvider.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/MachineComponentProvider.java
@@ -1,17 +1,30 @@
 package com.logistics.neoforge.client.compat;
 
 import com.logistics.LogisticsMod;
+import com.logistics.core.lib.resource.ResourceId;
 import com.logistics.core.machine.MachineHudLines;
+import com.logistics.core.machine.MachineHudModel;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier; // raw-id-ok: Jade's IJadeProvider.getUid() returns Identifier
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
 import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.fluid.JadeFluidObject;
+import snownee.jade.api.ui.BoxStyle;
+import snownee.jade.api.ui.JadeUI;
+import snownee.jade.api.view.FluidView;
+import snownee.jade.api.view.ProgressView;
 
 /**
- * Client half of the processing-machine Jade integration: renders the progress synced by
- * {@link MachineServerDataProvider}. Formatting is shared in {@link MachineHudLines}.
+ * Client half of the machine Jade integration: renders the HUD model synced by
+ * {@link MachineServerDataProvider}. Progress text is shared in {@link MachineHudLines}; fluid tanks are
+ * drawn here as a capacity-relative bar (the built-in Jade fluid element is stripped so they don't
+ * double up), because the Jade element API is version-specific.
  */
 public final class MachineComponentProvider implements IBlockComponentProvider {
     public static final MachineComponentProvider INSTANCE = new MachineComponentProvider();
@@ -27,9 +40,47 @@ public final class MachineComponentProvider implements IBlockComponentProvider {
     }
 
     @Override
+    public int getDefaultPriority() {
+        return 2000; // After Jade's built-in fluid bar (priority 1000) so remove() can replace it.
+    }
+
+    @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
         for (Component line : MachineHudLines.build(accessor.getServerData())) {
             tooltip.add(line);
         }
+        for (MachineHudModel.Entry entry : MachineHudModel.entries(accessor.getServerData())) {
+            if (entry instanceof MachineHudModel.FluidEntry fluid) {
+                renderFluidBar(tooltip, fluid);
+            }
+        }
+    }
+
+    private static void renderFluidBar(ITooltip tooltip, MachineHudModel.FluidEntry entry) {
+        ResourceId id = ResourceId.tryParse(entry.fluidId());
+        if (id == null) {
+            return;
+        }
+        Fluid fluid = BuiltInRegistries.FLUID.getValue(id.toIdentifier());
+        if (fluid == Fluids.EMPTY || entry.capacityMb() <= 0) {
+            return;
+        }
+        // The look-at HUD carries millibuckets; Jade elements measure fluid in native volume.
+        long perMb = JadeFluidObject.bucketVolume() / 1000;
+        JadeFluidObject object = JadeFluidObject.of(fluid, entry.amountMb() * perMb, entry.components());
+        FluidView view = FluidView.readDefault(new FluidView.Data(object, entry.capacityMb() * perMb));
+        if (view == null) {
+            return;
+        }
+        // Replace Jade's inconsistent built-in fluid element with our own bar.
+        tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE);
+        Component text = Component.translatable(
+                "jade.fluid", view.fluidName, Component.translatable("jade.fluid.with_capacity", view.current, view.max));
+        ProgressView bar = new ProgressView(
+                ProgressView.Part.of(view.ratio, view.overlay),
+                text,
+                JadeUI.progressStyle().canDecrease(true),
+                BoxStyle.nestedBox());
+        tooltip.add(JadeUI.progress(bar));
     }
 }


### PR DESCRIPTION
## Summary

Machines now render their fluid tank in the Jade look-at HUD as a capacity-relative bar (`Lava 500 mB / 10,000 mB`), consistent across every loader and version. Previously the machine HUD had no fluid handling at all — the crucible tank readout relied on Jade's built-in fluid detection, which was inconsistent (1.21.1 NeoForge showed amount only, 1.21.11 NeoForge showed nothing, Fabric showed nothing).

Rather than special-case the crucible, HUD contribution is centralized into the machine-component framework: a component declares its own HUD, and the machine's overlay is assembled from whatever components it hosts. **Adding a fluid-tank component to any machine now surfaces its tank in Jade automatically** — the crucible is just the first consumer.

Closes #700.

## Changes

- **`feat(fluids): render machine fluid tanks as a Jade bar`** — capacity-relative fluid bar on the machine HUD (crucible), matching the fluid-pipe/glass-tank look, on all loaders/versions.
- New `MachineComponent.HudContributor` facet + portable `MachineHudModel` (typed progress/fluid entries, key-iterated NBT — no `ListTag`).
- `RecipeProcessorComponent` owns the progress entry; `FluidStoreComponent` owns the fluid entry.
- Machine Jade provider replaces Jade's inconsistent built-in fluid element with the mod's own bar (priority 2000 so `remove()` runs after the built-in).

## Notes

- Version-fragile Jade element code is confined to `MachineComponentProvider`; the rest ports cleanly. Backport to `mc/1.21.11` → `mc/1.21.1` re-points only the element construction to older Jade's `IElementHelper` (`JadeUI`→`IElementHelper`, `Identifier`→`ResourceLocation`).
- Build green on both loaders; added `MachineHudModel` round-trip + `forEach` unit tests. NeoForge 26.2 has no Jade runtime yet, so its runtime check waits on upstream (compiles against the compile-only API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)