### PR TITLE
feat(compat): add Jade HUD support for the refinery and sequential fabricator

### DIFF
--- a/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
+++ b/fabric/src/client/java/com/logistics/compat/jade/JadeLogisticsPlugin.java
@@ -7,6 +7,8 @@ import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.automation.macerator.MaceratorBlock;
+import com.logistics.automation.refinery.RefineryBlock;
+import com.logistics.automation.fabricator.SequentialFabricatorBlock;
 import com.logistics.automation.sawmill.SawmillBlock;
 import com.logistics.pipe.block.FluidPipeBlock;
 import com.logistics.pipe.block.PipeBlock;
@@ -40,6 +42,8 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, AlloySmelterBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, CrucibleBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, RefineryBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, SequentialFabricatorBlock.class);
     }
 
     @Override
@@ -53,6 +57,8 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, AlloySmelterBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, CrucibleBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, RefineryBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SequentialFabricatorBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
         registration.registerBlockComponent(FluidPipeComponentProvider.INSTANCE, FluidPipeBlock.class);
     }

--- a/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/compat/JadeLogisticsPlugin.java
@@ -2,10 +2,13 @@ package com.logistics.neoforge.client.compat;
 
 import com.logistics.LogisticsMod;
 import com.logistics.automation.alloysmelter.AlloySmelterBlock;
+import com.logistics.automation.crucible.CrucibleBlock;
 import com.logistics.automation.kiln.KilnBlock;
 import com.logistics.automation.laserquarry.LaserQuarryBlock;
 import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.automation.macerator.MaceratorBlock;
+import com.logistics.automation.refinery.RefineryBlock;
+import com.logistics.automation.fabricator.SequentialFabricatorBlock;
 import com.logistics.automation.sawmill.SawmillBlock;
 import com.logistics.pipe.block.FluidPipeBlock;
 import com.logistics.pipe.block.PipeBlock;
@@ -39,6 +42,9 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, KilnBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, AlloySmelterBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, CrucibleBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, RefineryBlock.class);
+        registration.registerBlockDataProvider(MachineServerDataProvider.INSTANCE, SequentialFabricatorBlock.class);
     }
 
     @Override
@@ -51,6 +57,9 @@ public class JadeLogisticsPlugin implements IWailaPlugin {
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, KilnBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SawmillBlock.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, AlloySmelterBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, CrucibleBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, RefineryBlock.class);
+        registration.registerBlockComponent(MachineComponentProvider.INSTANCE, SequentialFabricatorBlock.class);
         registration.registerBlockComponent(PipeComponentProvider.INSTANCE, PipeBlock.class);
         registration.registerBlockComponent(FluidPipeComponentProvider.INSTANCE, FluidPipeBlock.class);
     }


### PR DESCRIPTION
## Summary

Adds the Refinery and Sequential Fabricator to the Jade HUD integration, and fixes a loader-parity gap for the Crucible. Every other machine already surfaces its progress/energy on the Jade HUD; these were missed.

## Changes

- **Refinery & Sequential Fabricator** — register both with the shared `MachineServerDataProvider`/`MachineComponentProvider` in **both** the Fabric and NeoForge Jade plugins. Both blocks extend `MachineBlock`, so the existing generic machine HUD reader handles them (the same reader already serves the fluid-based Crucible).
- **Crucible (NeoForge)** — was registered only on the Fabric plugin; add it to the NeoForge plugin too so the HUD is consistent across loaders.

## Notes

- Jade is a `clientCompileOnly`/`compileOnly` optional integration — these providers only initialize when Jade is installed.
- Validated with `./gradlew build` (both loaders compile). HUD rendering itself is runtime/visual, not unit-testable.
