### PR TITLE
build(ci): scope Maven repos so a TerraformersMC outage can't break builds

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,10 +14,12 @@ plugins {
 }
 
 repositories {
-    // BlameJared first: it mirrors JEI, and Gradle does not fail over to the next repo on a read
-    // timeout (only on a 404), so a TerraformersMC outage must not sit first in line.
-    maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // Scope each repo to the groups it serves so Gradle never probes a repo for artifacts it lacks.
+    // Gradle does not fail over on a read *timeout* (only on a 404), so an unfiltered repo that goes
+    // down (e.g. a TerraformersMC outage) breaks resolution of unrelated deps it gets probed for.
+    // BlameJared is listed first so JEI resolves from the mirror when TerraformersMC is down.
+    maven { name = "Jared's maven"; url = "https://maven.blamejared.com/"; content { includeGroup "mezz.jei" } }
+    maven { url = "https://maven.terraformersmc.com/releases/"; content { includeGroup "mezz.jei"; includeGroup "com.terraformersmc" } }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,10 +14,9 @@ plugins {
 }
 
 repositories {
-    // Scope each repo to the groups it serves so Gradle never probes a repo for artifacts it lacks.
-    // Gradle does not fail over on a read *timeout* (only on a 404), so an unfiltered repo that goes
-    // down (e.g. a TerraformersMC outage) breaks resolution of unrelated deps it gets probed for.
-    // BlameJared is listed first so JEI resolves from the mirror when TerraformersMC is down.
+    // Scope each repo to the groups it serves: Gradle advances to the next repo only on a 404, not on
+    // a transport error (e.g. read timeout), so an unscoped unreachable repo would stall any dependency
+    // it gets probed for. BlameJared precedes TerraformersMC so JEI resolves from the mirror during an outage.
     maven { name = "Jared's maven"; url = "https://maven.blamejared.com/"; content { includeGroup "mezz.jei" } }
     maven { url = "https://maven.terraformersmc.com/releases/"; content { includeGroup "mezz.jei"; includeGroup "com.terraformersmc" } }
     maven {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,8 +14,10 @@ plugins {
 }
 
 repositories {
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // BlameJared first: it mirrors JEI, and Gradle does not fail over to the next repo on a read
+    // timeout (only on a 404), so a TerraformersMC outage must not sit first in line.
     maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
+    maven { url = "https://maven.terraformersmc.com/releases/" }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -14,10 +14,9 @@ base {
 }
 
 repositories {
-    // Scope each repo to the groups it serves so Gradle never probes a repo for artifacts it lacks.
-    // Gradle does not fail over on a read *timeout* (only on a 404), so an unfiltered repo that goes
-    // down (e.g. a TerraformersMC outage) breaks resolution of unrelated deps it gets probed for.
-    // BlameJared is listed first so JEI resolves from the mirror when TerraformersMC is down.
+    // Scope each repo to the groups it serves: Gradle advances to the next repo only on a 404, not on
+    // a transport error (e.g. read timeout), so an unscoped unreachable repo would stall any dependency
+    // it gets probed for. BlameJared precedes TerraformersMC so JEI resolves from the mirror during an outage.
     maven { name = "Jared's maven"; url = "https://maven.blamejared.com/"; content { includeGroup "mezz.jei" } }
     maven { url = "https://maven.terraformersmc.com/releases/"; content { includeGroup "mezz.jei"; includeGroup "com.terraformersmc" } }
     maven {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -14,8 +14,10 @@ base {
 }
 
 repositories {
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // BlameJared first: it mirrors JEI, and Gradle does not fail over to the next repo on a read
+    // timeout (only on a 404), so a TerraformersMC outage must not sit first in line.
     maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
+    maven { url = "https://maven.terraformersmc.com/releases/" }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -14,10 +14,12 @@ base {
 }
 
 repositories {
-    // BlameJared first: it mirrors JEI, and Gradle does not fail over to the next repo on a read
-    // timeout (only on a 404), so a TerraformersMC outage must not sit first in line.
-    maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // Scope each repo to the groups it serves so Gradle never probes a repo for artifacts it lacks.
+    // Gradle does not fail over on a read *timeout* (only on a 404), so an unfiltered repo that goes
+    // down (e.g. a TerraformersMC outage) breaks resolution of unrelated deps it gets probed for.
+    // BlameJared is listed first so JEI resolves from the mirror when TerraformersMC is down.
+    maven { name = "Jared's maven"; url = "https://maven.blamejared.com/"; content { includeGroup "mezz.jei" } }
+    maven { url = "https://maven.terraformersmc.com/releases/"; content { includeGroup "mezz.jei"; includeGroup "com.terraformersmc" } }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -13,10 +13,12 @@ base {
 }
 
 repositories {
-    // BlameJared first: it mirrors JEI, and Gradle does not fail over to the next repo on a read
-    // timeout (only on a 404), so a TerraformersMC outage must not sit first in line.
-    maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // Scope each repo to the groups it serves so Gradle never probes a repo for artifacts it lacks.
+    // Gradle does not fail over on a read *timeout* (only on a 404), so an unfiltered repo that goes
+    // down (e.g. a TerraformersMC outage) breaks resolution of unrelated deps it gets probed for.
+    // BlameJared is listed first so JEI resolves from the mirror when TerraformersMC is down.
+    maven { name = "Jared's maven"; url = "https://maven.blamejared.com/"; content { includeGroup "mezz.jei" } }
+    maven { url = "https://maven.terraformersmc.com/releases/"; content { includeGroup "mezz.jei"; includeGroup "com.terraformersmc" } }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -13,10 +13,9 @@ base {
 }
 
 repositories {
-    // Scope each repo to the groups it serves so Gradle never probes a repo for artifacts it lacks.
-    // Gradle does not fail over on a read *timeout* (only on a 404), so an unfiltered repo that goes
-    // down (e.g. a TerraformersMC outage) breaks resolution of unrelated deps it gets probed for.
-    // BlameJared is listed first so JEI resolves from the mirror when TerraformersMC is down.
+    // Scope each repo to the groups it serves: Gradle advances to the next repo only on a 404, not on
+    // a transport error (e.g. read timeout), so an unscoped unreachable repo would stall any dependency
+    // it gets probed for. BlameJared precedes TerraformersMC so JEI resolves from the mirror during an outage.
     maven { name = "Jared's maven"; url = "https://maven.blamejared.com/"; content { includeGroup "mezz.jei" } }
     maven { url = "https://maven.terraformersmc.com/releases/"; content { includeGroup "mezz.jei"; includeGroup "com.terraformersmc" } }
     maven {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -13,8 +13,10 @@ base {
 }
 
 repositories {
-    maven { url = "https://maven.terraformersmc.com/releases/" }
+    // BlameJared first: it mirrors JEI, and Gradle does not fail over to the next repo on a read
+    // timeout (only on a 404), so a TerraformersMC outage must not sit first in line.
     maven { name = "Jared's maven"; url = "https://maven.blamejared.com/" }
+    maven { url = "https://maven.terraformersmc.com/releases/" }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"


### PR DESCRIPTION
## Summary
CI and clean local builds fail to resolve dependencies whenever `maven.terraformersmc.com` has an origin outage — as it does right now — with `Could not GET … Read timed out`. It takes down not just JEI but Jade too.

## Root cause
TerraformersMC was declared as an **unfiltered** repository, so Gradle probes it for *every* dependency it hasn't already resolved — including Jade and Configory, which actually live on Modrinth. Gradle only fails over to the next repository on a **404**, not on a **read timeout**, so a single probe to the down host is fatal. (BlameJared was already declared as a JEI fallback, but being listed after TerraformersMC it was never reached.)

## Change
Content-filter each third-party repo to the groups it actually serves, so Gradle routes every dependency to exactly one repo and never probes the dead host:
- **BlameJared** → `mezz.jei` (JEI), listed first so JEI resolves from the mirror during a TerraformersMC outage
- **TerraformersMC** → `mezz.jei` + `com.terraformersmc` (official JEI source kept as fallback; nothing depends on `com.terraformersmc`, so it is never contacted during an outage)
- **Modrinth** → `maven.modrinth` (Jade, Configory) — unchanged

Applied to `common`, `fabric`, and `neoforge`.

## Verification
`./gradlew :common:compileJava :fabric:compileClientJava :neoforge:compileJava --refresh-dependencies` → **BUILD SUCCESSFUL** with `maven.terraformersmc.com` fully down (JEI from BlameJared, Jade/Configory from Modrinth).

## Notes
- JEI's split dev/API artifacts (`jei-*-fabric-api`, `-common-api-intermediary`) exist only on the `mezz.jei` Mavens (TerraformersMC + BlameJared mirror), not on Modrinth's whole-jar Maven — so JEI stays on `mezz.jei`.
- Should be backported to 1.21.1 / 26.1 / 26.2 for parity.