### PR TITLE
test(common): fast unit coverage for embedded pure logic

### DIFF
--- a/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpComponent.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/FluidPumpComponent.java
@@ -135,13 +135,9 @@ public final class FluidPumpComponent implements MachineComponent {
         float target = targetY + 0.5f;
         boolean server = ctx.isServer();
         float armSpeed = armSpeedOverride >= 0f ? armSpeedOverride : LogisticsConfig.get().fluidPump.armSpeed;
-        if (armY > target) {
-            armY = Math.max(target, armY - armSpeed);
-            if (server) {
-                ctx.setChanged();
-            }
-        } else if (armY < target) {
-            armY = Math.min(target, armY + armSpeed);
+        float stepped = stepArm(armY, target, armSpeed);
+        if (stepped != armY) {
+            armY = stepped;
             if (server) {
                 ctx.setChanged();
             }
@@ -149,6 +145,17 @@ public final class FluidPumpComponent implements MachineComponent {
         if (targetY > pos.getY() - 1) {
             targetY = pos.getY() - 1;
         }
+    }
+
+    /** Steps {@code armY} one tick toward {@code target} at {@code armSpeed} without overshooting; unchanged at rest. */
+    static float stepArm(float armY, float target, float armSpeed) {
+        if (armY > target) {
+            return Math.max(target, armY - armSpeed);
+        }
+        if (armY < target) {
+            return Math.min(target, armY + armSpeed);
+        }
+        return armY;
     }
 
     private void pushOut(Level level, BlockPos pos) {

--- a/common/src/test/java/com/logistics/automation/laserquarry/ArmControllerTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/ArmControllerTest.java
@@ -1,0 +1,212 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.logistics.automation.laserquarry.entity.ArmController;
+import com.logistics.automation.laserquarry.entity.QuarryArmState;
+import com.logistics.test.MinecraftTestEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ArmController")
+class ArmControllerTest extends MinecraftTestEnvironment {
+
+    private static final float TOL = 1e-4f;
+
+    private static ArmController armAt(float x, float y, float z) {
+        ArmController arm = new ArmController();
+        arm.initializeAt(x, y, z);
+        return arm;
+    }
+
+    @Nested
+    @DisplayName("moveTowards")
+    class MoveTowards {
+
+        @Test
+        @DisplayName("advances one speed-step along a single axis without snapping")
+        void partialAxisMove() {
+            ArmController arm = armAt(0f, 0f, 0f);
+
+            boolean snapped = arm.moveTowards(10f, 0f, 0f, 2f);
+
+            assertThat(snapped).isFalse();
+            assertThat(arm.getX()).isCloseTo(2f, within(TOL));
+            assertThat(arm.getY()).isCloseTo(0f, within(TOL));
+            assertThat(arm.getZ()).isCloseTo(0f, within(TOL));
+        }
+
+        @Test
+        @DisplayName("advances proportionally along a diagonal (normalized by distance)")
+        void partialDiagonalMove() {
+            ArmController arm = armAt(0f, 0f, 0f);
+
+            // distance to (3,4,0) is 5; a speed of 2.5 covers half → (1.5, 2.0, 0)
+            boolean snapped = arm.moveTowards(3f, 4f, 0f, 2.5f);
+
+            assertThat(snapped).isFalse();
+            assertThat(arm.getX()).isCloseTo(1.5f, within(TOL));
+            assertThat(arm.getY()).isCloseTo(2.0f, within(TOL));
+        }
+
+        @Test
+        @DisplayName("snaps exactly to target and returns true when within one step")
+        void snapsWhenWithinSpeed() {
+            ArmController arm = armAt(0f, 0f, 0f);
+
+            // distance to (3,4,0) is exactly 5; speed 5 reaches it
+            boolean snapped = arm.moveTowards(3f, 4f, 0f, 5f);
+
+            assertThat(snapped).isTrue();
+            assertThat(arm.getX()).isEqualTo(3f);
+            assertThat(arm.getY()).isEqualTo(4f);
+            assertThat(arm.getZ()).isEqualTo(0f);
+        }
+    }
+
+    @Nested
+    @DisplayName("isAt")
+    class IsAt {
+
+        @Test
+        @DisplayName("true when the target is within one speed-step")
+        void withinRange() {
+            ArmController arm = armAt(0f, 0f, 0f);
+            assertThat(arm.isAt(1f, 0f, 0f, 2f)).isTrue();
+        }
+
+        @Test
+        @DisplayName("false when the target is farther than one speed-step")
+        void outOfRange() {
+            ArmController arm = armAt(0f, 0f, 0f);
+            assertThat(arm.isAt(5f, 0f, 0f, 2f)).isFalse();
+        }
+
+        @Test
+        @DisplayName("does not move the arm")
+        void isPure() {
+            ArmController arm = armAt(1f, 2f, 3f);
+            arm.isAt(9f, 9f, 9f, 1f);
+            assertThat(arm.getX()).isEqualTo(1f);
+            assertThat(arm.getY()).isEqualTo(2f);
+            assertThat(arm.getZ()).isEqualTo(3f);
+        }
+    }
+
+    @Nested
+    @DisplayName("travelTicksFor")
+    class TravelTicksFor {
+
+        @Test
+        @DisplayName("rounds the tick count up for a non-exact division")
+        void roundsUp() {
+            ArmController arm = armAt(0f, 0f, 0f);
+            assertThat(arm.travelTicksFor(10f, 0f, 0f, 3f)).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("returns the exact quotient when it divides evenly")
+        void exactDivision() {
+            ArmController arm = armAt(0f, 0f, 0f);
+            assertThat(arm.travelTicksFor(9f, 0f, 0f, 3f)).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("measures Euclidean distance across all axes")
+        void diagonalDistance() {
+            ArmController arm = armAt(0f, 0f, 0f);
+            assertThat(arm.travelTicksFor(3f, 4f, 0f, 5f)).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("warpTo")
+    class WarpTo {
+
+        @Test
+        @DisplayName("jumps straight to the target and records the matching travel ticks")
+        void jumpsAndRecordsTicks() {
+            ArmController arm = armAt(1f, 1f, 1f);
+
+            // distance from (1,1,1) to (4,5,1) is 5; at speed 2 → ceil(2.5) = 3 ticks
+            arm.warpTo(4f, 5f, 1f, 2f);
+
+            assertThat(arm.getX()).isEqualTo(4f);
+            assertThat(arm.getY()).isEqualTo(5f);
+            assertThat(arm.getZ()).isEqualTo(1f);
+            assertThat(arm.getExpectedTravelTicks()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("settling timer")
+    class Settling {
+
+        @Test
+        @DisplayName("counts down and only reports done on the final tick")
+        void countsDown() {
+            ArmController arm = new ArmController();
+            arm.enterSettling(3);
+
+            assertThat(arm.getState()).isEqualTo(QuarryArmState.SETTLING);
+            assertThat(arm.tickSettling()).isFalse();
+            assertThat(arm.tickSettling()).isFalse();
+            assertThat(arm.tickSettling()).isTrue();
+        }
+
+        @Test
+        @DisplayName("floors the settling duration to at least one tick")
+        void flooredToOneTick() {
+            ArmController arm = new ArmController();
+            arm.enterSettling(0);
+
+            assertThat(arm.tickSettling()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("state transitions")
+    class StateTransitions {
+
+        @Test
+        @DisplayName("initializeAt anchors the position, marks initialized, and resets to MOVING")
+        void initializeAt() {
+            ArmController arm = new ArmController();
+            arm.enterSettling(5);
+
+            arm.initializeAt(2f, 3f, 4f);
+
+            assertThat(arm.getX()).isEqualTo(2f);
+            assertThat(arm.getY()).isEqualTo(3f);
+            assertThat(arm.getZ()).isEqualTo(4f);
+            assertThat(arm.isInitialized()).isTrue();
+            assertThat(arm.getState()).isEqualTo(QuarryArmState.MOVING);
+            assertThat(arm.getExpectedTravelTicks()).isZero();
+        }
+
+        @Test
+        @DisplayName("markUninitialized clears the initialized flag so the next tick re-anchors")
+        void markUninitialized() {
+            ArmController arm = armAt(0f, 0f, 0f);
+            assertThat(arm.isInitialized()).isTrue();
+
+            arm.markUninitialized();
+
+            assertThat(arm.isInitialized()).isFalse();
+        }
+
+        @Test
+        @DisplayName("enterBreaking and enterMoving set the arm state")
+        void breakingAndMoving() {
+            ArmController arm = new ArmController();
+
+            arm.enterBreaking();
+            assertThat(arm.getState()).isEqualTo(QuarryArmState.BREAKING);
+
+            arm.enterMoving();
+            assertThat(arm.getState()).isEqualTo(QuarryArmState.MOVING);
+        }
+    }
+}

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryEnergyPolicyTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryEnergyPolicyTest.java
@@ -6,6 +6,7 @@ import com.logistics.automation.laserquarry.entity.QuarryEnergyPolicy;
 import com.logistics.core.machine.component.EnergyStorageComponent;
 import com.logistics.core.machine.upgrade.MachineModifiers;
 import com.logistics.test.MinecraftTestEnvironment;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ import org.junit.jupiter.api.Test;
 @DisplayName("QuarryEnergyPolicy")
 class QuarryEnergyPolicyTest extends MinecraftTestEnvironment {
 
-    private final int[] consumeCalls = {0};
+    private final AtomicInteger consumeCalls = new AtomicInteger();
 
     private EnergyStorageComponent chargedBuffer(long amount) {
         EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 100_000, () -> {});
@@ -22,7 +23,7 @@ class QuarryEnergyPolicyTest extends MinecraftTestEnvironment {
     }
 
     private QuarryEnergyPolicy policy(EnergyStorageComponent energy) {
-        return new QuarryEnergyPolicy(energy, MachineModifiers.identity(), () -> consumeCalls[0]++);
+        return new QuarryEnergyPolicy(energy, MachineModifiers.identity(), consumeCalls::incrementAndGet);
     }
 
     @Nested
@@ -39,7 +40,7 @@ class QuarryEnergyPolicyTest extends MinecraftTestEnvironment {
 
             assertThat(energy.amount()).isEqualTo(300);
             assertThat(policy.consumedThisTick()).isTrue();
-            assertThat(consumeCalls[0]).isEqualTo(1);
+            assertThat(consumeCalls.get()).isEqualTo(1);
         }
 
         @Test
@@ -52,7 +53,7 @@ class QuarryEnergyPolicyTest extends MinecraftTestEnvironment {
 
             assertThat(energy.amount()).isEqualTo(150);
             assertThat(policy.consumedThisTick()).isFalse();
-            assertThat(consumeCalls[0]).isZero();
+            assertThat(consumeCalls.get()).isZero();
         }
 
         @Test
@@ -119,7 +120,7 @@ class QuarryEnergyPolicyTest extends MinecraftTestEnvironment {
 
             assertThat(energy.amount()).isEqualTo(300);
             assertThat(policy.consumedThisTick()).isFalse();
-            assertThat(consumeCalls[0]).isEqualTo(1);
+            assertThat(consumeCalls.get()).isEqualTo(1);
         }
 
         @Test
@@ -142,7 +143,7 @@ class QuarryEnergyPolicyTest extends MinecraftTestEnvironment {
             policy.drainIdle(100);
 
             assertThat(energy.amount()).isZero();
-            assertThat(consumeCalls[0]).isZero();
+            assertThat(consumeCalls.get()).isZero();
         }
     }
 

--- a/common/src/test/java/com/logistics/automation/laserquarry/QuarryEnergyPolicyTest.java
+++ b/common/src/test/java/com/logistics/automation/laserquarry/QuarryEnergyPolicyTest.java
@@ -1,0 +1,154 @@
+package com.logistics.automation.laserquarry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.automation.laserquarry.entity.QuarryEnergyPolicy;
+import com.logistics.core.machine.component.EnergyStorageComponent;
+import com.logistics.core.machine.upgrade.MachineModifiers;
+import com.logistics.test.MinecraftTestEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("QuarryEnergyPolicy")
+class QuarryEnergyPolicyTest extends MinecraftTestEnvironment {
+
+    private final int[] consumeCalls = {0};
+
+    private EnergyStorageComponent chargedBuffer(long amount) {
+        EnergyStorageComponent energy = new EnergyStorageComponent("energy", 100_000, 100_000, 100_000, () -> {});
+        energy.setAmount(amount);
+        return energy;
+    }
+
+    private QuarryEnergyPolicy policy(EnergyStorageComponent energy) {
+        return new QuarryEnergyPolicy(energy, MachineModifiers.identity(), () -> consumeCalls[0]++);
+    }
+
+    @Nested
+    @DisplayName("consume")
+    class Consume {
+
+        @Test
+        @DisplayName("spends RF, flags work this tick, and notifies when affordable")
+        void spendsWhenAffordable() {
+            EnergyStorageComponent energy = chargedBuffer(500);
+            QuarryEnergyPolicy policy = policy(energy);
+
+            policy.consume(200);
+
+            assertThat(energy.amount()).isEqualTo(300);
+            assertThat(policy.consumedThisTick()).isTrue();
+            assertThat(consumeCalls[0]).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("does nothing when the buffer can't afford the cost")
+        void skipsWhenUnaffordable() {
+            EnergyStorageComponent energy = chargedBuffer(150);
+            QuarryEnergyPolicy policy = policy(energy);
+
+            policy.consume(200);
+
+            assertThat(energy.amount()).isEqualTo(150);
+            assertThat(policy.consumedThisTick()).isFalse();
+            assertThat(consumeCalls[0]).isZero();
+        }
+
+        @Test
+        @DisplayName("spends when the cost exactly equals the buffer")
+        void spendsExactlyAllBuffer() {
+            EnergyStorageComponent energy = chargedBuffer(200);
+            QuarryEnergyPolicy policy = policy(energy);
+
+            policy.consume(200);
+
+            assertThat(energy.amount()).isZero();
+            assertThat(policy.consumedThisTick()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("consumedThisTick lifecycle")
+    class ConsumedFlag {
+
+        @Test
+        @DisplayName("resets back to false")
+        void resets() {
+            QuarryEnergyPolicy policy = policy(chargedBuffer(500));
+            policy.consume(100);
+            assertThat(policy.consumedThisTick()).isTrue();
+
+            policy.resetConsumedThisTick();
+
+            assertThat(policy.consumedThisTick()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("has")
+    class Has {
+
+        @Test
+        @DisplayName("true when the buffer holds at least the amount")
+        void trueWhenEnough() {
+            QuarryEnergyPolicy policy = policy(chargedBuffer(100));
+            assertThat(policy.has(100)).isTrue();
+            assertThat(policy.has(99)).isTrue();
+        }
+
+        @Test
+        @DisplayName("false when the buffer holds less")
+        void falseWhenShort() {
+            QuarryEnergyPolicy policy = policy(chargedBuffer(100));
+            assertThat(policy.has(101)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("drainIdle")
+    class DrainIdle {
+
+        @Test
+        @DisplayName("bleeds RF and notifies but does not flag work this tick")
+        void bleedsWithoutFlaggingWork() {
+            EnergyStorageComponent energy = chargedBuffer(500);
+            QuarryEnergyPolicy policy = policy(energy);
+
+            policy.drainIdle(200);
+
+            assertThat(energy.amount()).isEqualTo(300);
+            assertThat(policy.consumedThisTick()).isFalse();
+            assertThat(consumeCalls[0]).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("floors the buffer at zero when draining more than it holds")
+        void floorsAtZero() {
+            EnergyStorageComponent energy = chargedBuffer(150);
+            QuarryEnergyPolicy policy = policy(energy);
+
+            policy.drainIdle(1_000);
+
+            assertThat(energy.amount()).isZero();
+        }
+
+        @Test
+        @DisplayName("does nothing on an empty buffer")
+        void noopWhenEmpty() {
+            EnergyStorageComponent energy = chargedBuffer(0);
+            QuarryEnergyPolicy policy = policy(energy);
+
+            policy.drainIdle(100);
+
+            assertThat(energy.amount()).isZero();
+            assertThat(consumeCalls[0]).isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("stored reflects the buffer amount")
+    void storedReflectsBuffer() {
+        assertThat(policy(chargedBuffer(742)).stored()).isEqualTo(742);
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/network/CrafterBufferStateTest.java
+++ b/common/src/test/java/com/logistics/core/lib/network/CrafterBufferStateTest.java
@@ -1,0 +1,55 @@
+package com.logistics.core.lib.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CrafterBufferState")
+class CrafterBufferStateTest {
+
+    @Test
+    @DisplayName("safeBatchCapacity is limited by input insert space")
+    void limitedByInserts() {
+        assertThat(new CrafterBufferState(3, 10).safeBatchCapacity()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("safeBatchCapacity is limited by output space")
+    void limitedByOutputSpace() {
+        assertThat(new CrafterBufferState(10, 4).safeBatchCapacity()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("safeBatchCapacity equals either limit when they match")
+    void equalLimits() {
+        assertThat(new CrafterBufferState(5, 5).safeBatchCapacity()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("FULL has no capacity")
+    void fullHasNoCapacity() {
+        assertThat(CrafterBufferState.FULL.safeBatchCapacity()).isZero();
+    }
+
+    @Test
+    @DisplayName("UNLIMITED reports the maximum capacity")
+    void unlimitedIsMax() {
+        assertThat(CrafterBufferState.UNLIMITED.safeBatchCapacity()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    @DisplayName("rejects a negative insert limit")
+    void rejectsNegativeInserts() {
+        assertThatThrownBy(() -> new CrafterBufferState(-1, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("rejects a negative output-space limit")
+    void rejectsNegativeOutputSpace() {
+        assertThatThrownBy(() -> new CrafterBufferState(0, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/network/CrafterSnapshotTest.java
+++ b/common/src/test/java/com/logistics/core/lib/network/CrafterSnapshotTest.java
@@ -1,0 +1,98 @@
+package com.logistics.core.lib.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.test.MinecraftTestEnvironment;
+import com.logistics.test.TestItemKey;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CrafterSnapshot")
+class CrafterSnapshotTest extends MinecraftTestEnvironment {
+
+    private static IItemKey key() {
+        return new TestItemKey(Items.COBBLESTONE);
+    }
+
+    private static RecipeIngredient ingredient() {
+        return new RecipeIngredient(key(), 1);
+    }
+
+    private static CrafterSnapshot snapshot(List<RecipeIngredient> ingredients) {
+        return new CrafterSnapshot(BlockPos.ZERO, key(), 4, ingredients, new CrafterBufferState(3, 10));
+    }
+
+    @Test
+    @DisplayName("availableBatchCapacity delegates to the buffer state")
+    void delegatesCapacity() {
+        assertThat(snapshot(List.of(ingredient())).availableBatchCapacity()).isEqualTo(3);
+    }
+
+    @Nested
+    @DisplayName("ingredients are captured defensively")
+    class DefensiveCopy {
+
+        @Test
+        @DisplayName("mutating the source list after capture does not affect the snapshot")
+        void sourceMutationIsolated() {
+            List<RecipeIngredient> source = new ArrayList<>();
+            source.add(ingredient());
+
+            CrafterSnapshot snapshot = snapshot(source);
+            source.add(ingredient());
+
+            assertThat(snapshot.ingredients()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("the exposed ingredient list is immutable")
+        void exposedListImmutable() {
+            CrafterSnapshot snapshot = snapshot(List.of(ingredient()));
+            assertThatThrownBy(() -> snapshot.ingredients().add(ingredient()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("validation")
+    class Validation {
+
+        @Test
+        @DisplayName("rejects a null position")
+        void rejectsNullPos() {
+            assertThatThrownBy(() ->
+                            new CrafterSnapshot(null, key(), 4, List.of(), new CrafterBufferState(1, 1)))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a null output key")
+        void rejectsNullOutput() {
+            assertThatThrownBy(() ->
+                            new CrafterSnapshot(BlockPos.ZERO, null, 4, List.of(), new CrafterBufferState(1, 1)))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive output count")
+        void rejectsNonPositiveOutputCount() {
+            assertThatThrownBy(() ->
+                            new CrafterSnapshot(BlockPos.ZERO, key(), 0, List.of(), new CrafterBufferState(1, 1)))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a null buffer state")
+        void rejectsNullBuffer() {
+            assertThatThrownBy(() -> new CrafterSnapshot(BlockPos.ZERO, key(), 4, List.of(), null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+}

--- a/common/src/test/java/com/logistics/core/lib/network/CrafterSnapshotTest.java
+++ b/common/src/test/java/com/logistics/core/lib/network/CrafterSnapshotTest.java
@@ -81,6 +81,14 @@ class CrafterSnapshotTest extends MinecraftTestEnvironment {
         }
 
         @Test
+        @DisplayName("rejects a null ingredient list")
+        void rejectsNullIngredients() {
+            assertThatThrownBy(() ->
+                            new CrafterSnapshot(BlockPos.ZERO, key(), 4, null, new CrafterBufferState(1, 1)))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
         @DisplayName("rejects a non-positive output count")
         void rejectsNonPositiveOutputCount() {
             assertThatThrownBy(() ->

--- a/common/src/test/java/com/logistics/pipe/block/entity/FluidPumpArmTest.java
+++ b/common/src/test/java/com/logistics/pipe/block/entity/FluidPumpArmTest.java
@@ -3,12 +3,11 @@ package com.logistics.pipe.block.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
-import com.logistics.test.MinecraftTestEnvironment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("FluidPumpComponent.stepArm")
-class FluidPumpArmTest extends MinecraftTestEnvironment {
+class FluidPumpArmTest {
 
     private static final float TOL = 1e-4f;
 

--- a/common/src/test/java/com/logistics/pipe/block/entity/FluidPumpArmTest.java
+++ b/common/src/test/java/com/logistics/pipe/block/entity/FluidPumpArmTest.java
@@ -1,0 +1,50 @@
+package com.logistics.pipe.block.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FluidPumpComponent.stepArm")
+class FluidPumpArmTest extends MinecraftTestEnvironment {
+
+    private static final float TOL = 1e-4f;
+
+    @Test
+    @DisplayName("descends one speed-step toward a lower target")
+    void descendsTowardLowerTarget() {
+        assertThat(FluidPumpComponent.stepArm(10f, 5f, 2f)).isCloseTo(8f, within(TOL));
+    }
+
+    @Test
+    @DisplayName("ascends one speed-step toward a higher target")
+    void ascendsTowardHigherTarget() {
+        assertThat(FluidPumpComponent.stepArm(5f, 10f, 2f)).isCloseTo(7f, within(TOL));
+    }
+
+    @Test
+    @DisplayName("clamps to the target instead of overshooting downward")
+    void clampsWithoutOvershootingDown() {
+        assertThat(FluidPumpComponent.stepArm(6f, 5f, 2f)).isEqualTo(5f);
+    }
+
+    @Test
+    @DisplayName("clamps to the target instead of overshooting upward")
+    void clampsWithoutOvershootingUp() {
+        assertThat(FluidPumpComponent.stepArm(5f, 6f, 2f)).isEqualTo(6f);
+    }
+
+    @Test
+    @DisplayName("lands exactly on the target when a step reaches it")
+    void landsExactlyOnTarget() {
+        assertThat(FluidPumpComponent.stepArm(7f, 5f, 2f)).isEqualTo(5f);
+    }
+
+    @Test
+    @DisplayName("returns the same value when already at rest on the target")
+    void unchangedAtRest() {
+        assertThat(FluidPumpComponent.stepArm(5f, 5f, 2f)).isEqualTo(5f);
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/network/NetworkJobTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/NetworkJobTest.java
@@ -1,0 +1,148 @@
+package com.logistics.pipe.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.core.lib.network.FulfillmentMode;
+import com.logistics.test.MinecraftTestEnvironment;
+import com.logistics.test.TestItemKey;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("NetworkJob")
+class NetworkJobTest extends MinecraftTestEnvironment {
+
+    private static NetworkJob job(long requested, long planned) {
+        return new NetworkJob(
+                new UUID(0L, 1L),
+                new TestItemKey(Items.COBBLESTONE),
+                requested,
+                planned,
+                FulfillmentMode.PARTIAL,
+                BlockPos.ZERO);
+    }
+
+    @Test
+    @DisplayName("starts PLANNED with the full planned amount outstanding")
+    void initialState() {
+        NetworkJob job = job(64, 64);
+        assertThat(job.state()).isEqualTo(JobState.PLANNED);
+        assertThat(job.outstanding()).isEqualTo(64);
+        assertThat(job.deliveredAmount()).isZero();
+        assertThat(job.invalidatedAmount()).isZero();
+    }
+
+    @Nested
+    @DisplayName("outstanding")
+    class Outstanding {
+
+        @Test
+        @DisplayName("is planned minus delivered minus invalidated")
+        void subtractsDeliveredAndInvalidated() {
+            NetworkJob job = job(100, 100);
+            job.recordDelivery(30);
+            job.recordInvalidation(20);
+            assertThat(job.outstanding()).isEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("never goes negative")
+        void floorsAtZero() {
+            NetworkJob job = job(10, 10);
+            job.recordDelivery(25);
+            assertThat(job.outstanding()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("recordDelivery")
+    class RecordDelivery {
+
+        @Test
+        @DisplayName("a partial delivery moves the job to DELIVERING")
+        void partialDeliveryIsDelivering() {
+            NetworkJob job = job(64, 64);
+            job.recordDelivery(20);
+            assertThat(job.deliveredAmount()).isEqualTo(20);
+            assertThat(job.state()).isEqualTo(JobState.DELIVERING);
+        }
+
+        @Test
+        @DisplayName("completing the planned amount moves the job to COMPLETE")
+        void fullDeliveryCompletes() {
+            NetworkJob job = job(64, 64);
+            job.recordDelivery(40);
+            job.recordDelivery(24);
+            assertThat(job.state()).isEqualTo(JobState.COMPLETE);
+        }
+
+        @Test
+        @DisplayName("ignores non-positive amounts")
+        void ignoresNonPositive() {
+            NetworkJob job = job(64, 64);
+            job.recordDelivery(0);
+            job.recordDelivery(-5);
+            assertThat(job.deliveredAmount()).isZero();
+            assertThat(job.state()).isEqualTo(JobState.PLANNED);
+        }
+    }
+
+    @Nested
+    @DisplayName("recordInvalidation")
+    class RecordInvalidation {
+
+        @Test
+        @DisplayName("invalidating everything with no delivery fails the job")
+        void allInvalidatedNoDeliveryFails() {
+            NetworkJob job = job(64, 64);
+            job.recordInvalidation(64);
+            assertThat(job.state()).isEqualTo(JobState.FAILED);
+        }
+
+        @Test
+        @DisplayName("invalidating the remainder after a partial delivery completes the job")
+        void invalidatedRemainderAfterDeliveryCompletes() {
+            NetworkJob job = job(64, 64);
+            job.recordDelivery(40);
+            job.recordInvalidation(24);
+            assertThat(job.state()).isEqualTo(JobState.COMPLETE);
+        }
+
+        @Test
+        @DisplayName("a partial invalidation with work still outstanding leaves the state unchanged")
+        void partialInvalidationKeepsState() {
+            NetworkJob job = job(100, 100);
+            job.recordInvalidation(30);
+            assertThat(job.invalidatedAmount()).isEqualTo(30);
+            assertThat(job.outstanding()).isEqualTo(70);
+            assertThat(job.state()).isEqualTo(JobState.PLANNED);
+        }
+    }
+
+    @Nested
+    @DisplayName("transitionTo")
+    class TransitionTo {
+
+        @Test
+        @DisplayName("moves to the requested state")
+        void moves() {
+            NetworkJob job = job(64, 64);
+            job.transitionTo(JobState.ACTIVE);
+            assertThat(job.state()).isEqualTo(JobState.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("is a no-op once the job has reached a terminal state")
+        void noOpWhenTerminal() {
+            NetworkJob job = job(64, 64);
+            job.transitionTo(JobState.FAILED);
+
+            job.transitionTo(JobState.ACTIVE);
+
+            assertThat(job.state()).isEqualTo(JobState.FAILED);
+        }
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/network/SupplySlotStateTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/SupplySlotStateTest.java
@@ -6,13 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.logistics.pipe.modules.SupplierModule.SupplyMode;
-import com.logistics.test.MinecraftTestEnvironment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("SupplySlotState")
-class SupplySlotStateTest extends MinecraftTestEnvironment {
+class SupplySlotStateTest {
 
     private static SupplierModeConfig partial() {
         return SupplierModeConfig.forMode(SupplyMode.PARTIAL, 64);

--- a/common/src/test/java/com/logistics/pipe/network/SupplySlotStateTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/SupplySlotStateTest.java
@@ -1,0 +1,100 @@
+package com.logistics.pipe.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.logistics.pipe.modules.SupplierModule.SupplyMode;
+import com.logistics.test.MinecraftTestEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SupplySlotState")
+class SupplySlotStateTest extends MinecraftTestEnvironment {
+
+    private static SupplierModeConfig partial() {
+        return SupplierModeConfig.forMode(SupplyMode.PARTIAL, 64);
+    }
+
+    private static SupplySlotState slot(long desired, long onHand, long inbound, long ordered, SupplierModeConfig cfg) {
+        return new SupplySlotState("minecraft:cobblestone", desired, onHand, inbound, ordered, cfg);
+    }
+
+    @Nested
+    @DisplayName("needed")
+    class Needed {
+
+        @Test
+        @DisplayName("subtracts on-hand, inbound, and ordered from the desired target")
+        void subtractsAllDemandSources() {
+            assertEquals(65, slot(100, 20, 10, 5, partial()).needed());
+        }
+
+        @Test
+        @DisplayName("floors at zero when supply already meets the target")
+        void floorsAtZeroWhenSatisfied() {
+            assertEquals(0, slot(10, 20, 0, 0, partial()).needed());
+        }
+
+        @Test
+        @DisplayName("floors at zero when inbound plus ordered overshoots the deficit")
+        void floorsAtZeroWhenInFlightCovers() {
+            assertEquals(0, slot(50, 0, 30, 25, partial()).needed());
+        }
+    }
+
+    @Nested
+    @DisplayName("shouldRestock")
+    class ShouldRestock {
+
+        @Test
+        @DisplayName("true when there is a deficit and the trigger threshold is met")
+        void restocksOnDeficit() {
+            assertTrue(slot(64, 5, 0, 0, partial()).shouldRestock());
+        }
+
+        @Test
+        @DisplayName("false when inbound/ordered already cover the deficit, even with low stock")
+        void noRestockWhenInFlightCovers() {
+            assertFalse(slot(64, 5, 0, 60, partial()).shouldRestock());
+        }
+
+        @Test
+        @DisplayName("respects the mode's trigger threshold (BULK50 waits until at/below half)")
+        void respectsTriggerThreshold() {
+            SupplierModeConfig bulk50 = SupplierModeConfig.forMode(SupplyMode.BULK50, 64);
+            // 60/100 on hand is above the 50% trigger, so no restock despite a 40-item deficit
+            assertFalse(slot(100, 60, 0, 0, bulk50).shouldRestock());
+            // 40/100 is at/below the trigger
+            assertTrue(slot(100, 40, 0, 0, bulk50).shouldRestock());
+        }
+    }
+
+    @Nested
+    @DisplayName("validation")
+    class Validation {
+
+        @Test
+        @DisplayName("rejects a blank item id")
+        void rejectsBlankItemId() {
+            assertThrows(IllegalArgumentException.class, () -> new SupplySlotState("", 1, 0, 0, 0, partial()));
+        }
+
+        @Test
+        @DisplayName("rejects negative quantities")
+        void rejectsNegatives() {
+            assertThrows(IllegalArgumentException.class, () -> slot(-1, 0, 0, 0, partial()));
+            assertThrows(IllegalArgumentException.class, () -> slot(0, -1, 0, 0, partial()));
+            assertThrows(IllegalArgumentException.class, () -> slot(0, 0, -1, 0, partial()));
+            assertThrows(IllegalArgumentException.class, () -> slot(0, 0, 0, -1, partial()));
+        }
+
+        @Test
+        @DisplayName("rejects a null mode config")
+        void rejectsNullConfig() {
+            assertThrows(NullPointerException.class, () -> slot(1, 0, 0, 0, null));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A self-paced testability sweep: **7 commits adding fast, deterministic unit coverage** for important behavior that was previously embedded in runtime/framework code or exercised only through game tests. Each commit was validated with `:common:test` (targeted + full suite) and `:common:spotlessJavaCheck`.

Six commits are **tests only** (no production change). One (`test(pump)`) extracts a tiny pure `stepArm` helper so the pump arm's stepping math can be tested deterministically instead of via the flaky `FluidPumpGameTest` — `advanceArm` still fires `setChanged` only when the arm actually moved on the server, so behavior is unchanged.

> [!IMPORTANT]
> **Land with "Rebase and merge" (or a merge commit) — do NOT squash.** Each commit is an independently-reviewable coverage addition with its own Conventional Commit subject; squashing collapses them and loses the granularity (release-please parses each).

## Coverage added

| Scope | Behavior now unit-covered |
|-------|---------------------------|
| quarry | `ArmController` kinematics — `moveTowards` (proportional step / diagonal normalization / exact snap), `isAt`, `travelTicksFor`, `warpTo`, settling-timer countdown + one-tick floor, state transitions |
| pump | pump arm stepping math (`stepArm`) — approach in both directions, overshoot clamping, exact arrival, at-rest (extracted from `advanceArm`) |
| quarry | `QuarryEnergyPolicy` spend/query — afford-or-skip `consume`, `consumedThisTick` lifecycle, `has`, `drainIdle` (bleed without flagging work, floor at zero, no-op when empty), `stored` |
| routing | `SupplySlotState` — the supplier demand formula (`needed`) and `shouldRestock` (deficit + trigger threshold + in-flight suppression) |
| routing | `NetworkJob` lifecycle — `outstanding`, `recordDelivery` (→DELIVERING/COMPLETE), `recordInvalidation` (→FAILED/COMPLETE/unchanged), terminal-guarded `transitionTo` |
| crafting | `CrafterBufferState` — `safeBatchCapacity` overflow guard, FULL/UNLIMITED sentinels, validation |
| crafting | `CrafterSnapshot` — defensive immutable copy of ingredients, capacity delegation, validation |

## Validation

- `./gradlew :common:test` — green after every commit and on the final tree
- `./gradlew :common:spotlessJavaCheck` — clean

## Notes

- The `FluidPumpGameTest` (flaky, races on arm speed) is retained for world-side integration; only the deterministic stepping math is now covered by a fast test.
- Modifier-scaled quarry cost formulas (`breakCost`/`moveCost`) read the global `LogisticsConfig` singleton and were left to the game tests to avoid cross-test config coupling.