### PR TITLE
ci(release): use full loader names in Modrinth version identifiers

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -353,11 +353,13 @@ jobs:
               echo "::error::RC version mismatch in $base (expected ${RC_VERSION})" >&2; exit 1; }
           done
 
-          # Build compact Modrinth identifiers deliberately (single-letter loader). Fail —
-          # never silently truncate — if an identifier still exceeds Modrinth's 32-char limit,
-          # since truncation could collide two loaders' versions.
-          MODRINTH_FABRIC="${RC_VERSION}+mc${MC_VERSION}.f"
-          MODRINTH_NEO="${RC_VERSION}+mc${MC_VERSION}.n"
+          # Modrinth requires a distinct version_number per loader upload (loaders aren't
+          # disambiguated by the version string), so suffix each with its loader name. Fail —
+          # never silently truncate — if an identifier exceeds Modrinth's 32-char limit
+          # (labrinth caps version_number at 32), since truncation could collide two loaders'
+          # versions on the same prefix.
+          MODRINTH_FABRIC="${RC_VERSION}+mc${MC_VERSION}.fabric"
+          MODRINTH_NEO="${RC_VERSION}+mc${MC_VERSION}.neoforge"
           for ID in "$MODRINTH_FABRIC" "$MODRINTH_NEO"; do
             if (( ${#ID} > 32 )); then
               echo "::error::Modrinth version identifier '${ID}' is ${#ID} chars (>32). Shorten the version scheme." >&2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -202,11 +202,13 @@ jobs:
             MODRINTH_FEATURED="true"
           fi
 
-          # Create potentially shortened version for Modrinth (32 char limit)
+          # Modrinth caps version_number at 32 chars (labrinth). Fail loudly rather than
+          # truncate — chopping the tail would drop the loader suffix and could collide the
+          # fabric and neoforge uploads onto the same version_number.
           MODRINTH_VERSION="${FULL_VERSION}"
           if (( ${#MODRINTH_VERSION} > 32 )); then
-            MODRINTH_VERSION="${MODRINTH_VERSION:0:32}"
-            echo "⚠️  Modrinth version truncated to 32 chars: $MODRINTH_VERSION"
+            echo "::error::Modrinth version '${MODRINTH_VERSION}' is ${#MODRINTH_VERSION} chars (>32). Shorten the version scheme." >&2
+            exit 1
           fi
 
           {


### PR DESCRIPTION
## Summary

Publishes Modrinth versions as `…+mc<mc>.fabric` / `…+mc<mc>.neoforge` instead of the cryptic single-letter `.f` / `.n`, and makes the stable workflow fail rather than silently truncate an over-length identifier.

## Background

Modrinth requires a **distinct `version_number` per loader upload** (loaders aren't disambiguated by the version string), which is why each upload carries a loader suffix. The RC workflow used single-letter suffixes out of caution about Modrinth's 32-char cap on `version_number` (confirmed in labrinth: `version_creation.rs` validates `length(min = 1, max = 32)`).

But the full loader names fit comfortably — the longest current identifier, `0.8.3-rc.1+mc1.21.11.neoforge`, is 29 chars — and the **stable release workflow already uses full names**, so the two were inconsistent. This aligns them on the readable form.

## Changes

- **`build-rc.yml`:** `.f` / `.n` → `.fabric` / `.neoforge`. The hard fail-if-over-32 guard stays.
- **`build-release.yml`:** replace the silent 32-char **truncation** with a hard fail. Truncation chopped the tail — i.e. the loader suffix — which could collapse the fabric and neoforge uploads onto the same `version_number` and collide. Failing loudly is the safer policy (and matches the RC workflow).

## Notes

- No behavior change for consumers beyond nicer version strings; identifiers stay well under 32 for the current scheme.
- Backport to `mc/26.1`, `mc/1.21.11`, `mc/1.21.1` after merge (same as #755).