### PR TITLE
refactor(routing): drop corner dyes from chipset module recipes

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/pipe/active_supplier_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/active_supplier_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/crafter_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/crafter_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/enchantment_sink_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/enchantment_sink_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/extractor_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/extractor_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/item_sink_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/item_sink_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/mod_item_sink_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/mod_item_sink_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/passive_supplier_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/passive_supplier_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/polymorphic_sink_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/polymorphic_sink_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/provider_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/provider_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/quicksort_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/quicksort_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABA",
+    " B ",
     "CDC",
     "ACA"
   ],

--- a/common/src/main/resources/data/logistics/recipe/pipe/terminus_module_from_chipset.json
+++ b/common/src/main/resources/data/logistics/recipe/pipe/terminus_module_from_chipset.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "ABC",
+    " B ",
     "DED",
     "CDA"
   ],


### PR DESCRIPTION
## Summary

Removes the decorative dyes from the top two corners of the chipset-alternative module recipes. Part of the same recipe rework already flagged in a previous commit for this release — internal cleanup, no standalone changelog entry.

## Changes

- 10 standard module recipes (`ABA/CDC/ACA` → `" B "/CDC/ACA`): top-corner dyes removed, chipset stays top-center. Bottom-corner dyes retained.
- `terminus` module (`ABC/DED/CDA` → `" B "/DED/CDA`): top black/purple dye corners removed; both dyes still present on the bottom row.

## Notes

- Source-only change under `common/src/main/...`; every dye key remains referenced by a surviving bottom corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)