### PR TITLE
fix(compat): show values in the Jade HUD instead of only labels

### DIFF
--- a/common/src/client/java/com/logistics/automation/laserquarry/QuarryHudLines.java
+++ b/common/src/client/java/com/logistics/automation/laserquarry/QuarryHudLines.java
@@ -24,7 +24,8 @@ public final class QuarryHudLines {
         boolean finished = NbtCompat.getBoolean(data, "finished", false);
 
         String phaseKey = finished ? "jade.logistics.quarry.phase.finished" : phaseKey(phase);
-        lines.add(Component.translatable("jade.logistics.quarry.phase")
+        lines.add(Component.empty()
+                .append(Component.translatable("jade.logistics.quarry.phase"))
                 .append(Component.literal(": "))
                 .append(Component.translatable(phaseKey).withStyle(ChatFormatting.AQUA)));
 
@@ -53,7 +54,9 @@ public final class QuarryHudLines {
     }
 
     private static Component row(String labelKey, String value, ChatFormatting valueColor) {
-        return Component.translatable(labelKey)
+        // Empty root so Jade's toCleanTranslation() doesn't rebuild a translatable root and drop the value.
+        return Component.empty()
+                .append(Component.translatable(labelKey))
                 .append(Component.literal(": "))
                 .append(Component.literal(value).withStyle(valueColor));
     }

--- a/common/src/client/java/com/logistics/core/machine/MachineHudLines.java
+++ b/common/src/client/java/com/logistics/core/machine/MachineHudLines.java
@@ -19,7 +19,9 @@ public final class MachineHudLines {
         List<Component> lines = new ArrayList<>();
         for (MachineHudModel.Entry entry : MachineHudModel.entries(data)) {
             if (entry instanceof MachineHudModel.ProgressEntry progress) {
-                lines.add(Component.translatable("jade.logistics.machine.progress")
+                // Empty root so Jade's toCleanTranslation() doesn't rebuild a translatable root and drop the value.
+                lines.add(Component.empty()
+                        .append(Component.translatable("jade.logistics.machine.progress"))
                         .append(Component.literal(": "))
                         .append(Component.literal(String.format("%.0f%%", progress.fraction() * 100))
                                 .withStyle(ChatFormatting.GREEN)));

--- a/common/src/client/java/com/logistics/pipe/PipeHudLines.java
+++ b/common/src/client/java/com/logistics/pipe/PipeHudLines.java
@@ -46,7 +46,9 @@ public final class PipeHudLines {
             return lines;
         }
 
-        lines.add(Component.translatable("jade.logistics.pipe.items")
+        // Empty root so Jade's toCleanTranslation() doesn't rebuild a translatable root and drop the value.
+        lines.add(Component.empty()
+                .append(Component.translatable("jade.logistics.pipe.items"))
                 .append(Component.literal(": "))
                 .append(Component.literal(String.valueOf(items.size())).withStyle(ChatFormatting.WHITE)));
 

--- a/common/src/client/java/com/logistics/power/PowerInfraHudLines.java
+++ b/common/src/client/java/com/logistics/power/PowerInfraHudLines.java
@@ -45,7 +45,9 @@ public final class PowerInfraHudLines {
     }
 
     private static Component row(String labelKey, String value, ChatFormatting valueColor) {
-        return Component.translatable(labelKey)
+        // Empty root so Jade's toCleanTranslation() doesn't rebuild a translatable root and drop the value.
+        return Component.empty()
+                .append(Component.translatable(labelKey))
                 .append(Component.literal(": "))
                 .append(Component.literal(value).withStyle(valueColor));
     }

--- a/common/src/client/java/com/logistics/power/engine/EngineHudLines.java
+++ b/common/src/client/java/com/logistics/power/engine/EngineHudLines.java
@@ -81,7 +81,10 @@ public final class EngineHudLines {
     }
 
     private static net.minecraft.network.chat.MutableComponent labelled(String labelKey) {
-        return Component.translatable(labelKey).append(Component.literal(": "));
+        // Root must NOT be a bare no-args translatable: Jade's TextElement runs each line through
+        // JadeLanguages.toCleanTranslation(), which rebuilds such a component from its key alone and
+        // drops appended siblings (the ": " + value). An empty root sidesteps that and keeps the value.
+        return Component.empty().append(Component.translatable(labelKey)).append(Component.literal(": "));
     }
 
     private static ChatFormatting stageColor(String stage) {

--- a/common/src/test/java/com/logistics/power/engine/EngineHudLinesTest.java
+++ b/common/src/test/java/com/logistics/power/engine/EngineHudLinesTest.java
@@ -2,40 +2,84 @@ package com.logistics.power.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.logistics.automation.laserquarry.QuarryHudData;
+import com.logistics.automation.laserquarry.QuarryHudLines;
+import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.core.machine.MachineHudLines;
+import com.logistics.core.machine.MachineHudModel;
+import com.logistics.pipe.PipeHudLines;
+import com.logistics.power.PowerInfraHudData;
+import com.logistics.power.PowerInfraHudLines;
 import com.logistics.test.MinecraftTestEnvironment;
 import java.util.List;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import org.junit.jupiter.api.Test;
 
 /**
  * Guards against the Jade rendering bug where a line whose <em>root</em> is a no-args translatable is
  * rebuilt by {@code JadeLanguages.toCleanTranslation()} from its key alone, silently dropping appended
- * siblings (the ": " + value). Label+value lines must therefore not have a bare translatable root.
+ * siblings (the ": " + value). Every shared HUD builder must therefore keep label+value lines off a bare
+ * translatable root, so this covers all of them, not just the engine.
  */
 class EngineHudLinesTest extends MinecraftTestEnvironment {
 
     @Test
     void labelValueLinesDoNotHaveABareTranslatableRoot() {
-        CompoundTag data = new CompoundTag();
-        data.putString(EngineHudData.KEY_STAGE, "WARM");
-        data.putBoolean(EngineHudData.KEY_HAS_HEAT, true);
-        data.putDouble(EngineHudData.KEY_TEMP, 123);
-        data.putDouble(EngineHudData.KEY_MAX_TEMP, 250);
-        data.putLong(EngineHudData.KEY_OUTPUT, 40);
-        data.putBoolean(EngineHudData.KEY_RUNNING, true);
+        CompoundTag engineData = new CompoundTag();
+        engineData.putString(EngineHudData.KEY_STAGE, "WARM");
+        engineData.putBoolean(EngineHudData.KEY_HAS_HEAT, true);
+        engineData.putDouble(EngineHudData.KEY_TEMP, 123);
+        engineData.putDouble(EngineHudData.KEY_MAX_TEMP, 250);
+        engineData.putLong(EngineHudData.KEY_OUTPUT, 40);
+        engineData.putBoolean(EngineHudData.KEY_RUNNING, true);
+        assertLabelValueLines(EngineHudLines.build(engineData, true), "engine", "123°C", "40 RF/t");
 
-        List<Component> lines = EngineHudLines.build(data, true);
+        CompoundTag quarryData = new CompoundTag();
+        quarryData.putString(QuarryHudData.KEY_PHASE, "MINING");
+        quarryData.putLong("powerIn", 120);
+        assertLabelValueLines(QuarryHudLines.build(quarryData, true), "quarry", "120 RF/t");
 
-        assertThat(lines).isNotEmpty();
+        MachineHudModel model = new MachineHudModel();
+        model.progress(0.42f);
+        CompoundTag machineData = new CompoundTag();
+        model.save(machineData);
+        assertLabelValueLines(MachineHudLines.build(machineData), "machine", "42%");
+
+        TravelingItem traveling = new TravelingItem(new ItemStack(Items.STONE), Direction.NORTH, 0.5f);
+        List<TravelingItem> items = List.of(traveling, traveling, traveling); // three items in transit
+        assertLabelValueLines(PipeHudLines.build(items, false), "pipe", "3");
+
+        CompoundTag sinkData = new CompoundTag();
+        sinkData.putString(PowerInfraHudData.KEY_TYPE, PowerInfraHudData.TYPE_CREATIVE_SINK);
+        sinkData.putLong(PowerInfraHudData.KEY_DRAIN_RATE, 64);
+        sinkData.putLong(PowerInfraHudData.KEY_RECEIVED, 32);
+        assertLabelValueLines(PowerInfraHudLines.creativeSink(sinkData), "creative sink", "64 RF/t", "32 RF/t");
+    }
+
+    /**
+     * Asserts the builder produced lines, none of which would lose their value to Jade's clean-translation
+     * pass, and that the given representative values survive in the rendered text.
+     */
+    private static void assertLabelValueLines(List<Component> lines, String builder, String... expectedValues) {
+        assertThat(lines).as("%s HUD lines", builder).isNotEmpty();
+
         for (Component line : lines) {
             // A line with appended siblings must not be rooted in a no-args translatable, or Jade drops them.
             if (!line.getSiblings().isEmpty() && line.getContents() instanceof TranslatableContents root) {
                 assertThat(root.getArgs())
-                        .as("line \"%s\" would lose its value in Jade", line.getString())
+                        .as("%s line \"%s\" would lose its value in Jade", builder, line.getString())
                         .isNotEmpty();
             }
+        }
+
+        String rendered = lines.stream().map(Component::getString).reduce("", (a, b) -> a + "\n" + b);
+        for (String expected : expectedValues) {
+            assertThat(rendered).as("%s HUD preserves value \"%s\"", builder, expected).contains(expected);
         }
     }
 }

--- a/common/src/test/java/com/logistics/power/engine/EngineHudLinesTest.java
+++ b/common/src/test/java/com/logistics/power/engine/EngineHudLinesTest.java
@@ -1,0 +1,41 @@
+package com.logistics.power.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.logistics.test.MinecraftTestEnvironment;
+import java.util.List;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards against the Jade rendering bug where a line whose <em>root</em> is a no-args translatable is
+ * rebuilt by {@code JadeLanguages.toCleanTranslation()} from its key alone, silently dropping appended
+ * siblings (the ": " + value). Label+value lines must therefore not have a bare translatable root.
+ */
+class EngineHudLinesTest extends MinecraftTestEnvironment {
+
+    @Test
+    void labelValueLinesDoNotHaveABareTranslatableRoot() {
+        CompoundTag data = new CompoundTag();
+        data.putString(EngineHudData.KEY_STAGE, "WARM");
+        data.putBoolean(EngineHudData.KEY_HAS_HEAT, true);
+        data.putDouble(EngineHudData.KEY_TEMP, 123);
+        data.putDouble(EngineHudData.KEY_MAX_TEMP, 250);
+        data.putLong(EngineHudData.KEY_OUTPUT, 40);
+        data.putBoolean(EngineHudData.KEY_RUNNING, true);
+
+        List<Component> lines = EngineHudLines.build(data, true);
+
+        assertThat(lines).isNotEmpty();
+        for (Component line : lines) {
+            // A line with appended siblings must not be rooted in a no-args translatable, or Jade drops them.
+            if (!line.getSiblings().isEmpty() && line.getContents() instanceof TranslatableContents root) {
+                assertThat(root.getArgs())
+                        .as("line \"%s\" would lose its value in Jade", line.getString())
+                        .isNotEmpty();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Backport of #757 to `mc/26.1`.

The Jade HUD showed each machine readout's **label** (e.g. "Temperature") but not its value. Jade runs every tooltip line through `JadeLanguages.toCleanTranslation()`, which — when a line's root is a bare no-args translatable — rebuilds it from the key alone and **drops the appended siblings** (the `": "` + value).

## Changes
- Root every label:value HUD line in `Component.empty()` across the shared builders: `EngineHudLines`, `PowerInfraHudLines`, `QuarryHudLines`, `MachineHudLines`, `PipeHudLines`.
- Add a regression test covering all five builders.

## Notes
Cherry-picked from #757. Jade on this branch is `26.1.0+fabric` — the fix is harmless regardless of whether this Jade version reproduces the bug, and keeps the branches in parity.
