### PR TITLE
test(common): add fast unit coverage for embedded domain logic

### DIFF
--- a/common/src/main/java/com/logistics/pipe/modules/SupplierModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/SupplierModule.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.LongSupplier;
 
 /**
  * Supplier module - maintains inventory stock levels by requesting items from the network.
@@ -206,35 +207,47 @@ public class SupplierModule implements Module, TickingModule, RoutingModule {
                     ctx.pos(), config.itemId(), mode, config.amount(), currentAmount, pendingAmount, needed);
 
             SupplierModeConfig modeConfig = SupplierModeConfig.forMode(mode, stack.getMaxStackSize());
-            long toRequest = 0;
-
-            if (modeConfig.isWindowBounded()) {
-                // INFINITE mode: continuously top-up; ignore target amount.
-                // Request = min(maxStack, roomForItem - inTransit), so we keep filling
-                // available space even while items are already in transit.
-                long availableSpace = getAvailableSpace(ctx, supplierDir, stack);
-                toRequest = Math.min(modeConfig.maxOpenRequestWindow(),
-                        Math.max(0, availableSpace - pendingAmount));
-            } else if (needed > 0 && modeConfig.isTriggerMet(currentAmount, config.amount())) {
-                if (modeConfig.fulfillmentMode() == FulfillmentMode.FULL) {
-                    // All-or-nothing: only request when full amount is available (chest)
-                    // or on-demand craftable (Long.MAX_VALUE). Crafter-busy (0) waits
-                    // for next check interval when the crafter re-advertises supply.
-                    long available = network.getAvailableAmount(stack);
-                    if (available >= needed) {
-                        toRequest = needed;
-                    }
-                } else {
-                    // PARTIAL: request needed regardless of availability;
-                    // dispatch validation handles fulfillability (same as RequesterModule).
-                    toRequest = needed;
-                }
-            }
+            long toRequest = requestAmount(modeConfig, config.amount(), currentAmount, pendingAmount,
+                    () -> getAvailableSpace(ctx, supplierDir, stack),
+                    () -> network.getAvailableAmount(stack));
 
             if (toRequest > 0) {
                 network.placeOrder(ItemStorageLookup.of(stack), toRequest, ctx.pos(), modeConfig.fulfillmentMode());
             }
         }
+    }
+
+    /**
+     * Decide how many items to order this cycle for one configured supply slot. Returns 0 when
+     * nothing should be ordered.
+     *
+     * <p>The two framework lookups are passed as suppliers so each is evaluated only on the branch
+     * that needs it: window-bounded (INFINITE) mode reads free inventory space and tops up toward it;
+     * threshold modes restock the shortfall once on-hand drops below the mode's trigger, and an
+     * all-or-nothing mode additionally waits until the network can cover the whole shortfall.
+     *
+     * @param modeConfig       resolved supplier mode (trigger threshold, fulfillment mode, window)
+     * @param targetAmount     configured stock target for the item
+     * @param currentAmount    amount already on hand in the supplied inventory
+     * @param pendingAmount    amount ordered but not yet delivered
+     * @param availableSpace   free room for the item in the supplied inventory (window-bounded only)
+     * @param networkAvailable network-wide available amount (all-or-nothing only)
+     */
+    static long requestAmount(SupplierModeConfig modeConfig, long targetAmount, long currentAmount,
+            long pendingAmount, LongSupplier availableSpace, LongSupplier networkAvailable) {
+        if (modeConfig.isWindowBounded()) {
+            return Math.min(modeConfig.maxOpenRequestWindow(),
+                    Math.max(0, availableSpace.getAsLong() - pendingAmount));
+        }
+
+        long needed = targetAmount - currentAmount - pendingAmount;
+        if (needed <= 0 || !modeConfig.isTriggerMet(currentAmount, targetAmount)) {
+            return 0;
+        }
+        if (modeConfig.fulfillmentMode() == FulfillmentMode.FULL) {
+            return networkAvailable.getAsLong() >= needed ? needed : 0;
+        }
+        return needed; // PARTIAL: dispatch validation handles fulfillability
     }
 
     /**

--- a/common/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
+++ b/common/src/main/java/com/logistics/pipe/modules/WeatheringModule.java
@@ -144,14 +144,24 @@ public class WeatheringModule implements Module, RandomTickModule {
             if (neighborStage > stage) moreOxidizedNeighbors++;
         }
 
-        double ratio = (moreOxidizedNeighbors + 1.0) / (weatheringNeighbors + 1.0);
-        double stageMultiplier = (stage == STAGE_UNAFFECTED) ? 0.75 : 1.0;
-        double chance = stageMultiplier * ratio * ratio;
-
+        double chance = oxidationChance(stage, weatheringNeighbors, moreOxidizedNeighbors);
         if (rand.nextDouble() < chance) {
             ctx.saveInt(this, OXIDATION_KEY, stage + 1);
             ctx.markDirtyAndSync();
         }
+    }
+
+    /**
+     * Probability that a pipe at {@code stage} advances one oxidation stage this tick, given how many
+     * same-family weathering neighbors it has and how many of those are further oxidized. Mirrors
+     * vanilla copper: the chance grows with the share of more-oxidized neighbors and is dampened for
+     * an as-yet unaffected pipe. Never exceeds 1.0 because a more-oxidized neighbor is also counted
+     * as a weathering neighbor, so {@code moreOxidizedNeighbors <= weatheringNeighbors}.
+     */
+    static double oxidationChance(int stage, int weatheringNeighbors, int moreOxidizedNeighbors) {
+        double ratio = (moreOxidizedNeighbors + 1.0) / (weatheringNeighbors + 1.0);
+        double stageMultiplier = (stage == STAGE_UNAFFECTED) ? 0.75 : 1.0;
+        return stageMultiplier * ratio * ratio;
     }
 
     @Override

--- a/common/src/test/java/com/logistics/automation/fabricator/FabricatorRecipeAllocationTest.java
+++ b/common/src/test/java/com/logistics/automation/fabricator/FabricatorRecipeAllocationTest.java
@@ -1,0 +1,116 @@
+package com.logistics.automation.fabricator;
+
+import com.logistics.core.lib.recipe.ItemResult;
+import com.logistics.test.MinecraftTestEnvironment;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.ItemLike;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Greedy per-ingredient/per-slot allocation used by the Fabricator to check and consume its inputs. */
+@DisplayName("FabricatorRecipe.allocateFrom")
+class FabricatorRecipeAllocationTest extends MinecraftTestEnvironment {
+
+    private record Take(int slot, int amount) {}
+
+    private record Result(boolean satisfied, List<Take> takes) {}
+
+    private static SizedIngredient ing(ItemLike item, int count) {
+        return new SizedIngredient(Ingredient.of(item), count);
+    }
+
+    private static FabricatorRecipe recipe(SizedIngredient... ingredients) {
+        return new FabricatorRecipe(List.of(ingredients), ItemResult.of(Items.IRON_INGOT, 1), 1000);
+    }
+
+    private static Result allocate(FabricatorRecipe recipe, ItemStack... pool) {
+        List<Take> takes = new ArrayList<>();
+        boolean ok = recipe.allocateFrom(List.of(pool), (slot, amount) -> takes.add(new Take(slot, amount)));
+        return new Result(ok, takes);
+    }
+
+    @Test
+    @DisplayName("a single ingredient is satisfied from one slot that holds enough")
+    void singleIngredient_fromOneSlot() {
+        Result r = allocate(recipe(ing(Items.COPPER_INGOT, 3)), new ItemStack(Items.COPPER_INGOT, 5));
+        assertThat(r.satisfied()).isTrue();
+        assertThat(r.takes()).containsExactly(new Take(0, 3));
+    }
+
+    @Test
+    @DisplayName("a single ingredient is drawn across multiple matching slots in order")
+    void singleIngredient_splitAcrossSlots() {
+        Result r = allocate(
+                recipe(ing(Items.COPPER_INGOT, 5)),
+                new ItemStack(Items.COPPER_INGOT, 2),
+                new ItemStack(Items.COPPER_INGOT, 4));
+        assertThat(r.satisfied()).isTrue();
+        assertThat(r.takes()).containsExactly(new Take(0, 2), new Take(1, 3));
+    }
+
+    @Test
+    @DisplayName("distinct ingredients each pull from their own matching slot")
+    void multipleIngredients_distinctSlots() {
+        Result r = allocate(
+                recipe(ing(Items.COPPER_INGOT, 3), ing(Items.GOLD_INGOT, 1)),
+                new ItemStack(Items.COPPER_INGOT, 3),
+                new ItemStack(Items.GOLD_INGOT, 1));
+        assertThat(r.satisfied()).isTrue();
+        assertThat(r.takes()).containsExactly(new Take(0, 3), new Take(1, 1));
+    }
+
+    @Test
+    @DisplayName("allocation fails when a slot lacks the required count")
+    void insufficientCount_fails() {
+        Result r = allocate(recipe(ing(Items.COPPER_INGOT, 3)), new ItemStack(Items.COPPER_INGOT, 2));
+        assertThat(r.satisfied()).isFalse();
+    }
+
+    @Test
+    @DisplayName("allocation fails and takes nothing when no slot matches the ingredient")
+    void wrongItem_takesNothing() {
+        Result r = allocate(recipe(ing(Items.COPPER_INGOT, 1)), new ItemStack(Items.GOLD_INGOT, 5));
+        assertThat(r.satisfied()).isFalse();
+        assertThat(r.takes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("two ingredients of the same item need the combined count, never double-counting units")
+    void sameItemTwoIngredients_needsCombinedCount() {
+        FabricatorRecipe recipe = recipe(ing(Items.COPPER_INGOT, 1), ing(Items.COPPER_INGOT, 1));
+        assertThat(allocate(recipe, new ItemStack(Items.COPPER_INGOT, 1)).satisfied()).isFalse();
+        assertThat(allocate(recipe, new ItemStack(Items.COPPER_INGOT, 2)).satisfied()).isTrue();
+    }
+
+    @Test
+    @DisplayName("an empty pool cannot satisfy any ingredient")
+    void emptyPool_fails() {
+        assertThat(allocate(recipe(ing(Items.COPPER_INGOT, 1))).satisfied()).isFalse();
+    }
+
+    @Test
+    @DisplayName("canCraftFrom mirrors allocateFrom's verdict without side effects")
+    void canCraftFrom_mirrorsVerdict() {
+        FabricatorRecipe recipe = recipe(ing(Items.COPPER_INGOT, 3));
+        assertThat(recipe.canCraftFrom(List.of(new ItemStack(Items.COPPER_INGOT, 3)))).isTrue();
+        assertThat(recipe.canCraftFrom(List.of(new ItemStack(Items.COPPER_INGOT, 2)))).isFalse();
+    }
+
+    @Test
+    @DisplayName("a failed multi-ingredient allocation may already have reported partial takes")
+    void failedAllocation_mayReportPartialTakes() {
+        // Copper is satisfied first, then gold is missing: the copper takes are already reported, so
+        // callers using the sink to consume must treat a false result as a rollback signal.
+        Result r = allocate(
+                recipe(ing(Items.COPPER_INGOT, 3), ing(Items.GOLD_INGOT, 1)),
+                new ItemStack(Items.COPPER_INGOT, 3));
+        assertThat(r.satisfied()).isFalse();
+        assertThat(r.takes()).containsExactly(new Take(0, 3));
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/FluidPipeCompositionTest.java
+++ b/common/src/test/java/com/logistics/pipe/FluidPipeCompositionTest.java
@@ -1,0 +1,93 @@
+package com.logistics.pipe;
+
+import com.logistics.core.lib.pipe.DestinationPriority;
+import com.logistics.core.lib.pipe.FluidPipeBehavior;
+import com.logistics.core.lib.pipe.Module;
+import com.logistics.pipe.modules.FluidBypassModule;
+import com.logistics.pipe.modules.FluidInsertionModule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("FluidPipe transport-policy composition")
+class FluidPipeCompositionTest {
+
+    /** A behavior facet with a fixed connect vote, for exercising the fold in isolation. */
+    private record Connects(boolean value) implements Module, FluidPipeBehavior {
+        @Override
+        public boolean canConnectToFluidHandler() {
+            return value;
+        }
+    }
+
+    /** A behavior facet that forces a destination priority, ignoring the running value. */
+    private record Priority(DestinationPriority forced) implements Module, FluidPipeBehavior {
+        @Override
+        public DestinationPriority destinationPriority(DestinationPriority priority) {
+            return forced;
+        }
+    }
+
+    // ==================== canConnectToFluidHandler ====================
+
+    @Test
+    @DisplayName("a bare fluid pipe connects to external handlers")
+    void connect_defaultsToTrue() {
+        assertThat(new FluidPipe().canConnectToFluidHandler()).isTrue();
+    }
+
+    @Test
+    @DisplayName("the bypass module vetoes external handler connections")
+    void connect_bypassVetoes() {
+        assertThat(new FluidPipe(new FluidBypassModule()).canConnectToFluidHandler()).isFalse();
+    }
+
+    @Test
+    @DisplayName("a single veto wins over any number of allowing behaviors")
+    void connect_anyVetoWins() {
+        assertThat(new FluidPipe(new Connects(true), new FluidBypassModule(), new Connects(true))
+                .canConnectToFluidHandler())
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("behaviors that do not veto leave the connection allowed")
+    void connect_allowedWhenNoVeto() {
+        assertThat(new FluidPipe(new Connects(true), new FluidInsertionModule()).canConnectToFluidHandler())
+                .isTrue();
+    }
+
+    // ==================== destinationPriority ====================
+
+    @Test
+    @DisplayName("a bare fluid pipe uses NORMAL destination priority")
+    void priority_defaultsToNormal() {
+        assertThat(new FluidPipe().destinationPriority()).isEqualTo(DestinationPriority.NORMAL);
+    }
+
+    @Test
+    @DisplayName("the insertion module prefers filling handlers first")
+    void priority_insertionForcesHandlersFirst() {
+        assertThat(new FluidPipe(new FluidInsertionModule()).destinationPriority())
+                .isEqualTo(DestinationPriority.HANDLERS_FIRST);
+    }
+
+    @Test
+    @DisplayName("priority folds left-to-right, so a later behavior overrides an earlier one")
+    void priority_laterBehaviorWins() {
+        assertThat(new FluidPipe(
+                        new Priority(DestinationPriority.HANDLERS_FIRST),
+                        new Priority(DestinationPriority.NORMAL))
+                .destinationPriority())
+                .isEqualTo(DestinationPriority.NORMAL);
+    }
+
+    @Test
+    @DisplayName("a module that does not override priority leaves the running value untouched")
+    void priority_nonOverridingModuleIsTransparent() {
+        assertThat(new FluidPipe(new Priority(DestinationPriority.HANDLERS_FIRST), new FluidBypassModule())
+                .destinationPriority())
+                .isEqualTo(DestinationPriority.HANDLERS_FIRST);
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/modules/FluidTransportModuleTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/FluidTransportModuleTest.java
@@ -1,0 +1,45 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.pipe.modules.FluidTransportModule.FlowRate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("FluidTransportModule flow-rate scaling")
+class FluidTransportModuleTest {
+
+    @ParameterizedTest(name = "{0} multiplier is {1}x")
+    @DisplayName("each tier multiplier defines the pipe throughput ladder")
+    @CsvSource({"SLOW, 1", "NORMAL, 2", "FAST, 4"})
+    void multiplier_perTier(FlowRate rate, int expected) {
+        assertThat(rate.multiplier()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "{0} scales base {1} to {2}")
+    @DisplayName("modifyTransferRate scales the incoming base rate by the tier multiplier")
+    @CsvSource({
+        "SLOW, 100, 100",
+        "NORMAL, 100, 200",
+        "FAST, 100, 400",
+        "NORMAL, 0, 0",
+        "FAST, 250, 1000",
+    })
+    void modifyTransferRate_scalesBaseRate(FlowRate rate, long base, long expected) {
+        assertThat(new FluidTransportModule(rate).modifyTransferRate(base)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("the tier ladder keeps NORMAL at 2x and FAST at 4x the slow baseline")
+    void tierLadder_ratiosHold() {
+        long base = 60;
+        long slow = new FluidTransportModule(FlowRate.SLOW).modifyTransferRate(base);
+        long normal = new FluidTransportModule(FlowRate.NORMAL).modifyTransferRate(base);
+        long fast = new FluidTransportModule(FlowRate.FAST).modifyTransferRate(base);
+
+        assertThat(normal).isEqualTo(2 * slow);
+        assertThat(fast).isEqualTo(4 * slow);
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/modules/SupplierRequestAmountTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/SupplierRequestAmountTest.java
@@ -1,0 +1,105 @@
+package com.logistics.pipe.modules;
+
+import com.logistics.pipe.modules.SupplierModule.SupplyMode;
+import com.logistics.pipe.network.SupplierModeConfig;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SupplierModule.requestAmount")
+class SupplierRequestAmountTest {
+
+    private static final int STACK = 64;
+
+    /** A framework lookup that must not be consulted on this branch; fails loudly if it is. */
+    private static final LongSupplier NEVER = () -> {
+        throw new AssertionError("supplier evaluated on a branch that should not need it");
+    };
+
+    private static SupplierModeConfig config(SupplyMode mode) {
+        return SupplierModeConfig.forMode(mode, STACK);
+    }
+
+    private static long request(SupplyMode mode, long target, long current, long pending,
+            LongSupplier space, LongSupplier networkAvailable) {
+        return SupplierModule.requestAmount(config(mode), target, current, pending, space, networkAvailable);
+    }
+
+    // ==================== INFINITE (window-bounded top-up) ====================
+
+    @Test
+    @DisplayName("INFINITE tops up toward free space minus in-flight, capped at the stack window")
+    void infinite_topsUpToFreeSpaceMinusPending() {
+        assertThat(request(SupplyMode.INFINITE, 0, 0, 10, () -> 50, NEVER)).isEqualTo(40);
+    }
+
+    @Test
+    @DisplayName("INFINITE is capped at the stack-size window even with lots of free space")
+    void infinite_cappedAtWindow() {
+        assertThat(request(SupplyMode.INFINITE, 0, 0, 0, () -> 1000, NEVER)).isEqualTo(STACK);
+    }
+
+    @Test
+    @DisplayName("INFINITE never requests a negative amount when in-flight exceeds free space")
+    void infinite_neverNegative() {
+        assertThat(request(SupplyMode.INFINITE, 0, 0, 30, () -> 20, NEVER)).isZero();
+    }
+
+    // ==================== PARTIAL (restock shortfall, any availability) ====================
+
+    @Test
+    @DisplayName("PARTIAL requests the shortfall regardless of network availability")
+    void partial_requestsShortfall() {
+        assertThat(request(SupplyMode.PARTIAL, 64, 10, 0, NEVER, NEVER)).isEqualTo(54);
+    }
+
+    @Test
+    @DisplayName("PARTIAL subtracts pending in-flight from the shortfall")
+    void partial_accountsForPending() {
+        assertThat(request(SupplyMode.PARTIAL, 64, 50, 10, NEVER, NEVER)).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("PARTIAL requests nothing once target is already met by stock plus pending")
+    void partial_nothingWhenSatisfied() {
+        assertThat(request(SupplyMode.PARTIAL, 64, 60, 10, NEVER, NEVER)).isZero();
+    }
+
+    // ==================== FULL (all-or-nothing) ====================
+
+    @Test
+    @DisplayName("FULL requests the shortfall only when the network can cover all of it")
+    void full_requestsWhenFullyCovered() {
+        assertThat(request(SupplyMode.FULL, 64, 0, 0, NEVER, () -> 64)).isEqualTo(64);
+    }
+
+    @Test
+    @DisplayName("FULL requests nothing when the network cannot cover the whole shortfall")
+    void full_nothingWhenPartiallyCovered() {
+        assertThat(request(SupplyMode.FULL, 64, 0, 0, NEVER, () -> 30)).isZero();
+    }
+
+    @Test
+    @DisplayName("FULL accepts an on-demand craftable source (unbounded availability)")
+    void full_acceptsCraftable() {
+        assertThat(request(SupplyMode.FULL, 64, 0, 0, NEVER, () -> Long.MAX_VALUE)).isEqualTo(64);
+    }
+
+    // ==================== Trigger thresholds (BULK modes) ====================
+
+    @Test
+    @DisplayName("BULK50 holds off until stock drops to at most half the target")
+    void bulk50_waitsForHalf() {
+        assertThat(request(SupplyMode.BULK50, 100, 60, 0, NEVER, NEVER)).isZero();
+        assertThat(request(SupplyMode.BULK50, 100, 40, 0, NEVER, NEVER)).isEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("BULK100 restocks only once the inventory is completely empty")
+    void bulk100_waitsForEmpty() {
+        assertThat(request(SupplyMode.BULK100, 100, 1, 0, NEVER, NEVER)).isZero();
+        assertThat(request(SupplyMode.BULK100, 100, 0, 0, NEVER, NEVER)).isEqualTo(100);
+    }
+}

--- a/common/src/test/java/com/logistics/pipe/modules/WeatheringModuleTest.java
+++ b/common/src/test/java/com/logistics/pipe/modules/WeatheringModuleTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.*;
@@ -108,5 +109,53 @@ class WeatheringModuleTest {
 
         assertThat(module.getOxidationStage(ctx)).isEqualTo(WeatheringModule.STAGE_WEATHERED);
         assertThat(module.isWaxed(ctx)).isTrue();
+    }
+
+    // ==================== Oxidation progression chance ====================
+
+    @Test
+    @DisplayName("an isolated unaffected pipe advances at the dampened 0.75 base rate")
+    void oxidationChance_isolatedUnaffected_isDampened() {
+        assertThat(WeatheringModule.oxidationChance(WeatheringModule.STAGE_UNAFFECTED, 0, 0))
+                .isEqualTo(0.75, within(1e-9));
+    }
+
+    @Test
+    @DisplayName("an isolated already-weathering pipe advances at the full base rate")
+    void oxidationChance_isolatedWeathering_isFullRate() {
+        assertThat(WeatheringModule.oxidationChance(WeatheringModule.STAGE_EXPOSED, 0, 0))
+                .isEqualTo(1.0, within(1e-9));
+    }
+
+    @ParameterizedTest(name = "stage={0}, weathering={1}, moreOxidized={2} -> {3}")
+    @DisplayName("chance = stageMultiplier * ((moreOxidized+1)/(weathering+1))^2")
+    @CsvSource({
+        // stage, weatheringNeighbors, moreOxidizedNeighbors, expectedChance
+        "0, 0, 0, 0.75", // isolated, dampened
+        "1, 0, 0, 1.0", // isolated, full rate
+        "0, 4, 0, 0.03", // surrounded by peers, none further along: 0.75 * (1/5)^2
+        "1, 4, 4, 1.0", // every neighbor further along: (5/5)^2
+        "1, 4, 2, 0.36", // (3/5)^2
+        "1, 3, 1, 0.25", // (2/4)^2
+    })
+    void oxidationChance_matchesFormula(int stage, int weathering, int moreOxidized, double expected) {
+        assertThat(WeatheringModule.oxidationChance(stage, weathering, moreOxidized))
+                .isEqualTo(expected, within(1e-9));
+    }
+
+    @ParameterizedTest(name = "stage={0}, weathering={1}, moreOxidized={2}")
+    @DisplayName("chance stays a valid probability in [0,1] (moreOxidized never exceeds weathering)")
+    @CsvSource({"0, 0, 0", "0, 8, 0", "1, 8, 8", "2, 5, 3", "1, 1, 1", "0, 100, 100"})
+    void oxidationChance_isValidProbability(int stage, int weathering, int moreOxidized) {
+        assertThat(WeatheringModule.oxidationChance(stage, weathering, moreOxidized))
+                .isBetween(0.0, 1.0);
+    }
+
+    @Test
+    @DisplayName("an unaffected pipe is exactly 0.75x as likely to advance as a further-along peer")
+    void oxidationChance_unaffectedIsDampenedRelativeToLaterStages() {
+        double unaffected = WeatheringModule.oxidationChance(WeatheringModule.STAGE_UNAFFECTED, 4, 2);
+        double exposed = WeatheringModule.oxidationChance(WeatheringModule.STAGE_EXPOSED, 4, 2);
+        assertThat(unaffected).isEqualTo(0.75 * exposed, within(1e-9));
     }
 }

--- a/common/src/test/java/com/logistics/pipe/network/NetworkCommandExecutorTest.java
+++ b/common/src/test/java/com/logistics/pipe/network/NetworkCommandExecutorTest.java
@@ -1,0 +1,137 @@
+package com.logistics.pipe.network;
+
+import com.logistics.core.lib.network.IWorldView;
+import com.logistics.core.lib.network.NetworkCommand;
+import com.logistics.core.lib.storage.IItemKey;
+import com.logistics.test.MinecraftTestEnvironment;
+import com.logistics.test.TestItemKey;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Maps the tri-state result of {@link IWorldView#dispatch} onto a {@link CommandResult}. */
+@DisplayName("NetworkCommandExecutor")
+class NetworkCommandExecutorTest extends MinecraftTestEnvironment {
+
+    private long dispatchReturn;
+    private Object[] lastDispatchArgs;
+    private int dispatchCalls;
+
+    private final IWorldView worldView = new IWorldView() {
+        @Override
+        public boolean isPipe(BlockPos pos) {
+            return false;
+        }
+
+        @Override
+        public List<BlockPos> getConnectedNeighbors(BlockPos pos) {
+            return List.of();
+        }
+
+        @Override
+        public boolean matchesSinkFilter(BlockPos pos, ItemStack stack) {
+            return false;
+        }
+
+        @Override
+        public long dispatch(BlockPos provider, BlockPos requester, IItemKey item, long amount, UUID deliveryId) {
+            dispatchCalls++;
+            lastDispatchArgs = new Object[] {provider, requester, item, amount, deliveryId};
+            return dispatchReturn;
+        }
+
+        @Override
+        public boolean isClientSide() {
+            return false;
+        }
+
+        @Override
+        public void broadcastAlert(BlockPos pos, Component message) {}
+
+        @Override
+        public long gameTime() {
+            return 0L;
+        }
+    };
+
+    private NetworkCommandExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        executor = new NetworkCommandExecutor(worldView);
+    }
+
+    private NetworkCommand.ExtractCommand extract(long amount) {
+        return new NetworkCommand.ExtractCommand(
+                new BlockPos(1, 2, 3),
+                new BlockPos(4, 5, 6),
+                new TestItemKey(Items.DIAMOND),
+                amount,
+                new UUID(7L, 8L));
+    }
+
+    @Test
+    @DisplayName("a positive dispatch reports success with the shipped count")
+    void extract_positiveShipped_isOk() {
+        dispatchReturn = 5;
+        CommandResult result = executor.execute(extract(8));
+        assertThat(result).isEqualTo(CommandResult.ok(5));
+    }
+
+    @Test
+    @DisplayName("a zero dispatch (nothing shipped) fails")
+    void extract_zeroShipped_fails() {
+        dispatchReturn = 0;
+        CommandResult result = executor.execute(extract(8));
+        assertThat(result).isEqualTo(CommandResult.failed());
+    }
+
+    @Test
+    @DisplayName("a negative dispatch (provider busy) defers rather than failing")
+    void extract_negativeShipped_defers() {
+        dispatchReturn = -1;
+        CommandResult result = executor.execute(extract(8));
+        assertThat(result).isEqualTo(CommandResult.defer());
+        assertThat(result.isDeferred()).isTrue();
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    @Test
+    @DisplayName("an extract forwards its command fields verbatim to the world view")
+    void extract_forwardsCommandFields() {
+        dispatchReturn = 3;
+        NetworkCommand.ExtractCommand cmd = extract(8);
+        executor.execute(cmd);
+
+        assertThat(dispatchCalls).isEqualTo(1);
+        assertThat(lastDispatchArgs)
+                .containsExactly(cmd.provider(), cmd.requester(), cmd.item(), cmd.amount(), cmd.deliveryId());
+    }
+
+    @Test
+    @DisplayName("crafter-input insertion is a reserved no-op that fails without touching the world")
+    void insertCrafterInputs_failsWithoutDispatch() {
+        CommandResult result = executor.execute(
+                new NetworkCommand.InsertCrafterInputsCommand(new BlockPos(0, 0, 0), Map.of()));
+        assertThat(result).isEqualTo(CommandResult.failed());
+        assertThat(dispatchCalls).isZero();
+    }
+
+    @Test
+    @DisplayName("direct delivery is a reserved no-op that fails without touching the world")
+    void deliver_failsWithoutDispatch() {
+        CommandResult result = executor.execute(new NetworkCommand.DeliverCommand(
+                new BlockPos(0, 0, 0), new TestItemKey(Items.DIAMOND), 4, new UUID(1L, 2L)));
+        assertThat(result).isEqualTo(CommandResult.failed());
+        assertThat(dispatchCalls).isZero();
+    }
+}


### PR DESCRIPTION
## Summary

A chain of atomic testability improvements from the testability loop, one per commit. Each moves important but hard-to-reach logic under fast unit coverage; two commits extract a small pure helper first, the rest add coverage to already-pure logic that simply lacked tests. No runtime behavior changes.

**Please rebase-merge** (not squash) so each `type(scope):` commit lands as its own changelog-relevant entry.

## Changes

- **`test(transport)`** — extract `WeatheringModule.oxidationChance(...)` (was buried in a live-world random tick) and cover the progression formula, boundaries, and the [0,1] probability invariant.
- **`test(routing)`** — extract `SupplierModule.requestAmount(...)`, passing the two framework lookups as lazily-evaluated suppliers so branch-only evaluation is preserved; cover each supply mode, trigger threshold, pending accounting, and the laziness invariant.
- **`test(fluids)`** — cover `FluidPipe`'s transport-policy composition (handler-connection veto and destination-priority fold) with real modules plus small record fakes.
- **`test(fluids)`** — pin `FluidTransportModule`'s flow-rate tier ladder (SLOW/NORMAL/FAST = 1/2/4×) so throughput ratios can't drift unnoticed.
- **`test(crafting)`** — cover `FabricatorRecipe.allocateFrom`, the greedy per-ingredient/per-slot matcher, including split/multi-ingredient allocation, insufficient/non-matching pools, same-item combined counts, and the documented partial-take-on-failure hazard.
- **`test(routing)`** — cover `NetworkCommandExecutor`'s ok/failed/defer mapping of `IWorldView.dispatch`'s tri-state result (over a fake world view), field forwarding, and the reserved no-ops.

## Notes

- Production changes are limited to two behavior-preserving extractions (`oxidationChance`, `requestAmount`); everything else is test-only.
- Validated with `./gradlew :common:test` (full common suite green).
- Each commit is independently reviewable and revertable.
