### PR TITLE
fix(sawmill): accept single-item deliveries for batched recipes

### DIFF
--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
@@ -9,6 +9,8 @@ import com.logistics.core.machine.MachineEntity;
 import com.logistics.core.machine.component.EnergyStorageComponent;
 import com.logistics.core.machine.component.RecipeProcessorComponent;
 import com.logistics.core.machine.component.SlotRole;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -19,6 +21,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -41,6 +44,11 @@ public class SawmillBlockEntity extends MachineEntity {
     private EnergyStorageComponent energy;
     private RecipeProcessorComponent processor;
     private ContainerData containerData;
+
+    // Cache of typed sawmill recipes for the insertion-probe check below, rebuilt only when the
+    // server's RecipeManager instance changes (e.g. on a data-pack reload).
+    private RecipeManager cachedRecipeManager;
+    private List<SawmillRecipe> cachedSawmillRecipes = List.of();
 
     public SawmillBlockEntity(BlockPos pos, BlockState state) {
         super(LogisticsAutomation.ENTITY.SAWMILL_BLOCK_ENTITY, pos, state);
@@ -81,12 +89,31 @@ public class SawmillBlockEntity extends MachineEntity {
         // Ingredient-only match: a single delivered stack rarely meets a recipe's full ingredientCount
         // on its own (e.g. 8 kelp), so the insertion gate can't reuse the full matches() check — that
         // would block every delivery smaller than the whole batch from ever entering the slot.
-        for (RecipeHolder<?> holder : serverLevel.getServer().getRecipeManager().getRecipes()) {
-            if (holder.value() instanceof SawmillRecipe recipe && recipe.acceptsAsInput(stack)) {
+        for (SawmillRecipe recipe : sawmillRecipes(serverLevel)) {
+            if (recipe.acceptsAsInput(stack)) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Typed sawmill recipes, cached against the server's current RecipeManager. Rebuilding only on a
+     * RecipeManager change avoids rescanning every recipe in the game on each insertion probe.
+     */
+    private List<SawmillRecipe> sawmillRecipes(ServerLevel serverLevel) {
+        RecipeManager recipeManager = serverLevel.getServer().getRecipeManager();
+        if (recipeManager != cachedRecipeManager) {
+            cachedRecipeManager = recipeManager;
+            List<SawmillRecipe> recipes = new ArrayList<>();
+            for (RecipeHolder<?> holder : recipeManager.getRecipes()) {
+                if (holder.value() instanceof SawmillRecipe recipe) {
+                    recipes.add(recipe);
+                }
+            }
+            cachedSawmillRecipes = recipes;
+        }
+        return cachedSawmillRecipes;
     }
 
     private void setLit(MachineContext ctx, boolean lit) {

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillBlockEntity.java
@@ -18,7 +18,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.SingleRecipeInput;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -70,6 +70,7 @@ public class SawmillBlockEntity extends MachineEntity {
         containerData = MachineData.source(processor, energy, capacity);
     }
 
+    /** Whether {@code stack} can serve as the input of some recipe (gates hopper/pipe insertion). */
     private boolean isSawable(ItemStack stack) {
         if (stack.isEmpty()) {
             return false;
@@ -77,9 +78,15 @@ public class SawmillBlockEntity extends MachineEntity {
         if (!(level instanceof ServerLevel serverLevel)) {
             return true; // permissive during load / on the client; validated again on the server tick
         }
-        return serverLevel.getServer().getRecipeManager()
-                .getRecipeFor(LogisticsAutomation.RECIPE.SAWMILL_RECIPE_TYPE, new SingleRecipeInput(stack), level)
-                .isPresent();
+        // Ingredient-only match: a single delivered stack rarely meets a recipe's full ingredientCount
+        // on its own (e.g. 8 kelp), so the insertion gate can't reuse the full matches() check — that
+        // would block every delivery smaller than the whole batch from ever entering the slot.
+        for (RecipeHolder<?> holder : serverLevel.getServer().getRecipeManager().getRecipes()) {
+            if (holder.value() instanceof SawmillRecipe recipe && recipe.acceptsAsInput(stack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void setLit(MachineContext ctx, boolean lit) {

--- a/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipe.java
+++ b/common/src/main/java/com/logistics/automation/sawmill/SawmillRecipe.java
@@ -89,6 +89,11 @@ public class SawmillRecipe extends AbstractLogisticsRecipe<SingleRecipeInput> {
         return ingredient.test(input.item()) && input.item().getCount() >= ingredientCount;
     }
 
+    /** Whether {@code stack} could ever feed this recipe, ignoring count (used to gate insertion). */
+    public boolean acceptsAsInput(ItemStack stack) {
+        return ingredient.test(stack);
+    }
+
     @Override
     public @NotNull String group() {
         return "";

--- a/common/src/test/java/com/logistics/automation/sawmill/SawmillRecipeTest.java
+++ b/common/src/test/java/com/logistics/automation/sawmill/SawmillRecipeTest.java
@@ -75,6 +75,26 @@ class SawmillRecipeTest extends MinecraftTestEnvironment {
         assertThat(twoLogs.matches(new SingleRecipeInput(new ItemStack(Items.OAK_LOG, 2)), null)).isTrue();
     }
 
+    // ==================== acceptsAsInput ====================
+
+    @Test
+    @DisplayName("acceptsAsInput: matches on ingredient alone, ignoring ingredientCount")
+    void acceptsAsInputIgnoresCount() {
+        SawmillRecipe eightKelp = new SawmillRecipe(
+                Ingredient.of(Items.KELP),
+                8,
+                ItemResult.of(Items.OAK_PLANKS, 1),
+                Optional.empty(),
+                2000,
+                SawmillRecipe.DEFAULT_EXPERIENCE);
+
+        // A single delivered item never satisfies matches() against a count-8 recipe, but it must
+        // still pass acceptsAsInput() or a hopper/pipe could never place kelp into the slot at all.
+        assertThat(eightKelp.matches(new SingleRecipeInput(new ItemStack(Items.KELP, 1)), null)).isFalse();
+        assertThat(eightKelp.acceptsAsInput(new ItemStack(Items.KELP, 1))).isTrue();
+        assertThat(eightKelp.acceptsAsInput(new ItemStack(Items.COAL, 1))).isFalse();
+    }
+
     // ==================== getters ====================
 
     @Test

--- a/fabric/src/gametest/java/com/logistics/gametest/automation/SawmillGameTest.java
+++ b/fabric/src/gametest/java/com/logistics/gametest/automation/SawmillGameTest.java
@@ -140,6 +140,27 @@ public class SawmillGameTest {
         context.succeed();
     }
 
+    /**
+     * Pipes/hoppers probe insertion with a single-item template (see ContainerItemStorage), not a
+     * stack already sized to the recipe's ingredientCount. A kelp recipe needing 8 must still accept
+     * single-item deliveries so the slot can accumulate toward that count.
+     */
+    @GameTest
+    public void testAcceptsSingleKelpFromAPipeProbe(GameTestHelper context) {
+        BlockPos pos = new BlockPos(1, 1, 1);
+        context.setBlock(pos, LogisticsAutomation.BLOCK.SAWMILL);
+        if (!(context.getBlockEntity(pos, SawmillBlockEntity.class) instanceof WorldlyContainer sided)) {
+            context.fail("Sawmill should implement WorldlyContainer");
+            return;
+        }
+
+        if (!sided.canPlaceItemThroughFace(INPUT, new ItemStack(Items.KELP, 1), Direction.UP)) {
+            context.fail("A single kelp item should be insertable even though the recipe needs 8");
+            return;
+        }
+        context.succeed();
+    }
+
     @GameTest(maxTicks = 150)
     public void testPulpsKelpIntoBiomass(GameTestHelper context) {
         BlockPos pos = new BlockPos(1, 1, 1);


### PR DESCRIPTION
## Summary
Pipes, hoppers, and other automated inserters could never feed items into the sawmill for any recipe that requires more than one of the input per operation — kelp (8), dried kelp (8), dried kelp block, fences, gates, and stairs (2 each). A supplier pipe configured to keep the sawmill stocked with kelp would place no orders and nothing would ever move, even with plenty of kelp available.

## Root cause
The sawmill's insertion filter reused the full recipe match (ingredient **and** count), but every automated insertion path probes a slot with a single-item stack before transferring the real amount. A lone probe item can never satisfy a recipe that needs 8, so the filter rejected every delivery outright — regardless of how much was actually available upstream.

## Fix
The insertion filter now only checks whether the item is ever a valid ingredient for some sawmill recipe, not whether a single delivered stack already meets that recipe's full count. This matches the pattern already used by the alloy smelter. The quantity requirement is still enforced separately at craft time, once the slot has accumulated enough.

## Notes
- Added a unit test and an in-world test that reproduce the bug via a single-item probe (the existing kelp test used a pre-built 8-count stack, which is why it didn't catch this).