### PR TITLE
fix(energy): correct cable connections to engines

### DIFF
--- a/common/src/main/java/com/logistics/power/cable/CableBlock.java
+++ b/common/src/main/java/com/logistics/power/cable/CableBlock.java
@@ -3,7 +3,10 @@ package com.logistics.power.cable;
 import com.logistics.LogisticsPower;
 import com.logistics.core.lib.block.ConnectedShapeCache;
 import com.logistics.core.lib.block.capability.HasEnergyStorage;
+import com.logistics.core.lib.power.AbstractEngineBlock;
 import com.logistics.core.lib.power.DirectEnergyReceiver;
+import com.logistics.core.lib.power.EngineEntity;
+import com.logistics.core.lib.power.LowTierEnergySource;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -230,6 +233,16 @@ public class CableBlock extends BaseEntityBlock implements SimpleWaterloggedBloc
         // Extraction pipes / pump are engine-powered only; cables never connect to them.
         if (neighbor instanceof DirectEnergyReceiver) {
             return ConnectionType.NONE;
+        }
+
+        // Bufferless engines still need a visual connection, but only on their output face.
+        // Low-tier engines are intentionally isolated from the cable network.
+        if (neighbor instanceof EngineEntity engine) {
+            if (engine instanceof LowTierEnergySource
+                    || AbstractEngineBlock.getOutputDirection(engine.getBlockState()) != direction.getOpposite()) {
+                return ConnectionType.NONE;
+            }
+            return ConnectionType.DEVICE;
         }
 
         if (neighbor instanceof HasEnergyStorage energyBlock

--- a/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
@@ -409,6 +409,58 @@ public class CableGameTest {
         context.succeed();
     }
 
+    @GameTest
+    public void testCableConnectsToBufferlessEngineOutputs(GameTestHelper context) {
+        BlockPos steamEnginePos = new BlockPos(1, 1, 1);
+        BlockPos steamCablePos = new BlockPos(2, 1, 1);
+        BlockPos reactionEnginePos = new BlockPos(4, 1, 1);
+        BlockPos reactionCablePos = new BlockPos(5, 1, 1);
+
+        context.setBlock(steamCablePos, LogisticsPower.BLOCK.COPPER_CABLE);
+        context.setBlock(steamEnginePos, LogisticsPower.BLOCK.STEAM_ENGINE
+                .defaultBlockState()
+                .setValue(AbstractEngineBlock.FACING, Direction.EAST));
+        context.setBlock(reactionCablePos, LogisticsPower.BLOCK.COPPER_CABLE);
+        context.setBlock(reactionEnginePos, LogisticsPower.BLOCK.REACTION_ENGINE
+                .defaultBlockState()
+                .setValue(AbstractEngineBlock.FACING, Direction.EAST));
+
+        CableBlockEntity steamCable = context.getBlockEntity(steamCablePos, CableBlockEntity.class);
+        CableBlockEntity reactionCable = context.getBlockEntity(reactionCablePos, CableBlockEntity.class);
+        if (steamCable == null || reactionCable == null) {
+            context.fail("Expected cable block entities");
+            return;
+        }
+        if (steamCable.getCachedConnectionType(Direction.WEST) != CableBlock.ConnectionType.DEVICE
+                || reactionCable.getCachedConnectionType(Direction.WEST) != CableBlock.ConnectionType.DEVICE) {
+            context.fail("Cables should connect to bufferless engine output faces");
+            return;
+        }
+        context.succeed();
+    }
+
+    @GameTest
+    public void testCableDoesNotConnectToRedstoneEngine(GameTestHelper context) {
+        BlockPos enginePos = new BlockPos(1, 1, 1);
+        BlockPos cablePos = new BlockPos(2, 1, 1);
+
+        context.setBlock(cablePos, LogisticsPower.BLOCK.COPPER_CABLE);
+        context.setBlock(enginePos, LogisticsCore.BLOCK.REDSTONE_ENGINE
+                .defaultBlockState()
+                .setValue(AbstractEngineBlock.FACING, Direction.EAST));
+
+        CableBlockEntity cable = context.getBlockEntity(cablePos, CableBlockEntity.class);
+        if (cable == null) {
+            context.fail("Expected cable block entity");
+            return;
+        }
+        if (cable.getCachedConnectionType(Direction.WEST) != CableBlock.ConnectionType.NONE) {
+            context.fail("Cable should not connect to redstone engine");
+            return;
+        }
+        context.succeed();
+    }
+
     @GameTest(maxTicks = 30)
     public void testRedstoneEngineIsNotPulledByCableNetwork(GameTestHelper context) {
         BlockPos enginePos = new BlockPos(1, 1, 1);

--- a/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/power/CableGameTest.java
@@ -449,6 +449,11 @@ public class CableGameTest {
                 .defaultBlockState()
                 .setValue(AbstractEngineBlock.FACING, Direction.EAST));
 
+        RedstoneEngineBlockEntity engine = context.getBlockEntity(enginePos, RedstoneEngineBlockEntity.class);
+        if (engine == null) {
+            context.fail("Expected redstone engine block entity");
+            return;
+        }
         CableBlockEntity cable = context.getBlockEntity(cablePos, CableBlockEntity.class);
         if (cable == null) {
             context.fail("Expected cable block entity");


### PR DESCRIPTION
## Summary

Corrects cable connections for engine outputs.

## Changes

- Cables now visibly connect to the output faces of Steam and Reaction Engines.
- Cables no longer connect to Redstone Engines, which are intentionally excluded from the cable network.

## Notes

- The issue affected shared cable connection logic, so the correction applies to Fabric and NeoForge.
- Validated with `./gradlew :fabric:compileGameTestJava spotlessCheck`.