### PR TITLE
feat(automation): make machine tuning configurable per machine

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -113,6 +113,8 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         private static final Config crucible = configFor(LogisticsConfigHost.MOD_ID, "machines.crucible");
         private static final Config alloySmelter = configFor(LogisticsConfigHost.MOD_ID, "machines.alloy_smelter");
         private static final Config quarry = configFor(LogisticsConfigHost.MOD_ID, "machines.quarry");
+        private static final Config refinery = configFor(LogisticsConfigHost.MOD_ID, "machines.refinery");
+        private static final Config fabricator = configFor(LogisticsConfigHost.MOD_ID, "machines.fabricator");
 
         private CONFIG() {}
 
@@ -159,6 +161,26 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
                 alloySmelter.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
         public static final ConfigKey<Long> ALLOY_SMELTER_ENERGY_PER_TICK =
                 alloySmelter.defineLong("energy_per_tick", 20L).min(1L).describe("RF/t spent processing (higher = faster)").register();
+
+        // Refinery
+        public static final ConfigKey<Long> REFINERY_ENERGY_CAPACITY =
+                refinery.defineLong("energy_capacity", 20_000L).min(1L).describe("Internal RF buffer capacity").register();
+        public static final ConfigKey<Long> REFINERY_MAX_ENERGY_INPUT =
+                refinery.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
+        public static final ConfigKey<Long> REFINERY_ENERGY_PER_TICK =
+                refinery.defineLong("energy_per_tick", 20L).min(1L).describe("RF/t spent processing (higher = faster)").register();
+        public static final ConfigKey<Long> REFINERY_INPUT_TANK_MB =
+                refinery.defineLong("input_tank_mb", 4_000L).min(1L).describe("Input fluid tank capacity (mB)").register();
+        public static final ConfigKey<Long> REFINERY_OUTPUT_TANK_MB =
+                refinery.defineLong("output_tank_mb", 10_000L).min(1L).describe("Output fluid tank capacity (mB)").register();
+
+        // Sequential Fabricator
+        public static final ConfigKey<Long> FABRICATOR_ENERGY_CAPACITY =
+                fabricator.defineLong("energy_capacity", 100_000L).min(1L).describe("Internal RF buffer capacity").register();
+        public static final ConfigKey<Long> FABRICATOR_MAX_ENERGY_INPUT =
+                fabricator.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
+        public static final ConfigKey<Long> FABRICATOR_ENERGY_PER_TICK =
+                fabricator.defineLong("energy_per_tick", 80L).min(1L).describe("RF/t spent processing (higher = faster)").register();
 
         // Laser Quarry
         public static final ConfigKey<Integer> QUARRY_AREA = quarry.defineInt("area", 16)

--- a/common/src/main/java/com/logistics/LogisticsAutomation.java
+++ b/common/src/main/java/com/logistics/LogisticsAutomation.java
@@ -101,60 +101,114 @@ public final class LogisticsAutomation extends LogisticsMod implements DomainBoo
         TICKET_TYPE.register();
     }
 
-    /** Machine tuning — {@code config/logistics/machines.json}. */
+    /**
+     * Machine tuning — one file per machine under {@code config/logistics/machines/}. Every recipe machine
+     * shares the same template: {@code energy_capacity}, {@code max_energy_input}, {@code energy_per_tick}.
+     * Defaults match the historical hardcoded values, so this is a pure "make it configurable" surface.
+     */
     public static final class CONFIG extends ConfigEntries {
-        private static final Config machines = configFor(LogisticsConfigHost.MOD_ID, "machines");
+        private static final Config macerator = configFor(LogisticsConfigHost.MOD_ID, "machines.macerator");
+        private static final Config kiln = configFor(LogisticsConfigHost.MOD_ID, "machines.kiln");
+        private static final Config sawmill = configFor(LogisticsConfigHost.MOD_ID, "machines.sawmill");
+        private static final Config crucible = configFor(LogisticsConfigHost.MOD_ID, "machines.crucible");
+        private static final Config alloySmelter = configFor(LogisticsConfigHost.MOD_ID, "machines.alloy_smelter");
+        private static final Config quarry = configFor(LogisticsConfigHost.MOD_ID, "machines.quarry");
 
         private CONFIG() {}
 
-        public static final ConfigKey<Integer> QUARRY_AREA = machines.defineInt("quarry_area", 16)
+        // Macerator
+        public static final ConfigKey<Long> MACERATOR_ENERGY_CAPACITY =
+                macerator.defineLong("energy_capacity", 10_000L).min(0L).describe("Internal RF buffer capacity").register();
+        public static final ConfigKey<Long> MACERATOR_MAX_ENERGY_INPUT =
+                macerator.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
+        public static final ConfigKey<Long> MACERATOR_ENERGY_PER_TICK =
+                macerator.defineLong("energy_per_tick", 10L).min(1L).describe("RF/t spent processing (higher = faster)").register();
+
+        // Kiln
+        public static final ConfigKey<Long> KILN_ENERGY_CAPACITY =
+                kiln.defineLong("energy_capacity", 10_000L).min(0L).describe("Internal RF buffer capacity").register();
+        public static final ConfigKey<Long> KILN_MAX_ENERGY_INPUT =
+                kiln.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
+        public static final ConfigKey<Long> KILN_ENERGY_PER_TICK =
+                kiln.defineLong("energy_per_tick", 20L).min(1L).describe("RF/t spent processing (higher = faster)").register();
+        public static final ConfigKey<Long> KILN_RF_PER_COOK_TICK =
+                kiln.defineLong("rf_per_cook_tick", 10L).min(1L).describe("RF per vanilla smelting cook-tick (recipe energy = cook time x this)").register();
+
+        // Sawmill
+        public static final ConfigKey<Long> SAWMILL_ENERGY_CAPACITY =
+                sawmill.defineLong("energy_capacity", 10_000L).min(0L).describe("Internal RF buffer capacity").register();
+        public static final ConfigKey<Long> SAWMILL_MAX_ENERGY_INPUT =
+                sawmill.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
+        public static final ConfigKey<Long> SAWMILL_ENERGY_PER_TICK =
+                sawmill.defineLong("energy_per_tick", 20L).min(1L).describe("RF/t spent processing (higher = faster)").register();
+
+        // Crucible
+        public static final ConfigKey<Long> CRUCIBLE_ENERGY_CAPACITY =
+                crucible.defineLong("energy_capacity", 40_000L).min(0L).describe("Internal RF buffer capacity").register();
+        public static final ConfigKey<Long> CRUCIBLE_MAX_ENERGY_INPUT =
+                crucible.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
+        public static final ConfigKey<Long> CRUCIBLE_ENERGY_PER_TICK =
+                crucible.defineLong("energy_per_tick", 40L).min(1L).describe("RF/t spent processing (higher = faster)").register();
+        public static final ConfigKey<Long> CRUCIBLE_TANK_CAPACITY_MB =
+                crucible.defineLong("tank_capacity_mb", 10_000L).min(1L).describe("Molten-metal tank capacity (mB)").register();
+
+        // Alloy Smelter
+        public static final ConfigKey<Long> ALLOY_SMELTER_ENERGY_CAPACITY =
+                alloySmelter.defineLong("energy_capacity", 10_000L).min(0L).describe("Internal RF buffer capacity").register();
+        public static final ConfigKey<Long> ALLOY_SMELTER_MAX_ENERGY_INPUT =
+                alloySmelter.defineLong("max_energy_input", 128L).min(0L).describe("Max RF/t accepted from the network").register();
+        public static final ConfigKey<Long> ALLOY_SMELTER_ENERGY_PER_TICK =
+                alloySmelter.defineLong("energy_per_tick", 20L).min(1L).describe("RF/t spent processing (higher = faster)").register();
+
+        // Laser Quarry
+        public static final ConfigKey<Integer> QUARRY_AREA = quarry.defineInt("area", 16)
                 .min(3)
                 .describe("Quarry mining area side length (NxN blocks)")
                 .register();
 
-        public static final ConfigKey<Long> QUARRY_ENERGY_PER_BLOCK = machines.defineLong("quarry_energy_per_block", 60L)
+        public static final ConfigKey<Long> QUARRY_ENERGY_PER_BLOCK = quarry.defineLong("energy_per_block", 60L)
                 .min(0L)
                 .describe("RF cost per block mined")
                 .register();
 
         public static final ConfigKey<Double> QUARRY_ENERGY_MULTIPLIER =
-                machines.defineDouble("quarry_energy_multiplier", 1.0)
+                quarry.defineDouble("energy_multiplier", 1.0)
                         .finite()
                         .min(0.0)
                         .describe("Global energy cost multiplier")
                         .register();
 
-        public static final ConfigKey<Float> QUARRY_ARM_SPEED = machines.defineFloat("quarry_arm_speed", 0.1f)
+        public static final ConfigKey<Float> QUARRY_ARM_SPEED = quarry.defineFloat("arm_speed", 0.1f)
                 .finite()
                 .min(0.0f)
                 .describe("Arm movement speed (blocks/tick)")
                 .register();
 
         public static final ConfigKey<Float> QUARRY_ARM_SPEED_SCALING =
-                machines.defineFloat("quarry_arm_speed_scaling", 2000f)
+                quarry.defineFloat("arm_speed_scaling", 2000f)
                         .finite()
                         .greaterThan(0.0f)
                         .describe("Energy-to-speed scaling constant")
                         .register();
 
-        public static final ConfigKey<Long> QUARRY_ARM_ENERGY = machines.defineLong("quarry_arm_energy", 20L)
+        public static final ConfigKey<Long> QUARRY_ARM_ENERGY = quarry.defineLong("arm_energy", 20L)
                 .min(0L)
                 .describe("RF/tick cost for arm movement")
                 .register();
 
-        public static final ConfigKey<Float> QUARRY_RAIN_PENALTY = machines.defineFloat("quarry_rain_penalty", 0.7f)
+        public static final ConfigKey<Float> QUARRY_RAIN_PENALTY = quarry.defineFloat("rain_penalty", 0.7f)
                 .finite()
                 .range(0.0f, 1.0f)
                 .describe("Speed multiplier when raining (0.0-1.0)")
                 .register();
 
-        public static final ConfigKey<Integer> QUARRY_SCAN_RATE = machines.defineInt("quarry_scan_rate", 256)
+        public static final ConfigKey<Integer> QUARRY_SCAN_RATE = quarry.defineInt("scan_rate", 256)
                 .min(1)
                 .max(65536)
                 .describe("Max blocks scanned per tick when searching")
                 .register();
 
-        public static final ConfigKey<Boolean> QUARRY_LOAD_CHUNKS = machines.defineBoolean("quarry_load_chunks", false)
+        public static final ConfigKey<Boolean> QUARRY_LOAD_CHUNKS = quarry.defineBoolean("load_chunks", false)
                 .describe("Keep the quarry and its work area chunk-loaded while running")
                 .register();
 

--- a/common/src/main/java/com/logistics/LogisticsPower.java
+++ b/common/src/main/java/com/logistics/LogisticsPower.java
@@ -68,33 +68,89 @@ public final class LogisticsPower extends LogisticsMod implements DomainBootstra
         ALIAS.register();
     }
 
-    /** Engine tuning — {@code config/logistics/engines.json}. */
+    /**
+     * Engine + power tuning — one file per unit under {@code config/logistics/engines/} and
+     * {@code config/logistics/power/}. Every engine shares a {@code buffer_capacity} knob; defaults
+     * match the historical hardcoded values, so this is a pure "make it configurable" surface.
+     */
     public static final class CONFIG extends ConfigEntries {
-        private static final Config engines = configFor(LogisticsConfigHost.MOD_ID, "engines");
+        private static final Config redstone = configFor(LogisticsConfigHost.MOD_ID, "engines.redstone");
+        private static final Config stirling = configFor(LogisticsConfigHost.MOD_ID, "engines.stirling");
+        private static final Config creative = configFor(LogisticsConfigHost.MOD_ID, "engines.creative");
+        private static final Config battery = configFor(LogisticsConfigHost.MOD_ID, "power.battery");
+        private static final Config cables = configFor(LogisticsConfigHost.MOD_ID, "power.cables");
 
         private CONFIG() {}
 
-        public static final ConfigKey<Long> REDSTONE_OUTPUT = engines.defineLong("redstone_output", 10L)
+        // Redstone engine
+        public static final ConfigKey<Long> REDSTONE_OUTPUT = redstone.defineLong("output", 10L)
                 .min(0L)
-                .describe("RF generated per 16-tick interval.")
+                .describe("RF generated per generation interval")
+                .register();
+        public static final ConfigKey<Long> REDSTONE_GENERATION_INTERVAL =
+                redstone.defineLong("generation_interval", 16L)
+                        .min(1L)
+                        .describe("Ticks between generation pulses when powered")
+                        .register();
+        public static final ConfigKey<Long> REDSTONE_BUFFER_CAPACITY = redstone.defineLong("buffer_capacity", 1_000L)
+                .min(0L)
+                .describe("Internal RF buffer capacity")
                 .register();
 
-        public static final ConfigKey<Double> STIRLING_MIN_OUTPUT = engines.defineDouble("stirling_min_output", 3.0)
+        // Stirling engine
+        public static final ConfigKey<Double> STIRLING_MIN_OUTPUT = stirling.defineDouble("min_output", 3.0)
                 .min(0.0)
                 .finite()
                 .maxValueOf(() -> CONFIG.STIRLING_MAX_OUTPUT)
-                .describe("Stirling engine minimum RF/t output.")
+                .describe("Minimum RF/t output")
                 .register();
-
-        public static final ConfigKey<Double> STIRLING_MAX_OUTPUT = engines.defineDouble("stirling_max_output", 10.0)
+        public static final ConfigKey<Double> STIRLING_MAX_OUTPUT = stirling.defineDouble("max_output", 10.0)
                 .min(0.0)
                 .finite()
                 .minValueOf(() -> CONFIG.STIRLING_MIN_OUTPUT)
-                .describe("Stirling engine maximum RF/t output.")
+                .describe("Maximum RF/t output")
+                .register();
+        public static final ConfigKey<Long> STIRLING_BUFFER_CAPACITY = stirling.defineLong("buffer_capacity", 10_000L)
+                .min(0L)
+                .describe("Internal RF buffer capacity")
+                .register();
+
+        // Creative engine
+        public static final ConfigKey<Long> CREATIVE_BUFFER_CAPACITY = creative.defineLong("buffer_capacity", 10_000L)
+                .min(0L)
+                .describe("Internal RF buffer capacity")
+                .register();
+
+        // Battery
+        public static final ConfigKey<Long> BATTERY_CAPACITY = battery.defineLong("capacity", 100_000L)
+                .min(0L)
+                .describe("Total RF storage")
+                .register();
+        public static final ConfigKey<Long> BATTERY_MAX_IO = battery.defineLong("max_io", 1_000L)
+                .min(0L)
+                .describe("Max RF/t inserted or extracted per side")
+                .register();
+        public static final ConfigKey<Long> BATTERY_OUTPUT_PER_SIDE = battery.defineLong("output_per_side", 200L)
+                .min(0L)
+                .describe("Max RF/t actively pushed into each adjacent machine")
+                .register();
+
+        // Cables
+        public static final ConfigKey<Long> CABLE_COPPER_TRANSFER = cables.defineLong("copper", 30L)
+                .min(0L)
+                .describe("Copper cable RF/t throughput")
+                .register();
+        public static final ConfigKey<Long> CABLE_GOLD_TRANSFER = cables.defineLong("gold", 60L)
+                .min(0L)
+                .describe("Gold cable RF/t throughput")
+                .register();
+        public static final ConfigKey<Long> CABLE_ENDER_TRANSFER = cables.defineLong("ender", 120L)
+                .min(0L)
+                .describe("Ender cable RF/t throughput")
                 .register();
 
         static void register() {
-            engines.registerSanitizeHook(() -> engines.repairMinMax(STIRLING_MIN_OUTPUT, STIRLING_MAX_OUTPUT));
+            stirling.registerSanitizeHook(() -> stirling.repairMinMax(STIRLING_MIN_OUTPUT, STIRLING_MAX_OUTPUT));
             LogisticsConfigMigrator.mapLegacy("engine", "redstoneOutput", REDSTONE_OUTPUT);
             LogisticsConfigMigrator.mapLegacyPair(
                     "engine", "stirlingMinOutput", "stirlingMaxOutput", STIRLING_MIN_OUTPUT, STIRLING_MAX_OUTPUT);

--- a/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.alloysmelter;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
 import com.logistics.core.machine.MachineData;
@@ -27,7 +28,7 @@ import net.minecraft.world.level.block.state.BlockState;
  *
  * <p>Composed from machine components — an energy buffer, a four-slot inventory (two inputs + two
  * outputs), and an RF-cost recipe processor. The recipe defines the total energy and the byproduct;
- * the processor spends {@link #ENERGY_PER_TICK} RF/tick and rolls the byproduct on completion.
+ * the processor spends a configurable RF/tick and rolls the byproduct on completion.
  * Top/sides feed the inputs; the bottom pulls both outputs.
  */
 public class AlloySmelterBlockEntity extends MachineEntity {
@@ -37,10 +38,6 @@ public class AlloySmelterBlockEntity extends MachineEntity {
     public static final int PRIMARY_OUTPUT_SLOT = 2;
     public static final int SECONDARY_OUTPUT_SLOT = 3;
     public static final int TOTAL_SLOTS = 4;
-
-    public static final long ENERGY_CAPACITY = 10_000L;
-    static final long MAX_ENERGY_INPUT = 128L;
-    static final int ENERGY_PER_TICK = 20;
 
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
@@ -52,9 +49,10 @@ public class AlloySmelterBlockEntity extends MachineEntity {
 
     @Override
     protected void configure(MachineBuilder machine) {
+        long capacity = LogisticsConfigHost.get(LogisticsAutomation.CONFIG.ALLOY_SMELTER_ENERGY_CAPACITY);
         energy = machine.energy("energy")
-                .capacity(ENERGY_CAPACITY)
-                .maxInput(MAX_ENERGY_INPUT)
+                .capacity(capacity)
+                .maxInput(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.ALLOY_SMELTER_MAX_ENERGY_INPUT))
                 .build();
 
         var items = machine.items("inventory")
@@ -64,13 +62,13 @@ public class AlloySmelterBlockEntity extends MachineEntity {
 
         processor = machine.recipeProcessor("processor")
                 .resolver(new AlloySmelterRecipeResolver())
-                .rfPerTick(ENERGY_PER_TICK)
+                .rfPerTick(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.ALLOY_SMELTER_ENERGY_PER_TICK))
                 .items(items)
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
 
-        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
+        containerData = MachineData.source(processor, energy, capacity);
     }
 
     /** Whether {@code stack} can serve as either input of some recipe (gates hopper insertion). */

--- a/common/src/main/java/com/logistics/automation/crucible/CrucibleBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/crucible/CrucibleBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.crucible;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.lib.fluids.FluidTankComponent;
 import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.core.machine.MachineBuilder;
@@ -28,17 +29,11 @@ import net.minecraft.world.level.block.state.BlockState;
  *
  * <p>Composed from machine components — an energy buffer, a single input slot, a fluid tank, and an
  * RF-cost recipe processor whose recipes output a {@code FluidResult} into the tank. The recipe defines
- * the total energy required; the processor spends {@link #ENERGY_PER_TICK} RF/tick toward it.
+ * the total energy required; the processor spends a configurable RF/tick toward it.
  */
 public class CrucibleBlockEntity extends MachineEntity {
 
     static final int INPUT_SLOT = 0;
-
-    static final long ENERGY_CAPACITY = 40_000L;
-    static final long MAX_ENERGY_INPUT = 128L;
-    static final int ENERGY_PER_TICK = 40;
-
-    static final long TANK_CAPACITY_MB = 10_000L;
 
     // Progress + energy sync as 0..MachineData.SCALE fractions (see MachineData); the tank adds two more.
     static final int DATA_FLUID_ID = MachineData.COUNT;
@@ -48,13 +43,14 @@ public class CrucibleBlockEntity extends MachineEntity {
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
     private FluidStoreComponent fluidStore;
+    private long energyCapacity;
 
     private final ContainerData containerData = new ContainerData() {
         @Override
         public int get(int index) {
             return switch (index) {
                 case MachineData.PROGRESS -> MachineData.progressFraction(processor);
-                case MachineData.ENERGY -> MachineData.energyFraction(energy, ENERGY_CAPACITY);
+                case MachineData.ENERGY -> MachineData.energyFraction(energy, energyCapacity);
                 case DATA_FLUID_ID -> fluidStore.tank().isEmpty()
                         ? -1
                         : BuiltInRegistries.FLUID.getId(fluidStore.tank().getFluidKey().getFluid());
@@ -81,9 +77,10 @@ public class CrucibleBlockEntity extends MachineEntity {
 
     @Override
     protected void configure(MachineBuilder machine) {
+        energyCapacity = LogisticsConfigHost.get(LogisticsAutomation.CONFIG.CRUCIBLE_ENERGY_CAPACITY);
         energy = machine.energy("energy")
-                .capacity(ENERGY_CAPACITY)
-                .maxInput(MAX_ENERGY_INPUT)
+                .capacity(energyCapacity)
+                .maxInput(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.CRUCIBLE_MAX_ENERGY_INPUT))
                 .build();
 
         var items = machine.items("inventory")
@@ -92,13 +89,13 @@ public class CrucibleBlockEntity extends MachineEntity {
                 .build();
 
         fluidStore = machine.fluids("tank")
-                .capacity(FluidUnits.mb(TANK_CAPACITY_MB))
+                .capacity(FluidUnits.mb(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.CRUCIBLE_TANK_CAPACITY_MB)))
                 .outputOnly()
                 .build();
 
         processor = machine.recipeProcessor("processor")
                 .resolver(new CrucibleRecipeResolver())
-                .rfPerTick(ENERGY_PER_TICK)
+                .rfPerTick(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.CRUCIBLE_ENERGY_PER_TICK))
                 .items(items)
                 .energy(energy)
                 .fluids(fluidStore)

--- a/common/src/main/java/com/logistics/automation/crucible/CrucibleScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/crucible/CrucibleScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.crucible;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineData;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
@@ -122,7 +123,7 @@ public class CrucibleScreenHandler extends AbstractContainerMenu {
     /** Tank fill as a 0..1 fraction of the tank's capacity. */
     public float getTankFillFraction() {
         int amount = data.get(CrucibleBlockEntity.DATA_FLUID_AMOUNT);
-        long capacity = CrucibleBlockEntity.TANK_CAPACITY_MB;
+        long capacity = LogisticsConfigHost.get(LogisticsAutomation.CONFIG.CRUCIBLE_TANK_CAPACITY_MB);
         if (amount <= 0 || capacity <= 0) {
             return 0f;
         }
@@ -136,6 +137,6 @@ public class CrucibleScreenHandler extends AbstractContainerMenu {
 
     /** Tank capacity in mB. */
     public int getTankCapacityMb() {
-        return (int) CrucibleBlockEntity.TANK_CAPACITY_MB;
+        return (int) (long) LogisticsConfigHost.get(LogisticsAutomation.CONFIG.CRUCIBLE_TANK_CAPACITY_MB);
     }
 }

--- a/common/src/main/java/com/logistics/automation/fabricator/SequentialFabricatorBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/fabricator/SequentialFabricatorBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.fabricator;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
 import com.logistics.core.machine.MachineData;
@@ -32,10 +33,6 @@ public class SequentialFabricatorBlockEntity extends MachineEntity {
 
     public static final int INPUT_SLOTS = 12;
 
-    static final long ENERGY_CAPACITY = 100_000L;
-    static final long MAX_ENERGY_INPUT = 128L;
-    static final long ENERGY_PER_TICK = 80L;
-
     private EnergyStorageComponent energy;
     private ItemStoreComponent items;
     private FabricatorProcessorComponent processor;
@@ -48,8 +45,8 @@ public class SequentialFabricatorBlockEntity extends MachineEntity {
     @Override
     protected void configure(MachineBuilder machine) {
         energy = machine.energy("energy")
-                .capacity(ENERGY_CAPACITY)
-                .maxInput(MAX_ENERGY_INPUT)
+                .capacity(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.FABRICATOR_ENERGY_CAPACITY))
+                .maxInput(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.FABRICATOR_MAX_ENERGY_INPUT))
                 .build();
 
         SlotRole[] roles = new SlotRole[INPUT_SLOTS];
@@ -60,14 +57,17 @@ public class SequentialFabricatorBlockEntity extends MachineEntity {
                 .build();
 
         processor = machine.add(new FabricatorProcessorComponent(
-                "processor", items, energy, ENERGY_PER_TICK, this::setLit, this::setChanged));
+                "processor", items, energy,
+                LogisticsConfigHost.get(LogisticsAutomation.CONFIG.FABRICATOR_ENERGY_PER_TICK),
+                this::setLit, this::setChanged));
 
         containerData = new ContainerData() {
             @Override
             public int get(int index) {
                 return switch (index) {
                     case MachineData.PROGRESS -> Math.round(processor.progress() * MachineData.SCALE);
-                    case MachineData.ENERGY -> MachineData.energyFraction(energy, ENERGY_CAPACITY);
+                    case MachineData.ENERGY -> MachineData.energyFraction(
+                            energy, LogisticsConfigHost.get(LogisticsAutomation.CONFIG.FABRICATOR_ENERGY_CAPACITY));
                     default -> 0;
                 };
             }

--- a/common/src/main/java/com/logistics/automation/fabricator/SequentialFabricatorBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/fabricator/SequentialFabricatorBlockEntity.java
@@ -66,8 +66,7 @@ public class SequentialFabricatorBlockEntity extends MachineEntity {
             public int get(int index) {
                 return switch (index) {
                     case MachineData.PROGRESS -> Math.round(processor.progress() * MachineData.SCALE);
-                    case MachineData.ENERGY -> MachineData.energyFraction(
-                            energy, LogisticsConfigHost.get(LogisticsAutomation.CONFIG.FABRICATOR_ENERGY_CAPACITY));
+                    case MachineData.ENERGY -> MachineData.energyFraction(energy, energy.capacity());
                     default -> 0;
                 };
             }

--- a/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/kiln/KilnBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.kiln;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
 import com.logistics.core.machine.MachineData;
@@ -34,11 +35,6 @@ public class KilnBlockEntity extends MachineEntity {
     static final int INPUT_SLOT = 0;
     static final int OUTPUT_SLOT = 1;
 
-    static final long ENERGY_CAPACITY = 10_000L;
-    static final long MAX_ENERGY_INPUT = 128L;
-
-    static final int ENERGY_PER_TICK = 20;
-
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
     private ContainerData containerData;
@@ -49,9 +45,10 @@ public class KilnBlockEntity extends MachineEntity {
 
     @Override
     protected void configure(MachineBuilder machine) {
+        long capacity = LogisticsConfigHost.get(LogisticsAutomation.CONFIG.KILN_ENERGY_CAPACITY);
         energy = machine.energy("energy")
-                .capacity(ENERGY_CAPACITY)
-                .maxInput(MAX_ENERGY_INPUT)
+                .capacity(capacity)
+                .maxInput(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.KILN_MAX_ENERGY_INPUT))
                 .build();
 
         var items = machine.items("inventory")
@@ -61,13 +58,13 @@ public class KilnBlockEntity extends MachineEntity {
 
         processor = machine.recipeProcessor("processor")
                 .resolver(new SmeltingRecipeResolver())
-                .rfPerTick(ENERGY_PER_TICK)
+                .rfPerTick(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.KILN_ENERGY_PER_TICK))
                 .items(items)
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
 
-        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
+        containerData = MachineData.source(processor, energy, capacity);
     }
 
     private boolean canSmelt(ItemStack stack) {

--- a/common/src/main/java/com/logistics/automation/kiln/SmeltingRecipeResolver.java
+++ b/common/src/main/java/com/logistics/automation/kiln/SmeltingRecipeResolver.java
@@ -1,5 +1,7 @@
 package com.logistics.automation.kiln;
 
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineContext;
 import com.logistics.core.machine.component.ProcessIO;
 import com.logistics.core.machine.component.RecipePlan;
@@ -14,12 +16,10 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Resolves a vanilla smelting recipe for the machine's input. Smelting recipes carry no RF cost,
  * so the energy required is derived from the recipe's cooking time
- * ({@code energyRequired = cookingTime × RF_PER_COOK_TICK}); the machine then spends its RF/tick
- * rate toward that total. A standard 200-tick vanilla recipe costs 2,000 RF.
+ * ({@code energyRequired = cookingTime × rf_per_cook_tick}); the machine then spends its RF/tick
+ * rate toward that total. At the default rate a standard 200-tick vanilla recipe costs 2,000 RF.
  */
 public final class SmeltingRecipeResolver implements RecipeResolver {
-
-    private static final int RF_PER_COOK_TICK = 10;
 
     @Override
     @Nullable
@@ -37,7 +37,7 @@ public final class SmeltingRecipeResolver implements RecipeResolver {
         return recipeManager
                 .getRecipeFor(RecipeType.SMELTING, recipeInput, level)
                 .map(holder -> new RecipePlan(
-                        (long) holder.value().cookingTime() * RF_PER_COOK_TICK,
+                        holder.value().cookingTime() * LogisticsConfigHost.get(LogisticsAutomation.CONFIG.KILN_RF_PER_COOK_TICK),
                         holder.value().assemble(recipeInput),
                         holder.value().experience()))
                 .orElse(null);

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.macerator;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
 import com.logistics.core.machine.MachineData;
@@ -23,19 +24,13 @@ import net.minecraft.world.level.block.state.BlockState;
  *
  * <p>Composed from machine components — an energy buffer, a two-slot furnace-style inventory, and
  * an RF-cost recipe processor. The recipe defines the total energy required; the processor spends
- * {@link #ENERGY_PER_TICK} RF/tick toward it.
+ * a configurable RF/tick toward it.
  */
 public class MaceratorBlockEntity extends MachineEntity {
 
     static final int INPUT_SLOT = 0;
     static final int OUTPUT_SLOT = 1;
     static final int SECONDARY_OUTPUT_SLOT = 2;
-
-    static final long ENERGY_CAPACITY = 10_000L;
-    static final long MAX_ENERGY_INPUT = 128L;
-
-    // Tuned so 1 coal in a Stirling Engine (16,000 RF) macerates 8 items (8 × 2,000 RF each).
-    static final int ENERGY_PER_TICK = 10;
 
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
@@ -47,9 +42,10 @@ public class MaceratorBlockEntity extends MachineEntity {
 
     @Override
     protected void configure(MachineBuilder machine) {
+        long capacity = LogisticsConfigHost.get(LogisticsAutomation.CONFIG.MACERATOR_ENERGY_CAPACITY);
         energy = machine.energy("energy")
-                .capacity(ENERGY_CAPACITY)
-                .maxInput(MAX_ENERGY_INPUT)
+                .capacity(capacity)
+                .maxInput(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.MACERATOR_MAX_ENERGY_INPUT))
                 .build();
 
         var items = machine.items("inventory")
@@ -59,13 +55,13 @@ public class MaceratorBlockEntity extends MachineEntity {
 
         processor = machine.recipeProcessor("processor")
                 .resolver(new MaceratorRecipeResolver())
-                .rfPerTick(ENERGY_PER_TICK)
+                .rfPerTick(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.MACERATOR_ENERGY_PER_TICK))
                 .items(items)
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
 
-        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
+        containerData = MachineData.source(processor, energy, capacity);
     }
 
     private void setLit(MachineContext ctx, boolean lit) {

--- a/common/src/main/java/com/logistics/automation/refinery/RefineryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/refinery/RefineryBlockEntity.java
@@ -44,12 +44,16 @@ public class RefineryBlockEntity extends MachineEntity {
 
     static final int OUTPUT_SLOT = 0;
 
-    // Progress + energy sync as 0..MachineData.SCALE fractions (see MachineData); the two tanks add four.
+    // Progress + energy sync as 0..MachineData.SCALE fractions (see MachineData); the two tanks add six
+    // (id, amount, and capacity each). Capacities are synced from the server so the GUI gauges don't read
+    // the client's own config, which can diverge from the server's in multiplayer.
     static final int DATA_IN_FLUID_ID = MachineData.COUNT;
     static final int DATA_IN_FLUID_AMOUNT = MachineData.COUNT + 1;
     static final int DATA_OUT_FLUID_ID = MachineData.COUNT + 2;
     static final int DATA_OUT_FLUID_AMOUNT = MachineData.COUNT + 3;
-    static final int DATA_COUNT = MachineData.COUNT + 4;
+    static final int DATA_IN_CAPACITY = MachineData.COUNT + 4;
+    static final int DATA_OUT_CAPACITY = MachineData.COUNT + 5;
+    static final int DATA_COUNT = MachineData.COUNT + 6;
 
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
@@ -62,12 +66,13 @@ public class RefineryBlockEntity extends MachineEntity {
         public int get(int index) {
             return switch (index) {
                 case MachineData.PROGRESS -> MachineData.progressFraction(processor);
-                case MachineData.ENERGY -> MachineData.energyFraction(
-                        energy, LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_ENERGY_CAPACITY));
+                case MachineData.ENERGY -> MachineData.energyFraction(energy, energy.capacity());
                 case DATA_IN_FLUID_ID -> fluidId(inputTank);
                 case DATA_IN_FLUID_AMOUNT -> amountMb(inputTank);
                 case DATA_OUT_FLUID_ID -> fluidId(outputTank);
                 case DATA_OUT_FLUID_AMOUNT -> amountMb(outputTank);
+                case DATA_IN_CAPACITY -> capacityMb(inputTank);
+                case DATA_OUT_CAPACITY -> capacityMb(outputTank);
                 default -> 0;
             };
         }
@@ -95,6 +100,10 @@ public class RefineryBlockEntity extends MachineEntity {
 
     private static int amountMb(FluidStoreComponent store) {
         return (int) Math.min(FluidUnits.toMillibuckets(store.tank().getAmount()), Integer.MAX_VALUE);
+    }
+
+    private static int capacityMb(FluidStoreComponent store) {
+        return (int) Math.min(FluidUnits.toMillibuckets(store.tank().getCapacity()), Integer.MAX_VALUE);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/automation/refinery/RefineryBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/refinery/RefineryBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.refinery;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.lib.fluids.FluidTankComponent;
 import com.logistics.core.lib.fluids.FluidUnits;
 import com.logistics.core.lib.fluids.IFluidKey;
@@ -43,13 +44,6 @@ public class RefineryBlockEntity extends MachineEntity {
 
     static final int OUTPUT_SLOT = 0;
 
-    static final long ENERGY_CAPACITY = 20_000L;
-    static final long MAX_ENERGY_INPUT = 128L;
-    static final int ENERGY_PER_TICK = 20;
-
-    static final long INPUT_TANK_CAPACITY_MB = 4_000L;
-    static final long OUTPUT_TANK_CAPACITY_MB = 10_000L;
-
     // Progress + energy sync as 0..MachineData.SCALE fractions (see MachineData); the two tanks add four.
     static final int DATA_IN_FLUID_ID = MachineData.COUNT;
     static final int DATA_IN_FLUID_AMOUNT = MachineData.COUNT + 1;
@@ -68,7 +62,8 @@ public class RefineryBlockEntity extends MachineEntity {
         public int get(int index) {
             return switch (index) {
                 case MachineData.PROGRESS -> MachineData.progressFraction(processor);
-                case MachineData.ENERGY -> MachineData.energyFraction(energy, ENERGY_CAPACITY);
+                case MachineData.ENERGY -> MachineData.energyFraction(
+                        energy, LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_ENERGY_CAPACITY));
                 case DATA_IN_FLUID_ID -> fluidId(inputTank);
                 case DATA_IN_FLUID_AMOUNT -> amountMb(inputTank);
                 case DATA_OUT_FLUID_ID -> fluidId(outputTank);
@@ -105,8 +100,8 @@ public class RefineryBlockEntity extends MachineEntity {
     @Override
     protected void configure(MachineBuilder machine) {
         energy = machine.energy("energy")
-                .capacity(ENERGY_CAPACITY)
-                .maxInput(MAX_ENERGY_INPUT)
+                .capacity(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_ENERGY_CAPACITY))
+                .maxInput(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_MAX_ENERGY_INPUT))
                 .build();
 
         var items = machine.items("inventory")
@@ -115,17 +110,17 @@ public class RefineryBlockEntity extends MachineEntity {
                 .build();
 
         inputTank = machine.fluids("input")
-                .capacity(FluidUnits.mb(INPUT_TANK_CAPACITY_MB))
+                .capacity(FluidUnits.mb(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_INPUT_TANK_MB)))
                 .build();
 
         outputTank = machine.fluids("output")
-                .capacity(FluidUnits.mb(OUTPUT_TANK_CAPACITY_MB))
+                .capacity(FluidUnits.mb(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_OUTPUT_TANK_MB)))
                 .outputOnly()
                 .build();
 
         processor = machine.recipeProcessor("processor")
                 .resolver(new RefineryRecipeResolver(inputTank))
-                .rfPerTick(ENERGY_PER_TICK)
+                .rfPerTick(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_ENERGY_PER_TICK))
                 .items(items)
                 .energy(energy)
                 .inputFluids(inputTank)

--- a/common/src/main/java/com/logistics/automation/refinery/RefineryScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/refinery/RefineryScreenHandler.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.refinery;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineData;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
@@ -128,11 +129,11 @@ public class RefineryScreenHandler extends AbstractContainerMenu {
     }
 
     public int getInputCapacityMb() {
-        return (int) RefineryBlockEntity.INPUT_TANK_CAPACITY_MB;
+        return LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_INPUT_TANK_MB).intValue();
     }
 
     public float getInputFillFraction() {
-        return fill(getInputAmountMb(), RefineryBlockEntity.INPUT_TANK_CAPACITY_MB);
+        return fill(getInputAmountMb(), LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_INPUT_TANK_MB));
     }
 
     public int getOutputFluidId() {
@@ -144,11 +145,11 @@ public class RefineryScreenHandler extends AbstractContainerMenu {
     }
 
     public int getOutputCapacityMb() {
-        return (int) RefineryBlockEntity.OUTPUT_TANK_CAPACITY_MB;
+        return LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_OUTPUT_TANK_MB).intValue();
     }
 
     public float getOutputFillFraction() {
-        return fill(getOutputAmountMb(), RefineryBlockEntity.OUTPUT_TANK_CAPACITY_MB);
+        return fill(getOutputAmountMb(), LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_OUTPUT_TANK_MB));
     }
 
     private static float fill(int amountMb, long capacityMb) {

--- a/common/src/main/java/com/logistics/automation/refinery/RefineryScreenHandler.java
+++ b/common/src/main/java/com/logistics/automation/refinery/RefineryScreenHandler.java
@@ -1,7 +1,6 @@
 package com.logistics.automation.refinery;
 
 import com.logistics.LogisticsAutomation;
-import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineData;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
@@ -129,11 +128,11 @@ public class RefineryScreenHandler extends AbstractContainerMenu {
     }
 
     public int getInputCapacityMb() {
-        return LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_INPUT_TANK_MB).intValue();
+        return data.get(RefineryBlockEntity.DATA_IN_CAPACITY);
     }
 
     public float getInputFillFraction() {
-        return fill(getInputAmountMb(), LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_INPUT_TANK_MB));
+        return fill(getInputAmountMb(), getInputCapacityMb());
     }
 
     public int getOutputFluidId() {
@@ -145,14 +144,14 @@ public class RefineryScreenHandler extends AbstractContainerMenu {
     }
 
     public int getOutputCapacityMb() {
-        return LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_OUTPUT_TANK_MB).intValue();
+        return data.get(RefineryBlockEntity.DATA_OUT_CAPACITY);
     }
 
     public float getOutputFillFraction() {
-        return fill(getOutputAmountMb(), LogisticsConfigHost.get(LogisticsAutomation.CONFIG.REFINERY_OUTPUT_TANK_MB));
+        return fill(getOutputAmountMb(), getOutputCapacityMb());
     }
 
-    private static float fill(int amountMb, long capacityMb) {
+    private static float fill(int amountMb, int capacityMb) {
         if (amountMb <= 0 || capacityMb <= 0) {
             return 0f;
         }

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.sawmill;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.core.machine.MachineBuilder;
 import com.logistics.core.machine.MachineContext;
 import com.logistics.core.machine.MachineData;
@@ -27,7 +28,7 @@ import net.minecraft.world.level.block.state.BlockState;
  *
  * <p>Composed from machine components — an energy buffer, a three-slot inventory (input + two
  * outputs), and an RF-cost recipe processor. The recipe defines the total energy and the byproduct;
- * the processor spends {@link #ENERGY_PER_TICK} RF/tick and rolls the byproduct on completion.
+ * the processor spends a configurable RF/tick and rolls the byproduct on completion.
  * Top/sides feed the input; the bottom pulls both outputs.
  */
 public class SawmillBlockEntity extends MachineEntity {
@@ -36,10 +37,6 @@ public class SawmillBlockEntity extends MachineEntity {
     public static final int PRIMARY_OUTPUT_SLOT = 1;
     public static final int SECONDARY_OUTPUT_SLOT = 2;
     public static final int TOTAL_SLOTS = 3;
-
-    public static final long ENERGY_CAPACITY = 10_000L;
-    static final long MAX_ENERGY_INPUT = 128L;
-    static final int ENERGY_PER_TICK = 20;
 
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
@@ -51,9 +48,10 @@ public class SawmillBlockEntity extends MachineEntity {
 
     @Override
     protected void configure(MachineBuilder machine) {
+        long capacity = LogisticsConfigHost.get(LogisticsAutomation.CONFIG.SAWMILL_ENERGY_CAPACITY);
         energy = machine.energy("energy")
-                .capacity(ENERGY_CAPACITY)
-                .maxInput(MAX_ENERGY_INPUT)
+                .capacity(capacity)
+                .maxInput(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.SAWMILL_MAX_ENERGY_INPUT))
                 .build();
 
         var items = machine.items("inventory")
@@ -63,13 +61,13 @@ public class SawmillBlockEntity extends MachineEntity {
 
         processor = machine.recipeProcessor("processor")
                 .resolver(new SawmillRecipeResolver())
-                .rfPerTick(ENERGY_PER_TICK)
+                .rfPerTick(LogisticsConfigHost.get(LogisticsAutomation.CONFIG.SAWMILL_ENERGY_PER_TICK))
                 .items(items)
                 .energy(energy)
                 .lit(this::setLit)
                 .build();
 
-        containerData = MachineData.source(processor, energy, ENERGY_CAPACITY);
+        containerData = MachineData.source(processor, energy, capacity);
     }
 
     private boolean isSawable(ItemStack stack) {

--- a/common/src/main/java/com/logistics/core/lib/power/AbstractBatteryBlockEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/AbstractBatteryBlockEntity.java
@@ -36,8 +36,10 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractBatteryBlockEntity extends BaseBlockEntity
         implements HasEnergyStorage, AcceptsLowTierEnergy {
 
-    /** Max RF to push into a single adjacent machine per tick. */
-    private static final long MAX_OUTPUT_PER_SIDE = 200L;
+    /** Max RF to push into a single adjacent machine per tick; subclasses may source it from config. */
+    protected long maxOutputPerSide() {
+        return 200L;
+    }
 
     /**
      * Discrete charge level (0–10) exposed as a block state property so the battery's fill bar is
@@ -82,7 +84,7 @@ public abstract class AbstractBatteryBlockEntity extends BaseBlockEntity
         for (Direction dir : Direction.values()) {
             BlockPos neighborPos = pos.relative(dir);
             if (level.getBlockEntity(neighborPos) instanceof DirectEnergyReceiver) continue;
-            long maxSend = Math.min(MAX_OUTPUT_PER_SIDE, energy.getAmount());
+            long maxSend = Math.min(maxOutputPerSide(), energy.getAmount());
             if (maxSend <= 0) break;
             long sent = pushService.push(level, neighborPos, dir.getOpposite(), energy, maxSend);
             if (sent > 0) {

--- a/common/src/main/java/com/logistics/core/machine/component/EnergyStorageComponent.java
+++ b/common/src/main/java/com/logistics/core/machine/component/EnergyStorageComponent.java
@@ -109,6 +109,11 @@ public final class EnergyStorageComponent implements MachineComponent, MachineCo
         return storage.getAmount();
     }
 
+    /** Total RF capacity, fixed at construction (use this for GUI fill fractions instead of rereading config). */
+    public long capacity() {
+        return capacity;
+    }
+
     /** Deducts energy for internal work (no change notification, matching the holder's semantics). */
     public void consume(long rf) {
         storage.consume(rf);

--- a/common/src/main/java/com/logistics/power/block/BatteryBlockItem.java
+++ b/common/src/main/java/com/logistics/power/block/BatteryBlockItem.java
@@ -31,7 +31,7 @@ public class BatteryBlockItem extends BlockItem {
             return 0;
         }
         // Clamp so any positive charge shows at least 1px and a full battery never overflows 13px.
-        int width = Math.round(13.0f * stored / BatteryBlockEntity.CAPACITY);
+        int width = Math.round(13.0f * stored / BatteryBlockEntity.capacity());
         return Math.max(1, Math.min(13, width));
     }
 

--- a/common/src/main/java/com/logistics/power/block/entity/BatteryBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/block/entity/BatteryBlockEntity.java
@@ -1,5 +1,6 @@
 package com.logistics.power.block.entity;
 
+import com.logistics.LogisticsConfigHost;
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.power.AbstractBatteryBlockEntity;
 import net.minecraft.core.BlockPos;
@@ -9,17 +10,29 @@ import net.minecraft.world.level.block.state.BlockState;
  * Energy buffer that accepts power from generators and distributes it to adjacent
  * machines and connected logistics pipe networks.
  *
- * <p>Capacity: 100,000 RF. Max insert/extract: 1,000 RF/t per side.
+ * <p>Capacity, per-side I/O, and active push rate are configurable (see the {@code power/battery}
+ * config); defaults are 100,000 RF storage and 1,000 RF/t per side.
  *
  * <p>When placed adjacent to a logistics pipe network, this battery registers itself
  * as an energy source for that network. Logistics pipe modules (requester, provider, etc.)
  * draw energy directly from the battery, so no per-pipe energy buffer is needed.
  */
 public class BatteryBlockEntity extends AbstractBatteryBlockEntity {
-    public static final long CAPACITY = 100_000L;
-    public static final long MAX_IO = 1_000L;
 
     public BatteryBlockEntity(BlockPos pos, BlockState state) {
-        super(LogisticsPower.ENTITY.BATTERY_BLOCK_ENTITY, pos, state, CAPACITY, MAX_IO, MAX_IO);
+        super(LogisticsPower.ENTITY.BATTERY_BLOCK_ENTITY, pos, state,
+                capacity(),
+                LogisticsConfigHost.get(LogisticsPower.CONFIG.BATTERY_MAX_IO),
+                LogisticsConfigHost.get(LogisticsPower.CONFIG.BATTERY_MAX_IO));
+    }
+
+    /** Configured total RF storage — used for item fill-bar rendering and tests. */
+    public static long capacity() {
+        return LogisticsConfigHost.get(LogisticsPower.CONFIG.BATTERY_CAPACITY);
+    }
+
+    @Override
+    protected long maxOutputPerSide() {
+        return LogisticsConfigHost.get(LogisticsPower.CONFIG.BATTERY_OUTPUT_PER_SIDE);
     }
 }

--- a/common/src/main/java/com/logistics/power/block/entity/BatteryBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/block/entity/BatteryBlockEntity.java
@@ -11,7 +11,9 @@ import net.minecraft.world.level.block.state.BlockState;
  * machines and connected logistics pipe networks.
  *
  * <p>Capacity, per-side I/O, and active push rate are configurable (see the {@code power/battery}
- * config); defaults are 100,000 RF storage and 1,000 RF/t per side.
+ * config). Defaults: 100,000 RF storage capacity; 1,000 RF/t insert/extract per side (the
+ * {@code max_io}-controlled limits passed to the constructor); and a 200 RF/t active push rate into
+ * each adjacent machine (from {@link AbstractBatteryBlockEntity#maxOutputPerSide()}).
  *
  * <p>When placed adjacent to a logistics pipe network, this battery registers itself
  * as an energy source for that network. Logistics pipe modules (requester, provider, etc.)

--- a/common/src/main/java/com/logistics/power/cable/CableTier.java
+++ b/common/src/main/java/com/logistics/power/cable/CableTier.java
@@ -1,20 +1,21 @@
 package com.logistics.power.cable;
 
+import com.logistics.LogisticsConfigHost;
+import com.logistics.LogisticsPower;
+
 public enum CableTier {
-    COPPER("copper_cable", "Copper Cable", 30),
-    GOLD("gold_cable", "Gold Cable", 60),
-    ENDER("ender_cable", "Ender Cable", 120);
+    COPPER("copper_cable", "Copper Cable"),
+    GOLD("gold_cable", "Gold Cable"),
+    ENDER("ender_cable", "Ender Cable");
 
     private static final String BASE_MODEL_PREFIX = "cable_";
 
     private final String id;
     private final String displayName;
-    private final long transferRate;
 
-    CableTier(String id, String displayName, long transferRate) {
+    CableTier(String id, String displayName) {
         this.id = id;
         this.displayName = displayName;
-        this.transferRate = transferRate;
     }
 
     public String id() {
@@ -25,8 +26,13 @@ public enum CableTier {
         return displayName;
     }
 
+    /** RF/tick throughput limit, sourced from the {@code power/cables} config. */
     public long transferRate() {
-        return transferRate;
+        return switch (this) {
+            case COPPER -> LogisticsConfigHost.get(LogisticsPower.CONFIG.CABLE_COPPER_TRANSFER);
+            case GOLD -> LogisticsConfigHost.get(LogisticsPower.CONFIG.CABLE_GOLD_TRANSFER);
+            case ENDER -> LogisticsConfigHost.get(LogisticsPower.CONFIG.CABLE_ENDER_TRANSFER);
+        };
     }
 
     public String modelName(String baseModelName) {

--- a/common/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/CreativeEngineBlockEntity.java
@@ -3,6 +3,7 @@ package com.logistics.power.engine.block.entity;
 import com.logistics.core.lib.power.AbstractEngineBlockEntity;
 import com.logistics.core.lib.compat.NbtCompat;
 import com.logistics.power.engine.block.CreativeEngineBlock;
+import com.logistics.LogisticsConfigHost;
 import com.logistics.LogisticsPower;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -22,8 +23,6 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
     /** Output levels that double with each wrench click. */
     public static final long[] OUTPUT_LEVELS = CreativeOutputLevels.DEFAULT_LEVELS.clone();
 
-    private static final long MAX_ENERGY = 10_000L;
-
     // ==================== State ====================
 
     private final CreativeOutputLevels outputLevels = new CreativeOutputLevels();
@@ -42,7 +41,7 @@ public class CreativeEngineBlockEntity extends AbstractEngineBlockEntity {
 
     @Override
     protected long getEnergyBufferCapacity() {
-        return MAX_ENERGY;
+        return LogisticsConfigHost.get(LogisticsPower.CONFIG.CREATIVE_BUFFER_CAPACITY);
     }
 
     @Override

--- a/common/src/main/java/com/logistics/power/engine/block/entity/RedstoneEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/RedstoneEngineBlockEntity.java
@@ -16,10 +16,6 @@ import net.minecraft.world.level.block.state.BlockState;
  * The simplest engine type that converts redstone signals to energy.
  */
 public class RedstoneEngineBlockEntity extends AbstractEngineBlockEntity implements LowTierEnergySource {
-    private static final long MAX_ENERGY = 1000L;
-
-    // Energy generation: configurable RF every 16 ticks when powered
-    private static final int ENERGY_TICK_INTERVAL = 16;
 
     public RedstoneEngineBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsPower.ENTITY.REDSTONE_ENGINE_BLOCK_ENTITY, pos, state);
@@ -31,7 +27,7 @@ public class RedstoneEngineBlockEntity extends AbstractEngineBlockEntity impleme
 
     @Override
     protected long getEnergyBufferCapacity() {
-        return MAX_ENERGY;
+        return LogisticsConfigHost.get(LogisticsPower.CONFIG.REDSTONE_BUFFER_CAPACITY);
     }
 
     @Override
@@ -78,7 +74,7 @@ public class RedstoneEngineBlockEntity extends AbstractEngineBlockEntity impleme
             return;
         }
 
-        if (level.getGameTime() % ENERGY_TICK_INTERVAL == 0) {
+        if (level.getGameTime() % LogisticsConfigHost.get(LogisticsPower.CONFIG.REDSTONE_GENERATION_INTERVAL) == 0) {
             addEnergy(LogisticsConfigHost.get(LogisticsPower.CONFIG.REDSTONE_OUTPUT));
         }
     }

--- a/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
+++ b/common/src/main/java/com/logistics/power/engine/block/entity/StirlingEngineBlockEntity.java
@@ -57,8 +57,6 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
     // ==================== Constants ====================
 
-    private static final long MAX_ENERGY = 10_000L;
-
     // PID controller settings (tuned via run/pid_simulator.py)
     private static final double PID_KP = 0.2;
     private static final double PID_KI = 0.0002;
@@ -202,7 +200,7 @@ public class StirlingEngineBlockEntity extends AbstractEngineBlockEntity
 
     @Override
     protected long getEnergyBufferCapacity() {
-        return MAX_ENERGY;
+        return LogisticsConfigHost.get(LogisticsPower.CONFIG.STIRLING_BUFFER_CAPACITY);
     }
 
     @Override

--- a/common/src/test/java/com/logistics/LogisticsConfigHostTest.java
+++ b/common/src/test/java/com/logistics/LogisticsConfigHostTest.java
@@ -18,40 +18,45 @@ import org.junit.jupiter.api.io.TempDir;
 @DisplayName("LogisticsConfigHost (configory)")
 class LogisticsConfigHostTest {
 
-    /** The shared engines child config the {@code Configs} constants are registered on. */
-    private static Config engines() {
+    /** The per-engine child configs the power {@code CONFIG} keys are registered on. */
+    private static Config redstone() {
         return ConfigRegistry.config(LogisticsPower.CONFIG.REDSTONE_OUTPUT.configId());
+    }
+
+    private static Config stirling() {
+        return ConfigRegistry.config(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT.configId());
     }
 
     @Test
     @DisplayName("engine keys expose defaults and reject invalid single- and cross-field values")
     void engineKeysDefaultsAndValidation() {
-        Config engines = engines();
+        Config redstone = redstone();
+        Config stirling = stirling();
 
         assertThat(LogisticsConfigHost.get(LogisticsPower.CONFIG.REDSTONE_OUTPUT)).isEqualTo(10L);
         assertThat(LogisticsConfigHost.get(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT)).isEqualTo(3.0);
         assertThat(LogisticsConfigHost.get(LogisticsPower.CONFIG.STIRLING_MAX_OUTPUT)).isEqualTo(10.0);
 
         // Single-field: redstone output must be >= 0 (a rejected trySet leaves the value unchanged).
-        assertThat(engines.trySet(LogisticsPower.CONFIG.REDSTONE_OUTPUT, -1L)).isFalse();
+        assertThat(redstone.trySet(LogisticsPower.CONFIG.REDSTONE_OUTPUT, -1L)).isFalse();
         assertThat(LogisticsConfigHost.get(LogisticsPower.CONFIG.REDSTONE_OUTPUT)).isEqualTo(10L);
 
         // Cross-field (recursion fixed in configory): min must not exceed max (default max 10).
-        assertThat(engines.trySet(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT, 12.0)).isFalse();
+        assertThat(stirling.trySet(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT, 12.0)).isFalse();
         assertThat(LogisticsConfigHost.get(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT)).isEqualTo(3.0);
     }
 
     @Test
     @DisplayName("repairMinMax heals an inverted range even with cross-field validators")
     void repairMinMaxHealsInvertedRange() {
-        Config engines = engines();
+        Config stirling = stirling();
 
         // Raw path set forces an inverted state (bypasses validation).
-        engines.set("stirling_min_output", 12.0);
-        engines.set("stirling_max_output", 10.0);
+        stirling.set("min_output", 12.0);
+        stirling.set("max_output", 10.0);
 
         // repairMinMax bypasses the validating get(), so it can heal a state the validators reject.
-        engines.repairMinMax(
+        stirling.repairMinMax(
                 LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT, LogisticsPower.CONFIG.STIRLING_MAX_OUTPUT);
 
         double min = LogisticsConfigHost.get(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT);
@@ -59,8 +64,8 @@ class LogisticsConfigHostTest {
         assertThat(min).isLessThanOrEqualTo(max);
 
         // Restore defaults so the shared registry config doesn't leak into other tests.
-        engines.set(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT, 3.0);
-        engines.set(LogisticsPower.CONFIG.STIRLING_MAX_OUTPUT, 10.0);
+        stirling.set(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT, 3.0);
+        stirling.set(LogisticsPower.CONFIG.STIRLING_MAX_OUTPUT, 10.0);
     }
 
     @Test
@@ -87,8 +92,12 @@ class LogisticsConfigHostTest {
         assertThat(ignored).isNotEmpty();
 
         List<String> ids = LogisticsConfigHost.domainConfigs().stream().map(Config::id).toList();
+        // Each domain declares one child config per unit (engines/machines/power) plus the flat pipe/fluid/reporting files.
         assertThat(ids).contains(
-                "logistics.engines", "logistics.machines", "logistics.pipes", "logistics.fluids", "logistics.reporting");
+                "logistics.engines.redstone", "logistics.engines.stirling",
+                "logistics.machines.macerator", "logistics.machines.quarry",
+                "logistics.power.battery", "logistics.power.cables",
+                "logistics.pipes", "logistics.fluids", "logistics.reporting");
     }
 
     @Test

--- a/common/src/test/java/com/logistics/LogisticsConfigHostTest.java
+++ b/common/src/test/java/com/logistics/LogisticsConfigHostTest.java
@@ -41,7 +41,7 @@ class LogisticsConfigHostTest {
         assertThat(redstone.trySet(LogisticsPower.CONFIG.REDSTONE_OUTPUT, -1L)).isFalse();
         assertThat(LogisticsConfigHost.get(LogisticsPower.CONFIG.REDSTONE_OUTPUT)).isEqualTo(10L);
 
-        // Cross-field (recursion fixed in configory): min must not exceed max (default max 10).
+        // Cross-field: min must not exceed max (default max 10).
         assertThat(stirling.trySet(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT, 12.0)).isFalse();
         assertThat(LogisticsConfigHost.get(LogisticsPower.CONFIG.STIRLING_MIN_OUTPUT)).isEqualTo(3.0);
     }
@@ -92,12 +92,25 @@ class LogisticsConfigHostTest {
         assertThat(ignored).isNotEmpty();
 
         List<String> ids = LogisticsConfigHost.domainConfigs().stream().map(Config::id).toList();
-        // Each domain declares one child config per unit (engines/machines/power) plus the flat pipe/fluid/reporting files.
-        assertThat(ids).contains(
-                "logistics.engines.redstone", "logistics.engines.stirling",
-                "logistics.machines.macerator", "logistics.machines.quarry",
-                "logistics.power.battery", "logistics.power.cables",
-                "logistics.pipes", "logistics.fluids", "logistics.reporting");
+        // The complete set of registered child configs: one per engine/machine/power unit plus the flat
+        // pipe/fluid/reporting files. Asserted exhaustively so a missing registration can't slip through.
+        assertThat(ids).containsExactlyInAnyOrder(
+                "logistics.engines.redstone",
+                "logistics.engines.stirling",
+                "logistics.engines.creative",
+                "logistics.power.battery",
+                "logistics.power.cables",
+                "logistics.machines.macerator",
+                "logistics.machines.kiln",
+                "logistics.machines.sawmill",
+                "logistics.machines.crucible",
+                "logistics.machines.alloy_smelter",
+                "logistics.machines.quarry",
+                "logistics.machines.refinery",
+                "logistics.machines.fabricator",
+                "logistics.pipes",
+                "logistics.fluids",
+                "logistics.reporting");
     }
 
     @Test

--- a/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
+++ b/common/src/test/java/com/logistics/core/LogisticsCommandTreeTest.java
@@ -34,10 +34,11 @@ class LogisticsCommandTreeTest extends MinecraftTestEnvironment {
         assertThat(root.getName()).isEqualTo("logistics");
         assertThat(root.getChild("debug")).isNotNull();
 
-        // Configory groups each domain under `config <domain>` with short keys, plus a sibling `reload-configs`.
+        // Configory groups each config file under `config <group>` (its id's last segment) with short keys,
+        // plus a sibling `reload-configs`. Machines/engines are per-unit files, so their group is the unit name.
         CommandNode<CommandSourceStack> config = root.getChild("config");
         assertThat(config).isNotNull();
-        assertThat(config.getChild("machines").getChild("quarry_area")).isNotNull();
+        assertThat(config.getChild("quarry").getChild("area")).isNotNull();
         assertThat(config.getChild("pipes").getChild("max_speed")).isNotNull();
         assertThat(config.getChild("reporting").getChild("enabled")).isNotNull();
         assertThat(root.getChild("reload-configs")).isNotNull();

--- a/common/src/test/java/com/logistics/power/block/BatteryBlockItemTest.java
+++ b/common/src/test/java/com/logistics/power/block/BatteryBlockItemTest.java
@@ -48,12 +48,12 @@ class BatteryBlockItemTest extends MinecraftTestEnvironment {
 
     @Test
     void bar_visibleAndScalesWithCharge() {
-        ItemStack full = stackWithEnergy(BatteryBlockEntity.CAPACITY);
+        ItemStack full = stackWithEnergy(BatteryBlockEntity.capacity());
         assertTrue(item.isBarVisible(full));
         assertEquals(13, item.getBarWidth(full), "full battery fills the whole bar");
         assertEquals(0x00AA00, item.getBarColor(full));
 
-        ItemStack half = stackWithEnergy(BatteryBlockEntity.CAPACITY / 2);
+        ItemStack half = stackWithEnergy(BatteryBlockEntity.capacity() / 2);
         int halfWidth = item.getBarWidth(half);
         assertTrue(halfWidth > 0 && halfWidth < 13, "half charge is a partial bar, got " + halfWidth);
     }

--- a/fabric/src/gametest/java/com/logistics/gametest/power/BatteryGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/BatteryGameTest.java
@@ -45,7 +45,7 @@ public class BatteryGameTest {
             context.fail("Battery should have a block entity");
             return;
         }
-        setStored(battery, BatteryBlockEntity.CAPACITY);
+        setStored(battery, BatteryBlockEntity.capacity());
 
         context.runAfterDelay(5, () -> {
             int charge = context.getBlockState(pos).getValue(AbstractBatteryBlockEntity.CHARGE);
@@ -89,7 +89,7 @@ public class BatteryGameTest {
             context.fail("Battery should have a block entity");
             return;
         }
-        setStored(battery, BatteryBlockEntity.CAPACITY);
+        setStored(battery, BatteryBlockEntity.capacity());
 
         context.runAfterDelay(25, () -> {
             PipeNetwork net = NetworkRegistry.getNetwork(context.getLevel(), context.absolutePos(pipePos));


### PR DESCRIPTION
Stacked on #712 (configory migration). Like #712, this stays draft until configory `0.2.0` clears Modrinth review; the two are intended to ship in the same release, so players only ever see the per-unit config layout.

## Summary

Machine and engine tuning values that were hardcoded constants are now configuration, organized as one file per machine/engine. Defaults exactly match the previous hardcoded values — this is a pure "make it configurable" surface with **no balance change**.

## Changes

- **Per-machine files** (`config/logistics/machines/<machine>.json`): every recipe machine shares the same template — `energy_capacity`, `max_energy_input`, `energy_per_tick` — plus machine-specific extras (crucible `tank_capacity_mb`, kiln `rf_per_cook_tick`). The Laser Quarry's existing keys moved here and dropped their redundant `quarry_` prefix.
- **Per-engine files** (`config/logistics/engines/<engine>.json`): `buffer_capacity` for every engine; redstone `output` + `generation_interval`; stirling `min_output`/`max_output`.
- **Power files** (`config/logistics/power/{battery,cables}.json`): battery `capacity`/`max_io`/`output_per_side`; cable throughput per tier.
- **Flat command groups**, one per unit: `/logistics config macerator energy_per_tick`, `/logistics config redstone buffer_capacity`, `/logistics config battery capacity`, …
- A legacy `logistics.json` migrates straight into the relocated keys.

## Notes

- Defaults are unchanged, so existing worlds behave identically.
- `core` stays decoupled from the domains — the battery's push rate became an overridable `maxOutputPerSide()` rather than a core→domain config import.
- Verified: all source sets compile, `checkImportBoundaries` passes, `:common:test` green, Fabric gametest 125/125, per-unit files written on fresh boot, and legacy migration lands in the new keys.

feat(energy): make engine, battery, and cable tuning configurable
