### PR TITLE
docs(docs): refocus the README on the repo and delegate content to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 [![GitHub](https://img.shields.io/badge/GitHub-indemnity83%2Flogistics-blue?logo=github)](https://github.com/indemnity83/logistics)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![codecov](https://codecov.io/gh/Indemnity83/logistics/branch/mc%2F26.1/graph/badge.svg)](https://codecov.io/gh/Indemnity83/logistics)
+[![codecov](https://codecov.io/gh/Indemnity83/logistics/branch/mc%2F26.2/graph/badge.svg)](https://codecov.io/gh/Indemnity83/logistics)
 [![Minecraft](https://img.shields.io/badge/Minecraft-26.2-brightgreen.svg)](https://www.minecraft.net/)
-[![Fabric](https://img.shields.io/badge/Fabric-0.18.6-orange.svg)](https://fabricmc.net/)
+[![Loaders](https://img.shields.io/badge/Loaders-Fabric%20%26%20NeoForge-orange.svg)](https://fabricmc.net/)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/94DP3CVNVt)
 
 </div>
@@ -18,273 +18,116 @@
 
 ## ⚠️ Early Development
 
-**Logistics is in active development.** Core pipe transport works, but expect rough edges, missing features, and the occasional bug. Report issues on [GitHub](https://github.com/indemnity83/logistics/issues) if something breaks, or [join the Discord](https://discord.gg/94DP3CVNVt) for help and discussion.
+**Logistics is in active development.** Core systems work, but expect rough edges, missing features, and the occasional bug. Report issues on [GitHub](https://github.com/indemnity83/logistics/issues), or [join the Discord](https://discord.gg/94DP3CVNVt) for help and discussion.
 
-**Updating worlds:** while in pre-release, save compatibility reaches back one major version (the second version digit). Load your world in the **latest release of each major in turn** before jumping ahead — e.g. a `0.5.x` world should pass through the latest `0.6.x` before `0.7+`. Skipping a major may drop renamed blocks/items or saved machine state.
+While in pre-release, save compatibility reaches back one major version (the second version digit), so load your world in the **latest release of each major in turn** before jumping ahead. See the [release notes](https://github.com/indemnity83/logistics/releases) whenever you update.
 
 
 ## About
 
-Logistics is a multiloader (Fabric & NeoForge) mod inspired by BuildCraft and Logistics Pipes, bringing authentic item pipe systems to modern Minecraft. Items travel smoothly through thin pipes with visible motion, integrating seamlessly with other mods' storage on both loaders.
+Logistics is a multiloader (Fabric & NeoForge) mod inspired by BuildCraft and Logistics Pipes, bringing authentic item pipe systems to modern Minecraft. Items travel smoothly through thin pipes with visible motion, integrating with other mods' item, fluid, and energy storage on both loaders.
 
-**Design Principles:**
-- **Material-Based Identity** - Each pipe uses distinct vanilla materials for visual clarity
-- **Layered Progression** - Three tiers: Mechanical pipes (basic operations), Smart pipes (decisions), Network logistics (abstract services)
-- **Authentic Visuals** - Items travel continuously through pipes with visible speed
-- **Mod Interoperability** - Works with other mods' item, fluid, and energy storage on both Fabric and NeoForge
-- **Classic Ergonomics** - Simple placement, visible connections, easy to understand
+**What's inside:**
 
+- **Pipes** — item transport, extraction, filtering, and full network logistics (providers, requesters, suppliers, crafting, chassis + modules)
+- **Fluids** — a standalone fluid pipe/tank/pump system, separate from the item network
+- **Power** — RF engines (redstone, stirling, creative) and power cables
+- **Automation** — machines like the macerator, kiln, laser quarry, refinery, and sequential fabricator
 
-## How It Works
+The full, always-current catalog of blocks, items, machines, and mechanics lives in the wiki — this README stays focused on the repository itself.
 
-Logistics is built on a **three-tier system** that grows with your world progression.
-
-### Tier 1: Mechanical Pipes (Implemented)
-**Basic routing without item awareness**
-
-Start here. These pipes perform mechanical operations—moving, merging, extracting, deleting—but they don't look at what's flowing through them. They just do their job, every time, regardless of item type.
-
-- **Stone Transport Pipe (Stone)** - Very slow backbone connectivity with random routing
-- **Copper Transport Pipe (Copper)** - Backbone connectivity with random routing
-- **Item Extractor Pipe (Wood)** - Pull items from adjacent inventories into your network
-- **Item Merger Pipe (Iron)** - All inputs converge to a single output
-- **Golden Transport Pipe (Gold)** - Speed boost when powered by redstone
-- **Item Passthrough Pipe (Sandstone)** - Connects only to pipes; bypasses inventories
-- **Item Void Pipe (Obsidian)** - Delete unwanted items
-
-### Tier 2: Smart Pipes (Implemented)
-**Item-aware routing decisions**
-
-These pipes are intelligent. They inspect items and change behavior based on what they see. This is where your network becomes conditional and responsive.
-
-- **Item Filter Pipe (Diamond)** - Route specific items to specific destinations (item-aware)
-- **Item Insertion Pipe (Quartz)** - Prefer inventories with space; otherwise route to pipes
-
-### Tier 3: Network Logistics (Implemented)
-**System-aware automation and requests**
-
-Your inventories become abstract resources. Provider modules advertise what's available; supplier modules push stock; requester modules pull what's needed; crafting pipes handle on-demand autocrafting.
-
-**Pipes:**
-- **Basic Logistics Pipe** - Network backbone; accepts and deposits addressed items with optional filtering
-- **Provider Logistics Pipe** - Advertises adjacent inventory contents to the network
-- **Requester Logistics Pipe** - Requests specific items from the network on demand
-- **Supplier Logistics Pipe** - Keeps a target inventory stocked with configured items
-- **Crafting Logistics Pipe** - Automates crafting recipes fulfilled by the network
-- **Process Logistics Pipe** - Routes in-progress crafting jobs to dedicated machines
-- **Satellite Logistics Pipe** - Remote output point for routing items to distant destinations
-- **Chassis Pipes (MkI–MkV)** - Modular pipes with swappable logistics module slots
-
-**Modules (for Chassis Pipes):**
-- **Provider Module (I–II)** - Advertise inventory contents at different range/speed tiers
-- **Extractor Module (I–III)** - Pull items from adjacent inventories at increasing speeds
-- **Passive / Active Supplier Module** - Push stock to requesters (passive waits; active seeks)
-- **Crafter Module (I–III)** - Fulfill crafting requests at increasing speeds
-- **Quicksort Module** - Route items by type to sorted destinations
-- **Terminus Module** - Mark a pipe as a terminal endpoint; prevents routing past it
-- **Sink Module** - Accept any overflow items
-- **Polymorphic Sink Module** - Accept overflow, treating NBT-equal items as equivalent
-- **Enchantment Sink Module** - Accept overflow, ignoring enchantment differences
-- **Mod Sink Module** - Accept overflow filtered by mod origin
-
-Each tier builds on the previous one—you'll use all three together as your base grows.
+📖 **[Read the documentation →](https://indemnity83.github.io/logistics/)**
 
 
-## Features
+## Install (players)
 
-Logistics includes a complete system for item transport, power generation, and automation.
+**Requirements:** Minecraft 26.2 • Fabric (with Fabric API) or NeoForge • Java 25+
 
-### Pipes
-Transport items through networks with different behaviors:
-- **Basic Transport** - Stone and Copper pipes for backbone connectivity
-- **Extraction & Routing** - Wood (extractor), Iron (merger), Diamond (filter), Quartz (insertion) pipes
-- **Special Pipes** - Gold (speed boost), Sandstone (passthrough), Obsidian (void)
+The mod bundles its libraries — Team Reborn Energy, [Configory](https://modrinth.com/mod/configory), and (when crash reporting is enabled) the Sentry SDK — inside the jar, so there's nothing extra to install beyond the loader and Fabric API.
 
-[View all pipes →](https://indemnity83.github.io/logistics/pipes/)
-
-### Fluids
-Move and store liquids with a standalone fluid system, separate from the item network:
-- **Fluid Pipes** - Stone, Copper, and Gold pipes carry one fluid per line at increasing rates; passive transport is free
-- **Fluid Extractor Pipe** - Pull fluids from adjacent tanks and machines using RF
-- **Void Fluid Pipe** - Discard unwanted fluids
-- **Glass Tank** - 16-bucket buffer; stack tanks vertically to form one larger reservoir; fill or drain by hand with a bucket
-- **Pump** - Extract fluid sources from the world into your tanks and pipes, powered by RF
-
-Works with any mod's fluid storage on both Fabric and NeoForge.
-
-### Power
-RF energy generation and distribution:
-- **Redstone Engine** - Simple, safe, steady power; never overheats
-- **Stirling Engine** - Fuel-powered with heat management; shuts down safely on overheat
-- **Creative Engine** - Infinite power for testing and creative mode
-- **Power Cables (Copper/Gold/Ender)** - Distribute energy from engines to connected machines at increasing transfer rates
-
-[Learn about power systems →](https://indemnity83.github.io/logistics/power/)
-
-### Automation
-- **[Macerator](https://indemnity83.github.io/logistics/automation/macerator/)** - Grind ores, gems, and materials into fine dusts for smelting and crafting
-- **[Kiln](https://indemnity83.github.io/logistics/automation/kiln/)** - Electric furnace; smelts any vanilla smelting recipe using RF energy
-- **[Laser Quarry](https://indemnity83.github.io/logistics/automation/laser-quarry/)** - Automated 16×16 mining with energy-scaled speed
-
-### Tools
-- **[Wrench](https://indemnity83.github.io/logistics/tools/wrench/)** - Configuration tool for pipes and machines
-- **[Marking Fluid](https://indemnity83.github.io/logistics/tools/marking-fluid/)** - Color-code your pipe networks
-
-
-## Installation
-
-**Requirements:** Minecraft 26.1+ • Fabric (Loader 0.18.6+ with Fabric API) or NeoForge • Java 25+
-
-**Download from:**
-- [GitHub Releases](https://github.com/indemnity83/logistics/releases) (includes dev builds)
-- [Modrinth](https://modrinth.com/mod/logistics) (stable releases)
-- [CurseForge](https://www.curseforge.com/minecraft/mc-mods/logistics-automation) (stable releases)
+Download from:
+- [Modrinth](https://modrinth.com/mod/logistics) — stable releases
+- [CurseForge](https://www.curseforge.com/minecraft/mc-mods/logistics-automation) — stable releases
+- [GitHub Releases](https://github.com/indemnity83/logistics/releases) — includes dev/RC builds
 
 [Full installation guide →](https://indemnity83.github.io/logistics/getting-started/install/)
 
 
-## Crash Reporting & Privacy
+## Building from source
 
-Logistics can optionally send **sanitized** crash diagnostics to help fix bugs. It is **off by
-default** and opt-in per install via `/logistics diagnostics enable`. It never intentionally sends
-player names, UUIDs, IPs, server addresses, chat, or world data. See
-[CRASH_REPORTING.md](CRASH_REPORTING.md) for exactly what is and isn't collected.
+**Requirements:** JDK 25 and Git. The Gradle wrapper (`./gradlew`) handles everything else.
 
+```bash
+git clone https://github.com/indemnity83/logistics.git
+cd logistics
+./gradlew build            # compile both loaders + run unit tests and gametests
+```
 
-## Quick Start
+Built jars land in `fabric/build/libs/` and `neoforge/build/libs/`.
 
-1. **Craft pipes** - Start with stone or copper transport pipes
-2. **Connect to inventories** - Pipes automatically connect to chests and other storage
-3. **Extract items** - Use wood extractor pipes (wrench to configure)
-4. **Route and filter** - Combine different pipe types to build your network
+**Run in a dev environment:**
 
-[Build your first pipe network →](https://indemnity83.github.io/logistics/getting-started/first-network/)
+```bash
+./gradlew :fabric:runClient      # or :neoforge:runClient
+./gradlew :fabric:runServer      # or :neoforge:runServer
+```
 
+**Test & format:**
 
-## Status
+```bash
+./gradlew test                   # unit tests
+./gradlew :fabric:runClientGameTest   # in-game tests (Fabric)
+./gradlew spotlessApply          # auto-format; spotlessCheck verifies in CI
+./gradlew installGitHooks        # one-time: pre-commit formatting hook
+```
 
-### ✅ Implemented
-- Thin pipe blocks with 6-way connections
-- Server-side traveling item simulation with continuous progress
-- Client-side smooth visual rendering
-- Extraction from and insertion into adjacent inventories
-- Mechanical and Smart pipe behaviors
-- Network logistics: provider, requester, supplier, crafting, satellite, and chassis pipes
-- Autocrafting via vanilla Crafter integration
-- Redstone, Stirling, and Creative engines with heat management
-- Power cables (copper, gold, ender) for RF energy distribution between machines
-- Macerator for grinding ores, gems, and materials into dusts
-- Kiln as an RF-powered electric furnace for any vanilla smelting recipe
-- Laser Quarry with automatic frame construction and energy-scaled mining speed
-- Fluid pipes (transport, extraction, void) carrying one fluid per line
-- Glass Tank with vertical stacking, bucket interaction, and dynamic fill rendering
-- Pump for extracting world fluid sources into tanks and pipes
-- Machine fluid I/O contract, working with any mod's fluid storage on both loaders
-- Full Fabric and NeoForge loader support
+### Project layout
 
-### 🔮 Future
-- Combustion-tier engines and fluid-fueled power generation
-- Fluid logistics over the network (fluid ↔ item packaging)
-- Additional pipe upgrades and advanced logistics features
+Multiloader split — shared code plus thin loader adapters:
 
-See the [documentation](https://indemnity83.github.io/logistics/) for detailed information on pipes, power, automation, and more.
+```
+common/     # loader-agnostic server/common + client code (no Fabric/NeoForge imports)
+fabric/     # Fabric adapter and client wiring
+neoforge/   # NeoForge adapter and client wiring
+```
+
+Common code is organized into decoupled **domains** (`pipe`, `power`, `automation`, `core`) that depend only on abstractions in `core.lib`. See [`CLAUDE.md`](CLAUDE.md) for the full architecture, multiloader rules, and bootstrap flow. To diagnose performance, see [`PROFILING.md`](PROFILING.md).
+
+### Branches
+
+The repo supports several Minecraft versions in parallel. New work starts on the main branch and is cherry-picked to the maintenance branches.
+
+| Branch | Role |
+|---|---|
+| `mc/26.2` | Main / default — active development |
+| `mc/26.1`, `mc/1.21.11`, `mc/1.21.1` | Maintenance / backport targets |
+
+Details and the cross-version workflow are in [`CLAUDE.md`](CLAUDE.md).
 
 
 ## Contributing
 
-Contributions welcome! Report issues on [GitHub Issues](https://github.com/indemnity83/logistics/issues). For code contributions, see `CLAUDE.md` for development guidance. To diagnose performance, see `PROFILING.md`.
+Contributions welcome! Report issues on [GitHub Issues](https://github.com/indemnity83/logistics/issues); for code, read [`CLAUDE.md`](CLAUDE.md) first.
 
-### Pull request titles and changelogs
-
-This project uses Conventional Commit-style pull request titles. Release notes are generated from PR titles, so titles should describe the player-visible impact whenever possible.
-
-Format:
+Pull request **titles** use Conventional Commit format — release notes are generated from them, so prefer wording that describes the player-visible impact:
 
 ```text
 type(scope): short description
 ```
 
-Examples:
+Player-facing types appear in the changelog: `feat` (Added), `fix` (Fixed), `balance`/`change`/`perf` (Changed), `remove` (Removed). Internal types are hidden: `refactor`, `test`, `build`, `ci`, `chore`, `docs`. The full type/scope tables live in [`CLAUDE.md`](CLAUDE.md).
 
-```text
-feat(pipes): add priority routing mode
-fix(neoforge): fix startup crash on NeoForge
-perf(automation): reduce idle machine tick cost
-refactor(common): simplify platform service lookup
-test(pipes): add routing tests
-build(fabric): update publishing task
-ci(build): update Gradle cache settings
-chore(release): update release metadata
-chore(update): update dependencies
-```
 
-#### Changelog-visible types
+## Crash reporting & privacy
 
-These appear in player-facing release notes:
-
-| Type | Changelog section | Use for |
-|---|---|---|
-| `feat` | Added | New player-visible behavior |
-| `fix` | Fixed | Player-visible bug fixes |
-| `perf` | Improved | Player-visible performance improvements |
-
-#### Internal types
-
-These are allowed for PR organization, but do not appear in release notes:
-
-| Type | Use for |
-|---|---|
-| `refactor` | Code cleanup without player-visible behavior changes |
-| `test` | Test coverage |
-| `build` | Gradle, publishing, or build system changes |
-| `ci` | GitHub Actions or automation changes |
-| `chore` | Maintenance work |
-| `docs` | Documentation-only changes |
-| `revert` | Revert a previous change |
-
-#### Allowed scopes
-
-Use the scope that best describes the part of the mod affected:
-
-| Scope | Use for |
-|---|---|
-| `core` | Shared mod behavior, base blocks/items, recipes, world behavior |
-| `automation` | Machines, upgrades, automation logic |
-| `pipes` | Pipes, routing, extraction, insertion, pipe networks |
-| `energy` | Energy transfer and storage behavior |
-| `storage` | Inventories, storage blocks, adapters |
-| `ui` | Screens, tooltips, overlays, visible rendering/UX |
-| `compat` | Integration with other mods |
-| `fabric` | Fabric-specific user-visible behavior |
-| `neoforge` | NeoForge-specific user-visible behavior |
-| `docs` | README, wiki, or user documentation |
-| `release` | Release metadata |
-| `update` | Dependency and automated update PRs |
-| `common` | Shared/internal code changes with no better user-facing scope |
-| `build` | Build tooling or CI support scope |
-
-Prefer player-facing scopes for `feat`, `fix`, and `perf`.
-
-Good:
-
-```text
-fix(pipes): fix items getting stuck when a route becomes invalid
-```
-
-Avoid for player-facing changes:
-
-```text
-fix(common): invalidate pipe graph cache on neighbor update
-```
-
-The second title may be technically accurate, but the first produces better release notes.
+Logistics can optionally send **sanitized** crash diagnostics to help fix bugs. It is **off by default** and opt-in per install via `/logistics diagnostics enable`. It never intentionally sends player names, UUIDs, IPs, server addresses, chat, or world data. See [CRASH_REPORTING.md](CRASH_REPORTING.md) for exactly what is and isn't collected.
 
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
 
-Some textures are licensed under CC BY 4.0 or CC BY-NC-SA 4.0 - see [CREDITS.md](CREDITS.md) for attribution details.
+Some textures are licensed under CC BY 4.0 or CC BY-NC-SA 4.0 — see [CREDITS.md](CREDITS.md) for attribution details.
 
 
 ## Acknowledgments
@@ -293,7 +136,7 @@ Inspired by:
 - **BuildCraft** — Classic pipe mechanics and visual style
 - **Logistics Pipes** — Request/provider logistics system design
 - **Forestry** — machines and progressive automation
-- The Fabric community for excellent modding tools and APIs
+- The Fabric and NeoForge communities for excellent modding tools and APIs
 
 **Textures:**
 - Some textures used, adapted, or inspired from [Unused Textures](https://github.com/malcolmriley/unused-textures) by Malcolm Riley, licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
## Summary

The README had grown into a full content catalog (every pipe, all modules, a Status checklist) that duplicates the wiki and constantly goes stale — an audit found it was already missing five machines (Sawmill, Alloy Smelter, Crucible, Refinery, Sequential Fabricator), several fluid pipes, and the entire Gears→Valves→Chipsets crafting ladder.

This refocuses the README on the **repository** and delegates the always-changing content to the [wiki](https://indemnity83.github.io/logistics/).

## Changes

- **Removed** the exhaustive catalog (three-tier deep dive, per-pipe/per-module lists, full Features breakdown, "Status/Implemented" checklist) in favor of a short, stable "What's inside" summary that links the wiki.
- **Added** a **Building from source** section — clone, `./gradlew build`, per-loader `runClient`/`runServer`, `test` + gametests, spotless + git hooks.
- **Added** a **Project layout** overview and a **Branches** table, both pointing to `CLAUDE.md`.
- Trimmed the large PR-title/scope tables to the essentials + link to `CLAUDE.md`.
- Added a **bundled libraries** note (Team Reborn Energy, Configory, Sentry ship jar-in-jar).

## Fixes (staleness)

- codecov badge `mc/26.1` → `mc/26.2`
- Fabric `0.18.6` badge → version-agnostic **Fabric & NeoForge** badge
- Requirements `Minecraft 26.1+ / Loader 0.18.6+` → `Minecraft 26.2`
- Acknowledgments now credits both the Fabric and NeoForge communities

## Notes

README-only; 307 → ~150 lines. Not backported yet — the branch-specific values (codecov branch, MC version, branch table) would need per-branch adaptation.