### PR TITLE
fix(fluids): render custom fluids in the look-at HUD

### DIFF
--- a/fabric/src/client/java/com/logistics/LogisticsFluidClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsFluidClient.java
@@ -48,7 +48,7 @@ public final class LogisticsFluidClient {
             Material overlay = def.overlay() != null ? material(def.overlay()) : null;
             FluidModel.Unbaked model = new FluidModel.Unbaked(
                     material(def.still()), material(def.flow()), overlay,
-                    BlockTintSources.constant(def.tint() & 0xFFFFFF));
+                    BlockTintSources.constant(def.tint() | 0xFF000000));
             FluidRenderingRegistry.register(source, source.getFlowing(), model);
         });
     }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
@@ -83,7 +83,7 @@ public final class NeoForgeClientSetup {
             Material overlay = def.overlay() != null ? material(def.overlay()) : null;
             FluidModel.Unbaked model = new FluidModel.Unbaked(
                     material(def.still()), material(def.flow()), overlay,
-                    BlockTintSources.constant(def.tint() & 0xFFFFFF));
+                    BlockTintSources.constant(def.tint() | 0xFF000000));
             event.register(model, source, flowings.get(name));
         });
     }


### PR DESCRIPTION
## Summary

Custom fluids (liquid redstone, liquid glowstone, crude oil, …) rendered correctly in tank/pipe blocks and machine GUIs, but showed **blank** in the Jade / look-at HUD — the tank/pipe HUD and the crucible HUD displayed the fluid name and amount with no fluid fill.

## Cause

The custom-fluid render model was registered with an **alpha-zero tint**: `def.tint() & 0xFFFFFF` masks off the alpha byte, producing `0x00FFFFFF`. The mod's own `FluidBoxRenderer` forces the tint opaque before drawing, so in-world blocks and GUIs looked fine — but Jade (and other consumers that read the tint raw via Fabric's fluid rendering API) blits the sprite with that fully transparent color, so the fluid renders invisible.

Vanilla fluids (lava, water) were unaffected — they resolve to an opaque `0xFFFFFFFF`.

## Fix

Register the tint opaque (`def.tint() | 0xFF000000`) on both loaders. No visible change in-world (the color is unchanged; only the alpha is forced opaque); Jade/JEI now render the fluid.

Fixes the fluid fill on the glass tank, fluid pipe, and machine (crucible) look-at HUDs at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)