### PR TITLE
balance(energy): gate engine harvesting by tool tier

### DIFF
--- a/common/src/main/java/com/logistics/LogisticsCore.java
+++ b/common/src/main/java/com/logistics/LogisticsCore.java
@@ -357,7 +357,8 @@ public final class LogisticsCore extends LogisticsMod implements DomainBootstrap
             OIL_SHALE = INSTANCE.registerBlockWithItem("oil_shale",
                 props -> new Block(props.strength(0.6f).sound(SoundType.GRAVEL)));
             REDSTONE_ENGINE = INSTANCE.registerBlockWithItem("redstone_engine",
-                props -> new RedstoneEngineBlock(props.strength(5.0f).sound(SoundType.WOOD).noOcclusion()));
+                props -> new RedstoneEngineBlock(
+                    props.strength(2.0f).sound(SoundType.WOOD).noOcclusion().requiresCorrectToolForDrops()));
         }
     }
 

--- a/common/src/main/java/com/logistics/LogisticsPower.java
+++ b/common/src/main/java/com/logistics/LogisticsPower.java
@@ -330,15 +330,20 @@ public final class LogisticsPower extends LogisticsMod implements DomainBootstra
 
         static void register() {
             STIRLING_ENGINE = INSTANCE.registerBlockWithItem("stirling_engine",
-                props -> new StirlingEngineBlock(props.strength(5.0f).sound(SoundType.COPPER).noOcclusion()));
+                props -> new StirlingEngineBlock(
+                    props.strength(1.5f).sound(SoundType.STONE).noOcclusion().requiresCorrectToolForDrops()));
             REACTION_ENGINE = INSTANCE.registerBlockWithItem("reaction_engine",
-                props -> new ReactionEngineBlock(props.strength(5.0f).sound(SoundType.COPPER).noOcclusion()));
+                props -> new ReactionEngineBlock(
+                    props.strength(50.0f).sound(SoundType.STONE).noOcclusion().requiresCorrectToolForDrops()));
             MAGMATIC_ENGINE = INSTANCE.registerBlockWithItem("magmatic_engine",
-                props -> new MagmaticEngineBlock(props.strength(5.0f).sound(SoundType.COPPER).noOcclusion()));
+                props -> new MagmaticEngineBlock(
+                    props.strength(2.0f).sound(SoundType.NETHER_BRICKS).noOcclusion().requiresCorrectToolForDrops()));
             STEAM_ENGINE = INSTANCE.registerBlockWithItem("steam_engine",
-                props -> new SteamEngineBlock(props.strength(5.0f).sound(SoundType.COPPER).noOcclusion()));
+                props -> new SteamEngineBlock(
+                    props.strength(3.0f).sound(SoundType.COPPER).noOcclusion().requiresCorrectToolForDrops()));
             FUEL_ENGINE = INSTANCE.registerBlockWithItem("fuel_engine",
-                props -> new FuelEngineBlock(props.strength(5.0f).sound(SoundType.COPPER).noOcclusion()));
+                props -> new FuelEngineBlock(
+                    props.strength(5.0f).sound(SoundType.METAL).noOcclusion().requiresCorrectToolForDrops()));
             CREATIVE_ENGINE = INSTANCE.registerBlockWithItem("creative_engine",
                 props -> new CreativeEngineBlock(props.strength(5.0f).sound(SoundType.STONE).noOcclusion()));
             CREATIVE_SINK = INSTANCE.registerBlockWithItem("creative_sink",

--- a/common/src/main/resources/data/minecraft/tags/block/needs_diamond_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/block/needs_diamond_tool.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "logistics:power/reaction_engine"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/block/needs_iron_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/block/needs_iron_tool.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "logistics:power/fuel_engine",
+    "logistics:power/steam_engine",
+    "logistics:power/magmatic_engine"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
+++ b/common/src/main/resources/data/minecraft/tags/block/needs_stone_tool.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
+    "logistics:power/stirling_engine",
     "logistics:core/tin_ore",
     "logistics:core/deepslate_tin_ore",
     "logistics:core/tin_block",


### PR DESCRIPTION
## Summary

Engines could be harvested with any tool — even bare hands — because none set `requiresCorrectToolForDrops()`. Each engine now requires a tool tier appropriate to its build, and its block hardness and break/place sound match its primary crafting material (the top row of its recipe).

## Changes

**Tool tier required to harvest** (drops nothing below the tier):

| Engine | Tool | Made of |
|---|---|---|
| Redstone | any **axe** | planks |
| Stirling | stone pickaxe+ | stone |
| Steam | iron pickaxe+ | copper |
| Fuel | iron pickaxe+ | iron |
| Magmatic | iron pickaxe+ | nether bricks |
| Reaction | diamond/netherite pickaxe | crying obsidian |

**Hardness** now matches the primary material's vanilla hardness: Redstone 2.0, Stirling 1.5, Steam 3.0, Fuel 5.0, Magmatic 2.0, Reaction 50.0.

**Break/place sound** now matches the material: Stirling → stone, Fuel → metal, Magmatic → nether bricks, Reaction → stone (Steam stays copper, Redstone stays wood).

## Notes

- The Reaction Engine's crying-obsidian hardness (50.0) makes it very slow to mine — faithful to the material and fitting for the end-game engine, but easy to dial back.
- Diamond tier covers both diamond and netherite tools (there is no vanilla netherite-only tier tag).
- All shared `common/` code — cherry-picks cleanly to the other `mc/*` branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)