### PR TITLE
fix(macerator): use blank JEI background so byproduct output displays correctly

### DIFF
--- a/common/src/client/java/com/logistics/automation/macerator/jei/MaceratorRecipeCategory.java
+++ b/common/src/client/java/com/logistics/automation/macerator/jei/MaceratorRecipeCategory.java
@@ -44,7 +44,7 @@ public class MaceratorRecipeCategory implements IRecipeCategory<MaceratorRecipeW
     private final IDrawable arrow;
 
     public MaceratorRecipeCategory(IGuiHelper guiHelper) {
-        this.background = guiHelper.createDrawable(TEXTURE, 48, 27, WIDTH, HEIGHT);
+        this.background = guiHelper.createBlankDrawable(WIDTH, HEIGHT);
         this.icon = guiHelper.createDrawableItemStack(
             new ItemStack(LogisticsAutomation.BLOCK.MACERATOR));
         this.arrow = guiHelper.createDrawable(TEXTURE, 199, 35, 24, 16);


### PR DESCRIPTION
## Summary

Fixes #728. In JEI, the macerator's secondary (byproduct) output rendered against misaligned slot art.

## Changes

- The macerator recipe category was the only one cropping a slice of the machine's GUI texture as its JEI background, which baked the machine's own slot outlines into the panel and clashed with JEI's real slots behind the byproduct output.
- Switched to `createBlankDrawable`, matching every sibling category on this branch (crucible, refinery, sawmill, alloy smelter). JEI now draws its own slot backgrounds; the side-by-side output layout is unchanged.

## Notes

- 1.21.1-only. The macerator category on mc/26.2 and mc/1.21.11 does not use a texture background, so there is nothing to backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)