### PR TITLE
docs(docs): surface programmable gates and pipe wiring on the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ Important to the long-term vision, but not part of the immediate core milestone.
 
 These ideas are under discussion and may change significantly.
 
-- Programmable pipe gates / pipe signaling
+- **Programmable automation (gates + pipe wiring)** — BuildCraft-style gates (trigger → action logic clipped onto pipes and machines) and the colored pipe wiring that carries their signals. The biggest open design question inherited from BuildCraft; deferred post-1.0 and tracked in RFC 0001 (`design/rfcs/0001-programmable-behavior.md`). Likely revisited when Forestry-style circuit boards need a logic layer.
 - Machine upgrades
 - Remote Orderer (handheld network access; really wants an Ender Chest-style companion to shine)
 - Railcraft-style multiblock steam boilers/engines


### PR DESCRIPTION
## Summary

Makes BuildCraft-style **programmable gates** and **colored pipe wiring** visible on the top-level roadmap instead of a bare one-liner.

## Changes

- Expand the `Exploring / RFC` entry to name gates and pipe wiring explicitly, describe what they are (trigger → action logic + the wiring that carries signals), and point at the owning doc, **RFC 0001** (`design/rfcs/0001-programmable-behavior.md`).

## Notes

- No change to scope or status — this remains deferred post-1.0 under RFC 0001. It's purely a visibility/discoverability fix so the roadmap's coverage of gates+wiring isn't buried.
- Facades stay separate under **Later** (cosmetic port), unrelated to the automation-logic RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)