### PR TITLE
fix(quarry): fix immediate crash on published Fabric builds

### DIFF
--- a/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryComponent.java
+++ b/common/src/main/java/com/logistics/automation/laserquarry/entity/QuarryComponent.java
@@ -226,7 +226,7 @@ public final class QuarryComponent implements MachineComponent, QuarryContext {
 
     @Override
     public void markChanged() {
-        ctx.setChanged();
+        ctx.markChanged();
     }
 
     @Override

--- a/common/src/main/java/com/logistics/automation/pump/FluidPumpComponent.java
+++ b/common/src/main/java/com/logistics/automation/pump/FluidPumpComponent.java
@@ -140,7 +140,7 @@ public final class FluidPumpComponent implements MachineComponent {
         if (stepped != armY) {
             armY = stepped;
             if (server) {
-                ctx.setChanged();
+                ctx.markChanged();
             }
         }
         if (targetY > pos.getY() - 1) {

--- a/common/src/main/java/com/logistics/core/lib/power/EngineEntity.java
+++ b/common/src/main/java/com/logistics/core/lib/power/EngineEntity.java
@@ -178,6 +178,11 @@ public abstract class EngineEntity extends BaseBlockEntity implements MachineCon
     }
 
     @Override
+    public void markChanged() {
+        setChanged();
+    }
+
+    @Override
     public void setBlockState(BlockState state, int flags) {
         if (level != null) {
             level.setBlock(worldPosition, state, flags);

--- a/common/src/main/java/com/logistics/core/machine/MachineContext.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineContext.java
@@ -29,8 +29,13 @@ public interface MachineContext {
     /** Registry access for ItemStack/codec deserialization; valid even when {@link #level()} is null. */
     HolderLookup.Provider registries();
 
-    /** Marks the host dirty for chunk saving. */
-    void setChanged();
+    /**
+     * Marks the host dirty for chunk saving. Named distinctly from {@code BlockEntity#setChanged()}
+     * on purpose: a mod interface method that shares a name with a Minecraft method is remapped
+     * inconsistently on obfuscated (Fabric intermediary) runtimes unless an implementor explicitly
+     * bridges it, which throws {@code AbstractMethodError} when called through this interface.
+     */
+    void markChanged();
 
     /** Marks dirty and pushes a block update to nearby clients. */
     void sync();

--- a/common/src/main/java/com/logistics/core/machine/MachineEntity.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineEntity.java
@@ -201,8 +201,8 @@ public abstract class MachineEntity extends BaseBlockEntity
     }
 
     @Override
-    public void setChanged() {
-        super.setChanged();
+    public void markChanged() {
+        setChanged();
     }
 
     @Override

--- a/common/src/main/java/com/logistics/core/machine/MachineEntity.java
+++ b/common/src/main/java/com/logistics/core/machine/MachineEntity.java
@@ -201,6 +201,11 @@ public abstract class MachineEntity extends BaseBlockEntity
     }
 
     @Override
+    public void setChanged() {
+        super.setChanged();
+    }
+
+    @Override
     public void setBlockState(BlockState state, int flags) {
         if (level != null) {
             level.setBlock(worldPosition, state, flags);

--- a/common/src/test/java/com/logistics/core/machine/FakeMachineContext.java
+++ b/common/src/test/java/com/logistics/core/machine/FakeMachineContext.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Minimal {@link MachineContext} for unit tests: no live {@link Level}, registries from the
- * bootstrapped built-in registry, and no-op world mutations. Records whether {@code setChanged}
+ * bootstrapped built-in registry, and no-op world mutations. Records whether {@code markChanged}
  * was called so tests can assert dirty-marking.
  */
 public final class FakeMachineContext implements MachineContext {
@@ -45,7 +45,7 @@ public final class FakeMachineContext implements MachineContext {
     }
 
     @Override
-    public void setChanged() {
+    public void markChanged() {
         changedCalls++;
     }
 


### PR DESCRIPTION
MachineEntity implements MachineContext but was missing the setChanged() implementation required by the interface.

Delegate the call to BaseBlockEntity#setChanged().

Fixes the AbstractMethodError triggered by Laser Quarry when QuarryComponent.markChanged() invokes MachineContext#setChanged().