### PR TITLE
fix(automation): stop the sawmill from silently rejecting seeds

### DIFF
--- a/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillRecipeCategory.java
+++ b/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillRecipeCategory.java
@@ -12,6 +12,7 @@ import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import mezz.jei.api.recipe.types.IRecipeType;
+import java.util.List;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
@@ -79,8 +80,15 @@ public class SawmillRecipeCategory implements IRecipeCategory<SawmillRecipe> {
 
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, SawmillRecipe recipe, IFocusGroup focuses) {
+        // .add(Ingredient) always shows each matching item at count 1, silently dropping ingredientCount()
+        // for recipes that need more than one (e.g. 8x Kelp) — build the stacks ourselves so JEI shows the
+        // real count players need to gather, instead of implying "just 1 of this."
+        int count = recipe.ingredientCount();
+        List<ItemStack> inputStacks = recipe.ingredient().items()
+                .map(holder -> new ItemStack(holder, count))
+                .toList();
         builder.addSlot(RecipeIngredientRole.INPUT, INPUT_X, INPUT_Y)
-            .add(recipe.ingredient());
+            .addItemStacks(inputStacks);
         builder.addSlot(RecipeIngredientRole.OUTPUT, OUTPUT_X, OUTPUT_Y)
             .add(recipe.getResultItem());
 

--- a/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillRecipeCategory.java
+++ b/common/src/client/java/com/logistics/automation/sawmill/jei/SawmillRecipeCategory.java
@@ -80,9 +80,7 @@ public class SawmillRecipeCategory implements IRecipeCategory<SawmillRecipe> {
 
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, SawmillRecipe recipe, IFocusGroup focuses) {
-        // .add(Ingredient) always shows each matching item at count 1, silently dropping ingredientCount()
-        // for recipes that need more than one (e.g. 8x Kelp) — build the stacks ourselves so JEI shows the
-        // real count players need to gather, instead of implying "just 1 of this."
+        // Counted stacks so JEI renders the real per-craft amount (e.g. 8x Kelp), not just 1 each.
         int count = recipe.ingredientCount();
         List<ItemStack> inputStacks = recipe.ingredient().items()
                 .map(holder -> new ItemStack(holder, count))

--- a/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_beetroot_seeds.json
+++ b/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_beetroot_seeds.json
@@ -1,0 +1,7 @@
+{
+  "type": "logistics:sawmill",
+  "ingredient": "minecraft:beetroot_seeds",
+  "count": 8,
+  "result": { "id": "logistics:core/pulped_biomass", "count": 1 },
+  "energy": 2000
+}

--- a/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_melon_seeds.json
+++ b/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_melon_seeds.json
@@ -1,6 +1,6 @@
 {
   "type": "logistics:sawmill",
-  "ingredient": "#c:seeds",
+  "ingredient": "minecraft:melon_seeds",
   "count": 8,
   "result": { "id": "logistics:core/pulped_biomass", "count": 1 },
   "energy": 2000

--- a/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_pumpkin_seeds.json
+++ b/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_pumpkin_seeds.json
@@ -1,0 +1,7 @@
+{
+  "type": "logistics:sawmill",
+  "ingredient": "minecraft:pumpkin_seeds",
+  "count": 8,
+  "result": { "id": "logistics:core/pulped_biomass", "count": 1 },
+  "energy": 2000
+}

--- a/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_torchflower_seeds.json
+++ b/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_torchflower_seeds.json
@@ -1,0 +1,7 @@
+{
+  "type": "logistics:sawmill",
+  "ingredient": "minecraft:torchflower_seeds",
+  "count": 8,
+  "result": { "id": "logistics:core/pulped_biomass", "count": 1 },
+  "energy": 2000
+}

--- a/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_wheat_seeds.json
+++ b/common/src/main/resources/data/logistics/recipe/sawmill/pulped_biomass_from_wheat_seeds.json
@@ -1,0 +1,7 @@
+{
+  "type": "logistics:sawmill",
+  "ingredient": "minecraft:wheat_seeds",
+  "count": 8,
+  "result": { "id": "logistics:core/pulped_biomass", "count": 1 },
+  "energy": 2000
+}

--- a/fabric/src/gametest/java/com/logistics/gametest/automation/SawmillGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/automation/SawmillGameTest.java
@@ -119,12 +119,7 @@ public class SawmillGameTest {
         });
     }
 
-    /**
-     * Regression coverage for the pulped-biomass recipe set (matched to vanilla composter chances —
-     * 0.3/0.5/0.65 tiers map to counts of 8/6/4 respectively): kelp and seeds are both 0.3-tier (count 8)
-     * and must accept insertion. Seeds previously never matched — {@code pulped_biomass_from_seeds.json}
-     * referenced the {@code #c:seeds} tag, which had no definition anywhere in the mod's data.
-     */
+    /** Verifies kelp and wheat seeds are both accepted as sawmill input at their required 8-item count. */
     @GameTest
     public void testAcceptsKelpAndSeedsAsInput(GameTestHelper context) {
         BlockPos pos = new BlockPos(1, 1, 1);

--- a/fabric/src/gametest/java/com/logistics/gametest/automation/SawmillGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/automation/SawmillGameTest.java
@@ -118,4 +118,83 @@ public class SawmillGameTest {
             context.succeed();
         });
     }
+
+    /**
+     * Regression coverage for the pulped-biomass recipe set (matched to vanilla composter chances —
+     * 0.3/0.5/0.65 tiers map to counts of 8/6/4 respectively): kelp and seeds are both 0.3-tier (count 8)
+     * and must accept insertion. Seeds previously never matched — {@code pulped_biomass_from_seeds.json}
+     * referenced the {@code #c:seeds} tag, which had no definition anywhere in the mod's data.
+     */
+    @GameTest
+    public void testAcceptsKelpAndSeedsAsInput(GameTestHelper context) {
+        BlockPos pos = new BlockPos(1, 1, 1);
+        context.setBlock(pos, LogisticsAutomation.BLOCK.SAWMILL);
+        if (!(context.getBlockEntity(pos, SawmillBlockEntity.class) instanceof WorldlyContainer sided)) {
+            context.fail("Sawmill should implement WorldlyContainer");
+            return;
+        }
+
+        if (!sided.canPlaceItemThroughFace(INPUT, new ItemStack(Items.KELP, 8), Direction.UP)) {
+            context.fail("Kelp should be insertable as a sawmill input");
+            return;
+        }
+        if (!sided.canPlaceItemThroughFace(INPUT, new ItemStack(Items.WHEAT_SEEDS, 8), Direction.UP)) {
+            context.fail("Wheat seeds should be insertable as a sawmill input");
+            return;
+        }
+        context.succeed();
+    }
+
+    @GameTest(maxTicks = 150)
+    public void testPulpsKelpIntoBiomass(GameTestHelper context) {
+        BlockPos pos = new BlockPos(1, 1, 1);
+        context.setBlock(pos, LogisticsAutomation.BLOCK.SAWMILL);
+        SawmillBlockEntity sawmill = context.getBlockEntity(pos, SawmillBlockEntity.class);
+
+        var energy = sawmill.energyStorage(null);
+        for (int i = 0; i < 200; i++) {
+            energy.insert(128, false);
+        }
+        sawmill.setItem(INPUT, new ItemStack(Items.KELP, 8));
+
+        // Pulped-biomass recipes cost 2,000 RF and saw in 100 ticks at 20 RF/t -> 1 pulped biomass.
+        context.runAfterDelay(120, () -> {
+            if (!sawmill.getItem(INPUT).isEmpty()) {
+                context.fail("Kelp input should be consumed, got " + sawmill.getItem(INPUT));
+                return;
+            }
+            ItemStack primary = sawmill.getItem(PRIMARY);
+            if (!primary.is(LogisticsCore.ITEM.PULPED_BIOMASS) || primary.getCount() != 1) {
+                context.fail("Primary output should be 1 pulped biomass, got " + primary);
+                return;
+            }
+            context.succeed();
+        });
+    }
+
+    @GameTest(maxTicks = 150)
+    public void testPulpsSeedsIntoBiomass(GameTestHelper context) {
+        BlockPos pos = new BlockPos(1, 1, 1);
+        context.setBlock(pos, LogisticsAutomation.BLOCK.SAWMILL);
+        SawmillBlockEntity sawmill = context.getBlockEntity(pos, SawmillBlockEntity.class);
+
+        var energy = sawmill.energyStorage(null);
+        for (int i = 0; i < 200; i++) {
+            energy.insert(128, false);
+        }
+        sawmill.setItem(INPUT, new ItemStack(Items.WHEAT_SEEDS, 8));
+
+        context.runAfterDelay(120, () -> {
+            if (!sawmill.getItem(INPUT).isEmpty()) {
+                context.fail("Seeds input should be consumed, got " + sawmill.getItem(INPUT));
+                return;
+            }
+            ItemStack primary = sawmill.getItem(PRIMARY);
+            if (!primary.is(LogisticsCore.ITEM.PULPED_BIOMASS) || primary.getCount() != 1) {
+                context.fail("Primary output should be 1 pulped biomass, got " + primary);
+                return;
+            }
+            context.succeed();
+        });
+    }
 }


### PR DESCRIPTION
fix(automation): stop the sawmill from silently rejecting seeds

fix(automation): show the sawmill's real ingredient count in JEI

## Summary

`pulped_biomass_from_seeds.json` used `#c:seeds` as its ingredient — a tag that doesn't exist anywhere in this mod's data. The recipe could never match, so seeds silently did nothing in the sawmill.

Separately, kelp turned out to work correctly — the actual reported symptom traced back to the JEI display never showing the sawmill's required ingredient count, so it looked like 1 kelp should be enough when the recipe actually needs 8 (matching its composter-chance tier, like every other biomass recipe).

## Changes

- **`#c:seeds` replaced with 5 explicit per-item recipes** (wheat/beetroot/melon/pumpkin/torchflower seeds), each at count 8 — matching the existing composter-tier ratio (0.3 chance → count 8) already used consistently across the other ~60 pulped-biomass recipes.
- **JEI now shows the real ingredient count.** `SawmillRecipeCategory` was calling `.add(Ingredient)`, which always displays matching items at count 1 regardless of the recipe's actual `ingredientCount()`. It now builds the input stacks explicitly at the correct count.
- Added gametest coverage: kelp and wheat seeds are both accepted as sawmill input and correctly process into pulped biomass end-to-end.

## Notes

- Verified the full pulped-biomass recipe set (60+ files) against vanilla's actual `ComposterBlock.COMPOSTABLES` table (extracted directly from the game jar): every recipe's `count` already matches its composter chance tier exactly (0.3→8, 0.5→6, 0.65→4), so this is scoped to just the missing tag — no other recipe needed a count change.
- Left the batch-count model in place rather than switching to a chance-based single-item model — several of these recipes (wheat, beetroot, pumpkin, melon, sugar cane, saplings) already use their one byproduct slot for something else, so a chance-based redesign would need `SawmillRecipe` to support multiple simultaneous byproducts. Out of scope here; the JEI fix directly addresses the actual discoverability problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
