### PR TITLE
fix(macerator): grind loose raw ore items into dust

### DIFF
--- a/common/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_raw_copper.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/copper_dust_from_raw_copper.json
@@ -1,0 +1,15 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": {
+    "item": "minecraft:raw_copper"
+  },
+  "result": {
+    "id": "logistics:core/copper_dust",
+    "count": 2
+  },
+  "energy": 2000,
+  "byproduct": {
+    "id": "logistics:core/gold_dust",
+    "chance": 0.1
+  }
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_raw_gold.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/gold_dust_from_raw_gold.json
@@ -1,0 +1,15 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": {
+    "item": "minecraft:raw_gold"
+  },
+  "result": {
+    "id": "logistics:core/gold_dust",
+    "count": 2
+  },
+  "energy": 2000,
+  "byproduct": {
+    "id": "logistics:core/quicksilver",
+    "chance": 0.1
+  }
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_raw_iron.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/iron_dust_from_raw_iron.json
@@ -1,0 +1,15 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": {
+    "item": "minecraft:raw_iron"
+  },
+  "result": {
+    "id": "logistics:core/iron_dust",
+    "count": 2
+  },
+  "energy": 2000,
+  "byproduct": {
+    "id": "logistics:core/tin_dust",
+    "chance": 0.1
+  }
+}

--- a/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_raw_tin.json
+++ b/common/src/main/resources/data/logistics/recipe/macerator/tin_dust_from_raw_tin.json
@@ -1,0 +1,15 @@
+{
+  "type": "logistics:macerator",
+  "ingredient": {
+    "item": "logistics:core/raw_tin"
+  },
+  "result": {
+    "id": "logistics:core/tin_dust",
+    "count": 2
+  },
+  "energy": 2000,
+  "byproduct": {
+    "id": "logistics:core/iron_dust",
+    "chance": 0.1
+  }
+}


### PR DESCRIPTION
## Summary

The Macerator had ore-doubling recipes for the **ore block**, the compressed **raw-metal storage block**, and the **ingot** — but never for the loose **raw ore item** (Raw Iron, Raw Copper, Raw Gold, Raw Tin). Since mining an ore block normally drops the raw item (not the block itself, which needs Silk Touch), the doubling recipe was effectively unreachable for most survival play.

## Changes

- Add Macerator recipes for Raw Iron, Raw Copper, Raw Gold, and Raw Tin
- Each produces the same output as its ore-block recipe (2 dust + the same 10% chance byproduct), minus XP — since XP is already paid out when the ore is mined

## Notes

Will forward-port to mc/26.1, mc/1.21.11, mc/26.2, and mc/26.3 once this merges.