### PR TITLE
refactor(worldgen): hide lake feature config arity behind LakeConfigCompat

### DIFF
--- a/common/src/main/java/com/logistics/core/lib/compat/LakeConfigCompat.java
+++ b/common/src/main/java/com/logistics/core/lib/compat/LakeConfigCompat.java
@@ -1,0 +1,27 @@
+package com.logistics.core.lib.compat;
+
+import net.minecraft.world.level.levelgen.feature.LakeFeature;
+import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
+
+/**
+ * Rebuilds a {@link LakeFeature.Configuration} with a replaced barrier state provider, hiding the
+ * cross-version arity of its constructor: mc/26.2 takes
+ * {@code (fluid, barrier, canPlaceFeature, canReplaceWithAirOrFluid, canReplaceWithBarrier)} while
+ * mc/26.1 and mc/1.21.x take {@code (fluid, barrier)}.
+ *
+ * <p>Per branch, only this file carries the matching constructor; the mc/26.2 form forwards the
+ * three extra placement flags from {@code base}.
+ */
+public final class LakeConfigCompat {
+
+    private LakeConfigCompat() {}
+
+    public static LakeFeature.Configuration withBarrier(LakeFeature.Configuration base, BlockStateProvider barrier) {
+        return new LakeFeature.Configuration(
+                base.fluid(),
+                barrier,
+                base.canPlaceFeature(),
+                base.canReplaceWithAirOrFluid(),
+                base.canReplaceWithBarrier());
+    }
+}

--- a/common/src/main/java/com/logistics/core/worldgen/OilSeepFeature.java
+++ b/common/src/main/java/com/logistics/core/worldgen/OilSeepFeature.java
@@ -1,5 +1,6 @@
 package com.logistics.core.worldgen;
 
+import com.logistics.core.lib.compat.LakeConfigCompat;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.WorldGenLevel;
@@ -33,12 +34,8 @@ public class OilSeepFeature extends LakeFeature {
     public boolean place(FeaturePlaceContext<LakeFeature.Configuration> context) {
         OilOreMix mix = OilOreMix.forBiome(context.level(), context.origin());
         LakeFeature.Configuration base = context.config();
-        LakeFeature.Configuration withOreBarrier = new LakeFeature.Configuration(
-                base.fluid(),
-                BlockStateProvider.simple(mix.ore().get()),
-                base.canPlaceFeature(),
-                base.canReplaceWithAirOrFluid(),
-                base.canReplaceWithBarrier());
+        LakeFeature.Configuration withOreBarrier =
+                LakeConfigCompat.withBarrier(base, BlockStateProvider.simple(mix.ore().get()));
         FeaturePlaceContext<LakeFeature.Configuration> withBarrier = new FeaturePlaceContext<>(
                 context.topFeature(), context.level(), context.chunkGenerator(),
                 context.random(), context.origin(), withOreBarrier);


### PR DESCRIPTION
## Summary

Extracts a small compat helper so `OilSeepFeature`'s lake-config construction stops diverging across MC-version branches. Behavior-preserving — a structural refactor that quarantines a version-specific Minecraft API difference in one place.

## Why

Vanilla `LakeFeature.Configuration` is a 5-arg record on mc/26.2 — `(fluid, barrier, canPlaceFeature, canReplaceWithAirOrFluid, canReplaceWithBarrier)` — but 2-arg `(fluid, barrier)` on mc/26.1 and both 1.21.x (MC 26.2 added the three placement flags). `OilSeepFeature` constructs one directly, so the file diverged on every other branch.

## Changes

- Add `core/lib/compat/LakeConfigCompat.withBarrier(base, barrier)` — rebuilds a `LakeFeature.Configuration` with a replaced barrier provider, hiding the constructor arity.
- Route `OilSeepFeature` through it.

## Notes

- **Behavior unchanged** — same configuration is built, just via the helper.
- **Cross-version parity:** `OilSeepFeature.java` becomes byte-identical across all four branches; only the one-file `LakeConfigCompat` body carries the API difference. Backports to mc/26.1, mc/1.21.11, mc/1.21.1 follow once this merges.
- `refactor` → hidden from the changelog (internal parity work).