### PR TITLE
feat(crafting): show sequential fabricator recipes in JEI

### DIFF
--- a/common/src/client/java/com/logistics/automation/fabricator/jei/FabricatorJeiPlugin.java
+++ b/common/src/client/java/com/logistics/automation/fabricator/jei/FabricatorJeiPlugin.java
@@ -1,0 +1,54 @@
+package com.logistics.automation.fabricator.jei;
+
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsMod;
+import com.logistics.automation.fabricator.FabricatorRecipe;
+import com.logistics.automation.jei.ClientMachineRecipes;
+import com.logistics.core.lib.resource.ResourceId;
+import java.util.List;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JEI plugin that registers the Sequential Fabricator recipe category and all fabricator recipes.
+ * Discovered by JEI via the "jei_mod_plugin" Fabric entrypoint in fabric.mod.json and the {@link JeiPlugin}
+ * annotation on NeoForge. Runtime sync hooks live in {@code MaceratorJeiPlugin}, so this plugin does not
+ * re-register them.
+ */
+@JeiPlugin
+public class FabricatorJeiPlugin implements IModPlugin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("Logistics/JEI");
+    private static final ResourceId PLUGIN_ID = LogisticsMod.modId("jei_fabricator_plugin");
+
+    @Override
+    public net.minecraft.resources.Identifier getPluginUid() { // raw-id-ok: JEI IModPlugin signature
+        return PLUGIN_ID.toIdentifier();
+    }
+
+    @Override
+    public void registerCategories(IRecipeCategoryRegistration registration) {
+        LOGGER.info("Registering fabricator recipe category");
+        registration.addRecipeCategories(
+            new FabricatorRecipeCategory(registration.getJeiHelpers().getGuiHelper()));
+    }
+
+    @Override
+    public void registerRecipes(IRecipeRegistration registration) {
+        // Recipes come from the server-synced client cache, so JEI works in singleplayer and multiplayer.
+        List<FabricatorRecipe> recipes = ClientMachineRecipes.fabricator();
+        LOGGER.info("Registering {} fabricator recipes with JEI", recipes.size());
+        registration.addRecipes(FabricatorRecipeCategory.RECIPE_TYPE, recipes);
+    }
+
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+        registration.addCraftingStation(
+            FabricatorRecipeCategory.RECIPE_TYPE, LogisticsAutomation.BLOCK.SEQUENTIAL_FABRICATOR);
+    }
+}

--- a/common/src/client/java/com/logistics/automation/fabricator/jei/FabricatorRecipeCategory.java
+++ b/common/src/client/java/com/logistics/automation/fabricator/jei/FabricatorRecipeCategory.java
@@ -1,0 +1,106 @@
+package com.logistics.automation.fabricator.jei;
+
+import com.logistics.LogisticsAutomation;
+import com.logistics.LogisticsMod;
+import com.logistics.automation.fabricator.FabricatorRecipe;
+import com.logistics.automation.fabricator.SizedIngredient;
+import com.logistics.core.lib.resource.ResourceId;
+import java.util.List;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.types.IRecipeType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * JEI recipe category for the Sequential Fabricator: a variable number of item ingredients combined into
+ * one output. Ingredients are packed from the left, so the arrow and output sit immediately after the
+ * last input; the category is sized for up to {@value #MAX_INPUTS} inputs (chipset recipes use one or two).
+ */
+public class FabricatorRecipeCategory implements IRecipeCategory<FabricatorRecipe> {
+
+    public static final IRecipeType<FabricatorRecipe> RECIPE_TYPE =
+        IRecipeType.create(LogisticsMod.MOD_ID, "fabricator", FabricatorRecipe.class);
+
+    // Matches SequentialFabricatorScreen.TEXTURE; the filled progress arrow sprite lives at UV (199,35), 24x16.
+    private static final ResourceId TEXTURE =
+        LogisticsMod.modId("textures/gui/automation/sequential_fabricator.png");
+
+    private static final int MAX_INPUTS = 3;
+    private static final int INPUT_X0 = 8, INPUT_Y = 9, INPUT_STEP = 18;
+    private static final int ARROW_Y = 10, ARROW_W = 24, ARROW_GAP = 2;
+    private static final int OUTPUT_Y = 9, OUTPUT_GAP = 6;
+
+    private static final int WIDTH = outputX(MAX_INPUTS) + 16;
+    private static final int HEIGHT = 28;
+
+    private final IDrawable icon;
+    private final IDrawable arrow;
+
+    public FabricatorRecipeCategory(IGuiHelper guiHelper) {
+        this.icon = guiHelper.createDrawableItemStack(
+            new ItemStack(LogisticsAutomation.BLOCK.SEQUENTIAL_FABRICATOR));
+        this.arrow = guiHelper.createDrawable(TEXTURE.toIdentifier(), 199, 35, ARROW_W, 16);
+    }
+
+    /** X of the progress arrow: immediately to the right of the packed inputs. */
+    private static int arrowX(int inputCount) {
+        return INPUT_X0 + inputCount * INPUT_STEP + ARROW_GAP;
+    }
+
+    /** X of the output slot: to the right of the arrow. */
+    private static int outputX(int inputCount) {
+        return arrowX(inputCount) + ARROW_W + OUTPUT_GAP;
+    }
+
+    @Override
+    public IRecipeType<FabricatorRecipe> getRecipeType() {
+        return RECIPE_TYPE;
+    }
+
+    @Override
+    public Component getTitle() {
+        return Component.translatable("block.logistics.automation.sequential_fabricator");
+    }
+
+    @Override
+    public int getWidth() {
+        return WIDTH;
+    }
+
+    @Override
+    public int getHeight() {
+        return HEIGHT;
+    }
+
+    @Override
+    public IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void createRecipeExtras(IRecipeExtrasBuilder builder, FabricatorRecipe recipe, IFocusGroup focuses) {
+        builder.addDrawable(arrow, arrowX(recipe.ingredients().size()), ARROW_Y);
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, FabricatorRecipe recipe, IFocusGroup focuses) {
+        List<SizedIngredient> ingredients = recipe.ingredients();
+        for (int i = 0; i < ingredients.size(); i++) {
+            SizedIngredient input = ingredients.get(i);
+            // Show each accepted item at the per-craft count, not a bare count-of-1 ingredient.
+            List<ItemStack> stacks = input.ingredient().items()
+                .map(item -> new ItemStack(item, input.count()))
+                .toList();
+            builder.addSlot(RecipeIngredientRole.INPUT, INPUT_X0 + i * INPUT_STEP, INPUT_Y)
+                .addItemStacks(stacks);
+        }
+        builder.addSlot(RecipeIngredientRole.OUTPUT, outputX(ingredients.size()), OUTPUT_Y)
+            .add(recipe.getResultItem());
+    }
+}

--- a/common/src/client/java/com/logistics/automation/jei/ClientMachineRecipes.java
+++ b/common/src/client/java/com/logistics/automation/jei/ClientMachineRecipes.java
@@ -2,6 +2,7 @@ package com.logistics.automation.jei;
 
 import com.logistics.automation.alloysmelter.AlloySmelterRecipe;
 import com.logistics.automation.crucible.CrucibleRecipe;
+import com.logistics.automation.fabricator.FabricatorRecipe;
 import com.logistics.automation.macerator.MaceratorRecipeWrapper;
 import com.logistics.automation.refinery.RefineryRecipe;
 import com.logistics.automation.sawmill.SawmillRecipe;
@@ -19,6 +20,7 @@ public final class ClientMachineRecipes {
     private static volatile List<CrucibleRecipe> crucible = List.of();
     private static volatile List<AlloySmelterRecipe> alloySmelter = List.of();
     private static volatile List<RefineryRecipe> refinery = List.of();
+    private static volatile List<FabricatorRecipe> fabricator = List.of();
 
     private ClientMachineRecipes() {}
 
@@ -28,6 +30,7 @@ public final class ClientMachineRecipes {
         crucible = List.copyOf(packet.crucible());
         alloySmelter = List.copyOf(packet.alloySmelter());
         refinery = List.copyOf(packet.refinery());
+        fabricator = List.copyOf(packet.fabricator());
         MachineRecipeJeiSync.pushToJei();
     }
 
@@ -38,6 +41,7 @@ public final class ClientMachineRecipes {
         crucible = List.of();
         alloySmelter = List.of();
         refinery = List.of();
+        fabricator = List.of();
     }
 
     public static List<MaceratorRecipeWrapper> macerator() {
@@ -58,5 +62,9 @@ public final class ClientMachineRecipes {
 
     public static List<RefineryRecipe> refinery() {
         return refinery;
+    }
+
+    public static List<FabricatorRecipe> fabricator() {
+        return fabricator;
     }
 }

--- a/common/src/client/java/com/logistics/automation/jei/MachineRecipeJeiSync.java
+++ b/common/src/client/java/com/logistics/automation/jei/MachineRecipeJeiSync.java
@@ -2,6 +2,7 @@ package com.logistics.automation.jei;
 
 import com.logistics.automation.alloysmelter.jei.AlloySmelterRecipeCategory;
 import com.logistics.automation.crucible.jei.CrucibleRecipeCategory;
+import com.logistics.automation.fabricator.jei.FabricatorRecipeCategory;
 import com.logistics.automation.macerator.jei.MaceratorRecipeCategory;
 import com.logistics.automation.refinery.jei.RefineryRecipeCategory;
 import com.logistics.automation.sawmill.jei.SawmillRecipeCategory;
@@ -40,5 +41,6 @@ public final class MachineRecipeJeiSync {
         recipes.addRecipes(CrucibleRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.crucible());
         recipes.addRecipes(AlloySmelterRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.alloySmelter());
         recipes.addRecipes(RefineryRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.refinery());
+        recipes.addRecipes(FabricatorRecipeCategory.RECIPE_TYPE, ClientMachineRecipes.fabricator());
     }
 }

--- a/common/src/main/java/com/logistics/automation/jei/SyncMachineRecipesPacket.java
+++ b/common/src/main/java/com/logistics/automation/jei/SyncMachineRecipesPacket.java
@@ -5,6 +5,8 @@ import com.logistics.automation.alloysmelter.AlloySmelterRecipe;
 import com.logistics.automation.alloysmelter.AlloySmelterRecipeSerializer;
 import com.logistics.automation.crucible.CrucibleRecipe;
 import com.logistics.automation.crucible.CrucibleRecipeSerializer;
+import com.logistics.automation.fabricator.FabricatorRecipe;
+import com.logistics.automation.fabricator.FabricatorRecipeSerializer;
 import com.logistics.automation.macerator.MaceratorRecipeSerializer;
 import com.logistics.automation.macerator.MaceratorRecipeWrapper;
 import com.logistics.automation.refinery.RefineryRecipe;
@@ -29,7 +31,8 @@ public record SyncMachineRecipesPacket(
         List<SawmillRecipe> sawmill,
         List<CrucibleRecipe> crucible,
         List<AlloySmelterRecipe> alloySmelter,
-        List<RefineryRecipe> refinery)
+        List<RefineryRecipe> refinery,
+        List<FabricatorRecipe> fabricator)
         implements CustomPacketPayload {
 
     public static final CustomPacketPayload.Type<SyncMachineRecipesPacket> TYPE =
@@ -47,6 +50,8 @@ public record SyncMachineRecipesPacket(
                     SyncMachineRecipesPacket::alloySmelter,
                     RefineryRecipeSerializer.STREAM_CODEC.apply(ByteBufCodecs.list()),
                     SyncMachineRecipesPacket::refinery,
+                    FabricatorRecipeSerializer.STREAM_CODEC.apply(ByteBufCodecs.list()),
+                    SyncMachineRecipesPacket::fabricator,
                     SyncMachineRecipesPacket::new);
 
     @Override
@@ -54,13 +59,14 @@ public record SyncMachineRecipesPacket(
         return TYPE;
     }
 
-    /** Reads the server's loaded recipes and partitions the five machine recipe types into one packet. */
+    /** Reads the server's loaded recipes and partitions the six machine recipe types into one packet. */
     public static SyncMachineRecipesPacket from(MinecraftServer server) {
         List<MaceratorRecipeWrapper> macerator = new ArrayList<>();
         List<SawmillRecipe> sawmill = new ArrayList<>();
         List<CrucibleRecipe> crucible = new ArrayList<>();
         List<AlloySmelterRecipe> alloySmelter = new ArrayList<>();
         List<RefineryRecipe> refinery = new ArrayList<>();
+        List<FabricatorRecipe> fabricator = new ArrayList<>();
 
         server.getRecipeManager().getRecipes().forEach(holder -> {
             var recipe = holder.value();
@@ -74,9 +80,11 @@ public record SyncMachineRecipesPacket(
                 alloySmelter.add(r);
             } else if (recipe instanceof RefineryRecipe r) {
                 refinery.add(r);
+            } else if (recipe instanceof FabricatorRecipe r) {
+                fabricator.add(r);
             }
         });
 
-        return new SyncMachineRecipesPacket(macerator, sawmill, crucible, alloySmelter, refinery);
+        return new SyncMachineRecipesPacket(macerator, sawmill, crucible, alloySmelter, refinery, fabricator);
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -22,7 +22,8 @@
       "com.logistics.automation.sawmill.jei.SawmillJeiPlugin",
       "com.logistics.automation.alloysmelter.jei.AlloySmelterJeiPlugin",
       "com.logistics.automation.crucible.jei.CrucibleJeiPlugin",
-      "com.logistics.automation.refinery.jei.RefineryJeiPlugin"
+      "com.logistics.automation.refinery.jei.RefineryJeiPlugin",
+      "com.logistics.automation.fabricator.jei.FabricatorJeiPlugin"
     ],
     "jade": ["com.logistics.compat.jade.JadeLogisticsPlugin"]
   },


### PR DESCRIPTION
## Summary

Adds a JEI recipe category for the Sequential Fabricator. It was the only machine whose recipes didn't show in JEI (a release-QA FAIL) — its chipset recipes were invisible.

## Changes

- **Synced-recipe cache** — route `FabricatorRecipe` through the same server→client sync the other machines use, so JEI works in singleplayer and multiplayer (modern MC doesn't sync full recipe objects). Extends `SyncMachineRecipesPacket`, `ClientMachineRecipes`, and `MachineRecipeJeiSync`.
- **`FabricatorJeiPlugin`** — registers the category, the synced recipes, and the Sequential Fabricator as the crafting station. (Runtime sync hooks stay in `MaceratorJeiPlugin`, so they aren't duplicated.)
- **`FabricatorRecipeCategory`** — lays out the recipe's **variable number** of ingredients packed from the left, with the arrow and output positioned right after the last input (chipset recipes use 1–2 inputs; sized with headroom to 3). Reuses the shared progress-arrow sprite.
- **`fabric.mod.json`** — registers the plugin in `jei_mod_plugin` (NeoForge auto-discovers via `@JeiPlugin`).

## Notes

- Follows the existing synced-cache pattern exactly; can't read from the client `RecipeManager` directly without reintroducing the multiplayer bug from #735/#736.
- Ingredient counts aren't shown in the slots — consistent with the other machine categories (macerator/alloy-smelter don't either); a possible future polish.
- Validated: `./gradlew build` (both loaders compile) and `:common:test`. HUD/JEI rendering is runtime/visual, not unit-testable.
