### PR TITLE
refactor(common): behavior-preserving maintainability cleanups

### DIFF
--- a/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/ProviderModule.java
@@ -293,37 +293,21 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
             if (head == null) break;
 
             long toExtract = Math.min(head.remaining(), Math.min(itemsLeft, item.toStack(1).getMaxStackSize()));
-            long extracted = 0;
-            Direction extractDir = null;
-            IItemStorage extractStorage = null;
+            Extraction extraction = extractFromNeighbors(ctx, item, toExtract, mode);
 
-            for (Direction direction : ctx.getInventoryConnections()) {
-                BlockPos targetPos = ctx.pos().relative(direction);
-                IItemStorage storage =
-                        ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
-                if (storage == null) continue;
-
-                long got = extractItems(storage, item, toExtract, mode);
-                if (got > 0) {
-                    extracted = got;
-                    extractDir = direction;
-                    extractStorage = storage;
-                    break;
-                }
-            }
-
-            if (extracted > 0) {
+            if (extraction.amount() > 0) {
+                long extracted = extraction.amount();
                 // Extraction already removed the items. If the network can't pay, refund them so an
                 // unpowered network never destroys items, then stop dispatching this tick.
                 if (!ctx.consumeEnergy(RF_PER_ITEM * extracted)) {
-                    extractStorage.insert(item, extracted, false);
+                    extraction.storage().insert(item, extracted, false);
                     break;
                 }
                 ItemStack stack = item.toStack((int) extracted);
                 TravelingItem traveling = new TravelingItem(
-                        stack, extractDir.getOpposite(), LogisticsConfigHost.get(LogisticsPipe.CONFIG.PIPE_MIN_SPEED), head.requester());
+                        stack, extraction.dir().getOpposite(), LogisticsConfigHost.get(LogisticsPipe.CONFIG.PIPE_MIN_SPEED), head.requester());
                 traveling.setDeliveryId(head.deliveryId());
-                ctx.pipeAccess().forceAddItem(traveling, extractDir);
+                ctx.pipeAccess().forceAddItem(traveling, extraction.dir());
                 queue.consumeFromHead(extracted);
                 itemsLeft -= extracted;
                 stacksLeft -= 1;
@@ -350,6 +334,30 @@ public class ProviderModule implements Module, TickingModule, DispatchableModule
         }
 
         saveQueue(ctx, queue);
+    }
+
+    /** Items pulled from a neighboring inventory: the amount and where it came from (for refunds/routing). */
+    private record Extraction(long amount, Direction dir, IItemStorage storage) {
+        static final Extraction NONE = new Extraction(0, null, null);
+    }
+
+    /**
+     * Scan each connected inventory in turn, extracting from the first that yields items.
+     * Extraction is eager (items are removed from the source immediately), so the caller must
+     * refund via {@link Extraction#storage()} if it can't complete the dispatch.
+     */
+    private Extraction extractFromNeighbors(PipeContext ctx, IItemKey item, long toExtract, ProviderMode mode) {
+        for (Direction direction : ctx.getInventoryConnections()) {
+            BlockPos targetPos = ctx.pos().relative(direction);
+            IItemStorage storage = ItemStorageLookup.find(ctx.world(), targetPos, direction.getOpposite());
+            if (storage == null) continue;
+
+            long got = extractItems(storage, item, toExtract, mode);
+            if (got > 0) {
+                return new Extraction(got, direction, storage);
+            }
+        }
+        return Extraction.NONE;
     }
 
     // ===== Queue NBT serialisation =====

--- a/common/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
@@ -109,16 +109,18 @@ public class WeatheringModule implements Module, RandomTickModule {
         int stage = getOxidationStage(ctx);
         if (stage >= STAGE_OXIDIZED) return;
 
-        // Step 1: random tick gate (vanilla copper uses 1125/64 odds)
+        // Random-tick gate: vanilla copper's 1125/64 odds.
         if (rand.nextInt(1125) >= 64) return;
 
         // Only consider neighbors of this pipe's own family (item pipes never influence fluid pipes).
         PipeFamily selfFamily =
                 (ctx.state().getBlock() instanceof ModularPipeBlock self) ? self.family() : null;
 
-        // Step 2: scan neighbors within Manhattan distance 4
-        int a = 0; // nearby non-waxed weathering pipes
-        int b = 0; // nearby pipes more oxidized than me
+        // Scan same-family weathering pipes within Manhattan distance 4, mirroring vanilla copper:
+        // progression scales with how many neighbors are further along, and aborts entirely if any
+        // neighbor is less oxidized than this pipe.
+        int weatheringNeighbors = 0;
+        int moreOxidizedNeighbors = 0;
         BlockPos origin = ctx.pos();
 
         for (BlockPos p : BlockPos.betweenClosed(origin.offset(-4, -4, -4), origin.offset(4, 4, 4))) {
@@ -136,20 +138,16 @@ public class WeatheringModule implements Module, RandomTickModule {
             if (isWaxed(neighbor)) continue;
 
             int neighborStage = getOxidationStage(neighbor);
-
-            // Abort if any neighbor is less oxidized
             if (neighborStage < stage) return;
 
-            a++;
-            if (neighborStage > stage) b++;
+            weatheringNeighbors++;
+            if (neighborStage > stage) moreOxidizedNeighbors++;
         }
 
-        // Step 3: compute progression chance
-        double c = (b + 1.0) / (a + 1.0);
-        double m = (stage == STAGE_UNAFFECTED) ? 0.75 : 1.0;
-        double chance = m * c * c;
+        double ratio = (moreOxidizedNeighbors + 1.0) / (weatheringNeighbors + 1.0);
+        double stageMultiplier = (stage == STAGE_UNAFFECTED) ? 0.75 : 1.0;
+        double chance = stageMultiplier * ratio * ratio;
 
-        // Step 4: roll for progression
         if (rand.nextDouble() < chance) {
             ctx.saveInt(this, OXIDATION_KEY, stage + 1);
             ctx.markDirtyAndSync();

--- a/common/src/main/java/com/logistics/power/engine/PIDController.java
+++ b/common/src/main/java/com/logistics/power/engine/PIDController.java
@@ -125,20 +125,11 @@ public class PIDController {
         // Compute the unclamped output using all three terms.
         double unclamped = proportional + proposedIntegral + derivative;
 
-        // Clamp to output range.
-        double output = unclamped;
-        if (output > maxOutput) {
-            output = maxOutput;
-        } else if (output < minOutput) {
-            output = minOutput;
-        }
+        double output = clamp(unclamped, minOutput, maxOutput);
 
-        // Conditional integration anti-windup: accept the integral update unless we're saturated
-        // and the error would push the output further into saturation (which would wind up the integral).
-        boolean saturatedHigh = output >= maxOutput && unclamped > maxOutput;
-        boolean saturatedLow = output <= minOutput && unclamped < minOutput;
-        boolean deepensSaturation = (saturatedHigh && error > 0.0) || (saturatedLow && error < 0.0);
-        if (!deepensSaturation) {
+        // Conditional-integration anti-windup: accept the integral update unless it would push an
+        // already-saturated output deeper into saturation.
+        if (!deepensSaturation(output, unclamped, error, minOutput, maxOutput)) {
             integral = proposedIntegral;
         }
 
@@ -152,6 +143,23 @@ public class PIDController {
         logData();
 
         return output;
+    }
+
+    private static double clamp(double value, double min, double max) {
+        if (value > max) {
+            return max;
+        }
+        if (value < min) {
+            return min;
+        }
+        return value;
+    }
+
+    /** Whether the clamped output sits at a rail and the unclamped output is still pushing past it in the error's direction. */
+    private static boolean deepensSaturation(double output, double unclamped, double error, double min, double max) {
+        boolean saturatedHigh = output >= max && unclamped > max;
+        boolean saturatedLow = output <= min && unclamped < min;
+        return (saturatedHigh && error > 0.0) || (saturatedLow && error < 0.0);
     }
 
     /**


### PR DESCRIPTION
## Summary

A small chain of behavior-preserving maintainability refactors, one per commit, produced by the code-quality loop. No runtime behavior changes — existing unit tests pass unchanged.

**Please rebase-merge** (not squash) so each commit lands as its own `refactor(scope):` entry.

## Changes

- **`refactor(energy)`** — `PIDController.compute` now delegates output clamping and the anti-windup saturation check to small named helpers, so the control flow reads as intent rather than inline arithmetic.
- **`refactor(routing)`** — `ProviderModule.processDispatchQueue` extracts its inventory scan-and-extract loop into `extractFromNeighbors` (returning a small `Extraction` record), separating item acquisition from dispatch/accounting and removing a nesting level.
- **`refactor(transport)`** — `WeatheringModule.tryOxidize` renames its cryptic single-letter locals (`a`/`b`/`c`/`m`) to intention-revealing names, letting the per-variable comments and "Step N" narration go.

## Notes

- Behavior unchanged in all three; validated with `./gradlew :common:test`.
- Each commit is independently reviewable and revertable.
