### PR TITLE
fix(automation): make the refinery and sequential fabricator harvestable

### DIFF
--- a/common/src/main/resources/data/logistics/loot_table/blocks/automation/sequential_fabricator.json
+++ b/common/src/main/resources/data/logistics/loot_table/blocks/automation/sequential_fabricator.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "logistics:automation/sequential_fabricator"
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
@@ -17,6 +17,8 @@
     "logistics:automation/fluid_pump",
     "logistics:automation/sawmill",
     "logistics:automation/alloy_smelter",
-    "logistics:automation/crucible"
+    "logistics:automation/crucible",
+    "logistics:automation/refinery",
+    "logistics:automation/sequential_fabricator"
   ]
 }

--- a/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
@@ -13,6 +13,8 @@
     "logistics:automation/fluid_pump",
     "logistics:automation/sawmill",
     "logistics:automation/alloy_smelter",
-    "logistics:automation/crucible"
+    "logistics:automation/crucible",
+    "logistics:automation/refinery",
+    "logistics:automation/sequential_fabricator"
   ]
 }


### PR DESCRIPTION
## Summary

Release-QA polish for the two machines added since `mc26.2-v0.8.2` (Refinery and Sequential Fabricator). Both were shipped unharvestable, and the Sequential Fabricator dropped nothing when broken.

## Changes

- **Sequential Fabricator** — add a self-drop loot table (it previously dropped nothing on break).
- **Refinery & Sequential Fabricator** — add both to `mineable/pickaxe` and `needs_stone_tool`. Both blocks use `requiresCorrectToolForDrops`, so without a mineable tag they were unharvestable — now they mine and drop like every other machine.

## Notes

- No `copy_components` on the loot tables — intentional, matching all sibling machines (machines wipe their inventory/energy on break).
- Validated with `./gradlew build` (resources load) and a re-run of the release-QA audit (both machines now PASS harvest/loot).
- **Deferred follow-up:** the `fabricator` recipe type still has no JEI category, so Sequential Fabricator recipes are invisible in JEI. Fixing it properly requires the synced-recipe-cache path (adding `FabricatorRecipe` to `SyncMachineRecipesPacket` + `ClientMachineRecipes` + `MachineRecipeJeiSync`, a `FabricatorJeiPlugin`, and a variable-ingredient `FabricatorRecipeCategory`) — feature-sized, tracked separately.
