### PR TITLE
ci(release): cut RCs from the dispatched branch and bump mc-publish to v3.3.1

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -1,8 +1,11 @@
 name: Build (Release Candidate)
 
 # Builds a Release Candidate from the EXACT combined state of:
-#   1. the latest commit on the base (default) branch, and
-#   2. the current open Release Please release PR branch.
+#   1. the latest commit on the branch this workflow is dispatched from, and
+#   2. that branch's open Release Please release PR branch.
+# Dispatch this workflow from the mc/* branch you want an RC for (mc/26.2, mc/26.1,
+# mc/1.21.11, mc/1.21.1) — the run targets whichever branch you select, NOT the repo
+# default branch, so each version line publishes its own RC.
 # The RC therefore carries all current development changes plus the pending version,
 # changelog, and release metadata that Release Please has staged — without pushing to
 # or modifying either source branch. RCs publish as beta on Modrinth/CurseForge, as a
@@ -17,10 +20,12 @@ on:
         required: true
         default: "1"
 
-# One publication per base branch at a time. Never cancel an in-flight publish — a
-# half-cancelled run can leave a partial RC live on one platform.
+# One publication per dispatched branch at a time. Keyed on the selected branch so
+# different version lines can publish RCs concurrently, while a single branch never
+# double-publishes. Never cancel an in-flight publish — a half-cancelled run can leave
+# a partial RC live on one platform.
 concurrency:
-  group: release-candidate-${{ github.event.repository.default_branch }}
+  group: release-candidate-${{ github.ref_name }}
   cancel-in-progress: false
 
 # Least privilege: write is only needed to create the prerelease/tag; the PR lookup is read-only.
@@ -59,13 +64,15 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          # The branch this workflow was dispatched from — NOT the repo default branch —
+          # so RCs can be cut for any mc/* version line, not just mc/26.2.
+          BASE_BRANCH: ${{ github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
 
           if [[ -z "$BASE_BRANCH" ]]; then
-            echo "::error::Could not determine the repository default branch" >&2
+            echo "::error::Could not determine the dispatched branch" >&2
             exit 1
           fi
           echo "Base branch: $BASE_BRANCH"
@@ -425,6 +432,11 @@ jobs:
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
+          # CurseForge requires an explicit environment tag (Client/Server); its inference
+          # from the jar's `"environment": "*"` no longer satisfies that group. The mod runs
+          # on both sides, so declare both.
+          curseforge-environment: client, server
+
           game-version-filter: releases
           version-type: beta
           version: ${{ env.FABRIC_FULL }}
@@ -440,6 +452,10 @@ jobs:
 
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+
+          # CurseForge requires an explicit environment tag (Client/Server); its inference
+          # from the jar metadata no longer satisfies that group. The mod runs on both sides.
+          curseforge-environment: client, server
 
           game-version-filter: releases
           version-type: beta

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -423,8 +423,6 @@ jobs:
           echo "Created prerelease $TAG"
 
       - name: Publish Fabric to Modrinth and CurseForge
-        # v3.3.1 propagates the mod's environment (fabric.mod.json "environment": "*")
-        # to CurseForge, which now requires an explicit Client/Server tag. v3.3.0 did not.
         uses: Kir-Antipov/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -423,7 +423,9 @@ jobs:
           echo "Created prerelease $TAG"
 
       - name: Publish Fabric to Modrinth and CurseForge
-        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659 # v3.3
+        # v3.3.1 propagates the mod's environment (fabric.mod.json "environment": "*")
+        # to CurseForge, which now requires an explicit Client/Server tag. v3.3.0 did not.
+        uses: Kir-Antipov/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -432,11 +434,6 @@ jobs:
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
-          # CurseForge requires an explicit environment tag (Client/Server); its inference
-          # from the jar's `"environment": "*"` no longer satisfies that group. The mod runs
-          # on both sides, so declare both.
-          curseforge-environment: client, server
-
           game-version-filter: releases
           version-type: beta
           version: ${{ env.FABRIC_FULL }}
@@ -444,7 +441,9 @@ jobs:
           files: ${{ steps.validate.outputs.fabric_jar }}
 
       - name: Publish NeoForge to Modrinth and CurseForge
-        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659 # v3.3
+        # v3.3.1 propagates the mod's environment (fabric.mod.json "environment": "*")
+        # to CurseForge, which now requires an explicit Client/Server tag. v3.3.0 did not.
+        uses: Kir-Antipov/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -452,10 +451,6 @@ jobs:
 
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
-
-          # CurseForge requires an explicit environment tag (Client/Server); its inference
-          # from the jar metadata no longer satisfies that group. The mod runs on both sides.
-          curseforge-environment: client, server
 
           game-version-filter: releases
           version-type: beta

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -441,8 +441,6 @@ jobs:
           files: ${{ steps.validate.outputs.fabric_jar }}
 
       - name: Publish NeoForge to Modrinth and CurseForge
-        # v3.3.1 propagates the mod's environment (fabric.mod.json "environment": "*")
-        # to CurseForge, which now requires an explicit Client/Server tag. v3.3.0 did not.
         uses: Kir-Antipov/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -228,7 +228,9 @@ jobs:
           path: artifacts/
 
       - name: Publish to Modrinth and CurseForge
-        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659 # v3.3
+        # v3.3.1 propagates the mod's environment (fabric.mod.json "environment": "*")
+        # to CurseForge, which now requires an explicit Client/Server tag. v3.3.0 did not.
+        uses: Kir-Antipov/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -237,11 +239,6 @@ jobs:
 
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
-
-          # CurseForge requires an explicit environment tag (Client/Server); its inference
-          # from the jar's `"environment": "*"` no longer satisfies that group. The mod runs
-          # on both sides, so declare both.
-          curseforge-environment: client, server
 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-tag: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -228,8 +228,6 @@ jobs:
           path: artifacts/
 
       - name: Publish to Modrinth and CurseForge
-        # v3.3.1 propagates the mod's environment (fabric.mod.json "environment": "*")
-        # to CurseForge, which now requires an explicit Client/Server tag. v3.3.0 did not.
         uses: Kir-Antipov/mc-publish@52307b03863581dec6b652b83e597aec02ebb075 # v3.3.1
         with:
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -238,6 +238,11 @@ jobs:
           curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
+          # CurseForge requires an explicit environment tag (Client/Server); its inference
+          # from the jar's `"environment": "*"` no longer satisfies that group. The mod runs
+          # on both sides, so declare both.
+          curseforge-environment: client, server
+
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-tag: ${{ steps.version.outputs.tag }}
 


### PR DESCRIPTION
## Summary

Fixes two independent defects in the Release Candidate workflow that surfaced when RCs were dispatched across all four version lines, plus the same CurseForge publish issue in the stable release workflow.

## What was happening

- **Wrong version built (the big one).** `build-rc.yml`'s `prepare` job resolved its base from `github.event.repository.default_branch`, which is *always* `mc/26.2`. So dispatching the workflow on `mc/26.1` still resolved Release Please PR #717 and built `0.8.3-rc.1` / MC 26.2 — the wrong version line entirely. The `concurrency` group was keyed the same way, so all four dispatches shared one group and the `mc/1.21.x` runs got cancelled/queued against each other instead of running.
- **CurseForge upload rejected.** `mc-publish` failed with `400 … "You must select at least one version from the environment group of versions"` (errorCode 1021). CurseForge started requiring an explicit Client/Server environment tag. mc-publish shipped **v3.3.1 on 2026-07-14** (three days before these runs) specifically to handle it — it now extracts the mod environment from metadata and propagates it to CurseForge ([v3.3.0…v3.3.1](https://github.com/Kir-Antipov/mc-publish/compare/v3.3.0...v3.3.1)). The workflows were pinned to **v3.3.0**, which predates that support.

## Changes

- **`build-rc.yml`:** key the base branch and the `concurrency` group off `github.ref_name` (the branch you dispatch from) instead of the repo default branch. Each version line now cuts and publishes its own RC.
- **`build-rc.yml` + `build-release.yml`:** bump the pinned `mc-publish` from v3.3.0 → **v3.3.1**. It auto-propagates the mod's `"environment": "*"` (already declared in `fabric.mod.json`) to CurseForge's required environment group — no new input needed.

## Notes

- **Backport required.** `workflow_dispatch` uses the workflow file *from the branch you dispatch on*, so per-branch RCs only work once this lands on each `mc/*` branch. Cherry-pick to `mc/26.1`, `mc/1.21.11`, and `mc/1.21.1` after merge.
- The CurseForge fix can't be verified without an actual publish run; the branch-resolution fix is verified against the four failed runs (all resolved `Base branch: mc/26.2`).