### PR TITLE
refactor(core): route the current-screen lookup through ClientScreenCompat

### DIFF
--- a/common/src/client/java/com/logistics/core/lib/compat/ClientScreenCompat.java
+++ b/common/src/client/java/com/logistics/core/lib/compat/ClientScreenCompat.java
@@ -1,0 +1,22 @@
+package com.logistics.core.lib.compat;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Hides the per-version accessor for the client's currently open screen.
+ *
+ * <p><b>26.2:</b> the screen sits behind the GUI object — {@code Minecraft.getInstance().gui.screen()}.
+ * <p><b>26.1 / 1.21.11 / 1.21.1:</b> the public {@code Minecraft.getInstance().screen} field.
+ */
+public final class ClientScreenCompat {
+
+    private ClientScreenCompat() {}
+
+    /** The client's currently open screen, or {@code null} when none is open. */
+    @Nullable
+    public static Screen currentScreen() {
+        return Minecraft.getInstance().gui.screen();
+    }
+}

--- a/fabric/src/client/java/com/logistics/LogisticsAutomationClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsAutomationClient.java
@@ -21,7 +21,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry;
-import net.minecraft.client.Minecraft;
+import com.logistics.core.lib.compat.ClientScreenCompat;
 import net.minecraft.client.gui.screens.MenuScreens;
 
 import static com.logistics.LogisticsMod.LOGGER;
@@ -48,7 +48,7 @@ public final class LogisticsAutomationClient implements ClientDomainBootstrap {
 
         ClientPlayNetworking.registerGlobalReceiver(SyncFabricatorOutputsPacket.TYPE, (packet, context) ->
                 context.client().execute(() -> {
-                    if (Minecraft.getInstance().gui.screen() instanceof SequentialFabricatorScreen screen) {
+                    if (ClientScreenCompat.currentScreen() instanceof SequentialFabricatorScreen screen) {
                         screen.updateOutputs(packet.pos(), packet.toOutputs());
                     }
                 }));

--- a/fabric/src/client/java/com/logistics/LogisticsPipeClient.java
+++ b/fabric/src/client/java/com/logistics/LogisticsPipeClient.java
@@ -7,7 +7,7 @@ import com.logistics.pipe.screen.ItemFilterScreen;
 import com.logistics.pipe.screen.RequesterScreen;
 import com.logistics.core.DebugLog;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.minecraft.client.Minecraft;
+import com.logistics.core.lib.compat.ClientScreenCompat;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 
@@ -49,7 +49,7 @@ public final class LogisticsPipeClient implements ClientDomainBootstrap {
         ClientPlayNetworking.registerGlobalReceiver(SyncRequesterInventoryPacket.TYPE, (packet, context) -> {
             context.client().execute(() -> {
                 // Update the requester screen if it's open
-                if (Minecraft.getInstance().gui.screen() instanceof RequesterScreen requesterScreen) {
+                if (ClientScreenCompat.currentScreen() instanceof RequesterScreen requesterScreen) {
                     requesterScreen.updateAvailableItems(packet.pipePos(), packet.items(), packet.amounts());
                 }
             });

--- a/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
+++ b/neoforge/src/main/java/com/logistics/neoforge/client/NeoForgeClientSetup.java
@@ -46,7 +46,7 @@ import com.logistics.core.lib.resource.ResourceId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.minecraft.client.Minecraft;
+import com.logistics.core.lib.compat.ClientScreenCompat;
 import net.minecraft.client.color.block.BlockTintSources;
 import net.minecraft.client.renderer.block.FluidModel;
 import net.minecraft.client.resources.model.sprite.Material;
@@ -238,13 +238,13 @@ public final class NeoForgeClientSetup {
 
     private static void registerClientPayloadHandlers(RegisterClientPayloadHandlersEvent event) {
         event.register(SyncRequesterInventoryPacket.TYPE, (packet, context) -> {
-            var screen = Minecraft.getInstance().gui.screen();
+            var screen = ClientScreenCompat.currentScreen();
             if (screen instanceof RequesterScreen requesterScreen) {
                 requesterScreen.updateAvailableItems(packet.pipePos(), packet.items(), packet.amounts());
             }
         });
         event.register(SyncFabricatorOutputsPacket.TYPE, (packet, context) -> {
-            var screen = Minecraft.getInstance().gui.screen();
+            var screen = ClientScreenCompat.currentScreen();
             if (screen instanceof SequentialFabricatorScreen fabricatorScreen) {
                 fabricatorScreen.updateOutputs(packet.pos(), packet.toOutputs());
             }


### PR DESCRIPTION
## Summary

Introduce `ClientScreenCompat` to hide the per-version accessor for the client's currently open screen, so the same call site compiles unchanged on every Minecraft branch. This is proactive cross-branch convergence — no player-visible change.

The current screen is read as `Minecraft.getInstance().gui.screen()` on 26.2 (the field moved behind the GUI object) but as the public `Minecraft.getInstance().screen` field on the maintenance branches (26.1 / 1.21.11 / 1.21.1). That forced difference otherwise reappears in every client file that inspects the open screen.

## Changes

- Add `common/src/client/.../core/lib/compat/ClientScreenCompat.java` — `public static @Nullable Screen currentScreen()`. It's a client-side compat shim (uses `net.minecraft.client.Minecraft`), so it lives in `common/src/client` rather than `common/src/main` where `NbtCompat` sits.
- Route the four call sites through it: `LogisticsPipeClient`, `LogisticsAutomationClient` (Fabric client) and `NeoForgeClientSetup` (×2).

## Notes

- Behavior-preserving: a pure accessor wrapper returning the same `Screen`.
- Convergence intent: with the accessor quarantined in the shim body, these call-site files become byte-identical across branches. The maintenance branches will adopt the identical call sites via backport, with only the shim's one `return` line adapted per version (`gui.screen()` here, `.screen` on legacy) — mirroring the existing `NbtCompat` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)