### PR TITLE
fix(fluids): never drop fluid packets on the ground

### DIFF
--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -329,8 +329,18 @@ public class PipeBlockEntity extends BaseBlockEntity
     /**
      * Drop an item entity at the specified pipe position.
      * Static method for external callers (PipeBlock, PipeRuntime).
+     *
+     * <p>Fluid packets are a hidden internal representation of in-transit fluid — never crafted or
+     * shown to players (see {@link com.logistics.pipe.item.FluidPacketItem}) — so an undeliverable
+     * one is voided here instead of spawning a pickup-able entity. Every drop path in the pipe
+     * runtime (routing failure, transfer failure, insertion overflow, block removal) funnels through
+     * this single method, so gating it here covers all of them.
      */
     public static void dropItem(Level level, BlockPos pos, TravelingItem item) {
+        if (item.getStack().getItem() == LogisticsPipe.ITEM.FLUID_PACKET) {
+            return;
+        }
+
         // Create item entity at center of pipe
         Vec3 spawnPos = Vec3.atCenterOf(pos);
 

--- a/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
+++ b/common/src/main/java/com/logistics/pipe/block/entity/PipeBlockEntity.java
@@ -330,11 +330,7 @@ public class PipeBlockEntity extends BaseBlockEntity
      * Drop an item entity at the specified pipe position.
      * Static method for external callers (PipeBlock, PipeRuntime).
      *
-     * <p>Fluid packets are a hidden internal representation of in-transit fluid — never crafted or
-     * shown to players (see {@link com.logistics.pipe.item.FluidPacketItem}) — so an undeliverable
-     * one is voided here instead of spawning a pickup-able entity. Every drop path in the pipe
-     * runtime (routing failure, transfer failure, insertion overflow, block removal) funnels through
-     * this single method, so gating it here covers all of them.
+     * <p>Undeliverable fluid packets are voided instead of spawning a ground-item entity.
      */
     public static void dropItem(Level level, BlockPos pos, TravelingItem item) {
         if (item.getStack().getItem() == LogisticsPipe.ITEM.FLUID_PACKET) {

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPacketDropGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPacketDropGameTest.java
@@ -1,0 +1,96 @@
+package com.logistics.gametest.pipe;
+
+import com.logistics.LogisticsConfigHost;
+import com.logistics.LogisticsPipe;
+import com.logistics.core.lib.pipe.TravelingItem;
+import com.logistics.pipe.block.entity.PipeBlockEntity;
+import com.logistics.pipe.data.PipeDataComponents.FluidPacket;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraft.world.phys.AABB;
+
+import java.util.List;
+
+/**
+ * Fluid packets are a hidden internal representation of in-transit fluid (see
+ * {@link com.logistics.pipe.item.FluidPacketItem}) — never crafted or shown to players — so an
+ * undeliverable one must be voided rather than spawned as a pickup-able ground item. Every drop path
+ * in the pipe runtime funnels through {@link PipeBlockEntity#dropItem}, so these tests exercise it via
+ * the block-removal path (the simplest reliable way to force a drop) and confirm normal items are
+ * unaffected by the fluid-packet gate.
+ *
+ * <p>Run in-game: /test run logistics-gametest.fluidpacketdropgametest.&lt;methodname&gt;
+ */
+public class FluidPacketDropGameTest {
+
+    private static final BlockPos FLUID_PIPE = new BlockPos(0, 1, 0);
+    private static final BlockPos ITEM_PIPE = new BlockPos(2, 1, 0);
+
+    private static ItemStack fluidPacketStack() {
+        long quantum = LogisticsConfigHost.get(LogisticsPipe.CONFIG.FLUID_PACKET_QUANTUM_MB);
+        ItemStack stack = new ItemStack(LogisticsPipe.ITEM.FLUID_PACKET);
+        stack.set(LogisticsPipe.DATA.FLUID_PACKET, new FluidPacket(Fluids.WATER, quantum));
+        return stack;
+    }
+
+    private static PipeBlockEntity placePipeCarrying(GameTestHelper context, BlockPos pos, ItemStack stack) {
+        context.setBlock(pos, LogisticsPipe.BLOCK.COPPER_TRANSPORT_PIPE);
+        PipeBlockEntity pipe = context.getBlockEntity(pos, PipeBlockEntity.class);
+        TravelingItem item = new TravelingItem(stack, Direction.WEST, 0.1f);
+        pipe.forceAddItem(item, Direction.WEST);
+        return pipe;
+    }
+
+    /**
+     * A fluid packet stranded in a pipe that gets broken (player break, explosion, /setblock) must not
+     * spawn as a ground item — it's voided instead.
+     */
+    @GameTest
+    public void testFluidPacketNeverDropsOnPipeBreak(GameTestHelper context) {
+        placePipeCarrying(context, FLUID_PIPE, fluidPacketStack());
+
+        ServerLevel level = context.getLevel();
+        BlockPos absPos = context.absolutePos(FLUID_PIPE);
+        level.destroyBlock(absPos, false);
+
+        List<ItemEntity> drops = level.getEntitiesOfClass(
+                ItemEntity.class,
+                new AABB(absPos).inflate(2.0),
+                e -> e.getItem().is(LogisticsPipe.ITEM.FLUID_PACKET));
+
+        if (!drops.isEmpty()) {
+            context.fail("Fluid packet should never spawn as a ground item, found " + drops.size());
+        }
+        context.succeed();
+    }
+
+    /**
+     * Control: a normal item stranded the same way must still drop as usual — confirms the fluid-packet
+     * gate in {@link PipeBlockEntity#dropItem} doesn't suppress drops in general.
+     */
+    @GameTest
+    public void testNormalItemStillDropsOnPipeBreak(GameTestHelper context) {
+        placePipeCarrying(context, ITEM_PIPE, new ItemStack(Items.COBBLESTONE, 3));
+
+        ServerLevel level = context.getLevel();
+        BlockPos absPos = context.absolutePos(ITEM_PIPE);
+        level.destroyBlock(absPos, false);
+
+        List<ItemEntity> drops = level.getEntitiesOfClass(
+                ItemEntity.class,
+                new AABB(absPos).inflate(2.0),
+                e -> e.getItem().is(Items.COBBLESTONE));
+
+        if (drops.size() != 1 || drops.get(0).getItem().getCount() != 3) {
+            context.fail("Expected exactly one dropped stack of 3 cobblestone, found " + drops.size());
+        }
+        context.succeed();
+    }
+}

--- a/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPacketDropGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/pipe/FluidPacketDropGameTest.java
@@ -19,12 +19,8 @@ import net.minecraft.world.phys.AABB;
 import java.util.List;
 
 /**
- * Fluid packets are a hidden internal representation of in-transit fluid (see
- * {@link com.logistics.pipe.item.FluidPacketItem}) — never crafted or shown to players — so an
- * undeliverable one must be voided rather than spawned as a pickup-able ground item. Every drop path
- * in the pipe runtime funnels through {@link PipeBlockEntity#dropItem}, so these tests exercise it via
- * the block-removal path (the simplest reliable way to force a drop) and confirm normal items are
- * unaffected by the fluid-packet gate.
+ * An undeliverable fluid packet must be voided rather than spawned as a pickup-able ground item, and
+ * normal items must still drop as usual.
  *
  * <p>Run in-game: /test run logistics-gametest.fluidpacketdropgametest.&lt;methodname&gt;
  */
@@ -49,8 +45,7 @@ public class FluidPacketDropGameTest {
     }
 
     /**
-     * A fluid packet stranded in a pipe that gets broken (player break, explosion, /setblock) must not
-     * spawn as a ground item — it's voided instead.
+     * A fluid packet stranded in a broken pipe must not spawn as a ground item — it's voided instead.
      */
     @GameTest
     public void testFluidPacketNeverDropsOnPipeBreak(GameTestHelper context) {
@@ -72,8 +67,7 @@ public class FluidPacketDropGameTest {
     }
 
     /**
-     * Control: a normal item stranded the same way must still drop as usual — confirms the fluid-packet
-     * gate in {@link PipeBlockEntity#dropItem} doesn't suppress drops in general.
+     * Control: a normal item stranded the same way must still drop as usual.
      */
     @GameTest
     public void testNormalItemStillDropsOnPipeBreak(GameTestHelper context) {

--- a/fabric/src/gametest/resources/fabric.mod.json
+++ b/fabric/src/gametest/resources/fabric.mod.json
@@ -27,6 +27,7 @@
 			"com.logistics.gametest.pipe.FluidLightGameTest",
 			"com.logistics.gametest.pipe.FluidProviderGameTest",
 			"com.logistics.gametest.pipe.FluidSupplierGameTest",
+			"com.logistics.gametest.pipe.FluidPacketDropGameTest",
 			"com.logistics.gametest.pipe.PowerJunctionGameTest",
 			"com.logistics.gametest.power.BatteryGameTest",
 			"com.logistics.gametest.power.CableGameTest",


### PR DESCRIPTION
## Summary

Fluid packets are a hidden internal representation of in-transit fluid — never crafted or shown to players (see `FluidPacketItem`'s own javadoc: "never crafted or shown to players"). But every failure path in the pipe network (no route found, transfer failure, insertion overflow, or the pipe itself being broken) spawned one as a regular pickup-able `ItemEntity` on the ground, same as any other stranded item.

## Changes

- `PipeBlockEntity.dropItem` — the single choke point every drop path in the pipe runtime funnels through (routing-time `RoutePlan.drop()`, transfer-time storage-full fallback, insertion-time capacity overflow, and pipe-block-removal) — now voids a `FLUID_PACKET` stack instead of spawning an entity. One gate covers all four families of drop site.

## Notes

- Added `FluidPacketDropGameTest` with two cases: confirms a fluid packet stranded in a broken pipe never becomes a ground item, and a control case confirming a normal item still drops as before (the gate is scoped to fluid packets only).
- Verified both new tests fail without the fix and pass with it.
- Investigated a fuller LogisticsPipes-style "reroute a stranded packet to a different sink" recovery (their `FluidRoutedPipe.endReached` fallback) as a follow-up, but our network's `findSinkFor` only resolves `registerSink`-based destinations (`SinkModule` and similar) — `FluidSupplierModule`/`SupplierModule` are order-based (`placeOrder`) and were never discoverable that way, so a naive port doesn't actually work for the realistic case. Left as a scoped future enhancement rather than shipping something that looks like it reroutes but can't reach a real supplier.