### PR TITLE
refactor(ui): converge pipe menu click handling behind a shared base

### DIFF
--- a/common/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/AdvancedExtractorScreenHandler.java
@@ -10,8 +10,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
@@ -25,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
  * Shows 9 filter ghost slots and an Include/Exclude toggle.
  * No mode selection (unlike the Provider GUI).
  */
-public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
+public class AdvancedExtractorScreenHandler extends CustomSlotScreenHandler {
     private static final int FILTER_SLOT_COUNT = 9;
     private static final int SLOT_SIZE = 18;
     private static final int FILTER_START_Y = 18;
@@ -142,15 +140,15 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
     public ItemStack quickMoveStack(Player player, int slot) { return ItemStack.EMPTY; }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         if (slotIndex >= 0 && slotIndex < FILTER_SLOT_COUNT) {
-            if (actionType == ContainerInput.QUICK_MOVE) return;
+            if (quickMove) return true;
 
             ItemStack cursor = getCarried();
 
             if (button == 1 || cursor.isEmpty()) {
                 if (itemConfigPlayer != null) {
-                    if (!isPinnedItemStillHeld()) return;
+                    if (!isPinnedItemStillHeld()) return true;
                     filterInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
@@ -164,13 +162,13 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                             module.setFilterItem(ctx, slotIndex, ""));
                 }
                 broadcastChanges();
-                return;
+                return true;
             }
 
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM
                     .getKey(cursor.getItem()).toString();
             if (itemConfigPlayer != null) {
-                if (!isPinnedItemStillHeld()) return;
+                if (!isPinnedItemStillHeld()) return true;
                 filterInventory.setItem(slotIndex, cursor.copyWithCount(1));
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
@@ -184,10 +182,10 @@ public class AdvancedExtractorScreenHandler extends AbstractContainerMenu {
                         module.setFilterItem(ctx, slotIndex, itemId));
             }
             broadcastChanges();
-            return;
+            return true;
         }
 
-        super.clicked(slotIndex, button, actionType, player);
+        return false;
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/CraftingScreenHandler.java
@@ -11,8 +11,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
@@ -25,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
  * Screen handler for the Crafting Logistics Pipe GUI.
  * Displays a 3x3 ghost crafting grid, a ghost result slot, and a blocking mode toggle.
  */
-public class CraftingScreenHandler extends AbstractContainerMenu {
+public class CraftingScreenHandler extends CustomSlotScreenHandler {
     // Slot layout
     private static final int INGREDIENT_SLOTS = 9;
     private static final int RESULT_SLOT = 9;
@@ -164,9 +162,9 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
     }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         if (slotIndex >= 0 && slotIndex < TOTAL_GHOST_SLOTS) {
-            if (actionType == ContainerInput.QUICK_MOVE) return;
+            if (quickMove) return true;
 
             ItemStack cursor = getCarried();
             boolean isResultSlot = slotIndex == RESULT_SLOT;
@@ -175,7 +173,7 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
                 if (isResultSlot) clearResultSlot();
                 else clearIngredientSlot(slotIndex);
                 broadcastChanges();
-                return;
+                return true;
             }
 
             // Left-click with item: place ghost item
@@ -184,10 +182,10 @@ public class CraftingScreenHandler extends AbstractContainerMenu {
             if (isResultSlot) setResultSlot(cursor.copyWithCount(count), itemId, count);
             else setIngredientSlot(slotIndex, cursor.copyWithCount(count), itemId, count);
             broadcastChanges();
-            return;
+            return true;
         }
 
-        super.clicked(slotIndex, button, actionType, player);
+        return false;
     }
 
     private void clearResultSlot() {

--- a/common/src/main/java/com/logistics/pipe/ui/CustomSlotScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/CustomSlotScreenHandler.java
@@ -1,0 +1,43 @@
+package com.logistics.pipe.ui;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerInput;
+import net.minecraft.world.inventory.MenuType;
+
+/**
+ * Base menu for pipe UIs that manage custom (filter / ghost) slots by intercepting slot clicks.
+ *
+ * <p>Quarantines the sole cross-version divergence in the {@link #clicked} override signature so
+ * every subclass stays byte-identical across branches. The click-action type is
+ * {@code ContainerInput} on mc/26.x and {@code ClickType} on mc/1.21.x; this class is the only
+ * place either name appears. Subclasses implement {@link #handleCustomSlotClick} with a
+ * version-stable signature and never reference it.
+ *
+ * <p>Per branch, this file carries the matching type — {@code ContainerInput} on mc/26.x,
+ * {@code ClickType} on mc/1.21.x — in the import and the two references in {@link #clicked}
+ * (parameter type and {@code QUICK_MOVE}). Nothing else here, or in any subclass, changes.
+ */
+public abstract class CustomSlotScreenHandler extends AbstractContainerMenu {
+
+    protected CustomSlotScreenHandler(MenuType<?> menuType, int syncId) {
+        super(menuType, syncId);
+    }
+
+    @Override
+    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+        if (handleCustomSlotClick(slotIndex, button, actionType == ContainerInput.QUICK_MOVE, player)) {
+            return;
+        }
+        super.clicked(slotIndex, button, actionType, player);
+    }
+
+    /**
+     * Handle a click on one of this menu's custom slots.
+     *
+     * @param quickMove whether this was a shift/quick-move click
+     * @return {@code true} if the click was fully handled and vanilla handling should be skipped;
+     *     {@code false} to fall through to {@link AbstractContainerMenu#clicked}
+     */
+    protected abstract boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player);
+}

--- a/common/src/main/java/com/logistics/pipe/ui/CustomSlotScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/CustomSlotScreenHandler.java
@@ -13,10 +13,6 @@ import net.minecraft.world.inventory.MenuType;
  * {@code ContainerInput} on mc/26.x and {@code ClickType} on mc/1.21.x; this class is the only
  * place either name appears. Subclasses implement {@link #handleCustomSlotClick} with a
  * version-stable signature and never reference it.
- *
- * <p>Per branch, this file carries the matching type — {@code ContainerInput} on mc/26.x,
- * {@code ClickType} on mc/1.21.x — in the import and the two references in {@link #clicked}
- * (parameter type and {@code QUICK_MOVE}). Nothing else here, or in any subclass, changes.
  */
 public abstract class CustomSlotScreenHandler extends AbstractContainerMenu {
 

--- a/common/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ItemFilterScreenHandler.java
@@ -14,15 +14,13 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import org.jetbrains.annotations.Nullable;
 
-public class ItemFilterScreenHandler extends AbstractContainerMenu {
+public class ItemFilterScreenHandler extends CustomSlotScreenHandler {
     private static final int FILTER_SLOT_COUNT =
             ItemFilterModule.FILTER_ORDER.length * ItemFilterModule.FILTER_SLOTS_PER_SIDE;
     private static final int SLOT_SIZE = 18;
@@ -124,10 +122,10 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
     }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         if (slotIndex >= 0 && slotIndex < FILTER_SLOT_COUNT) {
-            if (actionType == ContainerInput.QUICK_MOVE) {
-                return;
+            if (quickMove) {
+                return true;
             }
 
             ItemStack cursor = getCarried();
@@ -142,10 +140,10 @@ public class ItemFilterScreenHandler extends AbstractContainerMenu {
             }
 
             broadcastChanges();
-            return;
+            return true;
         }
 
-        super.clicked(slotIndex, button, actionType, player);
+        return false;
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/ui/ModSinkScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ModSinkScreenHandler.java
@@ -10,8 +10,6 @@ import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
@@ -35,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>On close, any item in the preview slot is returned to the player's inventory.
  */
-public class ModSinkScreenHandler extends AbstractContainerMenu {
+public class ModSinkScreenHandler extends CustomSlotScreenHandler {
     public static final int MAX_FILTER_SLOTS = ModSinkModule.MAX_FILTERS;
     public static final int PREVIEW_SLOT = 0;
     public static final int FILTER_SLOT_START = 1;
@@ -133,12 +131,9 @@ public class ModSinkScreenHandler extends AbstractContainerMenu {
     }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         // Filter display slots are not directly interactable
-        if (slotIndex >= FILTER_SLOT_START && slotIndex < FILTER_SLOT_START + MAX_FILTER_SLOTS) {
-            return;
-        }
-        super.clicked(slotIndex, button, actionType, player);
+        return slotIndex >= FILTER_SLOT_START && slotIndex < FILTER_SLOT_START + MAX_FILTER_SLOTS;
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/ui/ProcessScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ProcessScreenHandler.java
@@ -8,8 +8,6 @@ import com.logistics.pipe.network.NetworkRegistry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
@@ -27,7 +25,7 @@ import java.util.List;
  * ContainerData[0-8]: input counts. [9]: output count. [10]: active. [11]: satellite id. [12]: satellite registered (1=yes).
  * Button 0 = satellite prev, button 1 = satellite next (cycles through Off + registered IDs only).
  */
-public class ProcessScreenHandler extends AbstractContainerMenu {
+public class ProcessScreenHandler extends CustomSlotScreenHandler {
     private static final int INPUT_SLOTS = ProcessModule.MAX_INPUTS;   // 9
     private static final int OUTPUT_SLOTS = ProcessModule.MAX_OUTPUTS; // 1
     private static final int TOTAL_GHOST_SLOTS = INPUT_SLOTS + OUTPUT_SLOTS;
@@ -160,9 +158,9 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
     }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         if (slotIndex >= 0 && slotIndex < TOTAL_GHOST_SLOTS) {
-            if (actionType == ContainerInput.QUICK_MOVE) return;
+            if (quickMove) return true;
 
             ItemStack cursor = getCarried();
             boolean isInput = slotIndex < INPUT_SLOTS;
@@ -180,7 +178,7 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
                             else module.setOutput(ctx, moduleSlot, "", 1);
                         }));
                 broadcastChanges();
-                return;
+                return true;
             }
 
             // Left-click with item: place ghost item
@@ -201,10 +199,10 @@ public class ProcessScreenHandler extends AbstractContainerMenu {
                         }
                     }));
             broadcastChanges();
-            return;
+            return true;
         }
 
-        super.clicked(slotIndex, button, actionType, player);
+        return false;
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/ProviderScreenHandler.java
@@ -10,8 +10,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
@@ -24,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
  * Screen handler for the Provider GUI.
  * Displays mode selection button to control which items are available for extraction.
  */
-public class ProviderScreenHandler extends AbstractContainerMenu {
+public class ProviderScreenHandler extends CustomSlotScreenHandler {
     private static final int FILTER_SLOT_COUNT = 9;
     private static final int SLOT_SIZE = 18;
     private static final int FILTER_START_Y = 18;
@@ -148,9 +146,9 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
     }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         if (slotIndex >= 0 && slotIndex < FILTER_SLOT_COUNT) {
-            if (actionType == ContainerInput.QUICK_MOVE) return;
+            if (quickMove) return true;
 
             ItemStack cursor = getCarried();
 
@@ -158,16 +156,16 @@ public class ProviderScreenHandler extends AbstractContainerMenu {
                 if (itemConfigPlayer != null) handleClearSlotForPlayer(slotIndex);
                 else handleClearSlotForModule(slotIndex);
                 broadcastChanges();
-                return;
+                return true;
             }
 
             if (itemConfigPlayer != null) handlePlaceItemForPlayer(slotIndex, cursor);
             else handlePlaceItemForModule(slotIndex, cursor);
             broadcastChanges();
-            return;
+            return true;
         }
 
-        super.clicked(slotIndex, button, actionType, player);
+        return false;
     }
 
     private void handleClearSlotForPlayer(int slotIndex) {

--- a/common/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/SinkScreenHandler.java
@@ -11,8 +11,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
@@ -25,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
  * Screen handler for the Sink GUI (Basic Logistics Pipe).
  * Displays 9 filter slots and a Default Route toggle.
  */
-public class SinkScreenHandler extends AbstractContainerMenu {
+public class SinkScreenHandler extends CustomSlotScreenHandler {
     private static final int FILTER_SLOT_COUNT = SinkModule.MAX_FILTER_SLOTS;
     private static final int SLOT_SIZE = 18;
     private static final int PLAYER_INV_START_Y = 60;
@@ -168,11 +166,11 @@ public class SinkScreenHandler extends AbstractContainerMenu {
     }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         if (slotIndex >= 0 && slotIndex < FILTER_SLOT_COUNT) {
             // Prevent shift-click
-            if (actionType == ContainerInput.QUICK_MOVE) {
-                return;
+            if (quickMove) {
+                return true;
             }
 
             ItemStack cursor = getCarried();
@@ -180,7 +178,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             // Right-click: Clear slot
             if (button == 1) {
                 if (itemConfigPlayer != null) {
-                    if (!isPinnedItemStillHeld()) return;
+                    if (!isPinnedItemStillHeld()) return true;
                     sinkInventory.setItem(slotIndex, ItemStack.EMPTY);
                     final int s = slotIndex;
                     ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
@@ -199,12 +197,12 @@ public class SinkScreenHandler extends AbstractContainerMenu {
                     });
                 }
                 broadcastChanges();
-                return;
+                return true;
             }
 
             // Left-click: Set filter
             if (cursor.isEmpty()) {
-                return; // Nothing to do
+                return true; // Nothing to do
             }
 
             String itemId = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(cursor.getItem()).toString();
@@ -212,7 +210,7 @@ public class SinkScreenHandler extends AbstractContainerMenu {
 
             // Save to module configuration
             if (itemConfigPlayer != null) {
-                if (!isPinnedItemStillHeld()) return;
+                if (!isPinnedItemStillHeld()) return true;
                 sinkInventory.setItem(slotIndex, ghostItem);
                 final int s = slotIndex;
                 ItemTagUtils.writeToItemTag(itemConfigPlayer, itemConfigHand, tag -> {
@@ -228,10 +226,10 @@ public class SinkScreenHandler extends AbstractContainerMenu {
             }
 
             broadcastChanges();
-            return;
+            return true;
         }
 
-        super.clicked(slotIndex, button, actionType, player);
+        return false;
     }
 
     @Override

--- a/common/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
+++ b/common/src/main/java/com/logistics/pipe/ui/SupplierScreenHandler.java
@@ -11,8 +11,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.SimpleContainerData;
@@ -27,7 +25,7 @@ import java.util.function.BiConsumer;
  * Screen handler for the Supplier GUI.
  * Displays 9 supply slots where players can configure items and target amounts to maintain in the connected inventory.
  */
-public class SupplierScreenHandler extends AbstractContainerMenu {
+public class SupplierScreenHandler extends CustomSlotScreenHandler {
     private static final int SUPPLY_SLOT_COUNT = SupplierModule.MAX_SUPPLY_SLOTS;
     private static final int SLOT_SIZE = 18;
     private static final int PLAYER_INV_START_Y = 60;
@@ -148,10 +146,10 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
     }
 
     @Override
-    public void clicked(int slotIndex, int button, ContainerInput actionType, Player player) {
+    protected boolean handleCustomSlotClick(int slotIndex, int button, boolean quickMove, Player player) {
         if (slotIndex >= 0 && slotIndex < SUPPLY_SLOT_COUNT) {
-            if (actionType == ContainerInput.QUICK_MOVE) return;
-            if (itemConfigPlayer != null && !isPinnedItemStillHeld()) return;
+            if (quickMove) return true;
+            if (itemConfigPlayer != null && !isPinnedItemStillHeld()) return true;
 
             ItemStack cursor = getCarried();
             ItemStack slotItem = supplyInventory.getItem(slotIndex);
@@ -159,7 +157,7 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             if (button == 1 || cursor.isEmpty()) {
                 clearSupplySlot(slotIndex);
                 broadcastChanges();
-                return;
+                return true;
             }
 
             // Left-click with item: Add to count or place new item
@@ -178,10 +176,10 @@ public class SupplierScreenHandler extends AbstractContainerMenu {
             supplyInventory.setItem(slotIndex, cursor.copyWithCount(newAmount));
             saveSupplySlot(slotIndex, itemId, newAmount);
             broadcastChanges();
-            return;
+            return true;
         }
 
-        super.clicked(slotIndex, button, actionType, player);
+        return false;
     }
 
     private void clearSupplySlot(int slotIndex) {


### PR DESCRIPTION
## Summary

Extracts a shared `CustomSlotScreenHandler` base for the pipe UI menus so their click handling stops diverging across MC-version branches. Behavior is unchanged — this is a structural refactor that quarantines a version-specific Minecraft API difference in one place.

## Why

`AbstractContainerMenu.clicked(...)` takes a `ContainerInput` on mc/26.x but a `ClickType` on mc/1.21.x. Because that type sits in an `@Override` signature, all 8 pipe UI screen handlers carried the divergence, so the same 8 files differed on every version branch — friction for every future cross-version cherry-pick.

## Changes

- Add `com.logistics.pipe.ui.CustomSlotScreenHandler` — owns the single `clicked` override and delegates to a version-stable hook `handleCustomSlotClick(slotIndex, button, quickMove, player)` (return `true` to swallow the click, `false` to fall through to vanilla handling).
- Route all 8 handlers (Advanced Extractor, Crafting, Item Filter, Mod Sink, Process, Provider, Sink, Supplier) through the base.

## Notes

- **Behavior unchanged.** Each handler's custom-slot branch already handled-and-returned before ever reaching `super.clicked`; those paths now return `true`, out-of-range returns `false`.
- **Cross-version parity:** the branch-to-branch diff for `pipe/ui` drops from **8 files to 1** — only the base file carries the `ContainerInput`/`ClickType` token (3 lines). A matching backport to `mc/1.21.11` follows once this merges.
- `refactor` → hidden from the changelog (internal parity work).