### PR TITLE
refactor(automation): push synced machine recipes into JEI after registration

### DIFF
--- a/common/src/client/java/com/logistics/automation/jei/ClientMachineRecipes.java
+++ b/common/src/client/java/com/logistics/automation/jei/ClientMachineRecipes.java
@@ -28,6 +28,7 @@ public final class ClientMachineRecipes {
         crucible = List.copyOf(packet.crucible());
         alloySmelter = List.copyOf(packet.alloySmelter());
         refinery = List.copyOf(packet.refinery());
+        MachineRecipeJeiSync.pushToJei();
     }
 
     /** Drops cached recipes on disconnect so a later server's sync starts clean. */

--- a/common/src/client/java/com/logistics/automation/jei/MachineRecipeJeiSync.java
+++ b/common/src/client/java/com/logistics/automation/jei/MachineRecipeJeiSync.java
@@ -1,0 +1,44 @@
+package com.logistics.automation.jei;
+
+import com.logistics.automation.alloysmelter.jei.AlloySmelterRecipeCategory;
+import com.logistics.automation.crucible.jei.CrucibleRecipeCategory;
+import com.logistics.automation.macerator.jei.MaceratorRecipeCategory;
+import com.logistics.automation.refinery.jei.RefineryRecipeCategory;
+import com.logistics.automation.sawmill.jei.SawmillRecipeCategory;
+import mezz.jei.api.recipe.IRecipeManager;
+import mezz.jei.api.runtime.IJeiRuntime;
+
+/**
+ * Bridges late-arriving synced recipes into an already-loaded JEI. On some loaders (notably NeoForge)
+ * the server's recipe packet lands after JEI has run {@code registerRecipes} against an empty cache,
+ * so once the runtime is live we push the freshly-synced recipes straight in. Pushing only on packet
+ * arrival (never on runtime-available) keeps it dup-free: in any JEI load cycle exactly one of
+ * {@code registerRecipes} or this push supplies the recipes.
+ */
+public final class MachineRecipeJeiSync {
+
+    private static volatile IJeiRuntime runtime;
+
+    private MachineRecipeJeiSync() {}
+
+    public static void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
+        runtime = jeiRuntime;
+    }
+
+    public static void onRuntimeUnavailable() {
+        runtime = null;
+    }
+
+    public static void pushToJei() {
+        IJeiRuntime current = runtime;
+        if (current == null) {
+            return;
+        }
+        IRecipeManager recipes = current.getRecipeManager();
+        recipes.addRecipes(MaceratorRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.macerator());
+        recipes.addRecipes(SawmillRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.sawmill());
+        recipes.addRecipes(CrucibleRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.crucible());
+        recipes.addRecipes(AlloySmelterRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.alloySmelter());
+        recipes.addRecipes(RefineryRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.refinery());
+    }
+}

--- a/common/src/client/java/com/logistics/automation/macerator/jei/MaceratorJeiPlugin.java
+++ b/common/src/client/java/com/logistics/automation/macerator/jei/MaceratorJeiPlugin.java
@@ -3,9 +3,11 @@ package com.logistics.automation.macerator.jei;
 import com.logistics.LogisticsAutomation;
 import com.logistics.LogisticsMod;
 import com.logistics.automation.jei.ClientMachineRecipes;
+import com.logistics.automation.jei.MachineRecipeJeiSync;
 import com.logistics.automation.macerator.MaceratorRecipeWrapper;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.runtime.IJeiRuntime;
 import mezz.jei.api.registration.IRecipeCatalystRegistration;
 import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
@@ -49,5 +51,15 @@ public class MaceratorJeiPlugin implements IModPlugin {
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addCraftingStation(
             MaceratorRecipeCategory.RECIPE_TYPE, LogisticsAutomation.BLOCK.MACERATOR);
+    }
+
+    @Override
+    public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
+        MachineRecipeJeiSync.onRuntimeAvailable(jeiRuntime);
+    }
+
+    @Override
+    public void onRuntimeUnavailable() {
+        MachineRecipeJeiSync.onRuntimeUnavailable();
     }
 }


### PR DESCRIPTION
## Summary
Completes #735. That change syncs machine recipes to the client and the JEI plugins read them in `registerRecipes` — which works on Fabric (the sync packet lands before JEI registers) but **not on NeoForge**, where JEI runs `registerRecipes` against an empty cache *before* the join packet arrives, leaving all five machine categories empty on multiplayer clients.

## Change
- New `MachineRecipeJeiSync`: captures JEI's runtime via `onRuntimeAvailable`/`onRuntimeUnavailable`, and when a sync packet lands (`ClientMachineRecipes.set`) pushes the recipes straight in via `IRecipeManager.addRecipes`.
- `MaceratorJeiPlugin` forwards the runtime hooks; `ClientMachineRecipes.set` calls the push.

Dup-safe: the push only fires on packet arrival, never on runtime-available, so in any JEI load cycle exactly one of `registerRecipes` or the push supplies the recipes (Fabric uses the former, NeoForge the latter).

## Why `refactor`
#735 hasn't shipped in a release yet, so it and this completion land in the same release — the changelog already carries the "Fixed JEI multiplayer recipes" line from #735. This is labeled `refactor` to avoid a redundant second Fixed entry; it does change NeoForge behavior (that detail is in the commit body).

## Testing
Dedicated server + separate client (true multiplayer): verified all five machine categories now populate on **NeoForge** for both **mc/26.2** and **mc/1.21.1**. Fabric unchanged (still works via `registerRecipes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)