### PR TITLE
refactor(automation): converge machine-recipe assemble behind a base

### DIFF
--- a/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterRecipe.java
+++ b/common/src/main/java/com/logistics/automation/alloysmelter/AlloySmelterRecipe.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.alloysmelter;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.AbstractLogisticsRecipe;
 import com.logistics.core.lib.recipe.ItemResult;
 import com.logistics.core.lib.recipe.RecipeByproduct;
 import java.util.List;
@@ -8,7 +9,6 @@ import java.util.Optional;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.PlacementInfo;
-import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
  * {@code Cobblestone + Sand}). The resolver derives per-slot consumption counts from the actual
  * placement via {@link #consumptionForSlots}.
  */
-public class AlloySmelterRecipe implements Recipe<DualRecipeInput> {
+public class AlloySmelterRecipe extends AbstractLogisticsRecipe<DualRecipeInput> {
 
     public static final float DEFAULT_EXPERIENCE = 0.0f;
 
@@ -150,7 +150,7 @@ public class AlloySmelterRecipe implements Recipe<DualRecipeInput> {
     }
 
     @Override
-    public @NotNull ItemStack assemble(@NotNull DualRecipeInput input) {
+    protected @NotNull ItemStack assembleResult() {
         return result.toStack();
     }
 

--- a/common/src/main/java/com/logistics/automation/crucible/CrucibleRecipe.java
+++ b/common/src/main/java/com/logistics/automation/crucible/CrucibleRecipe.java
@@ -1,12 +1,12 @@
 package com.logistics.automation.crucible;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.AbstractLogisticsRecipe;
 import com.logistics.core.lib.recipe.FluidResult;
 import java.util.List;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.PlacementInfo;
-import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
  * their {@code logistics:crucible} type. The output is a {@link FluidResult} deposited into the
  * machine's tank — there is no item result.
  */
-public class CrucibleRecipe implements Recipe<SingleRecipeInput> {
+public class CrucibleRecipe extends AbstractLogisticsRecipe<SingleRecipeInput> {
 
     public static final int DEFAULT_INGREDIENT_COUNT = 1;
     public static final float DEFAULT_EXPERIENCE = 0.0f;
@@ -92,7 +92,7 @@ public class CrucibleRecipe implements Recipe<SingleRecipeInput> {
     }
 
     @Override
-    public @NotNull ItemStack assemble(@NotNull SingleRecipeInput input) {
+    protected @NotNull ItemStack assembleResult() {
         // Fluid-only output — nothing goes into an item slot.
         return ItemStack.EMPTY;
     }

--- a/common/src/main/java/com/logistics/automation/fabricator/FabricatorRecipe.java
+++ b/common/src/main/java/com/logistics/automation/fabricator/FabricatorRecipe.java
@@ -1,11 +1,11 @@
 package com.logistics.automation.fabricator;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.AbstractLogisticsRecipe;
 import com.logistics.core.lib.recipe.ItemResult;
 import java.util.List;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.PlacementInfo;
-import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Ingredient availability is checked against the whole 12-slot pool via {@link #canCraftFrom},
  * not vanilla grid matching, so the recipe carries no slot layout.
  */
-public class FabricatorRecipe implements Recipe<FabricatorInput> {
+public class FabricatorRecipe extends AbstractLogisticsRecipe<FabricatorInput> {
 
     private final List<SizedIngredient> ingredients;
     private final ItemResult result;
@@ -116,7 +116,7 @@ public class FabricatorRecipe implements Recipe<FabricatorInput> {
     }
 
     @Override
-    public @NotNull ItemStack assemble(@NotNull FabricatorInput input) {
+    protected @NotNull ItemStack assembleResult() {
         return result.toStack();
     }
 

--- a/common/src/main/java/com/logistics/automation/kiln/SmeltingRecipeResolver.java
+++ b/common/src/main/java/com/logistics/automation/kiln/SmeltingRecipeResolver.java
@@ -2,6 +2,7 @@ package com.logistics.automation.kiln;
 
 import com.logistics.LogisticsAutomation;
 import com.logistics.LogisticsConfigHost;
+import com.logistics.core.lib.compat.RecipeCompat;
 import com.logistics.core.machine.MachineContext;
 import com.logistics.core.machine.component.ProcessIO;
 import com.logistics.core.machine.component.RecipePlan;
@@ -38,7 +39,7 @@ public final class SmeltingRecipeResolver implements RecipeResolver {
                 .getRecipeFor(RecipeType.SMELTING, recipeInput, level)
                 .map(holder -> new RecipePlan(
                         holder.value().cookingTime() * LogisticsConfigHost.get(LogisticsAutomation.CONFIG.KILN_RF_PER_COOK_TICK),
-                        holder.value().assemble(recipeInput),
+                        RecipeCompat.assemble(holder.value(), recipeInput, level),
                         holder.value().experience()))
                 .orElse(null);
     }

--- a/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeWrapper.java
+++ b/common/src/main/java/com/logistics/automation/macerator/MaceratorRecipeWrapper.java
@@ -1,12 +1,12 @@
 package com.logistics.automation.macerator;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.AbstractLogisticsRecipe;
 import com.logistics.core.lib.recipe.ItemResult;
 import com.logistics.core.lib.recipe.RecipeByproduct;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.PlacementInfo;
-import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -28,7 +28,7 @@ import java.util.Optional;
  *
  * <p>Both the machine ({@code MaceratorBlockEntity}) and recipe display read this directly.
  */
-public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
+public class MaceratorRecipeWrapper extends AbstractLogisticsRecipe<SingleRecipeInput> {
 
     public static final int DEFAULT_ENERGY = 2000;
     public static final float DEFAULT_EXPERIENCE = 0.0f;
@@ -110,7 +110,7 @@ public class MaceratorRecipeWrapper implements Recipe<SingleRecipeInput> {
     }
 
     @Override
-    public @NotNull ItemStack assemble(@NotNull SingleRecipeInput input) {
+    protected @NotNull ItemStack assembleResult() {
         return result.toStack();
     }
 

--- a/common/src/main/java/com/logistics/automation/refinery/RefineryRecipe.java
+++ b/common/src/main/java/com/logistics/automation/refinery/RefineryRecipe.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.refinery;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.AbstractLogisticsRecipe;
 import com.logistics.core.lib.recipe.FluidResult;
 import com.logistics.core.lib.recipe.RecipeByproduct;
 import java.util.List;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
  * the input tank's fluid. The item-facing {@link Recipe} methods therefore behave as a non-placeable,
  * non-item recipe.
  */
-public class RefineryRecipe implements Recipe<SingleRecipeInput> {
+public class RefineryRecipe extends AbstractLogisticsRecipe<SingleRecipeInput> {
 
     public static final float DEFAULT_EXPERIENCE = 0.0f;
 
@@ -89,7 +90,7 @@ public class RefineryRecipe implements Recipe<SingleRecipeInput> {
     }
 
     @Override
-    public @NotNull ItemStack assemble(@NotNull SingleRecipeInput input) {
+    protected @NotNull ItemStack assembleResult() {
         // Fluid-only output — nothing goes into an item slot.
         return ItemStack.EMPTY;
     }

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipe.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipe.java
@@ -1,6 +1,7 @@
 package com.logistics.automation.sawmill;
 
 import com.logistics.LogisticsAutomation;
+import com.logistics.core.lib.recipe.AbstractLogisticsRecipe;
 import com.logistics.core.lib.recipe.ItemResult;
 import com.logistics.core.lib.recipe.RecipeByproduct;
 import java.util.List;
@@ -8,7 +9,6 @@ import java.util.Optional;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.PlacementInfo;
-import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
  * Sawmill recipe — one ingredient cut into a primary product plus a chance-based byproduct
  * (Wood Pulp). Loaded by vanilla's {@code RecipeManager} under the {@code logistics:sawmill} type.
  */
-public class SawmillRecipe implements Recipe<SingleRecipeInput> {
+public class SawmillRecipe extends AbstractLogisticsRecipe<SingleRecipeInput> {
 
     public static final int DEFAULT_INGREDIENT_COUNT = 1;
     public static final float DEFAULT_EXPERIENCE = 0.0f;
@@ -95,7 +95,7 @@ public class SawmillRecipe implements Recipe<SingleRecipeInput> {
     }
 
     @Override
-    public @NotNull ItemStack assemble(@NotNull SingleRecipeInput input) {
+    protected @NotNull ItemStack assembleResult() {
         return result.toStack();
     }
 

--- a/common/src/main/java/com/logistics/core/lib/compat/RecipeCompat.java
+++ b/common/src/main/java/com/logistics/core/lib/compat/RecipeCompat.java
@@ -1,0 +1,24 @@
+package com.logistics.core.lib.compat;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeInput;
+import net.minecraft.world.level.Level;
+
+/**
+ * Hides the cross-version arity of {@link Recipe#assemble} at call sites that invoke a
+ * <em>vanilla</em> recipe (which can't route through {@link
+ * com.logistics.core.lib.recipe.AbstractLogisticsRecipe}). The call is {@code assemble(input)} on
+ * mc/26.x and {@code assemble(input, level.registryAccess())} on mc/1.21.x.
+ *
+ * <p>Per branch, only this file carries the matching call; the mc/1.21.x form passes
+ * {@code level.registryAccess()} as the second argument.
+ */
+public final class RecipeCompat {
+
+    private RecipeCompat() {}
+
+    public static <I extends RecipeInput> ItemStack assemble(Recipe<I> recipe, I input, Level level) {
+        return recipe.assemble(input);
+    }
+}

--- a/common/src/main/java/com/logistics/core/lib/recipe/AbstractLogisticsRecipe.java
+++ b/common/src/main/java/com/logistics/core/lib/recipe/AbstractLogisticsRecipe.java
@@ -1,0 +1,27 @@
+package com.logistics.core.lib.recipe;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeInput;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Base for the mod's machine recipes. Quarantines the sole cross-version divergence in the vanilla
+ * {@link Recipe#assemble} override signature so subclasses stay byte-identical across branches: it
+ * is {@code assemble(I)} on mc/26.x and {@code assemble(I, HolderLookup.Provider)} on mc/1.21.x.
+ * Subclasses provide their output through the version-stable {@link #assembleResult()} hook and
+ * never override {@code assemble} themselves.
+ *
+ * <p>Per branch, only this file carries the matching signature; the mc/1.21.x form adds the
+ * {@code HolderLookup.Provider} parameter (and its import).
+ */
+public abstract class AbstractLogisticsRecipe<I extends RecipeInput> implements Recipe<I> {
+
+    @Override
+    public @NotNull ItemStack assemble(@NotNull I input) {
+        return assembleResult();
+    }
+
+    /** The recipe's assembled item output (the mod's machine recipes ignore the input here). */
+    protected abstract @NotNull ItemStack assembleResult();
+}


### PR DESCRIPTION
## Summary

Extracts a shared base for the mod's machine recipes so their `assemble` implementation stops diverging across MC-version branches. Behavior is unchanged — a structural refactor that quarantines a version-specific Minecraft API difference in one place.

## Why

Vanilla `Recipe.assemble` takes `assemble(input)` on mc/26.x but `assemble(input, HolderLookup.Provider)` on mc/1.21.x. Because that's an `@Override` signature, all 6 machine-recipe classes (plus one vanilla-recipe call site) carried the divergence on every legacy branch — friction for every future cross-version cherry-pick.

## Changes

- Add `core/lib/recipe/AbstractLogisticsRecipe<I>` — owns the single `assemble` override and delegates to a version-stable `assembleResult()` hook.
- Route `AlloySmelterRecipe`, `CrucibleRecipe`, `FabricatorRecipe`, `MaceratorRecipeWrapper`, `RefineryRecipe`, and `SawmillRecipe` through the base.
- Add `core/lib/compat/RecipeCompat.assemble(recipe, input, level)` for call sites that invoke a *vanilla* recipe's `assemble` (`SmeltingRecipeResolver`).

## Notes

- **Behavior unchanged** — the `assemble` bodies already ignored their input and returned a fixed result.
- **Cross-version parity:** these files become byte-identical across branches except the two quarantine files (`AbstractLogisticsRecipe`, `RecipeCompat`), which carry the one API difference. Backports to `mc/26.1` (fully identical) and `mc/1.21.11` follow once this merges.
- `refactor` → hidden from the changelog (internal parity work).